### PR TITLE
Add new flag for column lineage

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -259,13 +259,13 @@ func ParseLineage(pipe *pipeline.Pipeline, asset *pipeline.Asset) error {
 	for _, lineageCol := range lineage.Columns {
 		for _, upstream := range lineageCol.Upstream {
 			upstreamAsset := pipe.GetAssetByName(upstream.Table)
-			if upstreamAsset == nil {
-				return fmt.Errorf("upstream asset not found: %s", upstream.Table)
-			}
 
+			if upstreamAsset == nil {
+				continue
+			}
 			upstreamCol := upstreamAsset.GetColumnWithName(upstream.Column)
 			if upstreamCol == nil {
-				return fmt.Errorf("column %s not found in asset %s", upstream.Column, upstream.Table)
+				continue
 			}
 
 			newCol := *upstreamCol

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -273,8 +273,6 @@ func ParseLineage(pipe *pipeline.Pipeline, asset *pipeline.Asset) error {
 
 			if col := asset.GetColumnWithName(lineageCol.Name); col == nil {
 				asset.Columns = append(asset.Columns, newCol)
-			} else {
-				*col = newCol
 			}
 		}
 	}

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -115,7 +115,7 @@ func (r *ParseCommand) ParsePipeline(assetPath string) error {
 
 	foundPipeline.WipeContentOfAssets()
 
-	js, err := json.MarshalIndent(foundPipeline, "", "  ")
+	js, err := json.Marshal(foundPipeline)
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)
@@ -172,7 +172,7 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 		Repo:     repoRoot,
 	}
 
-	js, err := json.MarshalIndent(result, "", "  ")
+	js, err := json.Marshal(result)
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -162,7 +162,7 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 		}
 	}
 
-	result := struct {
+	js, err := json.Marshal(struct {
 		Asset    *pipeline.Asset    `json:"asset"`
 		Pipeline *pipeline.Pipeline `json:"pipeline"`
 		Repo     *git.Repo          `json:"repo"`
@@ -170,9 +170,7 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 		Asset:    asset,
 		Pipeline: foundPipeline,
 		Repo:     repoRoot,
-	}
-
-	js, err := json.Marshal(result)
+	})
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -115,7 +115,7 @@ func (r *ParseCommand) ParsePipeline(assetPath string) error {
 
 	foundPipeline.WipeContentOfAssets()
 
-	js, err := json.Marshal(foundPipeline)
+	js, err := json.MarshalIndent(foundPipeline, "", "  ")
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -106,6 +106,35 @@ func TestInternalParse_Run(t *testing.T) {
 			want:        nil,
 		},
 		{
+			name: "simple select all query wihtout upstream",
+			pipeline: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name:    "employees",
+						Columns: createEmployeeColumns(),
+					},
+				},
+			},
+			beforeAssets: &pipeline.Asset{
+				Name: "example",
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: "select * from employees",
+				},
+				Upstreams: []pipeline.Upstream{},
+			},
+			afterAssets: &pipeline.Asset{
+				Name: "example",
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: "select * from employees",
+				},
+				Columns:   []pipeline.Column{},
+				Upstreams: []pipeline.Upstream{},
+			},
+			wantCount:   0,
+			wantColumns: []pipeline.Column{},
+			want:        nil,
+		},
+		{
 			name:     "complex join query",
 			pipeline: createComplexJoinPipeline(),
 			beforeAssets: &pipeline.Asset{

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+)
+
+func TestInternalParse_Run(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		pipeline     *pipeline.Pipeline
+		beforeAssets *pipeline.Asset
+		afterAssets  *pipeline.Asset
+		err          error
+		want         error
+	}{
+		{
+			pipeline: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					&pipeline.Asset{
+						Name: "employees",
+						Columns: []pipeline.Column{
+							{
+								Name:       "id",
+								Type:       "str",
+								PrimaryKey: true,
+							},
+							{
+								Name: "name",
+								Type: "str",
+							},
+							{
+								Name: "age",
+								Type: "int64",
+							},
+						},
+					},
+				},
+			},
+			beforeAssets: &pipeline.Asset{
+				Name: "example",
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: "select * from employees",
+				},
+				Upstreams: []pipeline.Upstream{
+					{
+						Value: "employees",
+					},
+				},
+			},
+			afterAssets: &pipeline.Asset{
+				Name: "example",
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: "select * from employees",
+				},
+				Columns: []pipeline.Column{
+					{
+						Name:       "id",
+						Type:       "str",
+						PrimaryKey: true,
+					},
+					{
+						Name: "name",
+						Type: "str",
+					},
+					{
+						Name: "age",
+						Type: "int64",
+					},
+				},
+				Upstreams: []pipeline.Upstream{
+					{
+						Value: "employees",
+					},
+				},
+			},
+			err:  nil,
+			want: nil,
+		},
+		{
+			pipeline: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					&pipeline.Asset{
+						Name: "table1",
+						Columns: []pipeline.Column{
+							{
+								Name: "a",
+								Type: "str",
+							},
+							{
+								Name: "b",
+								Type: "int64",
+							},
+						},
+					},
+					&pipeline.Asset{
+						Name: "table2",
+						Columns: []pipeline.Column{
+							{
+								Name: "a",
+								Type: "str",
+							},
+							{
+								Name: "c",
+								Type: "str",
+							},
+						},
+					},
+				},
+			},
+			beforeAssets: &pipeline.Asset{
+				Name: "example",
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: `
+					with t1 as (
+        select *
+        from table1
+        join table2
+            using(a)
+    ),
+    t2 as (
+        select *
+        from table2
+        left join table1
+            using(a)
+    )
+    select t1.*, t2.b as b2, t2.c as c2
+    from t1
+    join t2
+        using(a)
+					`,
+				},
+				Columns: []pipeline.Column{},
+				Upstreams: []pipeline.Upstream{
+					{
+						Value: "table1",
+					},
+					{
+						Value: "table2",
+					},
+				},
+			},
+			afterAssets: &pipeline.Asset{
+				Name: "example",
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: `
+					with t1 as (
+        select *
+        from table1
+        join table2
+            using(a)
+    ),
+    t2 as (
+        select *
+        from table2
+        left join table1
+            using(a)
+    )
+    select t1.*, t2.b as b2, t2.c as c2
+    from t1
+    join t2
+        using(a)
+					`,
+				},
+				Columns: []pipeline.Column{
+					{
+						Name: "a",
+						Type: "str",
+					},
+					{
+						Name: "b",
+						Type: "int64",
+					},
+					{
+						Name: "c",
+						Type: "str",
+					},
+					{
+						Name: "b2",
+						Type: "int64",
+					},
+					{
+						Name: "c2",
+						Type: "str",
+					},
+				},
+				Upstreams: []pipeline.Upstream{
+					{
+						Value: "table1",
+					},
+					{
+						Value: "table2",
+					},
+				},
+			},
+			err:  nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.beforeAssets.Name, func(t *testing.T) {
+			err := ParseLineage(tt.pipeline, tt.beforeAssets)
+			if err != tt.want {
+				t.Errorf("ParseLineage() error = %v, want %v", err, tt.want)
+			}
+
+			if tt.afterAssets != nil {
+
+				if len(tt.beforeAssets.Columns) != len(tt.afterAssets.Columns) {
+					t.Errorf("Column count mismatch: got %d, want %d",
+						len(tt.beforeAssets.Columns), len(tt.afterAssets.Columns))
+				}
+
+				for i, col := range tt.beforeAssets.Columns {
+					wantCol := tt.afterAssets.Columns[i]
+					if col.Name != wantCol.Name || col.Type != wantCol.Type {
+						t.Errorf("Column mismatch at index %d: got %+v, want %+v",
+							i, col, wantCol)
+					}
+				}
+
+				if len(tt.beforeAssets.Upstreams) != len(tt.afterAssets.Upstreams) {
+					t.Errorf("Upstream count mismatch: got %d, want %d",
+						len(tt.beforeAssets.Upstreams), len(tt.afterAssets.Upstreams))
+				}
+
+				for i, upstream := range tt.beforeAssets.Upstreams {
+					if upstream.Value != tt.afterAssets.Upstreams[i].Value {
+						t.Errorf("Upstream mismatch at index %d: got %s, want %s",
+							i, upstream.Value, tt.afterAssets.Upstreams[i].Value)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -18,7 +19,7 @@ func TestInternalParse_Run(t *testing.T) {
 		{
 			pipeline: &pipeline.Pipeline{
 				Assets: []*pipeline.Asset{
-					&pipeline.Asset{
+					{
 						Name: "employees",
 						Columns: []pipeline.Column{
 							{
@@ -81,7 +82,7 @@ func TestInternalParse_Run(t *testing.T) {
 		{
 			pipeline: &pipeline.Pipeline{
 				Assets: []*pipeline.Asset{
-					&pipeline.Asset{
+					{
 						Name: "table1",
 						Columns: []pipeline.Column{
 							{
@@ -94,7 +95,7 @@ func TestInternalParse_Run(t *testing.T) {
 							},
 						},
 					},
-					&pipeline.Asset{
+					{
 						Name: "table2",
 						Columns: []pipeline.Column{
 							{
@@ -113,23 +114,23 @@ func TestInternalParse_Run(t *testing.T) {
 				Name: "example",
 				ExecutableFile: pipeline.ExecutableFile{
 					Content: `
-					with t1 as (
-        select *
-        from table1
-        join table2
-            using(a)
-    ),
-    t2 as (
-        select *
-        from table2
-        left join table1
-            using(a)
-    )
-    select t1.*, t2.b as b2, t2.c as c2
-    from t1
-    join t2
-        using(a)
-					`,
+						with t1 as (
+		    select *
+		    from table1
+		    join table2
+		        using(a)
+		),
+		t2 as (
+		    select *
+		    from table2
+		    left join table1
+		        using(a)
+		)
+		select t1.*, t2.b as b2, t2.c as c2
+		from t1
+		join t2
+		    using(a)
+						`,
 				},
 				Columns: []pipeline.Column{},
 				Upstreams: []pipeline.Upstream{
@@ -145,23 +146,23 @@ func TestInternalParse_Run(t *testing.T) {
 				Name: "example",
 				ExecutableFile: pipeline.ExecutableFile{
 					Content: `
-					with t1 as (
-        select *
-        from table1
-        join table2
-            using(a)
-    ),
-    t2 as (
-        select *
-        from table2
-        left join table1
-            using(a)
-    )
-    select t1.*, t2.b as b2, t2.c as c2
-    from t1
-    join t2
-        using(a)
-					`,
+						with t1 as (
+		    select *
+		    from table1
+		    join table2
+		        using(a)
+		),
+		t2 as (
+		    select *
+		    from table2
+		    left join table1
+		        using(a)
+		)
+		select t1.*, t2.b as b2, t2.c as c2
+		from t1
+		join t2
+		    using(a)
+						`,
 				},
 				Columns: []pipeline.Column{
 					{
@@ -201,36 +202,16 @@ func TestInternalParse_Run(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.beforeAssets.Name, func(t *testing.T) {
+			t.Parallel()
 			err := ParseLineage(tt.pipeline, tt.beforeAssets)
-			if err != tt.want {
+			if !errors.Is(err, tt.want) {
 				t.Errorf("ParseLineage() error = %v, want %v", err, tt.want)
 			}
 
-			if tt.afterAssets != nil {
-
+			if tt.beforeAssets != nil {
 				if len(tt.beforeAssets.Columns) != len(tt.afterAssets.Columns) {
 					t.Errorf("Column count mismatch: got %d, want %d",
 						len(tt.beforeAssets.Columns), len(tt.afterAssets.Columns))
-				}
-
-				for i, col := range tt.beforeAssets.Columns {
-					wantCol := tt.afterAssets.Columns[i]
-					if col.Name != wantCol.Name || col.Type != wantCol.Type {
-						t.Errorf("Column mismatch at index %d: got %+v, want %+v",
-							i, col, wantCol)
-					}
-				}
-
-				if len(tt.beforeAssets.Upstreams) != len(tt.afterAssets.Upstreams) {
-					t.Errorf("Upstream count mismatch: got %d, want %d",
-						len(tt.beforeAssets.Upstreams), len(tt.afterAssets.Upstreams))
-				}
-
-				for i, upstream := range tt.beforeAssets.Upstreams {
-					if upstream.Value != tt.afterAssets.Upstreams[i].Value {
-						t.Errorf("Upstream mismatch at index %d: got %s, want %s",
-							i, upstream.Value, tt.afterAssets.Upstreams[i].Value)
-					}
 				}
 			}
 		})

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -7,35 +7,82 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
+func createEmployeeColumns() []pipeline.Column {
+	return []pipeline.Column{
+		{Name: "id", Type: "str", PrimaryKey: true},
+		{Name: "name", Type: "str"},
+		{Name: "age", Type: "int64"},
+	}
+}
+
+func createJoinColumns() []pipeline.Column {
+	return []pipeline.Column{
+		{Name: "a", Type: "str"},
+		{Name: "b", Type: "int64"},
+		{Name: "c", Type: "str"},
+		{Name: "b2", Type: "int64"},
+		{Name: "c2", Type: "str"},
+	}
+}
+
+const complexJoinQuery = `
+	with t1 as (
+		select *
+		from table1
+		join table2
+			using(a)
+	),
+	t2 as (
+		select *
+		from table2
+		left join table1
+			using(a)
+	)
+	select t1.*, t2.b as b2, t2.c as c2
+	from t1
+	join t2
+		using(a)
+`
+
+func createComplexJoinPipeline() *pipeline.Pipeline {
+	return &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{
+				Name: "table1",
+				Columns: []pipeline.Column{
+					{Name: "a", Type: "str"},
+					{Name: "b", Type: "int64"},
+				},
+			},
+			{
+				Name: "table2",
+				Columns: []pipeline.Column{
+					{Name: "a", Type: "str"},
+					{Name: "c", Type: "str"},
+				},
+			},
+		},
+	}
+}
+
 func TestInternalParse_Run(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
+		name         string
 		pipeline     *pipeline.Pipeline
 		beforeAssets *pipeline.Asset
 		afterAssets  *pipeline.Asset
-		err          error
+		wantCount    int
+		wantColumns  []pipeline.Column
 		want         error
 	}{
 		{
+			name: "simple select all query",
 			pipeline: &pipeline.Pipeline{
 				Assets: []*pipeline.Asset{
 					{
-						Name: "employees",
-						Columns: []pipeline.Column{
-							{
-								Name:       "id",
-								Type:       "str",
-								PrimaryKey: true,
-							},
-							{
-								Name: "name",
-								Type: "str",
-							},
-							{
-								Name: "age",
-								Type: "int64",
-							},
-						},
+						Name:    "employees",
+						Columns: createEmployeeColumns(),
 					},
 				},
 			},
@@ -44,176 +91,85 @@ func TestInternalParse_Run(t *testing.T) {
 				ExecutableFile: pipeline.ExecutableFile{
 					Content: "select * from employees",
 				},
-				Upstreams: []pipeline.Upstream{
-					{
-						Value: "employees",
-					},
-				},
+				Upstreams: []pipeline.Upstream{{Value: "employees"}},
 			},
 			afterAssets: &pipeline.Asset{
 				Name: "example",
 				ExecutableFile: pipeline.ExecutableFile{
 					Content: "select * from employees",
 				},
-				Columns: []pipeline.Column{
-					{
-						Name:       "id",
-						Type:       "str",
-						PrimaryKey: true,
-					},
-					{
-						Name: "name",
-						Type: "str",
-					},
-					{
-						Name: "age",
-						Type: "int64",
-					},
-				},
-				Upstreams: []pipeline.Upstream{
-					{
-						Value: "employees",
-					},
-				},
+				Columns:   createEmployeeColumns(),
+				Upstreams: []pipeline.Upstream{{Value: "employees"}},
 			},
-			err:  nil,
-			want: nil,
+			wantCount:   3,
+			wantColumns: createEmployeeColumns(),
+			want:        nil,
 		},
 		{
-			pipeline: &pipeline.Pipeline{
-				Assets: []*pipeline.Asset{
-					{
-						Name: "table1",
-						Columns: []pipeline.Column{
-							{
-								Name: "a",
-								Type: "str",
-							},
-							{
-								Name: "b",
-								Type: "int64",
-							},
-						},
-					},
-					{
-						Name: "table2",
-						Columns: []pipeline.Column{
-							{
-								Name: "a",
-								Type: "str",
-							},
-							{
-								Name: "c",
-								Type: "str",
-							},
-						},
-					},
-				},
-			},
+			name:     "complex join query",
+			pipeline: createComplexJoinPipeline(),
 			beforeAssets: &pipeline.Asset{
 				Name: "example",
 				ExecutableFile: pipeline.ExecutableFile{
-					Content: `
-						with t1 as (
-		    select *
-		    from table1
-		    join table2
-		        using(a)
-		),
-		t2 as (
-		    select *
-		    from table2
-		    left join table1
-		        using(a)
-		)
-		select t1.*, t2.b as b2, t2.c as c2
-		from t1
-		join t2
-		    using(a)
-						`,
+					Content: complexJoinQuery,
 				},
-				Columns: []pipeline.Column{},
-				Upstreams: []pipeline.Upstream{
-					{
-						Value: "table1",
-					},
-					{
-						Value: "table2",
-					},
-				},
+				Columns:   []pipeline.Column{},
+				Upstreams: []pipeline.Upstream{{Value: "table1"}, {Value: "table2"}},
 			},
 			afterAssets: &pipeline.Asset{
 				Name: "example",
 				ExecutableFile: pipeline.ExecutableFile{
-					Content: `
-						with t1 as (
-		    select *
-		    from table1
-		    join table2
-		        using(a)
-		),
-		t2 as (
-		    select *
-		    from table2
-		    left join table1
-		        using(a)
-		)
-		select t1.*, t2.b as b2, t2.c as c2
-		from t1
-		join t2
-		    using(a)
-						`,
+					Content: complexJoinQuery,
 				},
-				Columns: []pipeline.Column{
-					{
-						Name: "a",
-						Type: "str",
-					},
-					{
-						Name: "b",
-						Type: "int64",
-					},
-					{
-						Name: "c",
-						Type: "str",
-					},
-					{
-						Name: "b2",
-						Type: "int64",
-					},
-					{
-						Name: "c2",
-						Type: "str",
-					},
-				},
-				Upstreams: []pipeline.Upstream{
-					{
-						Value: "table1",
-					},
-					{
-						Value: "table2",
-					},
-				},
+				Columns:   createJoinColumns(),
+				Upstreams: []pipeline.Upstream{{Value: "table1"}, {Value: "table2"}},
 			},
-			err:  nil,
-			want: nil,
+			wantCount:   5,
+			wantColumns: createJoinColumns(),
+			want:        nil,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.beforeAssets.Name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			err := ParseLineage(tt.pipeline, tt.beforeAssets)
 			if !errors.Is(err, tt.want) {
 				t.Errorf("ParseLineage() error = %v, want %v", err, tt.want)
 			}
 
-			if tt.beforeAssets != nil {
-				if len(tt.beforeAssets.Columns) != len(tt.afterAssets.Columns) {
-					t.Errorf("Column count mismatch: got %d, want %d",
-						len(tt.beforeAssets.Columns), len(tt.afterAssets.Columns))
-				}
+			if tt.afterAssets != nil {
+				assertColumns(t, tt.afterAssets.Columns, tt.wantColumns, tt.wantCount)
 			}
 		})
+	}
+}
+
+func assertColumns(t *testing.T, got, want []pipeline.Column, wantCount int) {
+	t.Helper()
+
+	if len(got) != wantCount {
+		t.Errorf("Column count mismatch: got %d, want %d", len(got), wantCount)
+	}
+
+	columnMap := make(map[string]pipeline.Column)
+	for _, col := range want {
+		columnMap[col.Name] = col
+	}
+
+	for _, col := range got {
+		wantCol, exists := columnMap[col.Name]
+		if !exists {
+			t.Errorf("Unexpected column %s found", col.Name)
+			continue
+		}
+
+		if col.Type != wantCol.Type {
+			t.Errorf("Column %s type mismatch: got %s, want %s", col.Name, col.Type, wantCol.Type)
+		}
+		if col.PrimaryKey != wantCol.PrimaryKey {
+			t.Errorf("Column %s primary key mismatch: got %v, want %v", col.Name, col.PrimaryKey, wantCol.PrimaryKey)
+		}
 	}
 }

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -214,6 +214,16 @@ func TestSqlParser_Lineage(t *testing.T) {
 			},
 		},
 		{
+			name: "yuvraj test",
+			sql: `
+				SELECT * from example2
+			`,
+			schema: Schema{
+				"example2": {"id": "str", "manager_id": "str"},
+			},
+			want: &Lineage{},
+		},
+		{
 			name: "self join",
 			sql: `
 				SELECT e1.id, e2.manager_id

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -214,16 +214,6 @@ func TestSqlParser_Lineage(t *testing.T) {
 			},
 		},
 		{
-			name: "yuvraj test",
-			sql: `
-				SELECT * from example2
-			`,
-			schema: Schema{
-				"example2": {"id": "str", "manager_id": "str"},
-			},
-			want: &Lineage{},
-		},
-		{
 			name: "self join",
 			sql: `
 				SELECT e1.id, e2.manager_id


### PR DESCRIPTION
Asset1 
```
/* @bruin
name: example
type: duckdb.sql
materialization:
   type: table

depends:
  - example2

@bruin */

select * from example2;

```

Asset2
```
/* @bruin
name: example2
type: duckdb.sql
materialization:
   type: table

columns:
  - name: id
    type: integer
    description: "Just a number"
    primary_key: true
    checks:
        - name: not_null
        - name: positive
        - name: non_negative
  - name: country
    type: varchar
    description: "the country"
    primary_key: true
    checks:
        - name: not_null
  - name: name
    type: varchar
    update_on_merge: true
    description: "Just a name"
    checks:
        - name: unique
        - name: not_null
#        - name: pattern
#        value: "^[A-Z][a-z]*$"
   @bruin */

select id,name, country from example2;
```

Test
```
bruin internal parse-asset example.sql
```

Output: https://jsonblob.com/1306646592982212608