### PR TITLE
Help command

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,11 +28,12 @@ func main() {
 	}
 
 	app := &cli.App{
-		Name:     "bruin",
-		Version:  version,
-		Usage:    "The CLI used for managing Bruin-powered data pipelines",
-		Compiled: time.Now(),
-		Action:   versionCommand.Action,
+		Name:           "bruin",
+		Version:        version,
+		Usage:          "The CLI used for managing Bruin-powered data pipelines",
+		Compiled:       time.Now(),
+		Action:         versionCommand.Action,
+		DefaultCommand: "help",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "debug",
@@ -54,6 +55,13 @@ func main() {
 			cmd.Connections(),
 			cmd.Fetch(),
 			versionCommand,
+			&cli.Command{
+				Name: "help",
+				Action: func(c *cli.Context) error {
+					cli.ShowAppHelp(c)
+					return nil
+				},
+			},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,12 +28,10 @@ func main() {
 	}
 
 	app := &cli.App{
-		Name:           "bruin",
-		Version:        version,
-		Usage:          "The CLI used for managing Bruin-powered data pipelines",
-		Compiled:       time.Now(),
-		Action:         versionCommand.Action,
-		DefaultCommand: "help",
+		Name:     "bruin",
+		Version:  version,
+		Usage:    "The CLI used for managing Bruin-powered data pipelines",
+		Compiled: time.Now(),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:        "debug",
@@ -55,13 +53,6 @@ func main() {
 			cmd.Connections(),
 			cmd.Fetch(),
 			versionCommand,
-			&cli.Command{
-				Name: "help",
-				Action: func(c *cli.Context) error {
-					cli.ShowAppHelp(c)
-					return nil
-				},
-			},
 		},
 	}
 


### PR DESCRIPTION
Test
```
❯ go run main.go er                                                                                                                       (base) 
No help topic for 'er'
exit status 3

~/Workspace/bruin on  help-command ?! 3s 
❯ go run main.go                                                                                                                          (base) 
NAME:
   bruin - The CLI used for managing Bruin-powered data pipelines

USAGE:
   bruin [global options] command [command options] 

VERSION:
   dev

COMMANDS:
   validate      validate the bruin pipeline configuration for all the pipelines in a given directory
   run           run a Bruin pipeline
   render        render a single Bruin SQL asset
   lineage       dump the lineage for a given asset
   clean         clean the temporary artifacts such as logs
   format        format given asset definition files
   init          init a Bruin pipeline
   environments  manage environments defined in .bruin.yml
   fetch         Manage data fetching operations
   version       
   help, h       Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --debug        show debug information (default: false)
   --help, -h     show help
   --version, -v  print the version
```