### PR TITLE
cmd: version: add timeout for fetching version information

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ func VersionCmd(commit string) *cli.Command {
 			},
 			&cli.DurationFlag{
 				Name:  "timeout",
-				Usage: "timeout for fetching version info in seconds",
+				Usage: "timeout for fetching version info",
 				Value: 5 * time.Second,
 			},
 		},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,11 +5,19 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/telemetry"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
 )
+
+type VersionInfo struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Latest  string `json:"latest"`
+}
 
 func VersionCmd(commit string) *cli.Command {
 	return &cli.Command{
@@ -20,29 +28,23 @@ func VersionCmd(commit string) *cli.Command {
 				Aliases: []string{"o"},
 				Usage:   "the output type, possible values are: plain, json",
 			},
+			&cli.DurationFlag{
+				Name:  "timeout",
+				Usage: "timeout for fetching version info in seconds",
+				Value: 5 * time.Second,
+			},
 		},
 		Action: func(c *cli.Context) error {
-			outputFormat := c.String("output")
+			timeout := c.Duration("timeout")
+			debug := c.Bool("debug")
+			latest := fetchLatestVersion(timeout, makeLogger(debug))
 			version := c.App.Version
-			res, err := http.Get("https://github.com/bruin-data/bruin/releases/latest") //nolint
-			if err != nil {
-				return errors.Wrap(err, "failed to check the latest version")
-			}
-			defer res.Body.Close()
-			latest := strings.TrimPrefix(res.Request.URL.String(), "https://github.com/bruin-data/bruin/releases/tag/")
+			outputFormat := c.String("output")
 
 			if outputFormat == "json" {
-				output := struct {
-					Version string `json:"version"`
-					Commit  string `json:"commit"`
-					Latest  string `json:"latest"`
-				}{
-					Version: version,
-					Commit:  commit,
-					Latest:  latest,
-				}
-
-				outputString, err := json.Marshal(output)
+				outputString, err := json.Marshal(
+					VersionInfo{version, commit, latest},
+				)
 				if err != nil {
 					return errors.Wrap(err, "failed to marshal the output")
 				}
@@ -58,4 +60,17 @@ func VersionCmd(commit string) *cli.Command {
 		Before: telemetry.BeforeCommand,
 		After:  telemetry.AfterCommand,
 	}
+}
+
+func fetchLatestVersion(timeout time.Duration, logger *zap.SugaredLogger) string {
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+	res, err := httpClient.Get("https://github.com/bruin-data/bruin/releases/latest") //nolint
+	if err != nil {
+		logger.Debugf("error fetching version information: %v", err)
+		return "<unknown: error fetching version information>"
+	}
+	res.Body.Close()
+	return strings.TrimPrefix(res.Request.URL.String(), "https://github.com/bruin-data/bruin/releases/tag/")
 }


### PR DESCRIPTION
**Summary**
Adds a default http timeout when version command is called. Also adds a `--timeout` flag to version command to override this default.

If the http request fails or times out, the version information is shown as:
```
Current: dev ()
Latest: <unknown: error fetching version information>
```

`--debug` flag can be used to obtain more information about why the request failed