### PR TITLE
downstream log bug

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -301,8 +301,9 @@ func Run(isDebug *bool) *cli.Command {
 				SingleTask:        task,
 				ExcludeTag:        c.String("exclude-tag"),
 			}
+			isSingleAsset := (runningForAnAsset && !filter.IncludeDownstream)
 
-			s := scheduler.NewScheduler(logger, foundPipeline)
+			s := scheduler.NewScheduler(logger, foundPipeline, isSingleAsset)
 
 			// Apply the filter to mark assets based on include/exclude tags
 			if err := filter.ApplyFiltersAndMarkAssets(foundPipeline, s); err != nil {


### PR DESCRIPTION
When we are running single asset and it fails - we return a false log message which says downstreams skipped due to upstream failing but we weren't trying to run them anyways 