### PR TITLE
Speedup Lineage Extraction 

### DIFF
--- a/pkg/pipeline/lineage.go
+++ b/pkg/pipeline/lineage.go
@@ -22,7 +22,6 @@ type LineageExtractor struct {
 
 // NewLineageExtractor creates a new LineageExtractor instance.
 func NewLineageExtractor(parser sqlParser) *LineageExtractor {
-
 	return &LineageExtractor{
 		sqlParser: parser,
 		renderer:  jinja.NewRendererWithYesterday("lineage-parser", "lineage-parser"),

--- a/pkg/pipeline/lineage.go
+++ b/pkg/pipeline/lineage.go
@@ -45,8 +45,7 @@ func (p *LineageExtractor) ColumnLineage(foundPipeline *Pipeline, asset *Asset, 
 	if asset == nil {
 		return nil
 	}
-	key := fmt.Sprintf("%s-%s", foundPipeline.Name, asset.Name)
-	if p.processed[key] {
+	if p.processed[asset.Name] {
 		return nil
 	}
 


### PR DESCRIPTION
```
❯ hyperfine 'bruin internal parse-pipeline -c ./pace-export/'                                                                                                                                    Benchmark 1: bruin internal parse-pipeline -c ./pace-export/
  Time (mean ± σ):      1.636 s ±  0.206 s    [User: 1.508 s, System: 0.070 s]
  Range (min … max):    1.339 s …  1.912 s    10 runs
```


```
❯ hyperfine 'bruin internal parse-asset -c ./pace-export/tasks/dashboard/example.sql'                                                                                                  
Benchmark 1: bruin internal parse-asset -c ./pace-export/tasks/dashboard/ai_conversations.sql
  Time (mean ± σ):     673.6 ms ± 143.4 ms    [User: 62.7 ms, System: 35.9 ms]
  Range (min … max):   461.1 ms … 853.3 ms    10 runs
```