### PR TITLE
emr_serverless: increase polling frequency + non-fatal rate limit

### DIFF
--- a/pkg/emr_serverless/operator.go
+++ b/pkg/emr_serverless/operator.go
@@ -164,8 +164,7 @@ func (job Job) Run(ctx context.Context) (err error) { //nolint
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			time.Sleep(3 * time.Second)
+		case <-time.After(3 * time.Second):
 			listJobArgs := &emrserverless.ListJobRunAttemptsInput{
 				ApplicationId: &job.params.ApplicationID,
 				JobRunId:      result.JobRunId,

--- a/pkg/emr_serverless/retry.go
+++ b/pkg/emr_serverless/retry.go
@@ -1,0 +1,28 @@
+package emr_serverless
+
+import (
+	"math"
+	"time"
+)
+
+type PollTimer struct {
+	BaseDuration time.Duration
+	RetryCount   int
+	MaxRetry     int
+}
+
+func (p *PollTimer) Duration() time.Duration {
+	return p.BaseDuration * time.Duration(
+		math.Pow(2, float64(p.RetryCount)),
+	)
+}
+
+func (p *PollTimer) Reset() {
+	p.RetryCount = 0
+}
+
+func (p *PollTimer) Increase() {
+	if p.MaxRetry > 0 && p.RetryCount < p.MaxRetry {
+		p.RetryCount += 1
+	}
+}

--- a/pkg/emr_serverless/retry.go
+++ b/pkg/emr_serverless/retry.go
@@ -1,4 +1,4 @@
-package emr_serverless
+package emr_serverless //nolint
 
 import (
 	"math"

--- a/pkg/emr_serverless/retry_test.go
+++ b/pkg/emr_serverless/retry_test.go
@@ -1,4 +1,4 @@
-package emr_serverless
+package emr_serverless //nolint
 
 import (
 	"testing"
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPollTimer(t *testing.T) {
+	t.Parallel()
+
 	type testCase struct {
 		Retry  int
 		Expect time.Duration

--- a/pkg/emr_serverless/retry_test.go
+++ b/pkg/emr_serverless/retry_test.go
@@ -1,0 +1,55 @@
+package emr_serverless
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPollTimer(t *testing.T) {
+	type testCase struct {
+		Retry  int
+		Expect time.Duration
+	}
+
+	const maxRetry = 5
+
+	testCases := []testCase{
+		{
+			0, time.Second,
+		},
+		{
+			1, 2 * time.Second,
+		},
+		{
+			2, 4 * time.Second,
+		},
+		{
+			3, 8 * time.Second,
+		},
+		{
+			4, 16 * time.Second,
+		},
+		{
+			5, 32 * time.Second,
+		},
+		{
+			6, 32 * time.Second, // max retry should limit it to 32
+		},
+	}
+	for _, testCase := range testCases {
+		timer := &PollTimer{
+			BaseDuration: time.Second,
+			MaxRetry:     maxRetry,
+		}
+		for range testCase.Retry {
+			timer.Increase()
+		}
+		assert.Equal(
+			t,
+			testCase.Expect,
+			timer.Duration(),
+		)
+	}
+}


### PR DESCRIPTION
* increases polling interval to 3 seconds for `ListJobRunAttempts`
* When rate limits are hit, doesn't treat it as a fatal error and continues polling.
* misc: handle pagination token