### PR TITLE
Refactor connections test

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -354,6 +354,11 @@ func PingConnection() *cli.Command {
 				Usage:   "the name of the environment (e.g., dev, prod). If not specified, the default environment will be used",
 			},
 			&cli.StringFlag{
+				Name:   "type",
+				Usage:  "deprecated: connection type is now automatically detected",
+				Hidden: true,
+			},
+			&cli.StringFlag{
 				Name:     "name",
 				Aliases:  []string{"n"},
 				Usage:    "the name of the connection to test",
@@ -386,13 +391,11 @@ func PingConnection() *cli.Command {
 			}
 			if environment == "" {
 				environment = cm.DefaultEnvironmentName
-			}	
+			}
 			err = cm.SelectEnvironment(environment)
 			if err != nil {
 				printErrorForOutput(output, errors2.Wrap(err, "failed to select the environment"))
 				return cli.Exit("", 1)
-			
-
 			}
 			manager, errs := connection.NewManagerFromConfig(cm)
 			if len(errs) > 0 {

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -385,17 +385,13 @@ func PingConnection() *cli.Command {
 				return cli.Exit("", 1)
 			}
 			if environment == "" {
-				err = cm.SelectEnvironment(cm.DefaultEnvironmentName)
-				if err != nil {
-					printErrorForOutput(output, errors2.Wrap(err, "failed to select the environment"))
-					return cli.Exit("", 1)
-				}
-			} else {
-				err = cm.SelectEnvironment(environment)
-				if err != nil {
-					printErrorForOutput(output, errors2.Wrap(err, "failed to select the environment"))
-					return cli.Exit("", 1)
-				}
+				environment = cm.DefaultEnvironmentName
+			}	
+			err = cm.SelectEnvironment(environment)
+			if err != nil {
+				printErrorForOutput(output, errors2.Wrap(err, "failed to select the environment"))
+				return cli.Exit("", 1)
+			
 
 			}
 			manager, errs := connection.NewManagerFromConfig(cm)

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -398,7 +398,6 @@ func PingConnection() *cli.Command {
 				}
 
 			}
-
 			manager, errs := connection.NewManagerFromConfig(cm)
 			if len(errs) > 0 {
 				// Handle each error in the errs slice

--- a/docs/commands/connections.md
+++ b/docs/commands/connections.md
@@ -90,7 +90,25 @@ bruin connections delete -e staging -n test-connection -o json
 To test if a connection is valid, you can use the test command. 
 This command runs a simple validation check for the connection.
 
-
 ```bash
-bruin connections test --env <environment> --type <connection-type> --name <connection-name>
+bruin connections test --name <connection-name> [--env <environment>]
+```
+
+If no environment flag (`--env`) is provided, the default environment from your `.bruin.yml` will be used.
+
+### Examples
+
+Test a connection in the default environment:
+```bash
+bruin connections test --name my-bigquery-conn
+```
+
+Test a connection in a specific environment:
+```bash
+bruin connections test --name my-snowflake-conn --env production
+```
+
+You can also get the output in JSON format:
+```bash
+bruin connections test --name my-postgres-conn --env staging --output json
 ```


### PR DESCRIPTION
changes made : 

- made environment flag optional  --> uses the default env if the flag isn't passed 
-  deleted the  type flag --> realized this was only used for error messages creates a worst user experience 