### PR TITLE
do not parse the whole pipeline for asset parsing

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/git"
@@ -256,26 +257,56 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 		return cli.Exit("", 1)
 	}
 
-	pipelinePath, err := path.GetPipelineRootFromTask(assetPath, pipelineDefinitionFiles)
+	absoluteAssetPath, err := filepath.Abs(assetPath)
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)
 	}
 
-	repoRoot, err := git.FindRepoFromPath(assetPath)
+	pipelinePath, err := path.GetPipelineRootFromTask(absoluteAssetPath, pipelineDefinitionFiles)
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)
 	}
 
-	foundPipeline, err := DefaultPipelineBuilder.CreatePipelineFromPath(pipelinePath, true)
+	repoRoot, err := git.FindRepoFromPath(absoluteAssetPath)
 	if err != nil {
 		printErrorJSON(err)
-
 		return cli.Exit("", 1)
 	}
 
-	asset := foundPipeline.GetAssetByPath(assetPath)
+	pipelineDefinitionPath, err := getPipelineDefinitionFullPath(pipelinePath)
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
+
+	var foundPipeline *pipeline.Pipeline
+
+	// column-level lineage requires the whole pipeline to be parsed by nature, therefore we need to use the default pipeline builder.
+	// however, since the primary usecase of this command requires speed, we'll use a faster alternative if there's no lineage requested.
+	if lineage {
+		foundPipeline, err = DefaultPipelineBuilder.CreatePipelineFromPath(pipelineDefinitionPath, true)
+	} else {
+		foundPipeline, err = pipeline.PipelineFromPath(pipelineDefinitionPath, afero.NewOsFs())
+	}
+
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
+
+	asset, err := DefaultPipelineBuilder.CreateAssetFromFile(absoluteAssetPath, nil)
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
+
+	asset, err = DefaultPipelineBuilder.MutateAsset(asset, foundPipeline)
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
 
 	if lineage {
 		panics := lineageWg.WaitAndRecover()

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -957,6 +957,8 @@ func PipelineFromPath(filePath string, fs afero.Fs) (*Pipeline, error) {
 	}
 
 	pl.Assets = make([]*Asset, 0)
+	pl.DefinitionFile.Name = filepath.Base(filePath)
+	pl.DefinitionFile.Path = filePath
 	return &pl, nil
 }
 


### PR DESCRIPTION
This PR changes the internal `parse-asset` command to avoid reading the full pipeline when not needed. This change itself causes ~12x speedup in a pipeline with ~1k assets on my macbook.

<img width="312" alt="image" src="https://github.com/user-attachments/assets/a9551696-3df8-40ce-8688-303a6b183f18" />
