### PR TITLE
Added validation for single assets in run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -253,6 +253,10 @@ func Run(isDebug *bool) *cli.Command {
 			}
 			infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", foundPipeline.Name, len(foundPipeline.Assets))
 
+			if runningForAnAsset {
+				infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
+			}
+
 			rules, err := lint.GetRules(fs, &git.RepoFinder{}, true)
 			if err != nil {
 				errorPrinter.Printf("An error occurred while linting the pipelines: %v\n", err)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -31,6 +31,7 @@ type Issue struct {
 
 type Rule interface {
 	Name() string
+	IsFast() bool
 	Validate(pipeline *pipeline.Pipeline) ([]*Issue, error)
 	ValidateAsset(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error)
 	GetApplicableLevels() []Level
@@ -39,6 +40,7 @@ type Rule interface {
 
 type SimpleRule struct {
 	Identifier       string
+	Fast             bool
 	Validator        PipelineValidator
 	AssetValidator   AssetValidator
 	ApplicableLevels []Level
@@ -47,6 +49,10 @@ type SimpleRule struct {
 
 func (g *SimpleRule) Validate(pipeline *pipeline.Pipeline) ([]*Issue, error) {
 	return g.Validator(pipeline)
+}
+
+func (g *SimpleRule) IsFast() bool {
+	return g.Fast
 }
 
 func (g *SimpleRule) ValidateAsset(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -32,6 +32,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 	rules := []Rule{
 		&SimpleRule{
 			Identifier:       "task-name-valid",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureTaskNameIsValidForASingleAsset),
 			AssetValidator:   EnsureTaskNameIsValidForASingleAsset,
@@ -39,6 +40,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "task-name-unique",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsureTaskNameIsUnique,
 			AssetValidator:   EnsureTaskNameIsUniqueForASingleAsset,
@@ -46,6 +48,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "dependency-exists",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureDependencyExistsForASingleAsset),
 			AssetValidator:   EnsureDependencyExistsForASingleAsset,
@@ -53,6 +56,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "valid-executable-file",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureExecutableFileIsValidForASingleAsset(fs)),
 			AssetValidator:   EnsureExecutableFileIsValidForASingleAsset(fs),
@@ -60,18 +64,21 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "valid-pipeline-schedule",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsurePipelineScheduleIsValidCron,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
 			Identifier:       "valid-pipeline-name",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsurePipelineNameIsValid,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
 			Identifier:       "valid-task-type",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureTypeIsCorrectForASingleAsset),
 			AssetValidator:   EnsureTypeIsCorrectForASingleAsset,
@@ -79,24 +86,28 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "acyclic-pipeline",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsurePipelineHasNoCycles,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
 			Identifier:       "valid-slack-notification",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsureSlackFieldInPipelineIsValid,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
 			Identifier:       "valid-ms-teams-notification",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsureMSTeamsFieldInPipelineIsValid,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
 			Identifier:       "materialization-config",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureMaterializationValuesAreValidForSingleAsset),
 			AssetValidator:   EnsureMaterializationValuesAreValidForSingleAsset,
@@ -104,6 +115,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "valid-snowflake-query-sensor",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureSnowflakeSensorHasQueryParameterForASingleAsset),
 			AssetValidator:   EnsureSnowflakeSensorHasQueryParameterForASingleAsset,
@@ -111,6 +123,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "valid-bigquery-table-sensor",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureBigQueryTableSensorHasTableParameterForASingleAsset),
 			AssetValidator:   EnsureBigQueryTableSensorHasTableParameterForASingleAsset,
@@ -118,6 +131,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "valid-ingestr",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(EnsureIngestrAssetIsValidForASingleAsset),
 			AssetValidator:   EnsureIngestrAssetIsValidForASingleAsset,
@@ -125,12 +139,14 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "valid-pipeline-start-date",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        EnsurePipelineStartDateIsValid,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
 			Identifier:       "valid-entity-references",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(gr.EnsureAssetEntitiesExistInGlossary),
 			AssetValidator:   gr.EnsureAssetEntitiesExistInGlossary,
@@ -138,6 +154,7 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 		},
 		&SimpleRule{
 			Identifier:       "duplicate-column-names",
+			Fast:             true,
 			Severity:         ValidatorSeverityCritical,
 			Validator:        CallFuncForEveryAsset(ValidateDuplicateColumnNames),
 			AssetValidator:   ValidateDuplicateColumnNames,
@@ -166,5 +183,15 @@ func FilterRulesByLevel(rules []Rule, level Level) []Rule {
 		}
 	}
 
+	return filtered
+}
+
+func FilterRulesBySpeed(rules []Rule, fast bool) []Rule {
+	filtered := make([]Rule, 0, len(rules))
+	for _, rule := range rules {
+		if rule.IsFast() == fast {
+			filtered = append(filtered, rule)
+		}
+	}
 	return filtered
 }

--- a/pkg/lint/query.go
+++ b/pkg/lint/query.go
@@ -43,7 +43,7 @@ func (q *QueryValidatorRule) Name() string {
 }
 
 func (q *QueryValidatorRule) IsFast() bool {
-	return true
+	return false
 }
 
 func (q *QueryValidatorRule) GetApplicableLevels() []Level {

--- a/pkg/lint/query.go
+++ b/pkg/lint/query.go
@@ -29,6 +29,7 @@ type materializer interface {
 
 type QueryValidatorRule struct {
 	Identifier   string
+	Fast         bool
 	TaskType     pipeline.AssetType
 	Connections  connectionManager
 	Extractor    queryExtractor
@@ -39,6 +40,10 @@ type QueryValidatorRule struct {
 
 func (q *QueryValidatorRule) Name() string {
 	return q.Identifier
+}
+
+func (q *QueryValidatorRule) IsFast() bool {
+	return true
 }
 
 func (q *QueryValidatorRule) GetApplicableLevels() []Level {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -780,6 +780,10 @@ func (u UsedTableValidatorRule) Name() string {
 	return "used-tables"
 }
 
+func (u UsedTableValidatorRule) IsFast() bool {
+	return true
+}
+
 func (u UsedTableValidatorRule) GetApplicableLevels() []Level {
 	return []Level{LevelPipeline, LevelAsset}
 }


### PR DESCRIPTION
Pipeline
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (bru-321) [1]> go run main.go run  ./examples/simple-pipeline/
Pipeline: bruin-init (.)
    └── Invalid cron schedule 'dailyadds' (valid-pipeline-schedule)

  destinations (assets/athena.sql)
    └── Asset name 'destinations' is not unique, please make sure all the task names are unique (task-name-unique)
        ├─ /Users/yuvraj/Workspace/bruin-data/bruin/examples/simple-pipeline/assets/athena.sql
        └─ /Users/yuvraj/Workspace/bruin-data/bruin/examples/simple-pipeline/assets/duckdb.sql


✘ Checked 1 pipeline and found 2 issues, please check above.
exit status 1
```
Single Assets 
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (bru-321) [1]> go run main.go run  ../test/bruin-pipeline/assets/example.sql 

Pipeline: bruin-init (.)
    └── The pipeline has a cycle with dependencies, make sure there are no cyclic dependencies (acyclic-pipeline)
        └─ Asset `myschema.example` depends on itself

  myschema.example (assets/example.sql)
    └── Asset name 'myschema.example' is not unique, please make sure all the task names are unique (task-name-unique)
        ├─ /Users/yuvraj/Workspace/bruin-data/test/bruin-pipeline/assets/example.sql
        └─ /Users/yuvraj/Workspace/bruin-data/test/bruin-pipeline/assets/pythonsample/country_list.py


✘ Checked 1 pipeline and found 2 issues, please check above.
exit status 1
```