### PR TITLE
Refactor query cmd

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -283,7 +283,7 @@ func executeQuery(c *cli.Context, conn interface{}, queryStr string) error {
 	return nil
 }
 
-// addLimitToQuery adds or updates a LIMIT clause in the query
+// addLimitToQuery adds or updates a LIMIT clause in the query.
 func addLimitToQuery(query string, limit int64) string {
 	// Regular expression to match LIMIT clause at the end of the query
 	re := regexp.MustCompile(`(?i)(\s*LIMIT\s+)\d+(\s*;?\s*)$`)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1511,3 +1511,20 @@ func (b *Builder) MutateAsset(task *Asset, foundPipeline *Pipeline) (*Asset, err
 
 	return task, nil
 }
+
+func (a *Asset) IsSQLAsset() bool {
+	sqlAssetTypes := map[AssetType]bool{
+		AssetTypeBigqueryQuery:   true,
+		AssetTypeSnowflakeQuery:  true,
+		AssetTypePostgresQuery:   true,
+		AssetTypeRedshiftQuery:   true,
+		AssetTypeMsSQLQuery:      true,
+		AssetTypeDatabricksQuery: true,
+		AssetTypeSynapseQuery:    true,
+		AssetTypeAthenaQuery:     true,
+		AssetTypeDuckDBQuery:     true,
+		AssetTypeClickHouse:      true,
+	}
+
+	return sqlAssetTypes[a.Type]
+}


### PR DESCRIPTION
Three new flags added  :**limit** --> to limit the rows returned 
**asset** --> asset where we get the query from
**env** --> env the asset is being used on

Previously we only had the option to use **connection** and **query** flags now we can either use these two in tandem or just pass the  **asset**  if its in the default environment or combine with the **env** if the asset is not used in the default environment.  This second option detects the connection that the asset needs and unmaterializes  the query from the asset and then runs the query 