### PR TITLE
Add validation rule

### DIFF
--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -154,14 +154,6 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlPa
 			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
 		},
 		&SimpleRule{
-			Identifier:       "duplicate-column-checks",
-			Fast:             true,
-			Severity:         ValidatorSeverityCritical,
-			Validator:        CallFuncForEveryAsset(ValidateDuplicateColumnChecks),
-			AssetValidator:   ValidateDuplicateColumnChecks,
-			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
-		},
-		&SimpleRule{
 			Identifier:       "custom-check-query-exists",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -154,6 +154,14 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlPa
 			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "duplicate-column-checks",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			Validator:        CallFuncForEveryAsset(ValidateDuplicateColumnChecks),
+			AssetValidator:   ValidateDuplicateColumnChecks,
+			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "assets-directory-exist",
 			Fast:             true,
 			Severity:         ValidatorSeverityWarning,

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -162,6 +162,14 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlPa
 			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "custom-check-query-exists",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			Validator:        CallFuncForEveryAsset(ValidateCustomCheckQueryExists),
+			AssetValidator:   ValidateCustomCheckQueryExists,
+			ApplicableLevels: []Level{LevelPipeline, LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "assets-directory-exist",
 			Fast:             true,
 			Severity:         ValidatorSeverityWarning,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -359,28 +359,6 @@ func ValidateCustomCheckQueryExists(ctx context.Context, p *pipeline.Pipeline, a
 	return issues, nil
 }
 
-// ValidateDuplicateColumnChecks checks for duplicate column checks within a single column.
-// It returns a slice of Issues, each representing a duplicate column check found.
-func ValidateDuplicateColumnChecks(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
-	var issues []*Issue
-
-	for _, column := range asset.Columns {
-		checkNames := make(map[string]bool)
-		for _, check := range column.Checks {
-			lowercaseName := strings.ToLower(check.Name)
-			if checkNames[lowercaseName] {
-				issues = append(issues, &Issue{
-					Task:        asset,
-					Description: fmt.Sprintf("Duplicate column check '%s' found", check.Name),
-				})
-			} else {
-				checkNames[lowercaseName] = true
-			}
-		}
-	}
-	return issues, nil
-}
-
 // ValidateDuplicateColumnNames checks for duplicate column names within a single asset.
 // It returns a slice of Issues, each representing a duplicate column name found.
 //

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -344,6 +344,28 @@ func EnsurePipelineStartDateIsValid(p *pipeline.Pipeline) ([]*Issue, error) {
 	return issues, nil
 }
 
+// ValidateDuplicateColumnChecks checks for duplicate column checks within a single column.
+// It returns a slice of Issues, each representing a duplicate column check found.
+func ValidateDuplicateColumnChecks(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	var issues []*Issue
+
+	CheckNames := make(map[string]bool)
+	for _, column := range asset.Columns {
+		for _, check := range column.Checks {
+			lowercaseName := fmt.Sprintf("%s-%s", strings.ToLower(column.Name), strings.ToLower(check.Name))
+			if CheckNames[lowercaseName] {
+				issues = append(issues, &Issue{
+					Task:        asset,
+					Description: fmt.Sprintf("Duplicate column check '%s' found ", check.Name),
+				})
+			} else {
+				CheckNames[lowercaseName] = true
+			}
+		}
+	}
+	return issues, nil
+}
+
 // ValidateDuplicateColumnNames checks for duplicate column names within a single asset.
 // It returns a slice of Issues, each representing a duplicate column name found.
 //


### PR DESCRIPTION
- Introduced a new validation rule for detecting duplicate column checks within a single column and check if custom check have query or not
- Implemented the `ValidateDuplicateColumnChecks` and `ValidateCustomCheckQueryExists` function
- Updated the rules list in `list.go` to include the new rule with critical severity.