### PR TITLE
emr_serverless: add support for spark logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.64
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.28.1
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.52.0
 	github.com/charmbracelet/bubbletea v1.1.2
 	github.com/databricks/databricks-sql-go v1.6.0
 	github.com/denisbrodbeck/machineid v1.0.1
@@ -81,7 +82,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.52.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.29.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 // indirect

--- a/pkg/emr_serverless/logs.go
+++ b/pkg/emr_serverless/logs.go
@@ -1,0 +1,27 @@
+package emr_serverless //nolint
+
+import (
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type LogLine struct {
+	Stream  string
+	Message string
+}
+
+type S3LogConsumer struct {
+	s3cli s3.Client
+	uri   *url.URL
+}
+
+func (l S3LogConsumer) Next() []LogLine {
+	return nil
+}
+
+type NoOpLogConsumer struct{}
+
+func (l NoOpLogConsumer) Next() []LogLine {
+	return nil
+}

--- a/pkg/emr_serverless/logs.go
+++ b/pkg/emr_serverless/logs.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
-	"fmt"
 	"net/url"
 	"strings"
 	"sync"
@@ -24,7 +23,7 @@ type logState struct {
 }
 
 type S3LogConsumer struct {
-	Ctx   context.Context
+	Ctx   context.Context //nolint
 	S3cli *s3.Client
 	URI   *url.URL
 	RunID string
@@ -34,7 +33,7 @@ type S3LogConsumer struct {
 	state map[string]logState
 }
 
-func (l *S3LogConsumer) Next() (lines []LogLine) {
+func (l *S3LogConsumer) Next() (lines []LogLine) { //nolint
 	l.once.Do(func() {
 		l.state = make(map[string]logState)
 	})
@@ -45,7 +44,7 @@ func (l *S3LogConsumer) Next() (lines []LogLine) {
 	return lines
 }
 
-func (l *S3LogConsumer) readStream(stream string) (lines []LogLine) {
+func (l *S3LogConsumer) readStream(stream string) (lines []LogLine) { //nolint
 
 	if !l.hasNewLogs(stream) {
 		return nil
@@ -82,7 +81,7 @@ func (l *S3LogConsumer) readStream(stream string) (lines []LogLine) {
 		read: len(lines) + l.state[stream].read,
 		size: *logStream.ContentLength,
 	}
-	return
+	return //nolint
 }
 
 func (l *S3LogConsumer) logFile(stream string) string {
@@ -92,7 +91,7 @@ func (l *S3LogConsumer) logFile(stream string) string {
 		"jobs",
 		l.RunID,
 		"SPARK_DRIVER",
-		fmt.Sprintf("%s.gz", stream),
+		stream+".gz",
 	).Path
 
 	return strings.TrimPrefix(fullPath, "/")

--- a/pkg/emr_serverless/logs.go
+++ b/pkg/emr_serverless/logs.go
@@ -1,7 +1,13 @@
 package emr_serverless //nolint
 
 import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"fmt"
 	"net/url"
+	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
@@ -11,17 +17,79 @@ type LogLine struct {
 	Message string
 }
 
-type S3LogConsumer struct {
-	s3cli s3.Client
-	uri   *url.URL
+type logState struct {
+	size int
+	read int
 }
 
-func (l S3LogConsumer) Next() []LogLine {
-	return nil
+type S3LogConsumer struct {
+	Ctx   context.Context
+	S3cli *s3.Client
+	URI   *url.URL
+	RunID string
+	AppID string
+
+	once  sync.Once
+	state map[string]logState
+}
+
+func (l *S3LogConsumer) Next() (lines []LogLine) {
+	l.once.Do(func() {
+		l.state = make(map[string]logState)
+	})
+
+	lines = append(lines, l.readStream("stdout")...)
+	lines = append(lines, l.readStream("stderr")...)
+
+	return lines
+}
+
+func (l *S3LogConsumer) readStream(stream string) (lines []LogLine) {
+
+	file := l.logFile(stream)
+
+	// todo: check state to detect whether we need
+	// to pull logs or not
+	logStream, err := l.S3cli.GetObject(l.Ctx, &s3.GetObjectInput{
+		Bucket: &l.URI.Host,
+		Key:    &file,
+	})
+
+	if err != nil {
+		return nil
+	}
+	defer logStream.Body.Close()
+	gzReader, err := gzip.NewReader(logStream.Body)
+	if err != nil {
+		return nil
+	}
+	defer gzReader.Close()
+
+	scanner := bufio.NewScanner(gzReader)
+	for scanner.Scan() {
+		lines = append(lines, LogLine{
+			Stream:  stream,
+			Message: strings.TrimSpace(scanner.Text()),
+		})
+	}
+	return
+}
+
+func (l *S3LogConsumer) logFile(stream string) string {
+	fullPath := l.URI.JoinPath(
+		"applications",
+		l.AppID,
+		"jobs",
+		l.RunID,
+		"SPARK_DRIVER",
+		fmt.Sprintf("%s.gz", stream),
+	).Path
+
+	return strings.TrimPrefix(fullPath, "/")
 }
 
 type NoOpLogConsumer struct{}
 
-func (l NoOpLogConsumer) Next() []LogLine {
+func (l *NoOpLogConsumer) Next() []LogLine {
 	return nil
 }

--- a/pkg/emr_serverless/operator.go
+++ b/pkg/emr_serverless/operator.go
@@ -227,7 +227,7 @@ func (job Job) Run(ctx context.Context) (err error) { //nolint
 				previousState = latestRun.State
 			}
 			for _, line := range jobLogs.Next() {
-				job.logger.Printf("log | %s | %s ", line.Stream, line.Message)
+				job.logger.Printf("%s | %s ", line.Stream, line.Message)
 			}
 			if slices.Contains(terminalJobRunStates, latestRun.State) {
 				return nil

--- a/pkg/emr_serverless/operator.go
+++ b/pkg/emr_serverless/operator.go
@@ -140,7 +140,6 @@ type Job struct {
 }
 
 func (job Job) buildJobRunConfig() *emrserverless.StartJobRunInput {
-
 	cfg := &emrserverless.StartJobRunInput{
 		ApplicationId:           &job.params.ApplicationID,
 		Name:                    &job.asset.Name,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -575,13 +575,13 @@ func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset
 
 	logLocation := strings.TrimSpace(asset.Parameters["logs"])
 	if logLocation != "" {
-		logUri, err := url.Parse(logLocation)
+		logURI, err := url.Parse(logLocation)
 		if err != nil {
 			issues = append(issues, &Issue{
 				Task:        asset,
 				Description: "parameters.logs must be a valid URI",
 			})
-		} else if logUri.Scheme != "s3" {
+		} else if logURI.Scheme != "s3" {
 			issues = append(issues, &Issue{
 				Task:        asset,
 				Description: "parameters.logs must be a valid S3 URI",

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -570,6 +571,22 @@ func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset
 			Task:        asset,
 			Description: "parameters.execution_role must be an Amazon Resource Name (ARN)",
 		})
+	}
+
+	logLocation := strings.TrimSpace(asset.Parameters["logs"])
+	if logLocation != "" {
+		logUri, err := url.Parse(logLocation)
+		if err != nil {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "parameters.logs must be a valid URI",
+			})
+		} else if logUri.Scheme != "s3" {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "parameters.logs must be a valid S3 URI",
+			})
+		}
 	}
 	return issues, nil
 }


### PR DESCRIPTION
This change adds support for spark driver log streaming.

Currently, only streaming of s3 logs is supported. The log location can be specified either globally once in the application configuration, or can specified as a part of the asset definition, like so:
``` yaml
name: spark_job
type: emr_serverless.spark
parameters:
   entrypoint: s3://org-bucket/jobs/spark/script.py
   logs: s3://org-bucket/logs/
   application_id: emr_app_123
```

Both stdout and stderr are streamed. 