### PR TITLE
Added validation rule for checking assets dir as warning 

### DIFF
--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -160,6 +160,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool) ([]Rule, err
 			AssetValidator:   ValidateDuplicateColumnNames,
 			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
 		},
+		&SimpleRule{
+			Identifier:       "assets-directory-exist",
+			Fast:             true,
+			Severity:         ValidatorSeverityWarning,
+			Validator:        ValidateAssetDirectoryExist,
+			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
+		},
 		UsedTableValidatorRule{
 			renderer: jinja.NewRendererWithYesterday("your-pipeline", "some-run-id"),
 			parser:   parser,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -370,6 +371,20 @@ func ValidateDuplicateColumnNames(ctx context.Context, p *pipeline.Pipeline, ass
 		} else {
 			columnNames[lowercaseName] = true
 		}
+	}
+	return issues, nil
+}
+
+func ValidateAssetDirectoryExist(p *pipeline.Pipeline) ([]*Issue, error) {
+	var issues []*Issue
+
+	parentDir := filepath.Dir(p.DefinitionFile.Path)
+
+	if _, err := os.Stat(fmt.Sprintf("%s/assets", parentDir)); os.IsNotExist(err) {
+		issues = append(issues, &Issue{
+			Task:        &pipeline.Asset{},
+			Description: fmt.Sprintf("Assets directory does not exist at '%s'", fmt.Sprintf("%s/assets", parentDir)),
+		})
 	}
 	return issues, nil
 }


### PR DESCRIPTION
Fix: https://linear.app/bruin/issue/BRU-506/warn-if-there-is-no-assets-folder-in-validation

Test:
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (bru-506)> go run main.go validate  ./examples/simple-pipeline/                                               (bruin) 

Validating pipelines in './examples/simple-pipeline/' for 'default' environment...

Pipeline: bruin-init (.)
    └── Invalid cron schedule 'dailyadds' (valid-pipeline-schedule)

   (/Users/yuvraj/Workspace/bruin-data/bruin/examples/simple-pipeline)
    └── Assets directory does not exist at '/Users/yuvraj/Workspace/bruin-data/bruin/examples/simple-pipeline/assets' (assets-directory-exist)


✘ Checked 1 pipeline and found 1 issue and 1 warning, please check above.
An error occurred: validation failed
exit status 1
```