### PR TITLE
Refactor lineage extraction for stateless

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/git"
+	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/sqlparser"
@@ -159,7 +160,7 @@ func (r *ParseCommand) ParsePipeline(assetPath string, lineage bool) error {
 
 		defer sqlParser.Close()
 
-		lineage := pipeline.NewLineageExtractor(foundPipeline.Name, sqlParser)
+		lineage := pipeline.NewLineageExtractor(jinja.NewRendererWithYesterday(foundPipeline.Name, "lineage-parser"), sqlParser)
 		for _, asset := range foundPipeline.Assets {
 			metadata := lineage.TableSchema(foundPipeline)
 
@@ -238,7 +239,7 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 			return cli.Exit("", 1)
 		}
 
-		lineageExtractor := pipeline.NewLineageExtractor(foundPipeline.Name, sqlParser)
+		lineageExtractor := pipeline.NewLineageExtractor(jinja.NewRendererWithYesterday(foundPipeline.Name, "lineage-parser"), sqlParser)
 		metadata := lineageExtractor.TableSchema(foundPipeline)
 
 		if err := lineageExtractor.ColumnLineage(foundPipeline, asset, metadata); err != nil {

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -159,11 +159,11 @@ func (r *ParseCommand) ParsePipeline(assetPath string, lineage bool) error {
 
 		defer sqlParser.Close()
 
-		lineage := pipeline.NewLineageExtractor(foundPipeline, sqlParser)
+		lineage := pipeline.NewLineageExtractor(foundPipeline.Name, sqlParser)
 		for _, asset := range foundPipeline.Assets {
-			metadata := lineage.TableSchema()
+			metadata := lineage.TableSchema(foundPipeline)
 
-			if err := lineage.ColumnLineage(asset, metadata); err != nil {
+			if err := lineage.ColumnLineage(foundPipeline, asset, metadata); err != nil {
 				printErrorJSON(err)
 				return cli.Exit("", 1)
 			}
@@ -238,10 +238,10 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 			return cli.Exit("", 1)
 		}
 
-		lineageExtractor := pipeline.NewLineageExtractor(foundPipeline, sqlParser)
-		metadata := lineageExtractor.TableSchema()
+		lineageExtractor := pipeline.NewLineageExtractor(foundPipeline.Name, sqlParser)
+		metadata := lineageExtractor.TableSchema(foundPipeline)
 
-		if err := lineageExtractor.ColumnLineage(asset, metadata); err != nil {
+		if err := lineageExtractor.ColumnLineage(foundPipeline, asset, metadata); err != nil {
 			printErrorJSON(err)
 			return cli.Exit("", 1)
 		}

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/git"
-	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/sqlparser"
@@ -160,7 +159,7 @@ func (r *ParseCommand) ParsePipeline(assetPath string, lineage bool) error {
 
 		defer sqlParser.Close()
 
-		lineage := pipeline.NewLineageExtractor(jinja.NewRendererWithYesterday(foundPipeline.Name, "lineage-parser"), sqlParser)
+		lineage := pipeline.NewLineageExtractor(sqlParser)
 		for _, asset := range foundPipeline.Assets {
 			metadata := lineage.TableSchema(foundPipeline)
 
@@ -239,7 +238,7 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 			return cli.Exit("", 1)
 		}
 
-		lineageExtractor := pipeline.NewLineageExtractor(jinja.NewRendererWithYesterday(foundPipeline.Name, "lineage-parser"), sqlParser)
+		lineageExtractor := pipeline.NewLineageExtractor(sqlParser)
 		metadata := lineageExtractor.TableSchema(foundPipeline)
 
 		if err := lineageExtractor.ColumnLineage(foundPipeline, asset, metadata); err != nil {

--- a/pkg/pipeline/lineage.go
+++ b/pkg/pipeline/lineage.go
@@ -20,10 +20,10 @@ type LineageExtractor struct {
 }
 
 // NewLineageExtractor creates a new LineageExtractor instance.
-func NewLineageExtractor(name string, parser sqlParser) *LineageExtractor {
+func NewLineageExtractor(jinjarender *jinja.Renderer, parser sqlParser) *LineageExtractor {
 	return &LineageExtractor{
 		sqlParser: parser,
-		renderer:  jinja.NewRendererWithYesterday(name, "lineage-parser"),
+		renderer:  jinjarender,
 	}
 }
 

--- a/pkg/pipeline/lineage.go
+++ b/pkg/pipeline/lineage.go
@@ -20,10 +20,10 @@ type LineageExtractor struct {
 }
 
 // NewLineageExtractor creates a new LineageExtractor instance.
-func NewLineageExtractor(jinjarender *jinja.Renderer, parser sqlParser) *LineageExtractor {
+func NewLineageExtractor(parser sqlParser) *LineageExtractor {
 	return &LineageExtractor{
 		sqlParser: parser,
-		renderer:  jinjarender,
+		renderer:  jinja.NewRendererWithYesterday("lineage-parser", "lineage-parser"),
 	}
 }
 

--- a/pkg/pipeline/lineage_test.go
+++ b/pkg/pipeline/lineage_test.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"testing"
 
-	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/sqlparser"
 )
 
@@ -56,7 +55,7 @@ func runLineageTests(t *testing.T, tests []struct {
 func runSingleLineageTest(t *testing.T, p, after *Pipeline, want error) {
 	t.Helper()
 
-	extractor := NewLineageExtractor(jinja.NewRendererWithYesterday(p.Name, "lineage-parser"), SQLParser)
+	extractor := NewLineageExtractor(SQLParser)
 	metadata := extractor.TableSchema(p)
 	for _, asset := range p.Assets {
 		err := extractor.ColumnLineage(p, asset, metadata)

--- a/pkg/pipeline/lineage_test.go
+++ b/pkg/pipeline/lineage_test.go
@@ -54,10 +54,10 @@ func runLineageTests(t *testing.T, tests []struct {
 
 func runSingleLineageTest(t *testing.T, p, after *Pipeline, want error) {
 	t.Helper()
-	extractor := NewLineageExtractor(p, SQLParser)
-	metadata := extractor.TableSchema()
+	extractor := NewLineageExtractor(p.Name, SQLParser)
+	metadata := extractor.TableSchema(p)
 	for _, asset := range p.Assets {
-		err := extractor.ColumnLineage(asset, metadata)
+		err := extractor.ColumnLineage(p, asset, metadata)
 		assertLineageError(t, err, want)
 
 		assertColumns(t, asset.Columns, after.GetAssetByName(asset.Name).Columns, len(asset.Columns))

--- a/pkg/pipeline/lineage_test.go
+++ b/pkg/pipeline/lineage_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"testing"
 
+	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/sqlparser"
 )
 
@@ -54,7 +55,8 @@ func runLineageTests(t *testing.T, tests []struct {
 
 func runSingleLineageTest(t *testing.T, p, after *Pipeline, want error) {
 	t.Helper()
-	extractor := NewLineageExtractor(p.Name, SQLParser)
+
+	extractor := NewLineageExtractor(jinja.NewRendererWithYesterday(p.Name, "lineage-parser"), SQLParser)
 	metadata := extractor.TableSchema(p)
 	for _, asset := range p.Assets {
 		err := extractor.ColumnLineage(p, asset, metadata)


### PR DESCRIPTION
- Updated `NewLineageExtractor` to only accept sqlparser.
- Modified `TableSchema` and `ColumnLineage` methods to take the pipeline as a parameter