### PR TITLE
Hotfix column lineage merge

### DIFF
--- a/pkg/pipeline/lineage.go
+++ b/pkg/pipeline/lineage.go
@@ -113,7 +113,7 @@ func (p *LineageExtractor) processLineageColumns(asset *Asset, lineage *sqlparse
 		for _, lineageCol := range lineage.NonSelectedColumns {
 			for _, lineageUpstream := range lineageCol.Upstream {
 				if _, ok := dict[fmt.Sprintf("%s-%s", lineageUpstream.Table, lineageCol.Name)]; !ok {
-					if lineageUpstream.Table == up.Value {
+					if strings.EqualFold(lineageUpstream.Table, up.Value) {
 						upstream.Columns = append(upstream.Columns, DependsColumn{
 							Name: lineageCol.Name,
 						})


### PR DESCRIPTION
To append the upstream column in the asset, we noticed an issue where the table name was defined in lowercase by the user, but the lineage system returned it in uppercase. This caused mismatches. To resolve this, we switched to using strings.EqualFold for case-insensitive comparison.