### PR TITLE
added validation for incremental keys

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -659,6 +659,14 @@ func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *p
 			return issues, nil
 		}
 
+		if asset.Materialization.IncrementalKey != "" &&
+			asset.Materialization.Strategy != pipeline.MaterializationStrategyDeleteInsert {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "Incremental key is only supported with 'delete+insert' strategy",
+			})
+		}
+
 		switch asset.Materialization.Strategy {
 		case pipeline.MaterializationStrategyNone:
 		case pipeline.MaterializationStrategyCreateReplace:

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1335,6 +1335,23 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "table materialization has incremental key but wrong strategy",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:           pipeline.MaterializationTypeTable,
+						Strategy:       pipeline.MaterializationStrategyCreateReplace,
+						IncrementalKey: "dt",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: []string{
+				"Incremental key is only supported with 'delete+insert' strategy",
+			},
+		},
+		{
 			name: "table materialization has delete+insert but no incremental key",
 			assets: []*pipeline.Asset{
 				{


### PR DESCRIPTION
if there's a materialization rule for the asset:

if there's incremental_key, the strategy for that materialization must be delete+insert

if there's delete+insert there must be incremental_key