### PR TITLE
Updated error message to 'Failed to build asset' and added path sugge…

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -169,7 +169,8 @@ func Run(isDebug *bool) *cli.Command {
 			if runningForAnAsset {
 				task, err = DefaultPipelineBuilder.CreateAssetFromFile(inputPath)
 				if err != nil {
-					errorPrinter.Printf("Failed to build task: %v\n", err.Error())
+					errorPrinter.Printf("Failed to build asset: %v. Are you sure you used the correct path?\n", err.Error())
+
 					return cli.Exit("", 1)
 				}
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1239,7 +1239,7 @@ func (b *Builder) CreateAssetFromFile(path string) (*Asset, error) {
 			return nil, err
 		}
 
-		return nil, errors.Wrapf(err, "error creating task from file '%s'", path)
+		return nil, errors.Wrapf(err, "error creating asset from file '%s'", path)
 	}
 
 	if task == nil {


### PR DESCRIPTION
This PR updates the error message shown when trying to run a non-existent file with the `bruin run` command.

- Changed "Failed to build task" to "Failed to build asset" to use consistent terminology.
- Added a helpful suggestion: "Are you sure you used the correct path?" to guide users in troubleshooting.
