### PR TITLE
feature/support table renaming for py

### DIFF
--- a/pkg/athena/operator_test.go
+++ b/pkg/athena/operator_test.go
@@ -24,6 +24,7 @@ func (m *mockExtractor) ExtractQueriesFromSlice(content []string) ([]*query.Quer
 	res := m.Called(content)
 	return res.Get(0).([]*query.Query), res.Error(1)
 }
+
 func (m *mockExtractor) ReextractQueriesFromSlice(content []string) ([]string, error) {
 	res := m.Called(content)
 	return res.Get(0).([]string), res.Error(1)

--- a/pkg/mssql/operator.go
+++ b/pkg/mssql/operator.go
@@ -45,6 +45,7 @@ func NewBasicOperator(conn connectionFetcher, extractor queryExtractor, material
 func (o BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error {
 	return o.RunTask(ctx, ti.GetPipeline(), ti.GetAsset())
 }
+
 func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Asset) error {
 	queries, err := o.extractor.ExtractQueriesFromString(t.ExecutableFile.Content)
 	if err != nil {

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -737,6 +737,22 @@ from raw.Bookings as bookings
 				"raw.Teams",
 			},
 		},
+		{
+			name: "transaction",
+			sql: `BEGIN TRANSACTION;
+DROP TABLE IF EXISTS public.example; 
+CREATE TABLE public.example AS SELECT 1 as id, 'Spain' as country, 'Juan' as name
+union all
+SELECT 2 as id, 'Germany' as country, 'Markus' as name
+union all
+SELECT 3 as id, 'France' as country, 'Antoine' as name
+union all
+SELECT 4 as id, 'Poland' as country, 'Franciszek' as name;
+COMMIT;`,
+			want: []string{
+				"public.example",
+			},
+		},
 	}
 
 	t.Run("blocking group", func(t *testing.T) {
@@ -745,6 +761,60 @@ from raw.Bookings as bookings
 				t.Parallel()
 
 				got, err := s.UsedTables(tt.sql, "bigquery")
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+
+				require.Equal(t, tt.want, got)
+			})
+		}
+	})
+
+	// wg.Wait()
+	s.Close()
+	require.NoError(t, err)
+}
+
+func TestSqlParser_RenameTables(t *testing.T) {
+	s, err := NewSQLParser(true)
+	require.NoError(t, err)
+
+	err = s.Start()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		query         string
+		tableMappings map[string]string
+		want          string
+		wantErr       bool
+	}{
+		{
+			name:  "simple select should get an alias if table names are different",
+			query: `SELECT * FROM items`,
+			tableMappings: map[string]string{
+				"items": "new_items",
+			},
+			want: "SELECT * FROM new_items AS items",
+		},
+		{
+			name:  "simple select, just change schema name",
+			query: `SELECT * FROM raw.items`,
+			tableMappings: map[string]string{
+				"raw.items": "raw_dev.items",
+			},
+			want: "SELECT * FROM raw_dev.items",
+		},
+	}
+
+	t.Run("blocking group", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, err := s.RenameTables(tt.query, "bigquery", tt.tableMappings)
 				if tt.wantErr {
 					require.Error(t, err)
 				} else {

--- a/pythonsrc/main.py
+++ b/pythonsrc/main.py
@@ -42,6 +42,14 @@ def main():
                 logging.info("got get-tables command")
                 c = cmd["contents"]
                 result = get_tables(c["query"], c["dialect"])
+            elif cmd["command"] == "replace-table-references":
+                from parser.rename import replace_table_references
+
+                logging.info("got replace-table-references command")
+                c = cmd["contents"]
+                result = replace_table_references(
+                    c["query"], c["dialect"], c["table_mapping"]
+                )
             elif cmd["command"] == "exit":
                 logging.info("got exit command amx")
                 break

--- a/pythonsrc/parser/main_test.py
+++ b/pythonsrc/parser/main_test.py
@@ -2,7 +2,7 @@ import pytest
 from sqlglot import parse_one
 from sqlglot.optimizer import optimize
 
-from .main import get_column_lineage, extract_non_selected_columns, Column
+from .main import get_column_lineage, extract_non_selected_columns, Column, get_tables
 
 SCHEMA = {
     "orders": {
@@ -1853,3 +1853,15 @@ def test_extract_non_select_column(query, schema, expected, dialect):
     optimized = optimize(parsed, schema, dialect=dialect)
     result = extract_non_selected_columns(optimized)
     assert result == expected
+
+
+def test_get_tables():
+    dialect = "bigquery"
+
+    query = "SELECT * FROM table1"
+    expected = {"tables": ["table1"]}
+    assert get_tables(query, dialect) == expected
+
+    query = """CREATE TABLE public.example AS SELECT 1 AS id, 'Spain' AS country, 'Juan' AS name UNION ALL SELECT 2 AS id, 'Germany' AS country, 'Markus' AS name UNION ALL SELECT 3 AS id, 'France' AS country, 'Antoine' AS name UNION ALL SELECT 4 AS id, 'Poland' AS country, 'Franciszek' AS name"""
+    expected = {"tables": ["public.example"]}
+    assert get_tables(query, dialect) == expected

--- a/pythonsrc/parser/rename.py
+++ b/pythonsrc/parser/rename.py
@@ -1,0 +1,43 @@
+from sqlglot import parse, exp
+
+
+# todo: this implementation does not support columns in select where they specify the schema as well, e.g. select raw.table1.col1, col2 from raw.table1
+def replace_table_references(
+    query: str, dialect: str, table_references: dict[str, str]
+):
+    parsed_queries = parse(query, dialect=dialect)
+    if parsed_queries is None:
+        return {"error": "unable to parse query"}
+
+    for parsed_query in parsed_queries:
+        for table_node in parsed_query.find_all(exp.Table):
+            for table_name, new_table_name in table_references.items():
+                parts = table_name.split(".")
+                source_schema = None
+                source_table = table_name
+                if len(parts) > 1:
+                    source_schema = parts[0]
+                    source_table = parts[1]
+
+                if table_node.name != source_table:
+                    continue
+
+                if source_schema is not None and source_schema != table_node.db:
+                    continue
+
+                parts = new_table_name.split(".")
+                dest_schema = None
+                dest_table = new_table_name
+                if len(parts) > 1:
+                    dest_schema = parts[0]
+                    dest_table = parts[1]
+
+                table_node.this.set("this", dest_table)
+                table_node.set("db", dest_schema)
+                if not table_node.alias and source_table != dest_table:
+                    table_node.set("alias", source_table)
+
+    return {
+        "query": "; ".join([q.sql() for q in parsed_queries]),
+        "error": None,
+    }

--- a/pythonsrc/parser/rename_test.py
+++ b/pythonsrc/parser/rename_test.py
@@ -1,0 +1,177 @@
+import pytest
+from sqlglot import parse
+
+from .rename import replace_table_references
+
+test_cases_rename = [
+    {
+        "name": "simple single table select",
+        "query": "SELECT * FROM items",
+        "table_references": {"items": "t1"},
+        "expected": "SELECT * FROM t1 AS items",
+    },
+    {
+        "name": "multi table with schemas",
+        "query": "SELECT * FROM raw.items join raw.orders on items.item_id = orders.item_id",
+        "table_references": {"raw.items": "t1", "orders": "raw_dev.t2"},
+        "expected": "SELECT * FROM t1 AS items JOIN raw_dev.t2 AS orders ON items.item_id = orders.item_id",
+    },
+    {
+        "name": "multiple queries",
+        "query": "DELETE FROM raw.items WHERE item_id = 1; SELECT * FROM raw.items join raw.orders on items.item_id = orders.item_id",
+        "table_references": {"raw.items": "t1", "orders": "raw_dev.t2"},
+        "expected": "DELETE FROM t1 AS items WHERE item_id = 1; SELECT * FROM t1 AS items JOIN raw_dev.t2 AS orders ON items.item_id = orders.item_id",
+    },
+    {
+        "name": "table name in select",
+        "query": """
+             SELECT
+                 items.item_id as item_id,
+                 CASE
+                     WHEN price > 1000 AND t2.somecol < 250 THEN 'high'
+                     WHEN price > 100 THEN 'medium'
+                     ELSE 'low'
+                 END as price_category
+             FROM raw.items
+             JOIN raw.orders as t2 on items.item_id = t2.item_id
+             WHERE in_stock = true
+         """,
+        "table_references": {"raw.items": "t1", "raw.orders": "raw_dev.orders"},
+        "expected": """SELECT items.item_id AS item_id, CASE WHEN price > 1000 AND t2.somecol < 250 THEN 'high' WHEN price > 100 THEN 'medium' ELSE 'low' END AS price_category FROM t1 AS items JOIN raw_dev.orders AS t2 ON items.item_id = t2.item_id WHERE in_stock = TRUE""",
+    },
+    {
+        "name": "subquery",
+        "query": """
+             SELECT
+                 emp_id,
+                 (SELECT AVG(salary) FROM raw.salaries WHERE salaries.emp_id = employees.emp_id) as avg_salary
+             FROM raw.employees
+         """,
+        "table_references": {
+            "raw.salaries": "raw_dev.salaries",
+            "raw.employees": "raw_dev.employees",
+        },
+        "expected": """SELECT emp_id, (SELECT AVG(salary) FROM raw_dev.salaries WHERE salaries.emp_id = employees.emp_id) AS avg_salary FROM raw_dev.employees""",
+    },
+    {
+        "name": "subquery",
+        "query": """
+WITH ufd AS (
+    SELECT
+        user_id,
+        MIN(date_utc) as my_date_col
+    FROM fact.some_other_table
+    GROUP BY 1
+),
+user_retention AS (
+    SELECT
+        d.user_id,
+        MAX(CASE WHEN DATEDIFF(day, f.my_date_col, d.date_utc) = 1 THEN 1 ELSE 0 END) as some_day1_metric,
+    FROM fact.some_daily_metrics d
+    INNER JOIN ufd f ON d.user_id = f.user_id
+    GROUP BY 1
+)
+SELECT
+    d.user_id, 
+    DATEDIFF(day, MAX(d.date_utc), CURRENT_DATE()) as recency,
+    COUNT(DISTINCT d.date_utc) as active_days, 
+    MIN_BY(d.first_device_type, d.first_activity_timestamp) as first_device_type, 
+    AVG(NULLIF(d.estimated_session_duration, 0)) as avg_session_duration, 
+    SUM(d.event_start) as total_event_start, 
+    MAX(r.some_day1_metric) as some_day1_metric, 
+    case when sum(d.event_start) > 0 then 'Player' else 'Visitor' end as user_type, 
+FROM fact.some_daily_metrics d
+LEFT JOIN user_retention r ON d.user_id = r.user_id
+GROUP BY 1""",
+        "table_references": {
+            "fact.some_daily_metrics": "fact_dev.some_daily_metrics",
+            "fact.some_other_table": "fact_dev.some_other_table",
+        },
+        "expected": """WITH ufd AS (
+    SELECT
+        user_id,
+        MIN(date_utc) as my_date_col
+    FROM fact_dev.some_other_table
+    GROUP BY 1
+),
+user_retention AS (
+    SELECT
+        d.user_id,
+        MAX(CASE WHEN DATEDIFF(day, f.my_date_col, d.date_utc) = 1 THEN 1 ELSE 0 END) as some_day1_metric,
+    FROM fact_dev.some_daily_metrics d
+    INNER JOIN ufd f ON d.user_id = f.user_id
+    GROUP BY 1
+)
+SELECT
+    d.user_id, 
+    DATEDIFF(day, MAX(d.date_utc), CURRENT_DATE()) as recency,
+    COUNT(DISTINCT d.date_utc) as active_days, 
+    MIN_BY(d.first_device_type, d.first_activity_timestamp) as first_device_type, 
+    AVG(NULLIF(d.estimated_session_duration, 0)) as avg_session_duration, 
+    SUM(d.event_start) as total_event_start, 
+    MAX(r.some_day1_metric) as some_day1_metric, 
+    case when sum(d.event_start) > 0 then 'Player' else 'Visitor' end as user_type, 
+FROM fact_dev.some_daily_metrics d
+LEFT JOIN user_retention r ON d.user_id = r.user_id
+GROUP BY 1""",
+    },
+    {
+        "name": "cte with similar names",
+        "query": """
+with
+t1 as
+(
+	select t1.col1, col2
+	from raw.table1 as t1
+),
+t2 as
+(
+	select t2.col1, col3
+	from raw.table1 t2
+),
+t3 as
+(
+	select table1.col1, col3
+	from raw.table1
+)
+select *
+from t1
+join t2
+	using(col1)
+        """,
+        "table_references": {"raw.table1": "raw_dev.table1"},
+        "expected": """
+with
+t1 as
+(
+	select t1.col1, col2
+	from raw_dev.table1 as t1
+),
+t2 as
+(
+	select t2.col1, col3
+	from raw_dev.table1 t2
+),
+t3 as
+(
+	select table1.col1, col3
+	from raw_dev.table1
+)
+select *
+from t1
+join t2
+	using(col1)
+        """,
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "query,table_references,expected",
+    [(tc["query"], tc["table_references"], tc["expected"]) for tc in test_cases_rename],
+    ids=[tc["name"] for tc in test_cases_rename],
+)
+def test_replace_table_references(query, table_references, expected):
+    result = replace_table_references(query, "bigquery", table_references)
+    assert result["query"] == "; ".join([q.sql() for q in parse(expected)])
+    assert result["error"] is None


### PR DESCRIPTION
This PR introduces a small functionality to rename tables in a given query, later on used as part of the new prefixed dev environment implementation.