### PR TITLE
Bq handle error 

### DIFF
--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -297,20 +297,15 @@ func (d *Client) DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Conte
 	if err != nil {
 		return err
 	}
-
 	// Fetch table metadata
 	meta, err := tableRef.Metadata(ctx)
 	if err != nil {
-		// Check if the error is a Google API 404 Not Found error
 		var apiErr *googleapi.Error
 		if errors.As(err, &apiErr) && apiErr.Code == 404 {
 			return nil
 		}
-		// For all other errors, return the error
 		return fmt.Errorf("failed to fetch metadata for table '%s': %w", tableName, err)
 	}
-
-	// Check if partitioning or clustering exists in metadata or is wanted by asset
 	if meta.TimePartitioning != nil || meta.RangePartitioning != nil || asset.Materialization.PartitionBy != "" || len(asset.Materialization.ClusterBy) > 0 {
 		if !IsSamePartitioning(meta, asset) || !IsSameClustering(meta, asset) {
 			if err := tableRef.Delete(ctx); err != nil {
@@ -326,7 +321,6 @@ func (d *Client) DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Conte
 }
 
 func IsSamePartitioning(meta *bigquery.TableMetadata, asset *pipeline.Asset) bool {
-	// If asset wants partitioning but table has none
 	if asset.Materialization.PartitionBy != "" &&
 		meta.TimePartitioning == nil &&
 		meta.RangePartitioning == nil {
@@ -337,7 +331,7 @@ func IsSamePartitioning(meta *bigquery.TableMetadata, asset *pipeline.Asset) boo
 		return false
 	}
 
-	// Safe to proceed only if table has any partitioning
+	//proceed only if table has any partitioning
 	if meta.TimePartitioning == nil && meta.RangePartitioning == nil {
 		return true
 	}
@@ -367,7 +361,6 @@ func IsSamePartitioning(meta *bigquery.TableMetadata, asset *pipeline.Asset) boo
 }
 
 func IsSameClustering(meta *bigquery.TableMetadata, asset *pipeline.Asset) bool {
-	// If asset wants clustering but table has none
 	if len(asset.Materialization.ClusterBy) > 0 &&
 		(meta.Clustering == nil || len(meta.Clustering.Fields) == 0) {
 		fmt.Printf(
@@ -377,7 +370,7 @@ func IsSameClustering(meta *bigquery.TableMetadata, asset *pipeline.Asset) bool 
 		return false
 	}
 
-	// Safe to proceed only if table has clustering
+	//proceed only if table has clustering
 	if meta.Clustering == nil {
 		return true
 	}

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -35,6 +35,7 @@ type MetadataUpdater interface {
 
 type TableManager interface {
 	DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error
+	CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Context) error
 }
 
 type DB interface {
@@ -398,4 +399,31 @@ func IsSameClustering(meta *bigquery.TableMetadata, asset *pipeline.Asset) bool 
 	}
 
 	return true
+}
+
+func (d *Client) CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Context) error {
+	tableName := asset.Name
+	tableComponents := strings.Split(tableName, ".")
+	var datasetName string
+	if len(tableComponents) == 2 {
+		datasetName = tableComponents[0]
+	} else if len(tableComponents) == 3 {
+		datasetName = tableComponents[1]
+	}
+	datasets := d.client.Datasets(ctx)
+	for {
+		dataset, err := datasets.Next()
+		// Process the dataset
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if datasetName == dataset.DatasetID {
+			return nil
+		}
+	}
+	d.client.DatasetInProject(d.config.ProjectID, datasetName)
+	return nil
 }

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -330,7 +330,6 @@ func IsSamePartitioning(meta *bigquery.TableMetadata, asset *pipeline.Asset) boo
 		return false
 	}
 
-	//proceed only if table has any partitioning
 	if meta.TimePartitioning == nil && meta.RangePartitioning == nil {
 		return true
 	}
@@ -368,8 +367,6 @@ func IsSameClustering(meta *bigquery.TableMetadata, asset *pipeline.Asset) bool 
 		)
 		return false
 	}
-
-	//proceed only if table has clustering
 	if meta.Clustering == nil {
 		return true
 	}

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -35,7 +35,6 @@ type MetadataUpdater interface {
 
 type TableManager interface {
 	DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error
-	CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Context) error
 }
 
 type DB interface {

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -74,6 +74,8 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	if err != nil {
 		return err
 	}
+	conn.CreateDataSetIfNotExist(t, ctx)
+
 	if o.materializer.IsFullRefresh() {
 		err = conn.DeleteTableIfPartitioningOrClusteringMismatch(ctx, t.Name, t)
 		if err != nil {

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -74,7 +74,6 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	if err != nil {
 		return err
 	}
-	conn.CreateDataSetIfNotExist(t, ctx)
 
 	if o.materializer.IsFullRefresh() {
 		err = conn.DeleteTableIfPartitioningOrClusteringMismatch(ctx, t.Name, t)


### PR DESCRIPTION
when a table doesn't exist, it shouldn't try to fetch its metadata and try to compare the clustering specs with the given asset 