### PR TITLE
fix: delete+insert snowflake

### DIFF
--- a/pkg/snowflake/materialization_test.go
+++ b/pkg/snowflake/materialization_test.go
@@ -132,11 +132,31 @@ func TestMaterializer_Render(t *testing.T) {
 				},
 			},
 			query: "SELECT 1",
-			want: "^BEGIN TRANSACTION;\n" +
-				"CREATE TEMP TABLE __bruin_tmp_.+ AS SELECT 1\n;\n" +
-				"DELETE FROM my\\.asset WHERE dt in \\(SELECT DISTINCT dt FROM __bruin_tmp_.+\\);\n" +
-				"INSERT INTO my\\.asset SELECT \\* FROM __bruin_tmp_.+;\n" +
-				"DROP TABLE IF EXISTS __bruin_tmp_.+;\n" +
+			want: "USE SCHEMA MY;\n" +
+				"BEGIN TRANSACTION;\n" +
+				"CREATE TEMP TABLE __bruin_tmp_abcefghi AS SELECT 1\n;\n" +
+				"DELETE FROM my\\.asset WHERE dt in \\(SELECT DISTINCT dt FROM __bruin_tmp_abcefghi\\);\n" +
+				"INSERT INTO my\\.asset SELECT \\* FROM __bruin_tmp_abcefghi;\n" +
+				"DROP TABLE IF EXISTS __bruin_tmp_abcefghi;\n" +
+				"COMMIT;$",
+		},
+		{
+			name: "delete+insert with three part name",
+			task: &pipeline.Asset{
+				Name: "db.my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
+					IncrementalKey: "dt",
+				},
+			},
+			query: "SELECT 1",
+			want: "USE SCHEMA MY;\n" +
+				"BEGIN TRANSACTION;\n" +
+				"CREATE TEMP TABLE __bruin_tmp_abcefghi AS SELECT 1\n;\n" +
+				"DELETE FROM db\\.my\\.asset WHERE dt in \\(SELECT DISTINCT dt FROM __bruin_tmp_abcefghi\\);\n" +
+				"INSERT INTO db\\.my\\.asset SELECT \\* FROM __bruin_tmp_abcefghi;\n" +
+				"DROP TABLE IF EXISTS __bruin_tmp_abcefghi;\n" +
 				"COMMIT;$",
 		},
 		{


### PR DESCRIPTION
patches delete+insert error:

 ```
 test2.products
    └── '100132 (P0000): JavaScript execution error: Uncaught Execution of multiple statements failed on statement "CREATE TEMP TABLE __bruin_tmp_..." (at line 2, position 0).  -  Cannot perform CREATE TEMPTABLE. This session does not have a current schema. Call 'USE SCHEMA', or use a qualified name. in SYSTEM$MULTISTMT at '    throw `Execution of multiple statements failed on statement {0} (at line {1}, position {2}).`.replace('{1}', LINES[i])' position 4  -  stackstrace:   -  SYSTEM$MULTISTMT line: 10'
`
```