### PR TITLE
Patch/add missing ssl params for mysql

### DIFF
--- a/docs/ingestion/mysql.md
+++ b/docs/ingestion/mysql.md
@@ -18,6 +18,9 @@ To connect to MySQL, you need to add a configuration item to the connections sec
           host: "localhost"
           port: 3306
           database: "mysql"
+          ssl_ca_path: "path/to/ca.pem"
+          ssl_cert_path: "path/to/cert.pem"
+          ssl_key_path: "path/to/key.pem"
 ```
 - `name`: The name to identify this MySQL connection
 - `username`: The MySQL username with access to the database
@@ -26,6 +29,9 @@ To connect to MySQL, you need to add a configuration item to the connections sec
 - `port`: The port number the database server is listening on (default: 3306)
 - `database`:  The name of the database to connect to
 - `driver`: (Optional) The name of the database driver to use
+- `ssl_ca_path`: (Optional) The path to the CA certificate file
+- `ssl_cert_path`: (Optional) The path to the client certificate file
+- `ssl_key_path`: (Optional) The path to the client key file
 
 ### Step 2: Create an asset file for data ingestion
 To ingest data from MySQL, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., mysql_ingestion.yml) inside the assets folder and add the following content:

--- a/integration-tests/expected_connections_schema.json
+++ b/integration-tests/expected_connections_schema.json
@@ -431,17 +431,20 @@
       ]
     },
     "GoogleSheetsConnection": {
-      "properties":{
-        "name":{"type":"string"},
-        "service_account_json":{
-          "type":"string"
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "service_account_file":{
-          "type":"string"
+        "service_account_json": {
+          "type": "string"
+        },
+        "service_account_file": {
+          "type": "string"
         }
-      },"additionalProperties":false,
-      "type":"object",
-      "required":[
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
         "name"
       ]
     },
@@ -659,6 +662,15 @@
           "type": "string"
         },
         "driver": {
+          "type": "string"
+        },
+        "ssl_ca_path": {
+          "type": "string"
+        },
+        "ssl_cert_path": {
+          "type": "string"
+        },
+        "ssl_key_path": {
           "type": "string"
         }
       },

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -145,13 +145,16 @@ func (c MsSQLConnection) GetName() string {
 }
 
 type MySQLConnection struct {
-	Name     string `yaml:"name" json:"name" mapstructure:"name"`
-	Username string `yaml:"username" json:"username" mapstructure:"username"`
-	Password string `yaml:"password" json:"password" mapstructure:"password"`
-	Host     string `yaml:"host"     json:"host" mapstructure:"host"`
-	Port     int    `yaml:"port"     json:"port" mapstructure:"port" jsonschema:"default=3306"`
-	Database string `yaml:"database" json:"database" mapstructure:"database"`
-	Driver   string `yaml:"driver" json:"driver,omitempty" mapstructure:"driver"`
+	Name        string `yaml:"name" json:"name" mapstructure:"name"`
+	Username    string `yaml:"username" json:"username" mapstructure:"username"`
+	Password    string `yaml:"password" json:"password" mapstructure:"password"`
+	Host        string `yaml:"host"     json:"host" mapstructure:"host"`
+	Port        int    `yaml:"port"     json:"port" mapstructure:"port" jsonschema:"default=3306"`
+	Database    string `yaml:"database" json:"database" mapstructure:"database"`
+	Driver      string `yaml:"driver" json:"driver,omitempty" mapstructure:"driver"`
+	SslCaPath   string `yaml:"ssl_ca_path" json:"ssl_ca_path,omitempty" mapstructure:"ssl_ca_path"`
+	SslCertPath string `yaml:"ssl_cert_path" json:"ssl_cert_path,omitempty" mapstructure:"ssl_cert_path"`
+	SslKeyPath  string `yaml:"ssl_key_path" json:"ssl_key_path,omitempty" mapstructure:"ssl_key_path"`
 }
 
 func (c MySQLConnection) GetName() string {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -352,6 +352,20 @@ func LoadFromFile(fs afero.Fs, path string) (*Config, error) {
 			}
 			env.Connections.GoogleCloudPlatform[i].ServiceAccountFile = filepath.Join(configLocation, conn.ServiceAccountFile)
 		}
+		// Make MySQL SSL file paths absolute
+		for i, conn := range env.Connections.MySQL {
+			if conn.SslCaPath != "" && !filepath.IsAbs(conn.SslCaPath) {
+				env.Connections.MySQL[i].SslCaPath = filepath.Join(configLocation, conn.SslCaPath)
+			}
+
+			if conn.SslCertPath != "" && !filepath.IsAbs(conn.SslCertPath) {
+				env.Connections.MySQL[i].SslCertPath = filepath.Join(configLocation, conn.SslCertPath)
+			}
+
+			if conn.SslKeyPath != "" && !filepath.IsAbs(conn.SslKeyPath) {
+				env.Connections.MySQL[i].SslKeyPath = filepath.Join(configLocation, conn.SslKeyPath)
+			}
+		}
 	}
 
 	err = config.SelectEnvironment(config.DefaultEnvironmentName)

--- a/pkg/mysql/config.go
+++ b/pkg/mysql/config.go
@@ -6,12 +6,15 @@ import (
 )
 
 type Config struct {
-	Username string
-	Password string
-	Host     string
-	Port     int
-	Database string
-	Driver   string
+	Username    string
+	Password    string
+	Host        string
+	Port        int
+	Database    string
+	Driver      string
+	SslCaPath   string
+	SslCertPath string
+	SslKeyPath  string
 }
 
 func (c Config) GetIngestrURI() string {
@@ -29,6 +32,20 @@ func (c Config) GetIngestrURI() string {
 		User:   url.UserPassword(c.Username, c.Password),
 		Host:   host,
 		Path:   c.Database,
+	}
+
+	if c.SslCaPath != "" || c.SslCertPath != "" || c.SslKeyPath != "" {
+		q := u.Query()
+		if c.SslCaPath != "" {
+			q.Set("ssl_ca", c.SslCaPath)
+		}
+		if c.SslCertPath != "" {
+			q.Set("ssl_cert", c.SslCertPath)
+		}
+		if c.SslKeyPath != "" {
+			q.Set("ssl_key", c.SslKeyPath)
+		}
+		u.RawQuery = q.Encode()
 	}
 
 	return u.String()

--- a/pkg/mysql/config_test.go
+++ b/pkg/mysql/config_test.go
@@ -20,6 +20,19 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 	assert.Equal(t, "mysql://user:password@localhost:3306/test", c.GetIngestrURI())
 
 	c = Config{
+		Username:    "user",
+		Password:    "password",
+		Host:        "localhost",
+		Port:        3306,
+		Database:    "test",
+		SslCaPath:   "/path/to/ca.pem",
+		SslCertPath: "/path/to/cert.pem",
+		SslKeyPath:  "/path/to/key.pem",
+	}
+
+	assert.Equal(t, "mysql://user:password@localhost:3306/test?ssl_ca=%2Fpath%2Fto%2Fca.pem&ssl_cert=%2Fpath%2Fto%2Fcert.pem&ssl_key=%2Fpath%2Fto%2Fkey.pem", c.GetIngestrURI())
+
+	c = Config{
 		Username: "user",
 		Password: "password",
 		Host:     "localhost",


### PR DESCRIPTION
This PR adds 3 new parameters for MySQL connection type for SSL config:
```yaml
     mysql:
        - name: "new-mysql"
          username: "test_user"
          password: "test_password"
          host: "localhost"
          port: 3306
          database: "mysql"
          ssl_ca_path: "path/to/ca.pem"
          ssl_cert_path: "path/to/cert.pem"
          ssl_key_path: "path/to/key.pem"
```

Fixes #338 