### PR TITLE
cmd: run: add --debug-ingestr-src flag

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -141,6 +141,10 @@ func Run(isDebug *bool) *cli.Command {
 				Name:  "exp-use-winget-for-uv",
 				Usage: "use powershell to manage and install uv on windows, on non-windows systems this has no effect.",
 			},
+			&cli.StringFlag{
+				Name:  "debug-ingestr-src",
+				Usage: "Use ingestr from the given path instead of the builtin version.",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			defer func() {
@@ -344,6 +348,7 @@ func Run(isDebug *bool) *cli.Command {
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigEndDate, endDate)
 			runCtx = context.WithValue(runCtx, executor.KeyIsDebug, isDebug)
 			runCtx = context.WithValue(runCtx, python.CtxUseWingetForUv, runConfig.ExpUseWingetForUv) //nolint:staticcheck
+			runCtx = context.WithValue(runCtx, python.LocalIngestr, c.String("debug-ingestr-src"))
 
 			ex.Start(runCtx, s.WorkQueue, s.Results)
 

--- a/pkg/python/debug.go
+++ b/pkg/python/debug.go
@@ -1,0 +1,7 @@
+package python
+
+type contextKey string
+
+const (
+	LocalIngestr contextKey = "local_ingestr"
+)

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -367,13 +367,25 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		}
 	}
 
-	ingestrPackageName := "ingestr@" + ingestrVersion
+	ingestrPackageName, isLocal := u.ingestrPackage(ctx)
 	err = u.Cmd.Run(ctx, execCtx.repo, &CommandInstance{
 		Name: u.binaryFullPath,
-		Args: []string{"tool", "install", "--quiet", "--python", pythonVersionForIngestr, ingestrPackageName},
+		Args: []string{
+			"tool",
+			"install",
+			"--quiet",
+			"--reinstall",
+			"--python",
+			pythonVersionForIngestr,
+			ingestrPackageName,
+		},
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to install ingestr")
+	}
+
+	if isLocal {
+		ingestrPackageName = "ingestr"
 	}
 
 	runArgs := slices.Concat([]string{"tool", "run", "--python", pythonVersionForIngestr, ingestrPackageName}, cmdArgs)

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -188,7 +188,6 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 	}
 	u.binaryFullPath = binaryFullPath
 
-	// ingestrPackageName := "ingestr@" + ingestrVersion
 	ingestrPackageName, isLocal := u.ingestrPackage(ctx)
 
 	installCmdline := []string{"tool", "install"}

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -198,12 +198,10 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 		installCmdline,
 		"--force",
 		"--quiet",
+		"--reinstall",
 		"--python",
 		pythonVersionForIngestr,
 	)
-	if isLocal {
-		installCmdline = append(installCmdline, "--reinstall")
-	}
 	installCmdline = append(installCmdline, ingestrPackageName)
 
 	err = u.Cmd.Run(ctx, repo, &CommandInstance{

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -202,8 +202,6 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 		pythonVersionForIngestr,
 	)
 	if isLocal {
-		// when local ingestr package is specified, we want
-		// to pull the latest changes
 		installCmdline = append(installCmdline, "--reinstall")
 	}
 	installCmdline = append(installCmdline, ingestrPackageName)
@@ -217,32 +215,7 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 	}
 
 	if isLocal {
-		// ingestrPackageName() returns the absolute path of
-		// the directory containing the ingestr package if it is local.
 		ingestrPackageName = "ingestr"
-
-		// When we use a local ingestr package that has the same
-		// version as the latest published version, it causes the
-		// published package to not be installed when we run
-		// without local ingestr. This is because when uv compares the
-		// installed version with the latest published version
-		// it sees that they're the same so it skips the
-		// installation altogether. To mitigate this, we change the
-		// version of the local ingestr package to debug.
-		//
-		// if for some reason this doesn't work for you,
-		// you can workaround this issue by uninstall the ingestr
-		// package using:
-		//   uv tool uninstall ingestr
-		// and then running the command again.
-		err = u.setIngestrVersionToDebug(pythonVersionForIngestr)
-		if err != nil {
-			u.Cmd.Run(ctx, repo, &CommandInstance{
-				Name: u.binaryFullPath,
-				Args: []string{"tool", "uninstall", "--quiet", "--python", pythonVersionForIngestr, ingestrPackageName},
-			})
-			return fmt.Errorf("failed to set ingestr package version to debug: %w", err)
-		}
 	}
 
 	flags := []string{"tool", "run", "--python", pythonVersionForIngestr, ingestrPackageName}
@@ -437,20 +410,6 @@ func (u *UvPythonRunner) ingestrPackage(ctx context.Context) (string, bool) {
 		}
 	}
 	return "ingestr@" + ingestrVersion, false
-}
-
-func (u *UvPythonRunner) setIngestrVersionToDebug(pythonVersion string) error {
-	// hacky code up ahead
-
-	// find path of the site-packages for uv tool
-	_ = exec.Command(u.binaryFullPath, "run", "--python", pythonVersion, "-m", "site", "--user-site")
-
-	// find the version of the installed ingestr package
-
-	// rename the installed ingestr package to debug
-
-	// TODO
-	return nil
 }
 
 const PythonArrowTemplate = `


### PR DESCRIPTION
This flag allows developers to provide the path of an `ingestr` source tree that they would like to use, instead of the version bruin CLI was compiled with.

This should make it easy for devs to test integrations in bruin CLI without having to create new releases

**Example**
```
bruin run --debug-ingestr-src /home/user/ingestr pipeline/assets/download.asset.yml
```