### PR TITLE
policies/additional builtin rules/BRU 1918

### DIFF
--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -157,13 +157,85 @@ In the future we will create dedicated schemas for custom rules with standards a
 
 Bruin provides a set of built-in lint rules that are ready to use without requiring a definition.
 
-| Rule | Target | Description |
-| :--- | :--- | :--- |
-| `asset-name-is-lowercase` | `asset` | Asset names must be in lowercase. |
-| `asset-name-is-schema-dot-table`  | `asset` | Asset names must follow the format `schema.table`. |
-| `asset-has-description` | `asset` | Assets must have a description. |
-| `asset-has-owner` | `asset` | Assets must have an owner assigned. |
-| `asset-has-columns` | `asset` | Assets must define their columns. |
+Here is your markdown table converted to an HTML table:
+
+<table>
+  <thead>
+    <tr>
+      <th width="45%">Rule</th>
+      <th>Target</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>asset-name-is-lowercase</code></td>
+      <td><code>asset</code></td>
+      <td>Asset names must be in lowercase.</td>
+    </tr>
+    <tr>
+      <td><code>asset-name-is-schema-dot-table</code></td>
+      <td><code>asset</code></td>
+      <td>Asset names must follow the format <code>schema.table</code>.</td>
+    </tr>
+    <tr>
+      <td><code>asset-has-description</code></td>
+      <td><code>asset</code></td>
+      <td>Assets must have a description.</td>
+    </tr>
+    <tr>
+      <td><code>asset-has-owner</code></td>
+      <td><code>asset</code></td>
+      <td>Assets must have an owner assigned.</td>
+    </tr>
+    <tr>
+      <td><code>asset-has-columns</code></td>
+      <td><code>asset</code></td>
+      <td>Assets must define their columns.</td>
+    </tr>
+    <tr>
+      <td><code>asset-has-primary-key</code></td>
+      <td><code>asset</code></td>
+      <td>Assets must define at least one column as a primary key.</td>
+    </tr>
+    <tr>
+      <td><code>asset-has-checks</code></td>
+      <td><code>asset</code></td>
+      <td>Asset must have at least one custom check.</td>
+    </tr>
+    <tr>
+      <td><code>asset-has-tags</code></td>
+      <td><code>asset</code></td>
+      <td>Asset must have at least one tag.</td>
+    </tr>
+    <tr>
+      <td><code>column-has-description</code></td>
+      <td><code>asset</code></td>
+      <td>All columns declared by Asset must have description.</td>
+    </tr>
+    <tr>
+      <td><code>column-name-is-snake-case</code></td>
+      <td><code>asset</code></td>
+      <td>Column names must be in <code>snake_case</code>.</td>
+    </tr>
+    <tr>
+      <td><code>column-name-is-camel-case</code></td>
+      <td><code>asset</code></td>
+      <td>Column names must be in <code>camelCase</code>.</td>
+    </tr>
+    <tr>
+      <td><code>column-type-is-valid-for-platform</code></td>
+      <td><code>asset</code></td>
+      <td>Ensure that column types declared by asset are valid types in the relevant platform (BigQuery and Snowflake only).</td>
+    </tr>
+    <tr>
+      <td><code>description-must-not-be-placeholder</code></td>
+      <td><code>asset</code></td>
+      <td><code>asset</code> and <code>column</code> descriptions must not contain placeholder strings</td>
+    </tr>
+  </tbody>
+</table>
+
 
 You can directly reference these rules in `rulesets[*].rules`.
 

--- a/integration-tests/integration-test.go
+++ b/integration-tests/integration-test.go
@@ -466,7 +466,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Successfully validated 1 assets across 1 pipeline"},
+				Contains: []string{"Successfully validated 2 assets across 1 pipeline"},
 			},
 			WorkingDir: currentFolder,
 			Asserts: []func(*e2e.Task) error{

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -12,17 +12,18 @@ custom_rules:
 rulesets:
   - name: builtin-policies
     selector:
-      - path: .*/builtin-policies/.*
+      - path: .*/policies-builtin/.*
     rules:
       - asset-name-is-lowercase
       - asset-name-is-schema-dot-table
       - asset-has-description
       - asset-has-owner
       - asset-has-columns
+      - asset-has-primary-key
 
   - name: cutom-policy
     selector:
-      - path: .*/custom-policies/.*
+      - path: .*/policies-custom/.*
     rules:
       - asset-has-three-columns
 

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -12,7 +12,7 @@ custom_rules:
 rulesets:
   - name: builtin-policies
     selector:
-      - path: .*/policies-builtin/.*
+      - path: .*/policies-builtin/.*standard.sql
       - asset: public.standard
     rules:
       - asset-name-is-lowercase
@@ -27,12 +27,13 @@ rulesets:
       - column-has-type
       - column-name-is-snake-case
 
-  - name: builtin-policies-alternative
-    selector:
-      - path: .*/policies-builtin/.*
-      - asset: public.alternative
-    rules:
-      - column-name-is-camel-case
+  # note(turtledev): temporarily disabled
+  # - name: builtin-policies-alternative
+  #   selector:
+  #     - path: .*/policies-builtin/.*
+  #     - asset: public.alternative
+  #   rules:
+  #     - column-name-is-camel-case
 
   - name: cutom-policy
     selector:

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -20,6 +20,7 @@ rulesets:
       - asset-has-owner
       - asset-has-columns
       - asset-has-primary-key
+      - asset-has-checks
       - column-has-description
 
   - name: cutom-policy

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -13,6 +13,7 @@ rulesets:
   - name: builtin-policies
     selector:
       - path: .*/policies-builtin/.*
+      - asset: public.standard
     rules:
       - asset-name-is-lowercase
       - asset-name-is-schema-dot-table
@@ -24,6 +25,13 @@ rulesets:
       - column-has-description
       - column-has-type
       - column-name-is-snake-case
+
+  - name: builtin-policies-alternative
+    selector:
+      - path: .*/policies-builtin/.*
+      - asset: public.alternative
+    rules:
+      - column-name-is-camel-case
 
   - name: cutom-policy
     selector:

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -23,6 +23,7 @@ rulesets:
       - asset-has-checks
       - column-has-description
       - column-has-type
+      - column-name-is-snake-case
 
   - name: cutom-policy
     selector:

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -22,6 +22,7 @@ rulesets:
       - asset-has-primary-key
       - asset-has-checks
       - column-has-description
+      - column-has-type
 
   - name: cutom-policy
     selector:

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -22,6 +22,7 @@ rulesets:
       - asset-has-columns
       - asset-has-primary-key
       - asset-has-checks
+      - asset-has-tags
       - column-has-description
       - column-has-type
       - column-name-is-snake-case

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -20,6 +20,7 @@ rulesets:
       - asset-has-owner
       - asset-has-columns
       - asset-has-primary-key
+      - column-has-description
 
   - name: cutom-policy
     selector:

--- a/integration-tests/test-pipelines/policies-builtin/assets/alternative.sql
+++ b/integration-tests/test-pipelines/policies-builtin/assets/alternative.sql
@@ -1,0 +1,15 @@
+/* @bruin
+name: public.alternative
+type: bq.sql
+description: |
+    This pipeline demonstrates the use of the standard policy.
+owner: engineering@getbruin.com
+columns:
+    - name: msgOfTheDay
+
+custom_checks:
+    - name: proof of concept
+      query: select true
+@bruin */
+
+select "easy comes easy goes" as msgOfTheDay

--- a/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
+++ b/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
@@ -9,6 +9,10 @@ columns:
       type: string
       primary_key: true
       description: The contents of the message
+
+custom_checks:
+    - name: proof of concept
+      query: select true
 @bruin */
 
 select "I'm the standard" as msg

--- a/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
+++ b/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
@@ -7,6 +7,7 @@ owner: engineering@getbruin.com
 columns:
     - name: msg
       type: string
+      primary_key: true
 @bruin */
 
 select "I'm the standard" as msg

--- a/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
+++ b/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
@@ -8,6 +8,7 @@ columns:
     - name: msg
       type: string
       primary_key: true
+      description: The contents of the message
 @bruin */
 
 select "I'm the standard" as msg

--- a/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
+++ b/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
@@ -5,10 +5,12 @@ description: |
     This pipeline demonstrates the use of the standard policy.
 owner: engineering@getbruin.com
 columns:
-    - name: msg
-      type: string
-      primary_key: true
-      description: The contents of the message
+  - name: msg
+    type: string
+    primary_key: true
+    description: The contents of the message
+tags:
+  - layer:raw
 
 custom_checks:
     - name: proof of concept

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -24,6 +24,86 @@ var (
 	camelCasePattern = regexp.MustCompile("^[a-z]+(?:[A-Z][a-z0-9])*$")
 )
 
+var validBigQueryTypes = map[string]struct{}{
+	"string":     {},
+	"bytes":      {},
+	"int64":      {},
+	"integer":    {}, // Alias for int64
+	"smallint":   {}, // Alias for int64
+	"tinyint":    {}, // Alias for int64
+	"byteint":    {}, // Alias for int64
+	"float64":    {},
+	"numeric":    {},
+	"decimal":    {}, // Alias for numeric
+	"bignumeric": {},
+	"bigdecimal": {}, // Alias for bignumeric
+	"bool":       {},
+	"boolean":    {}, // Alias for bool
+	"timestamp":  {},
+	"date":       {},
+	"time":       {},
+	"datetime":   {},
+	"interval":   {},
+	"geography":  {},
+	"json":       {},
+	"struct":     {}, // Type parameters are not validated here
+	"array":      {}, // Type parameters are not validated here
+	"range":      {}, // Type parameters are not validated here
+}
+
+var validSnowflakeTypes = map[string]struct{}{
+	"number":           {},
+	"decimal":          {}, // Alias for number
+	"numeric":          {}, // Alias for number
+	"int":              {}, // Alias for number
+	"integer":          {}, // Alias for number
+	"bigint":           {}, // Alias for number
+	"smallint":         {}, // Alias for number
+	"tinyint":          {}, // Alias for number
+	"byteint":          {}, // Alias for number
+	"float":            {},
+	"float4":           {}, // Alias for float
+	"float8":           {}, // Alias for float
+	"double":           {}, // Alias for float
+	"double precision": {}, // Alias for float
+	"real":             {}, // Alias for float
+	"varchar":          {},
+	"char":             {}, // Alias for varchar
+	"character":        {}, // Alias for varchar
+	"string":           {}, // Alias for varchar
+	"text":             {}, // Alias for varchar
+	"binary":           {},
+	"varbinary":        {}, // Alias for binary
+	"boolean":          {},
+	"date":             {},
+	"datetime":         {}, // Alias for timestamp_ntz
+	"time":             {},
+	"timestamp":        {}, // Alias for timestamp_ntz by default
+	"timestamp_ltz":    {},
+	"timestamp_ntz":    {},
+	"timestamp_tz":     {},
+	"variant":          {},
+	"object":           {},
+	"array":            {},
+	"geography":        {},
+	"geometry":         {},
+	"vector":           {},
+}
+
+var placeholderDescriptions = []string{
+	"todo",
+	"fixme",
+	"tbd",
+	"wip",
+	"temp",
+	"temporary",
+	"placeholder",
+	"add description",
+	"description goes here",
+	"to be added",
+	"work in progress",
+}
+
 var builtinRules = map[string]validators{
 	"asset-name-is-lowercase": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -212,6 +292,96 @@ var builtinRules = map[string]validators{
 				}, nil
 			}
 			return nil, nil
+		},
+	),
+	"column-type-is-valid-for-platform": validatorsFromAssetValidator(
+		func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			var validTypes map[string]struct{}
+			var platformName string
+
+			switch {
+			case strings.HasPrefix(string(asset.Type), "bq."):
+				validTypes = validBigQueryTypes
+				platformName = "BigQuery"
+			case strings.HasPrefix(string(asset.Type), "sf."):
+				validTypes = validSnowflakeTypes
+				platformName = "Snowflake"
+			default:
+				// Ignore assets of other types
+				return nil, nil
+			}
+
+			if len(validTypes) == 0 {
+				// Should not happen if sets are defined, but good practice
+				return nil, nil
+			}
+
+			var issues []*Issue
+			for _, col := range asset.Columns {
+				if strings.TrimSpace(col.Type) == "" {
+					// Let column-has-type rule handle this
+					continue
+				}
+
+				// Normalize type: lowercase and remove parameters like (size) or (precision, scale)
+				normalizedType := strings.ToLower(col.Type)
+				if idx := strings.Index(normalizedType, "("); idx != -1 {
+					normalizedType = normalizedType[:idx]
+				}
+				// Handle potential spaces in type names like 'double precision'
+				normalizedType = strings.TrimSpace(normalizedType)
+
+				if _, ok := validTypes[normalizedType]; !ok {
+					issues = append(issues, &Issue{
+						Task:        asset,
+						Description: "Column '" + col.Name + "' has invalid type '" + col.Type + "' for platform '" + platformName + "'",
+					})
+				}
+			}
+
+			return issues, nil
+		},
+	),
+	"disallow-placeholder-descriptions": validatorsFromAssetValidator(
+		func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			var issues []*Issue
+
+			// Check asset description
+			lowerAssetDesc := strings.ToLower(strings.TrimSpace(asset.Description))
+			if lowerAssetDesc != "" {
+				for _, placeholder := range placeholderDescriptions {
+					if strings.Contains(lowerAssetDesc, placeholder) {
+						issues = append(issues, &Issue{
+							Task:        asset,
+							Description: "Asset description appears to contain placeholder text: '" + placeholder + "'",
+						})
+						// Found one, no need to check others for this description
+						break
+					}
+				}
+			}
+
+			// Check column descriptions
+			for _, col := range asset.Columns {
+				lowerColDesc := strings.ToLower(strings.TrimSpace(col.Description))
+				if lowerColDesc == "" {
+					// Let column-has-description handle empty descriptions
+					continue
+				}
+
+				for _, placeholder := range placeholderDescriptions {
+					if strings.Contains(lowerColDesc, placeholder) {
+						issues = append(issues, &Issue{
+							Task:        asset,
+							Description: "Column '" + col.Name + "' description appears to contain placeholder text: '" + placeholder + "'",
+						})
+						// Found one, no need to check others for this column's description
+						break
+					}
+				}
+			}
+
+			return issues, nil
 		},
 	),
 }

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -14,6 +14,10 @@ func validatorsFromAssetValidator(av AssetValidator) validators {
 	}
 }
 
+const (
+	msgPrimaryKeyMustBeSet = "Asset must have atleast one primary key"
+)
+
 var builtinRules = map[string]validators{
 	"asset-name-is-lowercase": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -80,6 +84,34 @@ var builtinRules = map[string]validators{
 					Description: "Asset must have columns",
 				},
 			}, nil
+		},
+	),
+	"asset-has-primary-key": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if len(asset.Columns) == 0 {
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: msgPrimaryKeyMustBeSet,
+					},
+				}, nil
+			}
+			var primaryKeyFound bool
+			for _, col := range asset.Columns {
+				if col.PrimaryKey {
+					primaryKeyFound = true
+					break
+				}
+			}
+			if !primaryKeyFound {
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: msgPrimaryKeyMustBeSet,
+					},
+				}, nil
+			}
+			return nil, nil
 		},
 	),
 }

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -114,7 +114,19 @@ var builtinRules = map[string]validators{
 			return nil, nil
 		},
 	),
-
+	"asset-has-checks": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if len(asset.CustomChecks) == 0 {
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: "Asset must have a custom check",
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	),
 	"column-has-description": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			for _, col := range asset.Columns {

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -16,6 +17,10 @@ func validatorsFromAssetValidator(av AssetValidator) validators {
 
 const (
 	msgPrimaryKeyMustBeSet = "Asset must have atleast one primary key"
+)
+
+var (
+	snakeCasePattern = regexp.MustCompile("^[a-z]+(_[a-z]+)*$")
 )
 
 var builtinRules = map[string]validators{
@@ -155,6 +160,23 @@ var builtinRules = map[string]validators{
 					{
 						Task:        asset,
 						Description: "Columns must have a type",
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	),
+	"column-name-is-snake-case": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			for _, col := range asset.Columns {
+				if snakeCasePattern.MatchString(col.Name) {
+					continue
+				}
+
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: "Column names must be in snake_case",
 					},
 				}, nil
 			}

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -144,4 +144,21 @@ var builtinRules = map[string]validators{
 			return nil, nil
 		},
 	),
+	"column-has-type": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			for _, col := range asset.Columns {
+				if strings.TrimSpace(col.Type) != "" {
+					continue
+				}
+
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: "Columns must have a type",
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	),
 }

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -21,6 +21,7 @@ const (
 
 var (
 	snakeCasePattern = regexp.MustCompile("^[a-z]+(_[a-z]+)*$")
+	camelCasePattern = regexp.MustCompile("^[a-z]+(?:[A-Z][a-z0-9])*$")
 )
 
 var builtinRules = map[string]validators{
@@ -177,6 +178,23 @@ var builtinRules = map[string]validators{
 					{
 						Task:        asset,
 						Description: "Column names must be in snake_case",
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	),
+	"column-name-is-camel-case": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			for _, col := range asset.Columns {
+				if camelCasePattern.MatchString(col.Name) {
+					continue
+				}
+
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: "Column names must be in camelCase",
 					},
 				}, nil
 			}

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -133,6 +133,19 @@ var builtinRules = map[string]validators{
 			return nil, nil
 		},
 	),
+	"asset-has-tags": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			if len(asset.Tags) == 0 {
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: "Asset must have tags",
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	),
 	"column-has-description": validatorsFromAssetValidator(
 		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			for _, col := range asset.Columns {
@@ -143,7 +156,7 @@ var builtinRules = map[string]validators{
 				return []*Issue{
 					{
 						Task:        asset,
-						Description: "Columns must have a description",
+						Description: "Column must have a description",
 					},
 				}, nil
 			}
@@ -160,7 +173,7 @@ var builtinRules = map[string]validators{
 				return []*Issue{
 					{
 						Task:        asset,
-						Description: "Columns must have a type",
+						Description: "Column must have a type",
 					},
 				}, nil
 			}

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -342,11 +342,10 @@ var builtinRules = map[string]validators{
 			return issues, nil
 		},
 	),
-	"disallow-placeholder-descriptions": validatorsFromAssetValidator(
+	"description-must-not-be-placeholder": validatorsFromAssetValidator(
 		func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			var issues []*Issue
 
-			// Check asset description
 			lowerAssetDesc := strings.ToLower(strings.TrimSpace(asset.Description))
 			if lowerAssetDesc != "" {
 				for _, placeholder := range placeholderDescriptions {
@@ -355,17 +354,14 @@ var builtinRules = map[string]validators{
 							Task:        asset,
 							Description: "Asset description appears to contain placeholder text: '" + placeholder + "'",
 						})
-						// Found one, no need to check others for this description
 						break
 					}
 				}
 			}
 
-			// Check column descriptions
 			for _, col := range asset.Columns {
 				lowerColDesc := strings.ToLower(strings.TrimSpace(col.Description))
 				if lowerColDesc == "" {
-					// Let column-has-description handle empty descriptions
 					continue
 				}
 
@@ -375,7 +371,6 @@ var builtinRules = map[string]validators{
 							Task:        asset,
 							Description: "Column '" + col.Name + "' description appears to contain placeholder text: '" + placeholder + "'",
 						})
-						// Found one, no need to check others for this column's description
 						break
 					}
 				}

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -114,4 +114,22 @@ var builtinRules = map[string]validators{
 			return nil, nil
 		},
 	),
+
+	"column-has-description": validatorsFromAssetValidator(
+		func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+			for _, col := range asset.Columns {
+				if strings.TrimSpace(col.Description) != "" {
+					continue
+				}
+
+				return []*Issue{
+					{
+						Task:        asset,
+						Description: "Columns must have a description",
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	),
 }


### PR DESCRIPTION
- **lint: add builtin rule 'asset-has-primary-key'**
- **lint: policy: add builtin rule for 'column-has-description'**
- **lint: policy: add builtin rule for 'assets-has-checks'**
- **lint: policy: add builtin rule for 'column-has-type'**
- **lint: policy: add builtin rule for 'column-name-is-snake-case'**
- **lint: policy: add builtin rule 'column-name-is-camel-case'**
- **lint: policy: add builtin rule for 'asset-has-tags'**
- **feat: add new rules for column types**
