### PR TITLE
Migrate goreleaser from v1 to v2 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,3 +41,22 @@ jobs:
           go-version-file: 'go.mod'
 
       - run: make format
+
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --clean
+        env:
+          VERSION: 0.0.0-SNAPSHOT

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,21 +42,3 @@ jobs:
 
       - run: make format
 
-  goreleaser:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --snapshot --clean
-        env:
-          VERSION: 0.0.0-SNAPSHOT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-version: 1 
+version: 2
 
 builds:
   - env:
@@ -12,7 +12,9 @@ builds:
     goarch:
         - amd64
         - arm64
-
+    ignore:
+      - goos: windows
+        goarch: arm64
 archives:
   - format: tar.gz
     name_template: >-
@@ -43,7 +45,7 @@ brews:
       email: burak.karakan@getbruin.com
 
     # Folder inside the repository to put the formula.
-    folder: Formula
+    directory: Formula
 
     # The project name and current git tag are used in the format string.
     #


### PR DESCRIPTION
- Migrate goreleaser from v1 to v2
- Skip windows ARM build from goreleaser 