### PR TITLE
ClickHouse: Add Support for Secure Connection

### DIFF
--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -14,7 +14,8 @@ connections:
           host: "some-clickhouse-host.somedomain.com"   
           port: 9000
           database: "dev" #Optional for other assets, uneffective when using ClickHouse as an ingestr destination, as ingestr takes the database name from the asset file. 
-          http_port: 8123 #Only specify if you are using clickhouse as ingestr destination, by default it is 8123
+          http_port: 8443 #Only specify if you are using clickhouse as ingestr destination, by default it is 8443
+          secure: 1 #Only specify if you are using clickhouse as ingestr destination, by default, it is set to 1 (secure). Use 0 for a non-secure connection and 1 for a secure connection.
 ```
 ## Ingestr Assets:
 After adding connection in `bruin.yml`. To ingest data to clickhouse, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., stripe_ingestion.yml) inside the assets folder and add the following content:

--- a/integration-tests/expected_connections_schema.json
+++ b/integration-tests/expected_connections_schema.json
@@ -200,6 +200,9 @@
         },
         "http_port": {
           "type": "integer"
+        },
+        "secure": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,
@@ -211,7 +214,8 @@
         "host",
         "port",
         "database",
-        "http_port"
+        "http_port",
+        "secure"
       ]
     },
     "Connections": {

--- a/pkg/clickhouse/config.go
+++ b/pkg/clickhouse/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Port     int
 	Database string
 	HTTPPort int
+	Secure   int
 }
 
 func (c *Config) ToClickHouseOptions() *click_house.Options {
@@ -28,10 +29,19 @@ func (c *Config) ToClickHouseOptions() *click_house.Options {
 }
 
 func (c *Config) GetIngestrURI() string {
-	if c.HTTPPort != 0 {
-		//nolint:nosprintfhostport
-		return fmt.Sprintf("clickhouse://%s:%s@%s:%d?http_port=%d", c.Username, c.Password, c.Host, c.Port, c.HTTPPort)
-	}
 	//nolint:nosprintfhostport
-	return fmt.Sprintf("clickhouse://%s:%s@%s:%d", c.Username, c.Password, c.Host, c.Port)
+	uri := fmt.Sprintf("clickhouse://%s:%s@%s:%d", c.Username, c.Password, c.Host, c.Port)
+	if c.HTTPPort != 0 {
+		uri += fmt.Sprintf("?http_port=%d", c.HTTPPort)
+	}
+	if c.Secure != 0 {
+		if c.HTTPPort != 0 {
+			uri += "&"
+		} else {
+			uri += "?"
+		}
+		uri += fmt.Sprintf("secure=%d", c.Secure)
+	}
+
+	return uri
 }

--- a/pkg/clickhouse/config.go
+++ b/pkg/clickhouse/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	Port     int
 	Database string
 	HTTPPort int
-	Secure   int
+	Secure   *int
 }
 
 func (c *Config) ToClickHouseOptions() *click_house.Options {
@@ -34,14 +34,13 @@ func (c *Config) GetIngestrURI() string {
 	if c.HTTPPort != 0 {
 		uri += fmt.Sprintf("?http_port=%d", c.HTTPPort)
 	}
-	if c.Secure != 0 {
+	if c.Secure != nil {
 		if c.HTTPPort != 0 {
 			uri += "&"
 		} else {
 			uri += "?"
 		}
-		uri += fmt.Sprintf("secure=%d", c.Secure)
+		uri += fmt.Sprintf("secure=%d", *c.Secure)
 	}
-
 	return uri
 }

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -348,7 +348,7 @@ type ClickHouseConnection struct {
 	Port     int    `yaml:"port"     json:"port" mapstructure:"port"`
 	Database string `yaml:"database" json:"database" mapstructure:"database"`
 	HTTPPort int    `yaml:"http_port" json:"http_port" mapstructure:"http_port"`
-	Secure   int    `yaml:"secure" json:"secure" mapstructure:"secure"`
+	Secure   *int   `yaml:"secure" json:"secure" mapstructure:"secure"`
 }
 
 func (c ClickHouseConnection) GetName() string {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -348,6 +348,7 @@ type ClickHouseConnection struct {
 	Port     int    `yaml:"port"     json:"port" mapstructure:"port"`
 	Database string `yaml:"database" json:"database" mapstructure:"database"`
 	HTTPPort int    `yaml:"http_port" json:"http_port" mapstructure:"http_port"`
+	Secure   int    `yaml:"secure" json:"secure" mapstructure:"secure"`
 }
 
 func (c ClickHouseConnection) GetName() string {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -25,6 +25,8 @@ func TestLoadFromFile(t *testing.T) {
 		servicefile = "/path/to/service_account.json"
 	}
 
+	clickhouse_secure_value := 0
+
 	devEnv := Environment{
 		Connections: &Connections{
 			GoogleCloudPlatform: []GoogleCloudPlatformConnection{
@@ -224,6 +226,7 @@ func TestLoadFromFile(t *testing.T) {
 					Path: duckPath,
 				},
 			},
+
 			ClickHouse: []ClickHouseConnection{
 				{
 					Name:     "conn-clickhouse",
@@ -233,7 +236,7 @@ func TestLoadFromFile(t *testing.T) {
 					Password: "clickhousepass",
 					Database: "clickhousedb",
 					HTTPPort: 8124,
-					Secure:   0,
+					Secure:   &clickhouse_secure_value,
 				},
 			},
 			Hubspot: []HubspotConnection{

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -233,6 +233,7 @@ func TestLoadFromFile(t *testing.T) {
 					Password: "clickhousepass",
 					Database: "clickhousedb",
 					HTTPPort: 8124,
+					Secure:   0,
 				},
 			},
 			Hubspot: []HubspotConnection{

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -25,7 +25,7 @@ func TestLoadFromFile(t *testing.T) {
 		servicefile = "/path/to/service_account.json"
 	}
 
-	clickhouse_secure_value := 0
+	clickhouseSecureValue := 0
 
 	devEnv := Environment{
 		Connections: &Connections{
@@ -236,7 +236,7 @@ func TestLoadFromFile(t *testing.T) {
 					Password: "clickhousepass",
 					Database: "clickhousedb",
 					HTTPPort: 8124,
-					Secure:   &clickhouse_secure_value,
+					Secure:   &clickhouseSecureValue,
 				},
 			},
 			Hubspot: []HubspotConnection{

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -222,6 +222,7 @@ environments:
           password: "clickhousepass"
           database: "clickhousedb"
           http_port: 8124
+          secure: 0
       gcs:
         - name: "gcs-1"
           service_account_file: "/path/to/service_account.json"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -223,6 +223,7 @@ environments:
           password: "clickhousepass"
           database: "clickhousedb"
           http_port: 8124
+          secure: 0
       gcs:
         - name: "gcs-1"
           service_account_file: "/path/to/service_account.json"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1644,6 +1644,7 @@ func (m *Manager) AddClickHouseConnectionFromConfig(connection *config.ClickHous
 		Password: connection.Password,
 		Database: connection.Database,
 		HTTPPort: connection.HTTPPort,
+		Secure:   connection.Secure,
 	})
 	if err != nil {
 		return err

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -35,7 +35,7 @@ var AvailablePythonVersions = map[string]bool{
 const (
 	UvVersion               = "0.5.0"
 	pythonVersionForIngestr = "3.11"
-	ingestrVersion          = "0.13.0"
+	ingestrVersion          = "0.13.2"
 )
 
 // UvChecker handles checking and installing the uv package manager.


### PR DESCRIPTION
Following changes are made in this PR:
- Improved connection handling by allowing users to specify secure or non-secure connections using the secure parameter
- By default, the secure parameter is set to 1, i.e secure connection.

<img width="1242" alt="Screenshot 2025-02-03 at 11 15 14" src="https://github.com/user-attachments/assets/83190553-d808-476a-8426-16cf77bb21d5" />

<img width="1512" alt="Screenshot 2025-02-03 at 11 15 38" src="https://github.com/user-attachments/assets/723e5a01-e697-42dd-af46-a006fed19463" />
