### PR TITLE
Revert Big Query connection validation logic

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,7 @@ builds:
       - -s -w -X main.version={{ .Env.VERSION }}"
     flags:
       - -trimpath
-
+      - -buildmode=exe
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,6 @@ builds:
       - -s -w -X main.version={{ .Env.VERSION }}"
     flags:
       - -trimpath
-      - -buildmode=exe
 
 
 archives:

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -2,9 +2,7 @@ package connection
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/bruin-data/bruin/pkg/adjust"
@@ -740,15 +738,17 @@ func (m *Manager) AddBqConnectionFromConfig(connection *config.GoogleCloudPlatfo
 		return errors.New("credentials are required: provide either service_account_file or service_account_json")
 	}
 
-	// If ServiceAccountFile is provided, validate that it is readable and contains valid JSON.
+	// Validate ServiceAccountFile if provided.
 	if len(connection.ServiceAccountFile) > 0 {
-		file, err := os.ReadFile(connection.ServiceAccountFile)
-		if err != nil {
-			return errors.Errorf("failed to read service account file at '%s': %v", connection.ServiceAccountFile, err)
+		if err := validateServiceAccountFile(connection.ServiceAccountFile); err != nil {
+			return err
 		}
-		var js json.RawMessage
-		if err := json.Unmarshal(file, &js); err != nil {
-			return errors.Errorf("invalid JSON format in service account file at '%s'", connection.ServiceAccountFile)
+	}
+
+	// Validate ServiceAccountJSON if provided.
+	if len(connection.ServiceAccountJSON) > 0 {
+		if err := validateServiceAccountJSON(connection.ServiceAccountJSON); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/connection/helper.go
+++ b/pkg/connection/helper.go
@@ -1,0 +1,35 @@
+package connection
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// New helper function to validate ServiceAccountFile
+func validateServiceAccountFile(filePath string) error {
+	file, err := os.ReadFile(filePath)
+	if err != nil {
+		return errors.Errorf("failed to read service account file at '%s': %v", filePath, err)
+	}
+	var js json.RawMessage
+	if err := json.Unmarshal(file, &js); err != nil {
+		return errors.Errorf("invalid JSON format in service account file at '%s'", filePath)
+	}
+	return nil
+}
+
+// New helper function to validate ServiceAccountJSON
+func validateServiceAccountJSON(jsonStr string) error {
+	// Check if the path exists and is a file
+	if _, err := os.Stat(jsonStr); err == nil {
+		return errors.New("please use service_account_file instead of service_account_json to define path")
+	}
+
+	var js json.RawMessage
+	if err := json.Unmarshal([]byte(jsonStr), &js); err != nil {
+		return errors.Errorf("invalid JSON format in service account JSON")
+	}
+	return nil
+}

--- a/pkg/connection/helper.go
+++ b/pkg/connection/helper.go
@@ -9,6 +9,11 @@ import (
 
 // New helper function to validate ServiceAccountFile.
 func validateServiceAccountFile(filePath string) error {
+	var jsonStr json.RawMessage
+	if err := json.Unmarshal([]byte(filePath), &jsonStr); err == nil {
+		return errors.New("please use service_account_json instead of service_account_file to define json")
+	}
+
 	file, err := os.ReadFile(filePath)
 	if err != nil {
 		return errors.Errorf("failed to read service account file at '%s': %v", filePath, err)

--- a/pkg/connection/helper.go
+++ b/pkg/connection/helper.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// New helper function to validate ServiceAccountFile
+// New helper function to validate ServiceAccountFile.
 func validateServiceAccountFile(filePath string) error {
 	file, err := os.ReadFile(filePath)
 	if err != nil {
@@ -20,7 +20,7 @@ func validateServiceAccountFile(filePath string) error {
 	return nil
 }
 
-// New helper function to validate ServiceAccountJSON
+// New helper function to validate ServiceAccountJSON.
 func validateServiceAccountJSON(jsonStr string) error {
 	// Check if the path exists and is a file
 	if _, err := os.Stat(jsonStr); err == nil {

--- a/pkg/connection/helper_test.go
+++ b/pkg/connection/helper_test.go
@@ -1,0 +1,57 @@
+package connection
+
+import (
+	"os"
+	"testing"
+)
+
+// Test for validateServiceAccountFile function.
+func TestValidateServiceAccountFile(t *testing.T) {
+	t.Parallel() // Allow this test to run in parallel
+
+	// Create a temporary file for testing.
+	tempFile, err := os.CreateTemp("", "service_account.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name()) // Clean up
+
+	// Write valid JSON to the temp file.
+	validJSON := []byte(`{"type": "service_account"}`)
+	if _, err := tempFile.Write(validJSON); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tempFile.Close()
+
+	// Test valid file.
+	if err := validateServiceAccountFile(tempFile.Name()); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+
+	// Test invalid file.
+	if err := validateServiceAccountFile("invalid_path.json"); err == nil {
+		t.Error("expected error for invalid file path, got none")
+	}
+}
+
+// Test for validateServiceAccountJSON function.
+func TestValidateServiceAccountJSON(t *testing.T) {
+	t.Parallel() // Allow this test to run in parallel
+
+	// Test valid JSON string.
+	validJSON := `{"type": "service_account"}`
+	if err := validateServiceAccountJSON(validJSON); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+
+	// Test invalid JSON string.
+	invalidJSON := `{"type": "service_account",}`
+	if err := validateServiceAccountJSON(invalidJSON); err == nil {
+		t.Error("expected error for invalid JSON format, got none")
+	}
+
+	// Test using a file path.
+	if err := validateServiceAccountJSON("some_file_path.json"); err == nil {
+		t.Error("expected error for file path, got none")
+	}
+}

--- a/pkg/connection/helper_test.go
+++ b/pkg/connection/helper_test.go
@@ -7,17 +7,29 @@ import (
 
 // Test for validateServiceAccountFile function.
 func TestValidateServiceAccountFile(t *testing.T) {
-	t.Parallel() // Allow this test to run in parallel
+	t.Parallel()
 
 	// Create a temporary file for testing.
 	tempFile, err := os.CreateTemp("", "service_account.json")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tempFile.Name()) // Clean up
+	defer os.Remove(tempFile.Name())
 
 	// Write valid JSON to the temp file.
-	validJSON := []byte(`{"type": "service_account"}`)
+	validJSON := []byte(`{
+        "type": "service_account",
+        "project_id": "bruin-common-health-check",
+        "private_key_id": "TEST",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----\n",
+        "client_email": "bruin-health-check@bruin-common-health-check.iam.gserviceaccount.com",
+        "client_id": "TEST",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/bruin-health-check%40bruin-common-health-check.iam.gserviceaccount.com",
+        "universe_domain": "googleapis.com"
+    }`)
 	if _, err := tempFile.Write(validJSON); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
@@ -32,14 +44,44 @@ func TestValidateServiceAccountFile(t *testing.T) {
 	if err := validateServiceAccountFile("invalid_path.json"); err == nil {
 		t.Error("expected error for invalid file path, got none")
 	}
+
+	// Test empty file.
+	emptyFile, err := os.CreateTemp("", "empty_file.json")
+	if err != nil {
+		t.Fatalf("failed to create empty temp file: %v", err)
+	}
+	defer os.Remove(emptyFile.Name())
+	if err := validateServiceAccountFile(emptyFile.Name()); err == nil {
+		t.Error("expected error for empty file, got none")
+	}
+
+	// Test valid JSON string as filePath.
+	jsonString := `{"type": "service_account"}`
+	if err := validateServiceAccountFile(jsonString); err == nil {
+		t.Error("expected error for valid JSON string as filePath, got none")
+	} else if err.Error() != "please use service_account_json instead of service_account_file to define json" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
 }
 
 // Test for validateServiceAccountJSON function.
 func TestValidateServiceAccountJSON(t *testing.T) {
-	t.Parallel() // Allow this test to run in parallel
+	t.Parallel()
 
 	// Test valid JSON string.
-	validJSON := `{"type": "service_account"}`
+	validJSON := `{
+        "type": "service_account",
+        "project_id": "bruin-common-health-check",
+        "private_key_id": "TEST",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----\n",
+        "client_email": "bruin-health-check@bruin-common-health-check.iam.gserviceaccount.com",
+        "client_id": "TEST",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/bruin-health-check%40bruin-common-health-check.iam.gserviceaccount.com",
+        "universe_domain": "googleapis.com"
+    }`
 	if err := validateServiceAccountJSON(validJSON); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -48,10 +90,46 @@ func TestValidateServiceAccountJSON(t *testing.T) {
 	invalidJSON := `{"type": "service_account",}`
 	if err := validateServiceAccountJSON(invalidJSON); err == nil {
 		t.Error("expected error for invalid JSON format, got none")
+	} else if err.Error() != "invalid JSON format in service account JSON" {
+		t.Errorf("expected specific error message, got: %v", err)
 	}
 
-	// Test using a file path.
+	// Test using a file path that doesn't exist.
 	if err := validateServiceAccountJSON("some_file_path.json"); err == nil {
 		t.Error("expected error for file path, got none")
+	} else if err.Error() != "invalid JSON format in service account JSON" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
+
+	// Test using a file path that exist
+	tempFile, err := os.CreateTemp("", "service_account.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	if _, err := tempFile.WriteString(validJSON); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	if err := validateServiceAccountJSON(tempFile.Name()); err == nil {
+		t.Error("expected error for file path, got none")
+	} else if err.Error() != "please use service_account_file instead of service_account_json to define path" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
+
+	// Test empty JSON string.
+	emptyJSON := ``
+	if err := validateServiceAccountJSON(emptyJSON); err == nil {
+		t.Error("expected error for empty JSON string, got none")
+	} else if err.Error() != "invalid JSON format in service account JSON" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
+
+	// Test malformed JSON string.
+	malformedJSON := `{"type": "service_account", "project_id": "bruin-common-health-check", "private_key_id": "TEST", "private_key": "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----\n", "client_email": "bruin-health-check@bruin-common-health-check.iam.gserviceaccount.com", "client_id": "TEST", "auth_uri": "https://accounts.google.com/o/oauth2/auth", "token_uri": "https://oauth2.googleapis.com/token", "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/bruin-health-check%40bruin-common-health-check.iam.gserviceaccount.com", "universe_domain": "googleapis.com"`
+	if err := validateServiceAccountJSON(malformedJSON); err == nil {
+		t.Error("expected error for malformed JSON string, got none")
+	} else if err.Error() != "invalid JSON format in service account JSON" {
+		t.Errorf("expected specific error message, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Test Cases 

### Test Case 1 
When user have correct config.
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                                                                      (bruin) 

Validating pipelines in '../bruin-dev/' for 'default' environment...

Pipeline: bruin-init (bruin-pipeline)
  myschema.example (assets/example.sql)
    └── Invalid query found at index 0: googleapi: Error 403: Access Denied: Project name-of-the-project: User does not have bigquery.jobs.create permission in project name-of-the-project., accessDenied (bigquery-validator)
        ├─ The failing query is as follows:
        └─ CREATE OR REPLACE TABLE myschema.example   AS
           SELECT 1 as id, 'Spain' as country , 'Juan' as name
           union all
           SELECT 2 as id, 'Germany' as country , 'Markus' as name
           union all
           SELECT 3 as id, 'France' as country , 'Antoine' as name
           union all
           SELECT 4 as id, 'Poland' as country , 'Franciszek' as name


✘ Checked 1 pipeline and found 1 issue, please check above.
An error occurred: validation failed
exit status 1
```

### Test Case 2
When json file path is wrong 

```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                                                                      (bruin) 

Failed to register connections: [failed to add BigQuery connection 'gcp': failed to read service account file at '/Users/yuvraj/Workspace/bruin-data/bruin/service-account.jso': open /Users/yuvraj/Workspace/bruin-data/bruin/service-account.jso: no such file or directory]
exit status 1
```

### Test Case 3
When user provide  `service_account_json` and the value of `service_account_json` is correct path 
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                                                                      (bruin) 

Failed to register connections: [failed to add BigQuery connection 'gcp': please use service_account_file instead of service_account_json to define path]
exit status 1
```

### Test Case 4 
When user provide correct json in `service_account_json`
```
uvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                                                                      (bruin) 

Validating pipelines in '../bruin-dev/' for 'default' environment...

Pipeline: bruin-init (bruin-pipeline)
  myschema.example (assets/example.sql)
    └── Invalid query found at index 0: googleapi: Error 403: Access Denied: Project name-of-the-project: User does not have bigquery.jobs.create permission in project name-of-the-project., accessDenied (bigquery-validator)
        ├─ The failing query is as follows:
        └─ CREATE OR REPLACE TABLE myschema.example   AS
           SELECT 1 as id, 'Spain' as country , 'Juan' as name
           union all
           SELECT 2 as id, 'Germany' as country , 'Markus' as name
           union all
           SELECT 3 as id, 'France' as country , 'Antoine' as name
           union all
           SELECT 4 as id, 'Poland' as country , 'Franciszek' as name


✘ Checked 1 pipeline and found 1 issue, please check above.
An error occurred: validation failed
exit status 1
```

### Test Case 5
When user provide incorrect json in `service_account_json`

```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                                                                      (bruin) 

Failed to register connections: [failed to add BigQuery connection 'gcp': invalid JSON format in service account JSON]
exit status 1
```
### Test Case 6
When user have correct json in service_account_file 
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                (bruin) 

Failed to register connections: [failed to add BigQuery connection 'gcp': please use service_account_json instead of service_account_file to define json]
exit status 1
```

### Test Case 7
When user have incorrect json in service_account_file 
```
yuvraj@Yuvrajs-MacBook-Pro ~/W/b/bruin (revert-bgconnection)> go run main.go validate  ../bruin-dev/                (bruin) 

Failed to register connections: [failed to add BigQuery connection 'gcp': failed to read service account file at '    
....
"type":check.iam.gserviceaccount.com",     "universe_domain": "googleapis.com"   }: file name too long]
exit status 1
```


## Testing Env 
- Setup a boilerplate 
```
bruin init 
```
- change the `.bruin.yaml` content 
```
default_environment: default

environments:
  default:
    connections:

      google_cloud_platform:
        - name: "gcp"
          service_account_json: "/Users/yuvraj/Workspace/bruin-data/bruin/service-account.json"
          project_id: "name-of-the-project"
```

- Test different test cases by changing the `.bruin.yaml`
```
bruin validate 
```