### PR TITLE
Fix Image Paths in Documentation (Follow-up to Previous PR  #149)

### DIFF
--- a/docs/vscode-extension/configuration.md
+++ b/docs/vscode-extension/configuration.md
@@ -24,4 +24,4 @@ To access and modify the Bruin extension settings:
 4. Adjust the settings for **Default Folding State** and **Path Separator** as needed.
 
 
-![Extension Config](../vscode-extension/extension-config.png)
+![Extension Config](../public/vscode-extension/extension-config.png)

--- a/docs/vscode-extension/getting-started.md
+++ b/docs/vscode-extension/getting-started.md
@@ -29,7 +29,7 @@ To access Bruin features, add a Bruin section in your code. You can do this manu
 
 Syntax highlighting is automatic in a Bruin section. If the section is written without formatting errors, the syntax should be highlighted in YAML colors. If it appears as a comment instead, check the structure to ensure there are no errors. Autocompletion is also available in `pipeline.yaml` and `.bruin.yml` files, allowing you to access relevant properties and values as you type, with a JSON schema to maintain accuracy and completeness.
 
-![Bruin Autocomplete](../vscode-extension/snippets/autocomplete-postgres.gif)
+![Bruin Autocomplete](../public/vscode-extension/snippets/autocomplete-postgres.gif)
 
 ### 4. Run Bruin CLI Commands
 
@@ -38,7 +38,7 @@ Run Bruin CLI commands directly from the extension:
 - Use the command palette (`Ctrl + Shift + P`) and type the command you want, like `Bruin: Install Bruin CLI`.
 - Or, use the buttons in the UI to run commands without needing the terminal.
 
-![Bruin Action Buttons](../vscode-extension/render-asset.gif)
+![Bruin Action Buttons](../public/vscode-extension/render-asset.gif)
 
 ### 5. Explore the Bruin Panels
 
@@ -47,4 +47,4 @@ The Bruin extension provides two main panels :
 - **Side Panel**: Displays the current asset’s details with tabs for viewing asset information, columns, and settings.
 - **Lineage Panel**: Found at the bottom of VSCode, near the terminal, this panel shows the asset lineage, giving you a visual of how the asset connects to other assets.
 
-![Bruin Panels](../vscode-extension/panels/bruin-panels.png)
+![Bruin Panels](../public/vscode-extension/panels/bruin-panels.png)

--- a/docs/vscode-extension/installation.md
+++ b/docs/vscode-extension/installation.md
@@ -5,7 +5,7 @@
 3. **Search for "Bruin"**: Visit the [Bruin extension on the VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=bruin.bruin) or type "Bruin" in the Extensions search bar.
 4. **Install the Extension**: Click the Install button next to the Bruin extension in the results. You can also check the "Auto Update" option to ensure you don't miss out on new features and fixes.
 
-   ![Bruin Extension](../vscode-extension/bruin-extension.png)
+   ![Bruin Extension](../public/vscode-extension/bruin-extension.png)
 
 5. **Check Bruin CLI Installation**:
    - When you click the **Bruin Launch** button, the extension checks if Bruin CLI is installed.
@@ -15,11 +15,11 @@
       - If the CLI is **not installed**, a message will appear in the **Settings** tab with a button to install it.
       - It is also possible to install the CLI manually. For instructions, please refer to the [Installation Guide](../getting-started/introduction.md) section.
 
-      ![Install Bruin CLI](../vscode-extension/install-cli.png)
+      ![Install Bruin CLI](../public/vscode-extension/install-cli.png)
 
    - On **Windows**, it will also check for Go. If Go is missing, a message will guide you to the documentation for installation.
 
-   ![Go Not Found](../vscode-extension/go-not-found.png)
+   ![Go Not Found](../public/vscode-extension/go-not-found.png)
 
 6. **Linux Support**: Automatic CLI installation is not available on Linux. You will need to install the Bruin CLI manually.
 

--- a/docs/vscode-extension/overview.md
+++ b/docs/vscode-extension/overview.md
@@ -6,19 +6,19 @@ The Bruin VSCode extension complements the Bruin CLI by offering a more visual a
 
 - **Syntax Coloring, Autocompletion, and Snippets**: Enjoy syntax coloring, autocompletion, and ready-to-use snippets to make coding smoother and more intuitive.
 
-![Syntaxe Coloring](../vscode-extension/syntaxe-coloring.png)
+![Syntaxe Coloring](../public/vscode-extension/syntaxe-coloring.png)
 
 - **Bruin CLI Integration**: Run Bruin CLI commands effortlessly through easy-to-use buttons and panels.
 
-![CLI Integration](../vscode-extension/action-buttons.gif)
+![CLI Integration](../public/vscode-extension/action-buttons.gif)
 
 - **Data Asset Lineage Visualization**: Get a clear view of how data assets connect and interact, helping you understand your data's flow and dependencies.
 
-![Lineage Overview](../vscode-extension/panels/lineage-panel/lineage-overview.png)
+![Lineage Overview](../public/vscode-extension/panels/lineage-panel/lineage-overview.png)
 
 - **Real-time Updates and Feedback**: Stay informed with instant updates and error messages right in VSCode.
 
-![Real-Time Feedback](../vscode-extension/real-time-feedback.gif)
+![Real-Time Feedback](../public/vscode-extension/real-time-feedback.gif)
 <!-- ### What is a Bruin Section?
 A **Bruin section** refers to a block of code within SQL or Python files that is specifically designated for Bruin-related functionality. These sections are typically enclosed within specific delimiters, allowing the extension to identify and manage them effectively. Users can fold or expand these sections to improve code readability and organization.
 


### PR DESCRIPTION
# PR Overview
- Resolves issues from the previously merged PR that failed due to incorrect image paths.
- Updates all image paths in the documentation to use the public directory.
