### PR TITLE
Validate connections before running

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -259,7 +259,7 @@ func Run(isDebug *bool) *cli.Command {
 
 			err = cm.CanRunPipeline(foundPipeline)
 			if err != nil {
-				errorPrinter.Printf("Cannot run: %v\n", err)
+				errorPrinter.Printf(err.Error()) // nolint: govet
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -259,7 +259,7 @@ func Run(isDebug *bool) *cli.Command {
 
 			err = cm.CanRunPipeline(foundPipeline)
 			if err != nil {
-				errorPrinter.Printf(err.Error()) // nolint: govet
+				errorPrinter.Printf(err.Error()) //nolint: govet
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -257,6 +257,12 @@ func Run(isDebug *bool) *cli.Command {
 				infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
 			}
 
+			err = cm.CanRunPipeline(foundPipeline)
+			if err != nil {
+				errorPrinter.Printf("Cannot run: %v\n", err)
+				return cli.Exit("", 1)
+			}
+
 			rules, err := lint.GetRules(fs, &git.RepoFinder{}, true)
 			if err != nil {
 				errorPrinter.Printf("An error occurred while linting the pipelines: %v\n", err)

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -269,7 +269,7 @@ func (c *Config) CanRunPipeline(p *pipeline.Pipeline) error {
 			return errors2.Wrap(err, "Could not find connection name for asset "+task.Name)
 		}
 		if !c.SelectedEnvironment.Connections.Exists(connName) {
-			return errors.New("Connection " + connName + " does not exist in the selected environment and is needed for asset " + task.Name)
+			return errors2.Errorf("Connection '%s' does not exist in the selected environment and is needed for '%s'", connName, task.Name)
 		}
 	}
 

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -262,7 +262,7 @@ type Config struct {
 	Environments            map[string]Environment `yaml:"environments" json:"environments" mapstructure:"environments"`
 }
 
-func (c *Config) CanRunPipeline(p pipeline.Pipeline) error {
+func (c *Config) CanRunPipeline(p *pipeline.Pipeline) error {
 	for _, task := range p.Assets {
 		connName, err := p.GetConnectionNameForAsset(task)
 		if err != nil {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -262,18 +262,18 @@ type Config struct {
 	Environments            map[string]Environment `yaml:"environments" json:"environments" mapstructure:"environments"`
 }
 
-func (c *Config) CanRunPipeline(p pipeline.Pipeline) (bool, error) {
+func (c *Config) CanRunPipeline(p pipeline.Pipeline) error {
 	for _, task := range p.Assets {
 		connName, err := p.GetConnectionNameForAsset(task)
 		if err != nil {
-			return false, errors2.Wrap(err, "Could not find connection name for asset "+task.Name)
+			return errors2.Wrap(err, "Could not find connection name for asset "+task.Name)
 		}
 		if !c.SelectedEnvironment.Connections.Exists(connName) {
-			return false, nil
+			return errors.New("Connection " + connName + " does not exist in the selected environment")
 		}
 	}
 
-	return true, nil
+	return nil
 }
 
 func (c *Config) GetEnvironmentNames() []string {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -269,7 +269,7 @@ func (c *Config) CanRunPipeline(p pipeline.Pipeline) error {
 			return errors2.Wrap(err, "Could not find connection name for asset "+task.Name)
 		}
 		if !c.SelectedEnvironment.Connections.Exists(connName) {
-			return errors.New("Connection " + connName + " does not exist in the selected environment")
+			return errors.New("Connection " + connName + " does not exist in the selected environment and is needed for asset " + task.Name)
 		}
 	}
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -766,6 +766,50 @@ func TestCanRunPipeline(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name: "no specific connection, not found",
+			config: Config{
+				SelectedEnvironment: &Environment{
+					Connections: &Connections{
+						GoogleCloudPlatform: []GoogleCloudPlatformConnection{
+							{
+								Name: "gcp-default",
+							},
+						},
+					},
+				},
+			},
+			pipeline: pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Type: pipeline.AssetType("sf.sql"),
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "no specific connection, found",
+			config: Config{
+				SelectedEnvironment: &Environment{
+					Connections: &Connections{
+						GoogleCloudPlatform: []GoogleCloudPlatformConnection{
+							{
+								Name: "gcp-default",
+							},
+						},
+					},
+				},
+			},
+			pipeline: pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Type: pipeline.AssetType("bq.sql"),
+					},
+				},
+			},
+			expectedErr: false,
+		},
+		{
 			name: "2 assets 1 conn missing",
 			config: Config{
 				SelectedEnvironment: &Environment{

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -719,8 +719,7 @@ func TestCanRunPipeline(t *testing.T) {
 			pipeline: pipeline.Pipeline{
 				Assets: []*pipeline.Asset{},
 			},
-			expectedCanRun: true,
-			expectedErr:    false,
+			expectedErr: false,
 		},
 		{
 			name: "specific connection, not found",
@@ -742,8 +741,7 @@ func TestCanRunPipeline(t *testing.T) {
 					},
 				},
 			},
-			expectedCanRun: false,
-			expectedErr:    false,
+			expectedErr: true,
 		},
 		{
 			name: "specific connection, found",
@@ -765,8 +763,7 @@ func TestCanRunPipeline(t *testing.T) {
 					},
 				},
 			},
-			expectedCanRun: true,
-			expectedErr:    false,
+			expectedErr: false,
 		},
 		{
 			name: "2 assets 1 conn missing",
@@ -791,8 +788,7 @@ func TestCanRunPipeline(t *testing.T) {
 					},
 				},
 			},
-			expectedCanRun: false,
-			expectedErr:    false,
+			expectedErr: true,
 		},
 		{
 			name: "2 assets 2 conns",
@@ -822,8 +818,7 @@ func TestCanRunPipeline(t *testing.T) {
 					},
 				},
 			},
-			expectedCanRun: true,
-			expectedErr:    false,
+			expectedErr: false,
 		},
 	}
 
@@ -831,12 +826,11 @@ func TestCanRunPipeline(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			canRun, err := tt.config.CanRunPipeline(tt.pipeline)
+			err := tt.config.CanRunPipeline(tt.pipeline)
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expectedCanRun, canRun)
 			}
 		})
 	}

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -826,7 +826,7 @@ func TestCanRunPipeline(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.config.CanRunPipeline(tt.pipeline)
+			err := tt.config.CanRunPipeline(&tt.pipeline)
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/snowflake/checks_test.go
+++ b/pkg/snowflake/checks_test.go
@@ -27,7 +27,6 @@ func (m *mockQuerierWithResult) Select(ctx context.Context, q *query.Query) ([][
 }
 
 func (m *mockQuerierWithResult) SelectWithSchema(ctx context.Context, q *query.Query) (*query.QueryResult, error) {
-
 	args := m.Called(ctx, q)
 	get := args.Get(0)
 	if get == nil {
@@ -35,6 +34,7 @@ func (m *mockQuerierWithResult) SelectWithSchema(ctx context.Context, q *query.Q
 	}
 	return get.(*query.QueryResult), args.Error(1)
 }
+
 func (m *mockQuerierWithResult) RunQueryWithoutResult(ctx context.Context, query *query.Query) error {
 	args := m.Called(ctx, query)
 	return args.Error(0)

--- a/pkg/snowflake/db_test.go
+++ b/pkg/snowflake/db_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
before `bruin run` validate all connections necessary are present to avoid lots of errors on big pipelines