### PR TITLE
feat/athena/support profile

### DIFF
--- a/integration-tests/expected_connections_schema.json
+++ b/integration-tests/expected_connections_schema.json
@@ -146,6 +146,9 @@
         "secret_access_key": {
           "type": "string"
         },
+        "session_token": {
+          "type": "string"
+        },
         "query_results_path": {
           "type": "string"
         },
@@ -153,6 +156,9 @@
           "type": "string"
         },
         "database": {
+          "type": "string"
+        },
+        "profile": {
           "type": "string"
         }
       },
@@ -162,6 +168,7 @@
         "name",
         "access_key_id",
         "secret_access_key",
+        "session_token",
         "query_results_path",
         "region"
       ]

--- a/pkg/athena/config.go
+++ b/pkg/athena/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Region          string
 	AccessID        string
 	SecretAccessKey string
+	SessionToken    string
 	Database        string
 }
 
@@ -21,9 +22,13 @@ func (c *Config) ToDBConnectionURI() (string, error) {
 		return "", err
 	}
 
+	if c.SessionToken != "" {
+		conf.SetSessionToken(c.SessionToken)
+	}
+
 	conf.SetDB(c.Database)
 	if err != nil {
-		log.Fatalf("Failed to create Athena config: %v", err)
+		log.Fatalf("Failed to set database on Athena connection: %v", err)
 		return "", err
 	}
 
@@ -31,5 +36,9 @@ func (c *Config) ToDBConnectionURI() (string, error) {
 }
 
 func (c *Config) GetIngestrURI() string {
-	return "athena://?bucket=" + c.OutputBucket + "&access_key_id=" + c.AccessID + "&secret_access_key=" + c.SecretAccessKey + "&region_name=" + c.Region
+	str := "athena://?bucket=" + c.OutputBucket + "&access_key_id=" + c.AccessID + "&secret_access_key=" + c.SecretAccessKey + "&region_name=" + c.Region
+	if c.SessionToken != "" {
+		str += "&session_token=" + c.SessionToken
+	}
+	return str
 }

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
+	"github.com/aws/aws-sdk-go-v2/config"
 	"golang.org/x/oauth2/google"
 )
 
@@ -78,17 +81,80 @@ func (c GoogleCloudPlatformConnection) MarshalJSON() ([]byte, error) {
 	})
 }
 
-type AthenaConnection struct {
+type AthenaConnection struct { //nolint:recvcheck
 	Name             string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	AccessKey        string `yaml:"access_key_id,omitempty" json:"access_key_id" mapstructure:"access_key_id"`
 	SecretKey        string `yaml:"secret_access_key,omitempty" json:"secret_access_key" mapstructure:"secret_access_key"`
+	SessionToken     string `yaml:"session_token,omitempty" json:"session_token" mapstructure:"session_token"`
 	QueryResultsPath string `yaml:"query_results_path,omitempty" json:"query_results_path" mapstructure:"query_results_path"`
 	Region           string `yaml:"region,omitempty" json:"region" mapstructure:"region"`
 	Database         string `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
+	Profile          string `yaml:"profile,omitempty" json:"profile,omitempty" mapstructure:"profile"`
+
+	regionSetFromProfile bool
 }
 
 func (c AthenaConnection) GetName() string {
 	return c.Name
+}
+
+func (c *AthenaConnection) LoadCredentialsFromProfile(ctx context.Context) error {
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithSharedConfigProfile(c.Profile),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS credentials from profile %s: %w", c.Profile, err)
+	}
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve AWS credentials: %w", err)
+	}
+
+	c.AccessKey = creds.AccessKeyID
+	c.SecretKey = creds.SecretAccessKey
+	c.SessionToken = creds.SessionToken
+
+	if c.Region == "" {
+		c.Region = cfg.Region
+		c.regionSetFromProfile = true
+	}
+
+	return nil
+}
+
+func (c AthenaConnection) MarshalYAML() (interface{}, error) {
+	m := make(map[string]interface{})
+
+	if c.Name != "" {
+		m["name"] = c.Name
+	}
+
+	if c.QueryResultsPath != "" {
+		m["query_results_path"] = c.QueryResultsPath
+	}
+
+	if c.Database != "" {
+		m["database"] = c.Database
+	}
+
+	if c.Region != "" && !c.regionSetFromProfile {
+		m["region"] = c.Region
+	}
+
+	if c.Profile != "" {
+		m["profile"] = c.Profile
+		return m, nil
+	}
+
+	if c.AccessKey != "" {
+		m["access_key_id"] = c.AccessKey
+	}
+
+	if c.SecretKey != "" {
+		m["secret_access_key"] = c.SecretKey
+	}
+
+	return m, nil
 }
 
 type SynapseConnection struct {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1232,6 +1232,7 @@ func (m *Manager) GetAppLovinConnectionWithoutDefault(name string) (*applovin.Cl
 	}
 	return db, nil
 }
+
 func (m *Manager) GetFrankfurterConnection(name string) (*frankfurter.Client, error) {
 	db, err := m.GetFrankfurterConnectionWithoutDefault(name)
 	if err == nil {
@@ -1362,11 +1363,22 @@ func (m *Manager) AddAthenaConnectionFromConfig(connection *config.AthenaConnect
 		m.Athena = make(map[string]*athena.DB)
 	}
 
+	if connection.Profile != "" {
+		if connection.AccessKey != "" || connection.SecretKey != "" {
+			return errors.New("access_key and secret_key cannot be provided when profile is specified, you need specify either profile or access_key and secret_key")
+		}
+		err := connection.LoadCredentialsFromProfile(context.Background())
+		if err != nil {
+			return err
+		}
+	}
+
 	m.Athena[connection.Name] = athena.NewDB(&athena.Config{
 		Region:          connection.Region,
 		OutputBucket:    connection.QueryResultsPath,
 		AccessID:        connection.AccessKey,
 		SecretAccessKey: connection.SecretKey,
+		SessionToken:    connection.SessionToken,
 		Database:        connection.Database,
 	})
 

--- a/pkg/frankfurter/config.go
+++ b/pkg/frankfurter/config.go
@@ -1,7 +1,6 @@
 package frankfurter
 
-type Config struct {
-}
+type Config struct{}
 
 func (c *Config) GetIngestrURI() string {
 	return "frankfurter://"

--- a/pkg/salesforce/config.go
+++ b/pkg/salesforce/config.go
@@ -11,7 +11,7 @@ type Config struct {
 }
 
 func (c *Config) GetIngestrURI() string {
-	//salesforce://?username=<your_username>&password=<your_password>&token=<your_token>
+	// salesforce://?username=<your_username>&password=<your_password>&token=<your_token>
 	baseURL := "salesforce://"
 	params := url.Values{}
 	params.Add("username", c.Username)


### PR DESCRIPTION
This PR adds support for using `profile` for Athena and avoid replicating credentials. This also adds support for using the session token with ingestr.