### PR TITLE
Hotfix: fixed column name for query where column name used `as`

### DIFF
--- a/pkg/pipeline/lineage.go
+++ b/pkg/pipeline/lineage.go
@@ -194,7 +194,7 @@ func (p *LineageExtractor) processLineageColumns(foundPipeline *Pipeline, asset 
 			upstreamAsset := foundPipeline.GetAssetByName(upstream.Table)
 			if upstreamAsset == nil {
 				if err := p.addColumnToAsset(asset, lineageCol.Name, nil, &Column{
-					Name:   upstream.Column,
+					Name:   lineageCol.Name,
 					Type:   lineageCol.Type,
 					Checks: []ColumnCheck{},
 					Upstreams: []*UpstreamColumn{
@@ -212,7 +212,7 @@ func (p *LineageExtractor) processLineageColumns(foundPipeline *Pipeline, asset 
 			upstreamCol := upstreamAsset.GetColumnWithName(upstream.Column)
 			if upstreamCol == nil {
 				upstreamCol = &Column{
-					Name:   upstream.Column,
+					Name:   lineageCol.Name,
 					Type:   lineageCol.Type,
 					Checks: []ColumnCheck{},
 					Upstreams: []*UpstreamColumn{

--- a/pkg/pipeline/lineage_test.go
+++ b/pkg/pipeline/lineage_test.go
@@ -695,6 +695,78 @@ func testJoinsAndComplexQueries(t *testing.T) {
 func testAdvancedSQLFeatures(t *testing.T) {
 	tests := []TestCase{
 		{
+			name: "snowflake column name with as",
+			pipeline: &Pipeline{
+				Assets: []*Asset{
+					{
+						Name: "sales_summary",
+						Type: "bq.sql",
+						ExecutableFile: ExecutableFile{
+							Content: `
+								SELECT 
+									order_date as order,
+									COUNT(DISTINCT customer_id) as unique_customers,
+									SUM(amount) as total_sales,
+									AVG(amount) as avg_sale,
+									NOW() as report_generated_at
+								FROM raw_sales
+								GROUP BY DATE_TRUNC(order_date, MONTH)
+							`,
+						},
+						Upstreams: []Upstream{{Value: "raw_sales"}},
+					},
+					{
+						Name: "raw_sales",
+						Type: "bq.sql",
+						ExecutableFile: ExecutableFile{
+							Content: "SELECT * FROM data_sales",
+						},
+						Columns: []Column{
+							{Name: "order_date", Type: "timestamp", Description: "Order timestamp"},
+							{Name: "customer_id", Type: "int64", Description: "Customer identifier"},
+							{Name: "amount", Type: "float64", Description: "Sale amount"},
+						},
+					},
+				},
+			},
+			after: &Pipeline{
+				Assets: []*Asset{
+					{
+						Name: "sales_summary",
+						ExecutableFile: ExecutableFile{
+							Content: `
+								SELECT 
+									order_date as order,
+									COUNT(DISTINCT customer_id) as unique_customers,
+									SUM(amount) as total_sales,
+									AVG(amount) as avg_sale,
+									NOW() as report_generated_at
+								FROM raw_sales
+								GROUP BY DATE_TRUNC(order_date, MONTH)
+							`,
+						},
+						Columns: []Column{
+							{Name: "order", Type: "timestamp", Description: "Order timestamp", Upstreams: []*UpstreamColumn{{Column: "order_date", Table: "raw_sales"}}},
+							{Name: "unique_customers", Type: "int64", Description: "Customer identifier", Upstreams: []*UpstreamColumn{{Column: "customer_id", Table: "raw_sales"}}},
+							{Name: "total_sales", Type: "float64", Description: "Sale amount", Upstreams: []*UpstreamColumn{{Column: "amount", Table: "raw_sales"}}},
+							{Name: "avg_sale", Type: "float64", Description: "Sale amount", Upstreams: []*UpstreamColumn{{Column: "amount", Table: "raw_sales"}}},
+							{Name: "report_generated_at", Type: "UNKNOWN", Description: "Report generated at", Upstreams: []*UpstreamColumn{{}}},
+						},
+						Upstreams: []Upstream{{Value: "raw_sales"}},
+					},
+					{
+						Name: "raw_sales",
+						Columns: []Column{
+							{Name: "order_date", Type: "timestamp", Description: "Order timestamp"},
+							{Name: "customer_id", Type: "int64", Description: "Customer identifier"},
+							{Name: "amount", Type: "float64", Description: "Sale amount"},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
 			name: "advanced SQL functions and aggregations",
 			pipeline: &Pipeline{
 				Assets: []*Asset{

--- a/pythonsrc/parser/main_test.py
+++ b/pythonsrc/parser/main_test.py
@@ -1647,6 +1647,125 @@ GROUP BY 1
             }
         ],
     },
+    {
+        "name": "snowflake test",
+        "dialect": "snowflake",
+        "query": """
+       SELECT
+    t.event_date,
+    t.location_code as location,
+    t.session_id as session,
+    COUNT(DISTINCT t.customer_id) as visitor_count,
+    SUM(t.activity_count) as total_activities,
+    SUM(t.interaction_count) as total_interactions,
+    CURRENT_TIMESTAMP() as created_at
+FROM analytics.daily_customer_metrics t
+GROUP BY 1, 2, 3
+ORDER BY 1, 2, 3
+        """,
+        "schema": {
+            "analytics.daily_customer_metrics": {
+                "event_date": "date",
+                "location_code": "string",
+                "session_id": "string",
+                "customer_id": "integer",
+                "activity_count": "integer",
+                "interaction_count": "integer",
+            }
+        },
+        "expected": [
+            {"name": "CREATED_AT", "type": "TIMESTAMP", "upstream": []},
+            {
+                "name": "EVENT_DATE",
+                "type": "DATE",
+                "upstream": [
+                    {
+                        "column": "EVENT_DATE",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "LOCATION",
+                "type": "TEXT",
+                "upstream": [
+                    {
+                        "column": "LOCATION_CODE",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "SESSION",
+                "type": "TEXT",
+                "upstream": [
+                    {
+                        "column": "SESSION_ID",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "TOTAL_ACTIVITIES",
+                "type": "BIGINT",
+                "upstream": [
+                    {
+                        "column": "ACTIVITY_COUNT",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "TOTAL_INTERACTIONS",
+                "type": "BIGINT",
+                "upstream": [
+                    {
+                        "column": "INTERACTION_COUNT",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "VISITOR_COUNT",
+                "type": "BIGINT",
+                "upstream": [
+                    {
+                        "column": "CUSTOMER_ID",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+        ],
+        "expected_non_selected": [
+            {
+                "name": "EVENT_DATE",
+                "upstream": [
+                    {
+                        "column": "EVENT_DATE",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "LOCATION_CODE",
+                "upstream": [
+                    {
+                        "column": "LOCATION_CODE",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+            {
+                "name": "SESSION_ID",
+                "upstream": [
+                    {
+                        "column": "SESSION_ID",
+                        "table": "ANALYTICS.DAILY_CUSTOMER_METRICS",
+                    }
+                ],
+            },
+        ],
+    },
 ]
 
 


### PR DESCRIPTION
Fix: https://linear.app/bruin/issue/BRU-1557/column-lineage-bug