### PR TITLE
downstream Log bug

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -301,9 +301,8 @@ func Run(isDebug *bool) *cli.Command {
 				SingleTask:        task,
 				ExcludeTag:        c.String("exclude-tag"),
 			}
-			isSingleAsset := (runningForAnAsset && !filter.IncludeDownstream)
 
-			s := scheduler.NewScheduler(logger, foundPipeline, isSingleAsset)
+			s := scheduler.NewScheduler(logger, foundPipeline)
 
 			// Apply the filter to mark assets based on include/exclude tags
 			if err := filter.ApplyFiltersAndMarkAssets(foundPipeline, s); err != nil {
@@ -729,7 +728,7 @@ func (f *Filter) ApplyFiltersAndMarkAssets(pipeline *pipeline.Pipeline, s *sched
 	// Handle single-task execution
 	if f.SingleTask != nil {
 		// Skip all other tasks
-		s.MarkAll(scheduler.Succeeded)
+		s.MarkAll(scheduler.Skipped)
 
 		// Mark the single task and optionally its downstream tasks
 		s.MarkAsset(f.SingleTask, scheduler.Pending, f.IncludeDownstream)
@@ -771,7 +770,7 @@ func (f *Filter) ApplyFiltersAndMarkAssets(pipeline *pipeline.Pipeline, s *sched
 		if len(includedAssets) == 0 {
 			return fmt.Errorf("no assets found with include tag '%s'", f.IncludeTag)
 		}
-		s.MarkAll(scheduler.Succeeded) // Skip everything first
+		s.MarkAll(scheduler.Skipped) // Skip everything first
 		s.MarkByTag(f.IncludeTag, scheduler.Pending, f.IncludeDownstream)
 	}
 
@@ -781,18 +780,18 @@ func (f *Filter) ApplyFiltersAndMarkAssets(pipeline *pipeline.Pipeline, s *sched
 		if len(excludedAssets) == 0 {
 			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
 		}
-		s.MarkByTag(f.ExcludeTag, scheduler.Succeeded, f.IncludeDownstream)
+		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, f.IncludeDownstream)
 	}
 	// Mark tasks in the scheduler
 	if !runMain {
-		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeMain, scheduler.Succeeded)
+		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeMain, scheduler.Skipped)
 	}
 	if !runChecks {
-		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeColumnCheck, scheduler.Succeeded)
-		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeCustomCheck, scheduler.Succeeded)
+		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeColumnCheck, scheduler.Skipped)
+		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeCustomCheck, scheduler.Skipped)
 	}
 	if !runPushMetadata {
-		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeMetadataPush, scheduler.Succeeded)
+		s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeMetadataPush, scheduler.Skipped)
 	}
 
 	return nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -301,8 +301,9 @@ func Run(isDebug *bool) *cli.Command {
 				SingleTask:        task,
 				ExcludeTag:        c.String("exclude-tag"),
 			}
+			isSingleAsset := (runningForAnAsset && !filter.IncludeDownstream)
 
-			s := scheduler.NewScheduler(logger, foundPipeline)
+			s := scheduler.NewScheduler(logger, foundPipeline, isSingleAsset)
 
 			// Apply the filter to mark assets based on include/exclude tags
 			if err := filter.ApplyFiltersAndMarkAssets(foundPipeline, s); err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -298,7 +298,6 @@ func (s *Scheduler) MarkByTag(tag string, status TaskInstanceStatus, downstream 
 }
 
 func (s *Scheduler) MarkTaskInstance(instance TaskInstance, status TaskInstanceStatus, downstream bool) {
-
 	instance.MarkAs(status)
 	if !downstream {
 		return
@@ -334,7 +333,6 @@ func (s *Scheduler) MarkTaskInstanceSkipped(instance TaskInstance, status TaskIn
 }
 
 func (s *Scheduler) markTaskInstanceFailedWithDownstream(instance TaskInstance) {
-
 	s.MarkTaskInstanceSkipped(instance, UpstreamFailed, true)
 	s.MarkTaskInstanceSkipped(instance, Failed, false)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -313,12 +313,12 @@ func (s *Scheduler) MarkTaskInstance(instance TaskInstance, status TaskInstanceS
 	}
 }
 
-func (s *Scheduler) MarkTaskInstanceSkipped(instance TaskInstance, status TaskInstanceStatus, downstream bool) {
+func (s *Scheduler) MarkTaskInstanceIfNotSkipped(instance TaskInstance, status TaskInstanceStatus, markDownstream bool) {
 	if instance.GetStatus() == Skipped {
 		return
 	}
 	instance.MarkAs(status)
-	if !downstream {
+	if !markDownstream {
 		return
 	}
 
@@ -328,13 +328,13 @@ func (s *Scheduler) MarkTaskInstanceSkipped(instance TaskInstance, status TaskIn
 	}
 
 	for _, d := range downstreams {
-		s.MarkTaskInstanceSkipped(d, status, downstream)
+		s.MarkTaskInstanceIfNotSkipped(d, status, markDownstream)
 	}
 }
 
 func (s *Scheduler) markTaskInstanceFailedWithDownstream(instance TaskInstance) {
-	s.MarkTaskInstanceSkipped(instance, UpstreamFailed, true)
-	s.MarkTaskInstanceSkipped(instance, Failed, false)
+	s.MarkTaskInstanceIfNotSkipped(instance, UpstreamFailed, true)
+	s.MarkTaskInstanceIfNotSkipped(instance, Failed, false)
 }
 
 func (s *Scheduler) GetTaskInstancesByStatus(status TaskInstanceStatus) []TaskInstance {


### PR DESCRIPTION
Bug scenario:

I have a pipeline like that: a -> b -> c -> d

I run only asset b: bruin run pipeline/assets/b.py

task fails

Log message:

These assets couldn't run since their parent has failed
c ,d 
-----------------------------------------------------
This error happens because we are marking the downstream of the failed Task as -> Upstreamfailed  even if we are not going to run them ( for example can happen when we are running a single asset or running specific assets with --tag without the downstream)