### PR TITLE
Update filtering logic 

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -989,7 +989,7 @@ func HandleSingleTask(ctx context.Context, f *Filter, s *scheduler.Scheduler, p 
 	}
 	if f.ExcludeTag != "" {
 		if !f.IncludeDownstream {
-			return fmt.Errorf("when running a single asset with '--exclude-tag', you must also use the '--downstream' flag")
+			return errors.New("when running a single asset with '--exclude-tag', you must also use the '--downstream' flag")
 		}
 		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
 		if len(excludedAssets) == 0 {


### PR DESCRIPTION
This PR updates the filtering logic : 
It rolls back the following  features:

1. Existent logic :  combining --downstream and  --tags flags  while running the whole pipeline   -->  this would run the assets that has the specified tag and their downstream 
2. combining --downstream and  --exclude tag while running the whole pipeline  -->  this would  exclude  the assets that has the specified tag and also exclude  their downstream  .

And it ADDs the new logic:

1.  downstream flag can only be used if you are running a single asset (not the pipeline)
2.  Downstream flag can be combined with  --exclude-tags  flag   --> this runs  the asset and the downstream but excludes the assets that have that tag 
