### PR TITLE
Handle materialization type changes

### DIFF
--- a/pkg/bigquery/checks_test.go
+++ b/pkg/bigquery/checks_test.go
@@ -74,6 +74,10 @@ func (m *mockQuerierWithResult) IsSameClustering(meta *bigquery.TableMetadata, a
 	args := m.Called(meta, asset)
 	return args.Bool(0)
 }
+func (m *mockQuerierWithResult) DeleteTableIfMaterializationTypeMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error {
+	args := m.Called(ctx, tableName, asset)
+	return args.Error(0)
+}
 
 func (m *mockQuerierWithResult) CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Context) error {
 	args := m.Called(asset, ctx)

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -37,6 +37,7 @@ type MetadataUpdater interface {
 type TableManager interface {
 	DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error
 	CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Context) error
+	DeleteTableIfMaterializationTypeMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error
 }
 
 type DB interface {
@@ -296,6 +297,7 @@ func (d *Client) Ping(ctx context.Context) error {
 }
 
 func (d *Client) DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error {
+
 	tableRef, err := d.getTableRef(tableName)
 	if err != nil {
 		return err
@@ -433,5 +435,29 @@ func (d *Client) CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Cont
 		return err
 	}
 	d.datasetNameCache.Store(datasetName, true) // Cache the created dataset
+}
+
+func (d Client) DeleteTableIfMaterializationTypeMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error {
+	if asset.Materialization.Type == pipeline.MaterializationTypeNone {
+		return nil
+	}
+	tableRef, err := d.getTableRef(tableName)
+	if err != nil {
+		return err
+	}
+	meta, err := tableRef.Metadata(ctx)
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil
+		}
+		return fmt.Errorf("failed to fetch metadata for table '%s': %w", tableName, err)
+	}
+	tableType := meta.Type
+	if strings.ToLower(string(tableType)) != strings.ToLower(string(asset.Materialization.Type)) {
+		if err := tableRef.Delete(ctx); err != nil {
+			return fmt.Errorf("failed to delete table '%s': %w", tableName, err)
+		}
+	}
 	return nil
 }

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -297,7 +297,6 @@ func (d *Client) Ping(ctx context.Context) error {
 }
 
 func (d *Client) DeleteTableIfPartitioningOrClusteringMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error {
-
 	tableRef, err := d.getTableRef(tableName)
 	if err != nil {
 		return err
@@ -435,9 +434,10 @@ func (d *Client) CreateDataSetIfNotExist(asset *pipeline.Asset, ctx context.Cont
 		return err
 	}
 	d.datasetNameCache.Store(datasetName, true) // Cache the created dataset
+	return nil
 }
 
-func (d Client) DeleteTableIfMaterializationTypeMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error {
+func (d *Client) DeleteTableIfMaterializationTypeMismatch(ctx context.Context, tableName string, asset *pipeline.Asset) error {
 	if asset.Materialization.Type == pipeline.MaterializationTypeNone {
 		return nil
 	}
@@ -454,7 +454,7 @@ func (d Client) DeleteTableIfMaterializationTypeMismatch(ctx context.Context, ta
 		return fmt.Errorf("failed to fetch metadata for table '%s': %w", tableName, err)
 	}
 	tableType := meta.Type
-	if strings.ToLower(string(tableType)) != strings.ToLower(string(asset.Materialization.Type)) {
+	if !strings.EqualFold(string(tableType), string(asset.Materialization.Type)) {
 		if err := tableRef.Delete(ctx); err != nil {
 			return fmt.Errorf("failed to delete table '%s': %w", tableName, err)
 		}

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -1,11 +1,17 @@
 package bigquery
 
 import (
-	"cloud.google.com/go/bigquery"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/stretchr/testify/assert"
@@ -15,11 +21,6 @@ import (
 	bigquery2 "google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
-	"time"
 )
 
 const testProjectID = "test-project"
@@ -1334,7 +1335,10 @@ func TestClient_DeleteTableIfMaterializationTypeMismatch(t *testing.T) {
 						return
 					}
 					w.WriteHeader(http.StatusOK)
-					json.NewEncoder(w).Encode(tt.tableResponse)
+					if err := json.NewEncoder(w).Encode(tt.tableResponse); err != nil {
+						fmt.Printf("Error encoding table response: %v\n", err)
+					}
+
 					return
 
 				case http.MethodDelete:

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -81,6 +81,10 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		if err != nil {
 			return errors.Wrap(err, "failed to compare clustering and partitioning metadata")
 		}
+		err = conn.DeleteTableIfMaterializationTypeMismatch(ctx, t.Name, t)
+		if err != nil {
+			return errors.Wrap(err, "failed to compare table materialization type with expected type")
+		}
 	}
 
 	return conn.RunQueryWithoutResult(ctx, q)


### PR DESCRIPTION
Handles materialization type changes when full-refresh flag  is given
Example Case : User has an bq.sql asset with materialization type table and wants to change it to view  