### PR TITLE
Policies: add pipeline level rules

### DIFF
--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -8,7 +8,7 @@ This document explains how to define, configure, and use custom linting policies
 
 1. Create a `policy.yml` file in your project root.
 2. Define custom rules under `custom_rules` (optional if only using built-in rules).
-3. Group rules into `rulesets`, specifying which assets they should apply to using selectors.
+3. Group rules into `rulesets`, specifying which resource they should apply to using selectors.
 
 Example:
 
@@ -43,6 +43,10 @@ Each ruleset must include:
 - **rules**: List of rule names (built-in or custom) to apply.
 
 If a **selector** is not specified, the ruleset applies to **all assets**.
+
+>[!note]
+> Names be must alphanumeric or use dashes (`-`). This applies to both `rulesets` and `rules`.
+
 
 ### Selector Predicates
 
@@ -89,7 +93,7 @@ In this example:
 Custom lint rules are defined inside the `custom_rules` section of `policy.yml`.
 
 Each rule must include:
-- **name**: A unique name for the rule.
+- **name**: A unique name for the rule. 
 - **description**: A human-readable description of the rule.
 - **criteria**: An [expr](https://expr-lang.org/) boolean expression. If the expression evalutes to `true` then the asset passes validation.
 

--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -4,6 +4,8 @@ Bruin supports **policies** to verify that data transformation jobs follow best 
 
 This document explains how to define, configure, and use custom linting policies.
 
+> [!NOTE]
+> For the purpose of this document, a `resource` means either an `asset` or a `pipeline`.
 ## Quick Start
 
 1. Create a `policy.yml` file in your project root.
@@ -23,34 +25,34 @@ rulesets:
       - asset-has-description
 ```
 
-> 🚀 That's it! Bruin will now lint your assets according to these policies.
+> 🚀 That's it! Bruin will now lint your resources according to these policies.
 
-To verify that your assets satsify your policies, you can run:
+To verify that your resources satsify your policies, you can run:
 ```sh
 $ bruin validate /path/to/pipelines
 ```
 
 > [!tip]
-> `bruin run` normally runs lint before pipeline execution. So you can rest assured that any non-compliant assets will get stopped in it's tracks.
+> `bruin run` normally runs lint before pipeline execution. So you can rest assured that any non-compliant resources will get stopped in it's tracks.
 
 ## Rulesets
 
-A **ruleset** groups one or more rules together and specifies which assets they apply to, based on selectors.
+A **ruleset** groups one or more rules together and specifies which resources they apply to, based on selectors.
 
 Each ruleset must include:
 - **name**: A unique name for the ruleset.
-- **selector** (optional): One or more predicates to select the applicable assets.
+- **selector** (optional): One or more predicates to select the applicable resources.
 - **rules**: List of rule names (built-in or custom) to apply.
 
-If a **selector** is not specified, the ruleset applies to **all assets**.
+If a **selector** is not specified, the ruleset applies to **all resources**.
 
->[!note]
+>[!NOTE]
 > Names be must alphanumeric or use dashes (`-`). This applies to both `rulesets` and `rules`.
 
 
 ### Selector Predicates
 
-Selectors determine which assets a ruleset should apply to. Supported predicates are:
+Selectors determine which resources a ruleset should apply to. Supported predicates are:
 
 | Predicate | Target | Description |
 | :--- | :--- | :--- |
@@ -63,11 +65,11 @@ Each predicate is a regex string.
 
 > If multiple selectors are specified within a ruleset, **all selectors must match** for the ruleset to apply
 
-If no selectors are defined for a ruleset, **the ruleset applies to all assets/pipelines**. Some selectors only work with certain
+If no selectors are defined for a ruleset, **the ruleset applies to all resources**. Some selectors only work with certain
 rule targets. For instance `tag` selector only works for rules that [target](#targets) assets. Pipeline level rules will just ignore
 this selector. 
 
-> [!NOTE]
+> [!TIP]
 > If your ruleset only contains asset selectors, but uses `pipeline` rules, then those pipeline rules will apply to all pipelines. Make sure to define a `pipeline` or `path` selector if you don't intend for that to happen.
 
 ### Example
@@ -84,7 +86,7 @@ rulesets:
 ```
 
 In this example:
-- `production` applies **only** to assets that match both:
+- `production` applies **only** to resources that match both:
   - path regex `.*/production/.*`
   - and have a tag matching `critical`.
 
@@ -95,7 +97,7 @@ Custom lint rules are defined inside the `custom_rules` section of `policy.yml`.
 Each rule must include:
 - **name**: A unique name for the rule. 
 - **description**: A human-readable description of the rule.
-- **criteria**: An [expr](https://expr-lang.org/) boolean expression. If the expression evalutes to `true` then the asset passes validation.
+- **criteria**: An [expr](https://expr-lang.org/) boolean expression. If the expression evalutes to `true` then the resource passes validation.
 
 ### Example
 

--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -14,13 +14,13 @@ Example:
 
 ```yaml
 rulesets:
-  - name: ruleset_1
+  - name: ruleset-1
     selector:
       - path: .*/foo/.*
     rules:
-      - asset_has_owner
-      - asset_name_is_lowercase
-      - asset_has_description
+      - asset-has-owner
+      - asset-name-is-lowercase
+      - asset-has-description
 ```
 
 > 🚀 That's it! Bruin will now lint your assets according to these policies.
@@ -70,8 +70,8 @@ rulesets:
       - path: .*/prod/.*
       - tag: critical
     rules:
-      - asset_has_owner
-      - asset_name_is_lowercase
+      - asset-has-owner
+      - asset-name-is-lowercase
 ```
 
 In this example:
@@ -94,7 +94,7 @@ Each rule must include:
 
 ```yaml
 custom_rules:
-  - name: asset_has_owner
+  - name: asset-has-owner
     description: every asset should have an owner
     criteria: asset.Owner != ""
 ```
@@ -118,11 +118,11 @@ Bruin provides a set of built-in lint rules that are ready to use without requir
 
 | Rule | Description |
 | :--- | :--- |
-| `asset_name_is_lowercase` | Asset names must be in lowercase. |
-| `asset_name_is_schema_dot_table` | Asset names must follow the format `schema.table`. |
-| `asset_has_description` | Assets must have a description. |
-| `asset_has_owner` | Assets must have an owner assigned. |
-| `asset_has_columns` | Assets must define their columns. |
+| `asset-name-is-lowercase` | Asset names must be in lowercase. |
+| `asset-name-is-schema-dot-table` | Asset names must follow the format `schema.table`. |
+| `asset-has-description` | Assets must have a description. |
+| `asset-has-owner` | Assets must have an owner assigned. |
+| `asset-has-columns` | Assets must define their columns. |
 
 You can directly reference these rules in `rulesets[*].rules`.
 
@@ -130,7 +130,7 @@ You can directly reference these rules in `rulesets[*].rules`.
 
 ```yaml
 custom_rules:
-  - name: asset_has_owner
+  - name: asset-has-owner
     description: every asset should have an owner
     criteria: asset.Owner != ""
 
@@ -140,15 +140,15 @@ rulesets:
       - path: .*/production/.*
       - tag: critical
     rules:
-      - asset_has_owner
-      - asset_name_is_lowercase
-      - asset_has_description
+      - asset-has-owner
+      - asset-name-is-lowercase
+      - asset-has-description
   - name: staging
     selector:
       - asset: stage.*
       - pipeline: staging
     rules:
-      - asset_name_is_lowercase
+      - asset-name-is-lowercase
 ```
 
 

--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -90,7 +90,7 @@ rulesets:
 
 In this example:
 - `production` applies **only** to resources that match both:
-  - path regex `.*/production/.*`
+  - path regex `.*/prod/.*`
   - and have a tag matching `critical`.
 
 ## Custom Rules

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -41,24 +41,28 @@ rulesets:
     
   - name: select_by_tag
     selector:
+      - pipeline: policy-selector
       - tag: test
     rules:
       - asset_has_sql_tag
 
   - name: fail_case_1
     selector:
+      - pipeline: non-compliant-policies 
       - asset: "^non_compliant.primary$"
     rules:
       - asset_has_three_columns
   
   - name: fail_case_2
     selector:
+      - pipeline: non-compliant-policies 
       - asset: "^non_compliant.secondary$"
     rules:
       - asset_name_contains_public
     
   - name: fail_case_3
     selector:
+      - pipeline: non-compliant-policies 
       - asset: "^non_compliant.tertiary$"
     rules:
       - asset_has_owner

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -1,68 +1,68 @@
 custom_rules:
-  - name: asset_has_three_columns
+  - name: asset-has-three-columns
     description: "Asset should have three columns"
     criteria: len(asset.Columns) == 3
-  - name: asset_name_contains_public
+  - name: asset-name-contains-public
     description: "Asset name should contain the word public"
     criteria: indexOf(asset.Name, "public") != -1
-  - name: asset_has_sql_tag
+  - name: asset-has-sql-tag
     description: "Asset should have sql tag"
     criteria: "'sql' in asset.Tags"
 
 rulesets:
-  - name: builtin_policies
+  - name: builtin-policies
     selector:
       - path: .*/builtin-policies/.*
     rules:
-      - asset_name_is_lowercase
-      - asset_name_is_schema_dot_table
-      - asset_has_description
-      - asset_has_owner
-      - asset_has_columns
+      - asset-name-is-lowercase
+      - asset-name-is-schema-dot-table
+      - asset-has-description
+      - asset-has-owner
+      - asset-has-columns
 
-  - name: cutom_policy
+  - name: cutom-policy
     selector:
       - path: .*/custom-policies/.*
     rules:
-      - asset_has_three_columns
+      - asset-has-three-columns
 
-  - name: select_asset
+  - name: select-asset
     selector:
       - asset: .*\.primary
       - path: .*/policies-selector/.*
     rules:
-      - asset_name_contains_public
+      - asset-name-contains-public
 
-  - name: select_pipeline
+  - name: select-pipeline
     selector:
       - pipeline: policy-selector
     rules:
-      - asset_has_description
+      - asset-has-description
     
-  - name: select_by_tag
+  - name: select-by-tag
     selector:
       - pipeline: policy-selector
       - tag: test
     rules:
-      - asset_has_sql_tag
+      - asset-has-sql-tag
 
-  - name: fail_case_1
+  - name: fail-case-1
     selector:
       - pipeline: non-compliant-policies 
-      - asset: "^non_compliant.primary$"
+      - asset: "^non-compliant.primary$"
     rules:
-      - asset_has_three_columns
+      - asset-has-three-columns
   
-  - name: fail_case_2
+  - name: fail-case-2
     selector:
       - pipeline: non-compliant-policies 
-      - asset: "^non_compliant.secondary$"
+      - asset: "^non-compliant.secondary$"
     rules:
-      - asset_name_contains_public
+      - asset-name-contains-public
     
-  - name: fail_case_3
+  - name: fail-case-3
     selector:
       - pipeline: non-compliant-policies 
-      - asset: "^non_compliant.tertiary$"
+      - asset: "^non-compliant.tertiary$"
     rules:
-      - asset_has_owner
+      - asset-has-owner

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -37,7 +37,7 @@ type RuleTarget string
 
 var (
 	RuleTargetAsset    = RuleTarget("asset")
-	RuleTargetPipeline = RuleTarget("asset")
+	RuleTargetPipeline = RuleTarget("pipeline")
 )
 
 // todo: set default

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -24,7 +24,10 @@ var (
 	errEmptyCriteria = errors.New("Criteria is empty")
 	errNoRules       = errors.New("No rules specified")
 	errNoSuchTarget  = errors.New("No such target")
+	errBadName       = errors.New("Only alphanumeric characters and dash allowed")
 )
+
+var validRulePattern = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
 
 type assetValidatorEnv struct {
 	Asset    *pipeline.Asset    `expr:"asset"`
@@ -70,6 +73,9 @@ func (def *RuleDefinition) validate() error {
 	if strings.TrimSpace(def.Name) == "" {
 		return errEmptyName
 	}
+	if !validRulePattern.MatchString(def.Name) {
+		return errBadName
+	}
 	if strings.TrimSpace(def.Description) == "" {
 		return errEmptyDesc
 	}
@@ -112,6 +118,9 @@ type RuleSet struct {
 func (rs *RuleSet) validate() error {
 	if strings.TrimSpace(rs.Name) == "" {
 		return errEmptyName
+	}
+	if !validRulePattern.MatchString(rs.Name) {
+		return errBadName
 	}
 	if len(rs.Rules) == 0 {
 		return errNoRules

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -278,7 +278,6 @@ func withSelector(selector []map[string]any, downstream validators) validators {
 			return downstream.Asset(ctx, pipeline, asset)
 		},
 	}
-
 }
 
 func doesSelectorMatch(selectors []map[string]any, pipeline *pipeline.Pipeline, asset *pipeline.Asset) (bool, error) {

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -134,6 +134,12 @@ func (spec *PolicySpecification) init() error {
 		if err != nil {
 			return fmt.Errorf("invalid rule definition at index %d: %w", idx, err)
 		}
+		if spec.compiledRules[def.Name] != nil {
+			return fmt.Errorf("duplicate rule: %s", def.Name)
+		}
+		if _, exists := builtinRules[def.Name]; exists {
+			return fmt.Errorf("rule is builtin: %s", def.Name)
+		}
 		if err := def.compile(); err != nil {
 			return err
 		}

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -267,6 +267,10 @@ func withSelector(selector []map[string]any, downstream validators) validators {
 func doesSelectorMatch(selectors []map[string]any, pipeline *pipeline.Pipeline, asset *pipeline.Asset) (bool, error) {
 	for _, sel := range selectors {
 		for key, val := range sel {
+			if asset == nil && slices.Contains([]string{"asset", "tag"}, key) {
+				continue
+			}
+
 			pattern, ok := val.(string)
 			if !ok {
 				return false, fmt.Errorf("invalid selector value for key %s: %v", key, val)
@@ -278,7 +282,11 @@ func doesSelectorMatch(selectors []map[string]any, pipeline *pipeline.Pipeline, 
 			case "asset":
 				subject = asset.Name
 			case "path":
-				subject = asset.ExecutableFile.Path
+				if asset == nil {
+					subject = pipeline.DefinitionFile.Path
+				} else {
+					subject = asset.ExecutableFile.Path
+				}
 			case "tag":
 				subject = strings.Join(asset.Tags, " ")
 			default:

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -175,8 +175,10 @@ func (spec *PolicySpecification) Rules() ([]Rule, error) {
 func (spec *PolicySpecification) getValidators(name string) (validators, bool) {
 	def, found := spec.compiledRules[name]
 	if !found {
-		return validators{}, false
+		validators, found := builtinRules[name]
+		return validators, found
 	}
+
 	v := validators{}
 
 	switch def.RuleTarget {

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -7,62 +7,79 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
-var builtinRules = map[string]AssetValidator{
-	"asset_name_is_lowercase": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
-		if strings.ToLower(asset.Name) == asset.Name {
-			return nil, nil
-		}
+func validatorsFromAssetValidator(av AssetValidator) validators {
+	return validators{
+		Pipeline: CallFuncForEveryAsset(av),
+		Asset:    av,
+	}
+}
 
-		return []*Issue{
-			{
-				Task:        asset,
-				Description: "Asset name must be lowercase",
-			},
-		}, nil
-	},
-	"asset_name_is_schema_dot_table": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
-		if strings.Count(asset.Name, ".") == 1 {
-			return nil, nil
-		}
+var builtinRules = map[string]validators{
+	"asset_name_is_lowercase": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if strings.ToLower(asset.Name) == asset.Name {
+				return nil, nil
+			}
 
-		return []*Issue{
-			{
-				Task:        asset,
-				Description: "Asset name must be of the form {schema}.{table}",
-			},
-		}, nil
-	},
-	"asset_has_description": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
-		if strings.TrimSpace(asset.Description) != "" {
-			return nil, nil
-		}
-		return []*Issue{
-			{
-				Task:        asset,
-				Description: "Asset must have a description",
-			},
-		}, nil
-	},
-	"asset_has_owner": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
-		if strings.TrimSpace(asset.Owner) != "" {
-			return nil, nil
-		}
-		return []*Issue{
-			{
-				Task:        asset,
-				Description: "Asset must have an owner",
-			},
-		}, nil
-	},
-	"asset_has_columns": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
-		if len(asset.Columns) > 0 {
-			return nil, nil
-		}
-		return []*Issue{
-			{
-				Task:        asset,
-				Description: "Asset must have columns",
-			},
-		}, nil
-	},
+			return []*Issue{
+				{
+					Task:        asset,
+					Description: "Asset name must be lowercase",
+				},
+			}, nil
+		},
+	),
+	"asset_name_is_schema_dot_table": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if strings.Count(asset.Name, ".") == 1 {
+				return nil, nil
+			}
+
+			return []*Issue{
+				{
+					Task:        asset,
+					Description: "Asset name must be of the form {schema}.{table}",
+				},
+			}, nil
+		},
+	),
+	"asset_has_description": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if strings.TrimSpace(asset.Description) != "" {
+				return nil, nil
+			}
+			return []*Issue{
+				{
+					Task:        asset,
+					Description: "Asset must have a description",
+				},
+			}, nil
+		},
+	),
+	"asset_has_owner": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if strings.TrimSpace(asset.Owner) != "" {
+				return nil, nil
+			}
+			return []*Issue{
+				{
+					Task:        asset,
+					Description: "Asset must have an owner",
+				},
+			}, nil
+		},
+	),
+	"asset_has_columns": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if len(asset.Columns) > 0 {
+				return nil, nil
+			}
+			return []*Issue{
+				{
+					Task:        asset,
+					Description: "Asset must have columns",
+				},
+			}, nil
+		},
+	),
 }

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -1,0 +1,68 @@
+package lint
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+)
+
+var builtinRules = map[string]AssetValidator{
+	"asset_name_is_lowercase": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		if strings.ToLower(asset.Name) == asset.Name {
+			return nil, nil
+		}
+
+		return []*Issue{
+			{
+				Task:        asset,
+				Description: "Asset name must be lowercase",
+			},
+		}, nil
+	},
+	"asset_name_is_schema_dot_table": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		if strings.Count(asset.Name, ".") == 1 {
+			return nil, nil
+		}
+
+		return []*Issue{
+			{
+				Task:        asset,
+				Description: "Asset name must be of the form {schema}.{table}",
+			},
+		}, nil
+	},
+	"asset_has_description": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		if strings.TrimSpace(asset.Description) != "" {
+			return nil, nil
+		}
+		return []*Issue{
+			{
+				Task:        asset,
+				Description: "Asset must have a description",
+			},
+		}, nil
+	},
+	"asset_has_owner": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		if strings.TrimSpace(asset.Owner) != "" {
+			return nil, nil
+		}
+		return []*Issue{
+			{
+				Task:        asset,
+				Description: "Asset must have an owner",
+			},
+		}, nil
+	},
+	"asset_has_columns": func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		if len(asset.Columns) > 0 {
+			return nil, nil
+		}
+		return []*Issue{
+			{
+				Task:        asset,
+				Description: "Asset must have columns",
+			},
+		}, nil
+	},
+}

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -15,7 +15,7 @@ func validatorsFromAssetValidator(av AssetValidator) validators {
 }
 
 var builtinRules = map[string]validators{
-	"asset_name_is_lowercase": validatorsFromAssetValidator(
+	"asset-name-is-lowercase": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			if strings.ToLower(asset.Name) == asset.Name {
 				return nil, nil
@@ -29,7 +29,7 @@ var builtinRules = map[string]validators{
 			}, nil
 		},
 	),
-	"asset_name_is_schema_dot_table": validatorsFromAssetValidator(
+	"asset-name-is-schema-dot-table": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			if strings.Count(asset.Name, ".") == 1 {
 				return nil, nil
@@ -43,7 +43,7 @@ var builtinRules = map[string]validators{
 			}, nil
 		},
 	),
-	"asset_has_description": validatorsFromAssetValidator(
+	"asset-has-description": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			if strings.TrimSpace(asset.Description) != "" {
 				return nil, nil
@@ -56,7 +56,7 @@ var builtinRules = map[string]validators{
 			}, nil
 		},
 	),
-	"asset_has_owner": validatorsFromAssetValidator(
+	"asset-has-owner": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			if strings.TrimSpace(asset.Owner) != "" {
 				return nil, nil
@@ -69,7 +69,7 @@ var builtinRules = map[string]validators{
 			}, nil
 		},
 	),
-	"asset_has_columns": validatorsFromAssetValidator(
+	"asset-has-columns": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			if len(asset.Columns) > 0 {
 				return nil, nil

--- a/pkg/lint/policy_test.go
+++ b/pkg/lint/policy_test.go
@@ -1,7 +1,6 @@
 package lint_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/lint"
@@ -102,7 +101,7 @@ func TestPolicyRuleDefinition(t *testing.T) {
 			spec := &lint.PolicySpecification{
 				RuleSets: []lint.RuleSet{
 					{
-						Name:  fmt.Sprintf("ruleset-%s", invalid),
+						Name:  "ruleset-" + invalid,
 						Rules: []string{invalid},
 					},
 				},
@@ -131,7 +130,7 @@ func TestPolicyRuleDefinition(t *testing.T) {
 			spec := &lint.PolicySpecification{
 				RuleSets: []lint.RuleSet{
 					{
-						Name:  fmt.Sprintf("ruleset-%s", invalid),
+						Name:  "ruleset-" + invalid,
 						Rules: []string{"placeholder"},
 					},
 				},

--- a/pkg/lint/policy_test.go
+++ b/pkg/lint/policy_test.go
@@ -1,6 +1,7 @@
 package lint_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/lint"
@@ -88,6 +89,63 @@ func TestPolicyRuleDefinition(t *testing.T) {
 		}
 		_, err := spec.Rules()
 		assert.Error(t, err)
+	})
+	t.Run("rule name must only be alpha-numeric and dash", func(t *testing.T) {
+		t.Parallel()
+		invalidNames := []string{
+			"rule one",
+			"rule.two",
+			"rule?three",
+			"rule/four",
+		}
+		for _, invalid := range invalidNames {
+			spec := &lint.PolicySpecification{
+				RuleSets: []lint.RuleSet{
+					{
+						Name:  fmt.Sprintf("ruleset-%s", invalid),
+						Rules: []string{invalid},
+					},
+				},
+				Definitions: []*lint.RuleDefinition{
+					{
+						Name:        invalid,
+						Description: "unit test",
+						Criteria:    "true",
+					},
+				},
+			}
+			_, err := spec.Rules()
+			assert.Error(t, err)
+		}
+	})
+
+	t.Run("ruleset name must only be alpha-numeric and dash", func(t *testing.T) {
+		t.Parallel()
+		invalidNames := []string{
+			"rule set one",
+			"rule.set.two",
+			"rule?set?three",
+			"rule/set/four",
+		}
+		for _, invalid := range invalidNames {
+			spec := &lint.PolicySpecification{
+				RuleSets: []lint.RuleSet{
+					{
+						Name:  fmt.Sprintf("ruleset-%s", invalid),
+						Rules: []string{"placeholder"},
+					},
+				},
+				Definitions: []*lint.RuleDefinition{
+					{
+						Name:        "placeholder",
+						Description: "unit test",
+						Criteria:    "true",
+					},
+				},
+			}
+			_, err := spec.Rules()
+			assert.Error(t, err)
+		}
 	})
 }
 

--- a/pkg/lint/policy_test.go
+++ b/pkg/lint/policy_test.go
@@ -50,6 +50,45 @@ func TestPolicyRuleDefinition(t *testing.T) {
 		_, err := spec.Rules()
 		assert.Error(t, err)
 	})
+	t.Run("every rule must have a unique name", func(t *testing.T) {
+		t.Parallel()
+		spec := &lint.PolicySpecification{
+			Definitions: []*lint.RuleDefinition{
+				{
+					Name:        "unique-rule",
+					Description: "I am unique",
+					Criteria:    "true",
+				},
+				{
+					Name:        "unique-rule",
+					Description: "I am unique",
+					Criteria:    "true",
+				},
+			},
+		}
+		_, err := spec.Rules()
+		assert.Error(t, err)
+	})
+
+	t.Run("custom rules cannot shadow builtin rules", func(t *testing.T) {
+		t.Parallel()
+		spec := &lint.PolicySpecification{
+			Definitions: []*lint.RuleDefinition{
+				{
+					Name:        "unique-rule",
+					Description: "I am unique",
+					Criteria:    "true",
+				},
+				{
+					Name:        "asset-has-description",
+					Description: "I am unique",
+					Criteria:    "true",
+				},
+			},
+		}
+		_, err := spec.Rules()
+		assert.Error(t, err)
+	})
 }
 
 func TestPolicyRuleSet(t *testing.T) {


### PR DESCRIPTION
This change adds a `target` to rule definitions. This can be used to control at what level of the job hierachy the rule applies.

Valid values: `asset` or `pipeline`. If the key is omitted, it defaults to `asset`.


**Example**
```yaml
custom_rules:

  - name: pipline-must-have-prefix-acme
    description: Pipeline names must start with the prefix 'acme'
    criteria: pipeline.Name startsWith 'acme'
    target: pipeline

  - name: asset-name-must-be-layer-dot-schema-dot-table
    description: Asset names must be of the form {layer}.{schema}.{table}
    criteria: len(split(asset.Name, '.')) == 3
    target: asset # optional

ruleset:
  - name: std
    rules:
      - pipeline-must-have-prefix-acme
      - asset-name-must-be-layer-dot-schema-dot-table
```

**Note**
`pipeline` target doesn't work with certain selectors. In particular `asset` and `tag` selectors are not supported. If they're specified in combination with `pipeline` rules, they're ignored.