### PR TITLE
Use ephemeral duck connection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - mnd
     - wrapcheck
     - funlen
-    - gomnd
     - gochecknoglobals
     - lll
     - wsl

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -17,7 +17,7 @@ func (c AwsConnection) GetName() string {
 	return c.Name
 }
 
-type GoogleCloudPlatformConnection struct {
+type GoogleCloudPlatformConnection struct { //nolint:recvcheck
 	Name               string `yaml:"name" json:"name" mapstructure:"name"`
 	ServiceAccountJSON string `yaml:"service_account_json" json:"service_account_json,omitempty" mapstructure:"service_account_json"`
 	ServiceAccountFile string `yaml:"service_account_file" json:"service_account_file,omitempty" mapstructure:"service_account_file"`

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 
 	"github.com/bruin-data/bruin/pkg/query"
-	"github.com/jmoiron/sqlx"
 	_ "github.com/marcboeker/go-duckdb"
 )
 
@@ -25,7 +24,7 @@ type connection interface {
 }
 
 func NewClient(c DuckDBConfig) (*Client, error) {
-	conn, err := sqlx.Open("duckdb", c.ToDBConnectionURI())
+	conn, err := NewEphemeralConnection(c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -12,9 +12,6 @@ type EphemeralConnection struct {
 }
 
 func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
-	LockDatabase(c.ToDBConnectionURI())
-	defer UnlockDatabase(c.ToDBConnectionURI())
-
 	conn, err := sqlx.Open("duckdb", c.ToDBConnectionURI())
 	if err != nil {
 		return nil, err
@@ -45,7 +42,7 @@ func (c *EphemeralConnection) QueryContext(ctx context.Context, query string, ar
 func (c *EphemeralConnection) ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error) {
 	LockDatabase(c.config.ToDBConnectionURI())
 	defer UnlockDatabase(c.config.ToDBConnectionURI())
-	
+
 	conn, err := sqlx.Open("duckdb", c.config.ToDBConnectionURI())
 	if err != nil {
 		return nil, err

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -16,6 +16,8 @@ func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer conn.Close()
+
 	err = conn.Ping()
 	if err != nil {
 		return nil, err
@@ -31,7 +33,7 @@ func (c *EphemeralConnection) QueryContext(ctx context.Context, query string, ar
 	}
 	defer conn.Close()
 
-	return conn.QueryContext(ctx, query, args...)
+	return conn.QueryContext(ctx, query, args...) //nolint
 }
 
 func (c *EphemeralConnection) ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error) {

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -12,6 +12,9 @@ type EphemeralConnection struct {
 }
 
 func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
+	LockDatabase(c.ToDBConnectionURI())
+	defer UnlockDatabase(c.ToDBConnectionURI())
+
 	conn, err := sqlx.Open("duckdb", c.ToDBConnectionURI())
 	if err != nil {
 		return nil, err
@@ -27,6 +30,9 @@ func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
 }
 
 func (c *EphemeralConnection) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	LockDatabase(c.config.ToDBConnectionURI())
+	defer UnlockDatabase(c.config.ToDBConnectionURI())
+
 	conn, err := sqlx.Open("duckdb", c.config.ToDBConnectionURI())
 	if err != nil {
 		return nil, err
@@ -37,6 +43,9 @@ func (c *EphemeralConnection) QueryContext(ctx context.Context, query string, ar
 }
 
 func (c *EphemeralConnection) ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error) {
+	LockDatabase(c.config.ToDBConnectionURI())
+	defer UnlockDatabase(c.config.ToDBConnectionURI())
+	
 	conn, err := sqlx.Open("duckdb", c.config.ToDBConnectionURI())
 	if err != nil {
 		return nil, err

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -1,0 +1,45 @@
+package duck
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type EphemeralConnection struct {
+	config DuckDBConfig
+}
+
+func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
+	conn, err := sqlx.Open("duckdb", c.ToDBConnectionURI())
+	if err != nil {
+		return nil, err
+	}
+	err = conn.Ping()
+	if err != nil {
+		return nil, err
+	}
+
+	return &EphemeralConnection{config: c}, nil
+}
+
+func (c *EphemeralConnection) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	conn, err := sqlx.Open("duckdb", c.config.ToDBConnectionURI())
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	return conn.QueryContext(ctx, query, args...)
+}
+
+func (c *EphemeralConnection) ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error) {
+	conn, err := sqlx.Open("duckdb", c.config.ToDBConnectionURI())
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	return conn.ExecContext(ctx, sql, arguments...)
+}

--- a/pkg/duckdb/lock.go
+++ b/pkg/duckdb/lock.go
@@ -1,34 +1,101 @@
 package duck
 
-import "sync"
+import (
+	"math/rand/v2"
+	"sync"
+	"time"
+)
 
-// databaseLocks maps database paths to their corresponding locks to prevent concurrent access
-var databaseLocks = struct {
-	sync.RWMutex
-	locks map[string]*sync.Mutex
-}{
-	locks: make(map[string]*sync.Mutex),
+// Mutex is the mutex with synchronized map, it allows reducing unnecessary locks among different keys.
+// This implementation comes from the mapmutex package, I simply copied it here instead of adding it as a dependency.
+// See the code here: https://github.com/EagleChen/mapmutex/blob/master/mutex.go
+type Mutex struct {
+	locks     map[interface{}]interface{}
+	m         *sync.Mutex
+	maxRetry  int
+	maxDelay  float64 // in nanosend
+	baseDelay float64 // in nanosecond
+	factor    float64
+	jitter    float64
 }
 
-// this allows us to share locks between different components to the same database
-func LockDatabase(path string) {
-	databaseLocks.RLock()
-	lock, ok := databaseLocks.locks[path]
-	databaseLocks.RUnlock()
-	if !ok {
-		databaseLocks.Lock()
-		lock = &sync.Mutex{}
-		lock.Lock()
-		databaseLocks.locks[path] = lock
-		databaseLocks.Unlock()
-		return
+// TryLock tries to acquire the lock.
+func (m *Mutex) TryLock(key interface{}) bool {
+	for i := range m.maxRetry {
+		m.m.Lock()
+		if _, ok := m.locks[key]; ok { // if locked
+			m.m.Unlock()
+			time.Sleep(m.backoff(i))
+		} else { // if unlock, lockit
+			m.locks[key] = struct{}{}
+			m.m.Unlock()
+			return true
+		}
 	}
 
-	lock.Lock()
+	return false
+}
+
+// Unlock unlocks for the key
+// please call Unlock only after having acquired the lock.
+func (m *Mutex) Unlock(key interface{}) {
+	m.m.Lock()
+	delete(m.locks, key)
+	m.m.Unlock()
+}
+
+func (m *Mutex) backoff(retries int) time.Duration {
+	if retries == 0 {
+		return time.Duration(m.baseDelay) * time.Nanosecond
+	}
+	backoff, max := m.baseDelay, m.maxDelay
+	for backoff < max && retries > 0 {
+		backoff *= m.factor
+		retries--
+	}
+	if backoff > max {
+		backoff = max
+	}
+	backoff *= 1 + m.jitter*(rand.Float64()*2-1) //nolint:gosec
+	if backoff < 0 {
+		return 0
+	}
+	return time.Duration(backoff) * time.Nanosecond
+}
+
+// NewMapMutex returns a mapmutex with default configs.
+func NewMapMutex() *Mutex {
+	return &Mutex{
+		locks:     make(map[interface{}]interface{}),
+		m:         &sync.Mutex{},
+		maxRetry:  200,
+		maxDelay:  100000000, // 0.1 second
+		baseDelay: 10,        // 10 nanosecond
+		factor:    1.1,
+		jitter:    0.2,
+	}
+}
+
+// NewCustomizedMapMutex returns a customized mapmutex.
+func NewCustomizedMapMutex(mRetry int, mDelay, bDelay, factor, jitter float64) *Mutex {
+	return &Mutex{
+		locks:     make(map[interface{}]interface{}),
+		m:         &sync.Mutex{},
+		maxRetry:  mRetry,
+		maxDelay:  mDelay,
+		baseDelay: bDelay,
+		factor:    factor,
+		jitter:    jitter,
+	}
+}
+
+var databaseLocks = NewMapMutex()
+
+func LockDatabase(path string) {
+	for !databaseLocks.TryLock(path) {
+	}
 }
 
 func UnlockDatabase(path string) {
-	databaseLocks.Lock()
-	delete(databaseLocks.locks, path)
-	databaseLocks.Unlock()
+	databaseLocks.Unlock(path)
 }

--- a/pkg/duckdb/lock.go
+++ b/pkg/duckdb/lock.go
@@ -1,0 +1,34 @@
+package duck
+
+import "sync"
+
+// databaseLocks maps database paths to their corresponding locks to prevent concurrent access
+var databaseLocks = struct {
+	sync.RWMutex
+	locks map[string]*sync.Mutex
+}{
+	locks: make(map[string]*sync.Mutex),
+}
+
+// this allows us to share locks between different components to the same database
+func LockDatabase(path string) {
+	databaseLocks.RLock()
+	lock, ok := databaseLocks.locks[path]
+	databaseLocks.RUnlock()
+	if !ok {
+		databaseLocks.Lock()
+		lock = &sync.Mutex{}
+		lock.Lock()
+		databaseLocks.locks[path] = lock
+		databaseLocks.Unlock()
+		return
+	}
+
+	lock.Lock()
+}
+
+func UnlockDatabase(path string) {
+	databaseLocks.Lock()
+	delete(databaseLocks.locks, path)
+	databaseLocks.Unlock()
+}

--- a/pkg/duckdb/lock_test.go
+++ b/pkg/duckdb/lock_test.go
@@ -1,0 +1,75 @@
+package duck
+
+import (
+	"testing"
+)
+
+func TestLockSuccess(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapMutex()
+
+	if !m.TryLock("123") {
+		t.Error("fail to get lock")
+	}
+	m.Unlock("123")
+}
+
+func TestLockFail(t *testing.T) {
+	t.Parallel()
+
+	// fail fast
+	m := NewCustomizedMapMutex(1, 1, 1, 2, 0.1)
+
+	c := make(chan bool)
+	finish := make(chan bool)
+
+	num := 5
+	success := make([]int, num)
+
+	for i := range num {
+		go func(i int) {
+			if m.TryLock("123") {
+				<-c // block here
+				success[i] = 1
+				m.Unlock("123")
+			}
+			finish <- true
+		}(i)
+	}
+
+	// most goroutines fail to get the lock
+	for range num - 1 {
+		<-finish
+	}
+
+	sum := 0
+	for _, s := range success {
+		sum += s
+	}
+
+	if sum != 0 {
+		t.Error("some other goroutine got the lock")
+	}
+
+	// finish the success one
+	c <- true
+	// wait
+	<-finish
+	for _, s := range success {
+		sum += s
+	}
+	if sum != 1 {
+		t.Error("no goroutine got the lock")
+	}
+}
+
+func TestLockIndivisually(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapMutex()
+
+	if !m.TryLock(123) || !m.TryLock(456) {
+		t.Error("different locks affect each other")
+	}
+}

--- a/pkg/lint/print.go
+++ b/pkg/lint/print.go
@@ -95,7 +95,7 @@ func (l *Printer) printPipelineSummary(pipelineIssues *PipelineIssues) {
 	}
 }
 
-func (l Printer) relativePipelinePath(p *pipeline.Pipeline) string {
+func (l *Printer) relativePipelinePath(p *pipeline.Pipeline) string {
 	absolutePipelineRoot := filepath.Dir(p.DefinitionFile.Path)
 
 	absRootPath, err := filepath.Abs(l.RootCheckPath)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -78,7 +78,7 @@ type Notifications struct {
 	Discord []DiscordNotification `yaml:"discord" json:"discord" mapstructure:"discord"`
 }
 
-type DefaultTrueBool struct {
+type DefaultTrueBool struct { //nolint:recvcheck
 	Value *bool
 }
 
@@ -228,7 +228,7 @@ func (m Materialization) MarshalJSON() ([]byte, error) {
 	})
 }
 
-type ColumnCheckValue struct {
+type ColumnCheckValue struct { //nolint:recvcheck
 	IntArray    *[]int    `json:"int_array"`
 	Int         *int      `json:"int"`
 	Float       *float64  `json:"float"`
@@ -788,7 +788,7 @@ func uniqueAssets(assets []*Asset) []*Asset {
 	return unique
 }
 
-type EmptyStringMap map[string]string
+type EmptyStringMap map[string]string //nolint:recvcheck
 
 func (m EmptyStringMap) MarshalJSON() ([]byte, error) { //nolint: stylecheck
 	if m == nil {
@@ -816,7 +816,7 @@ func (b *EmptyStringMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type EmptyStringArray []string
+type EmptyStringArray []string //nolint:recvcheck
 
 func (a EmptyStringArray) MarshalJSON() ([]byte, error) {
 	if a == nil {


### PR DESCRIPTION
# Context

At the moment CLI locks the DB as soon as it instantiates the connection and it unlocks it on exit. This means that if for example, we had a python asset that was also trying to access that same db it won't be able to since CLI is blocking anything else from writing. 

We only need to lock the DB for the time it takes to run queries (select or update)

# AC

Only lock DB when sending SQL to the connections, and unlock right after. This could be achieved by wrapping the current duckdb connection