### PR TITLE
patch/make git repo root finding faster

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/git"
@@ -256,26 +257,56 @@ func (r *ParseCommand) Run(assetPath string, lineage bool) error {
 		return cli.Exit("", 1)
 	}
 
-	pipelinePath, err := path.GetPipelineRootFromTask(assetPath, pipelineDefinitionFiles)
+	absoluteAssetPath, err := filepath.Abs(assetPath)
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)
 	}
 
-	repoRoot, err := git.FindRepoFromPath(assetPath)
+	pipelinePath, err := path.GetPipelineRootFromTask(absoluteAssetPath, pipelineDefinitionFiles)
 	if err != nil {
 		printErrorJSON(err)
 		return cli.Exit("", 1)
 	}
 
-	foundPipeline, err := DefaultPipelineBuilder.CreatePipelineFromPath(pipelinePath, true)
+	repoRoot, err := git.FindRepoFromPath(absoluteAssetPath)
 	if err != nil {
 		printErrorJSON(err)
-
 		return cli.Exit("", 1)
 	}
 
-	asset := foundPipeline.GetAssetByPath(assetPath)
+	pipelineDefinitionPath, err := getPipelineDefinitionFullPath(pipelinePath)
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
+
+	var foundPipeline *pipeline.Pipeline
+
+	// column-level lineage requires the whole pipeline to be parsed by nature, therefore we need to use the default pipeline builder.
+	// however, since the primary usecase of this command requires speed, we'll use a faster alternative if there's no lineage requested.
+	if lineage {
+		foundPipeline, err = DefaultPipelineBuilder.CreatePipelineFromPath(pipelineDefinitionPath, true)
+	} else {
+		foundPipeline, err = pipeline.PipelineFromPath(pipelineDefinitionPath, afero.NewOsFs())
+	}
+
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
+
+	asset, err := DefaultPipelineBuilder.CreateAssetFromFile(absoluteAssetPath, nil)
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
+
+	asset, err = DefaultPipelineBuilder.MutateAsset(asset, foundPipeline)
+	if err != nil {
+		printErrorJSON(err)
+		return cli.Exit("", 1)
+	}
 
 	if lineage {
 		panics := lineageWg.WaitAndRecover()

--- a/pkg/git/root.go
+++ b/pkg/git/root.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var knownRepoRoots = make(map[string]string)
+var knownRepoRoots = make(map[string]bool)
 
 // RepoFinder is a wrapper for finding the root path of a git repository.
 type RepoFinder struct{}
@@ -35,8 +35,10 @@ func (*RepoFinder) Repo(path string) (*Repo, error) {
 //}
 
 func FindRepoFromPath(path string) (*Repo, error) {
-	if knownRepoRoots[path] != "" {
-		return &Repo{Path: knownRepoRoots[path]}, nil
+	for knownPath, _ := range knownRepoRoots {
+		if strings.HasPrefix(path, knownPath + "/") {
+			return &Repo{Path: knownPath}, nil
+		}
 	}
 
 	d, err := detectGitPath(path)
@@ -48,7 +50,7 @@ func FindRepoFromPath(path string) (*Repo, error) {
 		d = strings.Replace(d, "/", "\\", -1)
 	}
 
-	knownRepoRoots[path] = d
+	knownRepoRoots[d] = true
 
 	return &Repo{
 		Path: d,

--- a/pkg/git/root.go
+++ b/pkg/git/root.go
@@ -40,6 +40,10 @@ func FindRepoFromPath(path string) (*Repo, error) {
 		return nil, err
 	}
 
+	if runtime.GOOS == "windows" {
+		d = strings.Replace(d, "/", "\\", -1)
+	}
+
 	return &Repo{
 		Path: d,
 	}, nil

--- a/pkg/git/root_test.go
+++ b/pkg/git/root_test.go
@@ -41,8 +41,7 @@ func TestRepo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			finder := &RepoFinder{}
-			got, err := finder.Repo(tt.path)
+			got, err := FindRepoFromPath(tt.path)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -51,5 +50,18 @@ func TestRepo(t *testing.T) {
 
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func BenchmarkFindRepoFromPath(b *testing.B) {
+	// Reset the timer to exclude setup time
+	b.ResetTimer()
+
+	// Run the benchmark
+	for i := 0; i < b.N; i++ {
+		_, err := FindRepoFromPath(".")
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/pkg/glossary/entity.go
+++ b/pkg/glossary/entity.go
@@ -108,7 +108,7 @@ func (r *GlossaryReader) GetEntities(pathToPipeline string) ([]*Entity, error) {
 
 func LoadGlossaryFromFile(path string) (*Glossary, error) {
 	var glossary glossaryYaml
-	err := path2.ReadYaml(afero.NewCacheOnReadFs(afero.NewOsFs(), afero.NewMemMapFs(), 30), path, &glossary)
+	err := path2.ReadYaml(afero.NewOsFs(), path, &glossary)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read entities")
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -957,6 +957,8 @@ func PipelineFromPath(filePath string, fs afero.Fs) (*Pipeline, error) {
 	}
 
 	pl.Assets = make([]*Asset, 0)
+	pl.DefinitionFile.Name = filepath.Base(filePath)
+	pl.DefinitionFile.Path = filePath
 	return &pl, nil
 }
 


### PR DESCRIPTION
This PR is based on the changes in #480, and improves upon the git repo root finding.

Previously we have relied on `git` cmd to be installed to find the repo root, which required spawning a new process, which turned out to be rather slow. This PR replaces that implementation with traversing the file tree.

I tested this both on macOS and Windows, the behavior doesn't seem to change in any way.

## Micro-benchmark
I have ran a Go benchmark for this method specifically, the change is **very** significant:
```
                    │    old.txt     │               new.txt               │
                    │     sec/op     │   sec/op     vs base                │
FindRepoFromPath-12   5032.729µ ± 8%   4.520µ ± 9%  -99.91% (p=0.000 n=10)

                    │    old.txt    │               new.txt                │
                    │     B/op      │     B/op      vs base                │
FindRepoFromPath-12   54.342Ki ± 0%   1.627Ki ± 0%  -97.01% (p=0.000 n=10)

                    │   old.txt   │              new.txt               │
                    │  allocs/op  │ allocs/op   vs base                │
FindRepoFromPath-12   130.00 ± 0%   16.00 ± 0%  -87.69% (p=0.000 n=10)
```

99% faster than the previous version with 97% less memory.

## Impact on asset parsing
On top of the improvements in #480, this seems to deliver an additional ~30% on my MBP.

<img width="316" alt="image" src="https://github.com/user-attachments/assets/f92a0b83-2dc6-467b-84e1-4e0b4d074646" />

I tested this on a windows VM on my mac, the difference is 77%:

<img width="275" alt="image" src="https://github.com/user-attachments/assets/d06f184a-92dc-4f07-9348-80d12d941bc2" />

