### PR TITLE
fix panic in render command

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -69,9 +70,13 @@ func marshal[K ErrorResponse | ErrorResponses](m K) ([]byte, error) {
 }
 
 func printErrorJSON(err error) {
-	js, err := marshal[ErrorResponse](ErrorResponse{
-		Error: err.Error(),
-	})
+	errResponse := ErrorResponse{
+		Error: errors.New("something went wrong").Error(),
+	}
+	if err != nil {
+		errResponse.Error = err.Error()
+	}
+	js, err := marshal[ErrorResponse](errResponse)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -111,9 +111,12 @@ func Render() *cli.Command {
 			}
 
 			asset, err := DefaultPipelineBuilder.CreateAssetFromFile(inputPath)
-
-			if err != nil || asset == nil {
-				printError(err, c.String("output"), "Failed to read the asset definition file: ")
+			if err != nil {
+				printError(err, c.String("output"), "Failed to read the asset definition file:")
+				return cli.Exit("", 1)
+			}
+			if asset == nil {
+				printError(errors.New("no asset found"), c.String("output"), "Failed to read the asset definition file:")
 				return cli.Exit("", 1)
 			}
 


### PR DESCRIPTION
Test

```
❯ go run main.go render -o json  templates/duckdb/assets/non-asset.py                                                                                                                               (base) 
{"error":"no asset found"}
exit status 1

```