### PR TITLE
add-new-path-logic

### DIFF
--- a/pkg/connection/helper.go
+++ b/pkg/connection/helper.go
@@ -3,25 +3,48 @@ package connection
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
 
-// New helper function to validate ServiceAccountFile.
+func getProjectRoot() (string, error) {
+	// Get the absolute path of the executable
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", errors.New("failed to determine executable path: " + err.Error())
+	}
+	// The project root is the parent directory of the "bin" directory
+	return filepath.Dir(filepath.Dir(executablePath)), nil
+}
+
+// Resolve file paths relative to the project root directory
+func resolveFilePath(relativePath string) (string, error) {
+	projectRoot, err := getProjectRoot()
+	if err != nil {
+		return "", errors.New("failed to determine project root: " + err.Error())
+	}
+	absPath := filepath.Join(projectRoot, relativePath)
+	return absPath, nil
+}
+
+// Function to validate the service account file
 func validateServiceAccountFile(filePath string) error {
 	var jsonStr json.RawMessage
 	if err := json.Unmarshal([]byte(filePath), &jsonStr); err == nil {
-		return errors.New("please use service_account_json instead of service_account_file to define json")
+		return errors.New("please use service_account_json instead of service_account_file to define JSON")
 	}
 
 	file, err := os.ReadFile(filePath)
 	if err != nil {
-		return errors.Errorf("failed to read service account file at '%s': %v", filePath, err)
+		return errors.New("failed to read service account file at '" + filePath + "': " + err.Error())
 	}
+
 	var js json.RawMessage
 	if err := json.Unmarshal(file, &js); err != nil {
-		return errors.Errorf("invalid JSON format in service account file at '%s'", filePath)
+		return errors.New("invalid JSON format in service account file at '" + filePath + "': " + err.Error())
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Refactored the connection management code by resolving file paths relative to the project root and ensuring that service account files are always validated using absolute paths for bigquery.
Relative paths like keys/service_account.json worked fine when running commands from the project root, but failed when running commands from subdirectories

Example. Let's say our service account file is in a folder called keys in our project --> `keys/service_account.json`
and we pass this path to our .bruin.yml not as absolute but as  `keys/service_account.json` . This works fine in the regular case but if we go inside any folder like lets say cd  chess-template , this path wasn't getting recognized 