### PR TITLE
feature/remove colors from timestamps

### DIFF
--- a/integration-tests/integration-test.go
+++ b/integration-tests/integration-test.go
@@ -513,7 +513,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 1,
-				Contains: []string{" Starting: shopify_raw.products:metadata-push", "Starting: shopify_raw.inventory_items:metadata-push"},
+				Contains: []string{"Running:  shopify_raw.products:metadata-push", "Running:  shopify_raw.inventory_items:metadata-push"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -833,7 +833,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 1,
-				Contains: []string{"Starting: example", "Finished: example", "Catalog Error: Table with name my does not exist!", "Failed: my-other-asset"},
+				Contains: []string{"Running:  example", "Finished: example", "Catalog Error: Table with name my does not exist!", "Failed: my-other-asset"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -310,7 +310,6 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 			return errors.New("Sensor timed out after 24 hours")
 		default:
 			res, err := conn.Select(ctx, &query.Query{Query: qq})
-
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR removes colors from timestamps to make the logs a bit more readable. Also changes the message from "starting" to "running" for clarity.

**Before:**
<img width="455" alt="image" src="https://github.com/user-attachments/assets/122ec651-82cb-47ff-9f67-45e8e862556f" />


**After:**
<img width="459" alt="image" src="https://github.com/user-attachments/assets/90989687-3e75-42e0-9020-853e9f4ad504" />
