### PR TITLE
run: log subprocess cmdline when --debug is set

### DIFF
--- a/pkg/python/local.go
+++ b/pkg/python/local.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -91,6 +92,13 @@ type CommandInstance struct {
 }
 
 func (l *CommandRunner) Run(ctx context.Context, repo *git.Repo, command *CommandInstance) error {
+	log := ctx.Value(executor.ContextLogger).(*zap.SugaredLogger)
+	log.Debugf(
+		"%s %s",
+		command.Name,
+		strings.Join(command.Args, " "),
+	)
+
 	cmd := exec.Command(command.Name, command.Args...) //nolint:gosec
 	cmd.Dir = repo.Path
 


### PR DESCRIPTION
example:
```
$ bruin --debug run ./chess
2025-03-10T23:23:07.471+0530    DEBUG   cmd/run.go:486  given start date: 2025-03-09 00:00:00 +0000 UTC
2025-03-10T23:23:07.471+0530    DEBUG   cmd/run.go:496  given end date: 2025-03-09 23:59:59.999999 +0000 UTC
Analyzed the pipeline 'chess_duckdb' with 3 assets.

Pipeline: chess_duckdb (.)
  No issues found

✓ Successfully validated 3 assets across 1 pipeline, all good.

Starting the pipeline execution...

2025-03-10T23:23:07.479+0530    DEBUG   scheduler/scheduler.go:615      started the scheduler loop
[2025-03-10 23:23:07] Starting: chess_playground.profiles
[2025-03-10 23:23:07] Starting: chess_playground.games
2025-03-10T23:23:07.483+0530    DEBUG   python/local.go:96      /home/user/.bruin/uv tool install --force --quiet --python 3.11 ingestr@0.13.18
2025-03-10T23:23:07.544+0530    DEBUG   python/local.go:96      /home/user/.bruin/uv tool run --python 3.11 ingestr ingest --source-uri chess://?players=MagnusCarlsen,Hikaru --source-table profiles --dest-uri duckdb:////home/user/out.db --dest-table chess_playground.profiles --yes --progress log --interval-start 2025-03-09T00:00:00Z --interval-end 2025-03-09T23:59:59Z
[2025-03-10 23:23:09] [chess_playground.profiles] >> 
[2025-03-10 23:23:09] [chess_playground.profiles] >> Initiated the pipeline with the following:
[2025-03-10 23:23:09] [chess_playground.profiles] >>   Source: chess / profiles
[2025-03-10 23:23:09] [chess_playground.profiles] >>   Destination: duckdb / chess_playground.profiles
[2025-03-10 23:23:09] [chess_playground.profiles] >>   Incremental Strategy: Platform-specific
[2025-03-10 23:23:09] [chess_playground.profiles] >>   Incremental Key: None
[2025-03-10 23:23:09] [chess_playground.profiles] >>   Primary Key: None
[2025-03-10 23:23:09] [chess_playground.profiles] >> 
[2025-03-10 23:23:09] [chess_playground.profiles] >> 
[2025-03-10 23:23:09] [chess_playground.profiles] >> Starting the ingestion...

... redacted ...
```