### PR TITLE
Refactor Goggle Sheets URI

### DIFF
--- a/docs/ingestion/google_sheets.md
+++ b/docs/ingestion/google_sheets.md
@@ -5,11 +5,19 @@
 Bruin supports Google Sheets as a source, and you can use it to ingest data from Google Sheets into your data warehouse.
 
 In order to have set up a Google Sheets connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema.
-For more information on how to get these credentials check the Google Sheets section in [Ingestr documentation](https://bruin-data.github.io/ingestr/supported-sources/gsheets.html).
+
 
 ```yaml
     connections:
       google_sheets:
         - name: "connection_name"
-          credentials_path: "/path/to/service/account.json"
+          # you can either specify a path to the service account file
+          service_account_file: "path/to/file.json"
+          
+          # or you can specify the service account json directly
+          service_account_json: |
+            {
+              "type": "service_account",
+              ...
+            }
 ```

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -354,8 +354,9 @@ func (c HubspotConnection) GetName() string {
 }
 
 type GoogleSheetsConnection struct {
-	Name            string `yaml:"name" json:"name" mapstructure:"name"`
-	CredentialsPath string `yaml:"credentials_path" json:"credentials_path" mapstructure:"credentials_path"`
+	Name               string `yaml:"name" json:"name" mapstructure:"name"`
+	ServiceAccountJSON string `yaml:"service_account_json" json:"service_account_json,omitempty" mapstructure:"service_account_json"`
+	ServiceAccountFile string `yaml:"service_account_file" json:"service_account_file,omitempty" mapstructure:"service_account_file"`
 }
 
 func (c GoogleSheetsConnection) GetName() string {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -230,6 +230,7 @@ func TestLoadFromFile(t *testing.T) {
 			GoogleSheets: []GoogleSheetsConnection{
 				{
 					Name:               "conn22",
+					ServiceAccountJSON: "{\"key1\": \"value1\"}",
 					ServiceAccountFile: "/path/to/service_account.json",
 				},
 			},

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -229,8 +229,8 @@ func TestLoadFromFile(t *testing.T) {
 			},
 			GoogleSheets: []GoogleSheetsConnection{
 				{
-					Name:            "conn22",
-					CredentialsPath: "/path/to/service_account.json",
+					Name:               "conn22",
+					ServiceAccountFile: "/path/to/service_account.json",
 				},
 			},
 			Chess: []ChessConnection{

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -141,7 +141,7 @@ environments:
           api_key: "hubspotkey"
       google_sheets:
           - name: conn22
-            credentials_path: "/path/to/service_account.json"
+            service_account_file: "/path/to/service_account.json"
       chess:
         - name: conn24
           players:

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -141,6 +141,7 @@ environments:
           api_key: "hubspotkey"
       google_sheets:
           - name: conn22
+            service_account_json: "{\"key1\": \"value1\"}"
             service_account_file: "/path/to/service_account.json"
       chess:
         - name: conn24

--- a/pkg/gsheets/config.go
+++ b/pkg/gsheets/config.go
@@ -2,7 +2,6 @@ package gsheets
 
 import (
 	"encoding/base64"
-	"fmt"
 	"os"
 )
 
@@ -25,5 +24,6 @@ func (c *Config) GetIngestrURI() string {
 	default:
 		return ""
 	}
-	return fmt.Sprintf("gsheets://?credentials_base64=%s", base64.StdEncoding.EncodeToString(creds))
+
+	return "gsheets://?credentials_base64=" + base64.StdEncoding.EncodeToString(creds)
 }

--- a/pkg/gsheets/config.go
+++ b/pkg/gsheets/config.go
@@ -1,9 +1,29 @@
 package gsheets
 
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
 type Config struct {
-	CredentialsPath string
+	CredentialsFilePath string
+	CredentialsJSON     string
 }
 
 func (c *Config) GetIngestrURI() string {
-	return "gsheets://?credentials_path=" + c.CredentialsPath
+	var creds []byte
+	switch {
+	case c.CredentialsJSON != "":
+		creds = []byte(c.CredentialsJSON)
+	case c.CredentialsFilePath != "":
+		var err error
+		creds, err = os.ReadFile(c.CredentialsFilePath)
+		if err != nil {
+			return ""
+		}
+	default:
+		return ""
+	}
+	return fmt.Sprintf("gsheets://?credentials_base64=%s", base64.StdEncoding.EncodeToString(creds))
 }


### PR DESCRIPTION
Below changes are done in this PR:
- Users can provide ServiceAccountJSON or ServiceAccountFile for credentials.
- Credentials are converted to credentials_base64.