### PR TITLE
Added nil pointer checks in run.go

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -287,7 +287,6 @@ func Run(isDebug *bool) *cli.Command {
 			}
 			executionStartLog := "Starting execution..."
 			if !c.Bool("minimal-logs") {
-
 				if pipelineInfo.RunningForAnAsset {
 					if task != nil {
 						infoPrinter.Printf("Running only the asset '%s'\n", task.Name)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -278,6 +278,10 @@ func Run(isDebug *bool) *cli.Command {
 					errorPrinter.Printf("Failed to mutate asset: %v\n", err)
 					return cli.Exit("", 1)
 				}
+				if task == nil {
+					errorPrinter.Printf("Failed to create asset from file '%s'\n", inputPath)
+					return cli.Exit("", 1)
+				}
 			}
 
 			// handle log files
@@ -290,12 +294,7 @@ func Run(isDebug *bool) *cli.Command {
 				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 
 				if pipelineInfo.RunningForAnAsset {
-					if task != nil {
-						infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
-					} else {
-						infoPrinter.Printf("Failed to build asset for '%s'\n", inputPath)
-						return cli.Exit("", 1)
-					}
+					infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
 				}
 				executionStartLog = "Starting the pipeline execution..."
 			}
@@ -351,9 +350,7 @@ func Run(isDebug *bool) *cli.Command {
 			if !runConfig.NoLogFile {
 				logFileName := fmt.Sprintf("%s__%s", runID, foundPipeline.Name)
 				if pipelineInfo.RunningForAnAsset {
-					if task != nil {
-						logFileName = fmt.Sprintf("%s__%s__%s", runID, foundPipeline.Name, task.Name)
-					}
+					logFileName = fmt.Sprintf("%s__%s__%s", runID, foundPipeline.Name, task.Name)
 				}
 
 				logPath, err := filepath.Abs(fmt.Sprintf("%s/%s/%s.log", repoRoot.Path, LogsFolder, logFileName))
@@ -546,6 +543,7 @@ func GetPipeline(ctx context.Context, inputPath string, runConfig *scheduler.Run
 
 	if runningForAnAsset {
 		task, err = DefaultPipelineBuilder.CreateAssetFromFile(inputPath, foundPipeline)
+
 		if err != nil {
 			errorPrinter.Printf("Failed to build asset: %v. Are you sure you used the correct path?\n", err.Error())
 			return &PipelineInfo{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -287,6 +287,8 @@ func Run(isDebug *bool) *cli.Command {
 			}
 			executionStartLog := "Starting execution..."
 			if !c.Bool("minimal-logs") {
+				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
+
 				if pipelineInfo.RunningForAnAsset {
 					if task != nil {
 						infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
@@ -295,8 +297,6 @@ func Run(isDebug *bool) *cli.Command {
 						return cli.Exit("", 1)
 					}
 				}
-
-				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 				executionStartLog = "Starting the pipeline execution..."
 			}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -290,6 +290,9 @@ func Run(isDebug *bool) *cli.Command {
 				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 
 				if pipelineInfo.RunningForAnAsset {
+					//if task != nil {
+					//	infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
+					//}
 					infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
 				}
 				executionStartLog = "Starting the pipeline execution..."
@@ -346,7 +349,9 @@ func Run(isDebug *bool) *cli.Command {
 			if !runConfig.NoLogFile {
 				logFileName := fmt.Sprintf("%s__%s", runID, foundPipeline.Name)
 				if pipelineInfo.RunningForAnAsset {
-					logFileName = fmt.Sprintf("%s__%s__%s", runID, foundPipeline.Name, task.Name)
+					if task != nil {
+						logFileName = fmt.Sprintf("%s__%s__%s", runID, foundPipeline.Name, task.Name)
+					}
 				}
 
 				logPath, err := filepath.Abs(fmt.Sprintf("%s/%s/%s.log", repoRoot.Path, LogsFolder, logFileName))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -287,13 +287,17 @@ func Run(isDebug *bool) *cli.Command {
 			}
 			executionStartLog := "Starting execution..."
 			if !c.Bool("minimal-logs") {
-				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 
 				if pipelineInfo.RunningForAnAsset {
 					if task != nil {
 						infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
+					} else {
+						infoPrinter.Printf("Failed to build asset for '%s'\n", inputPath)
+						return cli.Exit("", 1)
 					}
 				}
+
+				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 				executionStartLog = "Starting the pipeline execution..."
 			}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -290,10 +290,9 @@ func Run(isDebug *bool) *cli.Command {
 				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 
 				if pipelineInfo.RunningForAnAsset {
-					//if task != nil {
-					//	infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
-					//}
-					infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
+					if task != nil {
+						infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
+					}
 				}
 				executionStartLog = "Starting the pipeline execution..."
 			}


### PR DESCRIPTION
Running a malformed asset was previously causing a nil pointer error as two functions were trying to access task.Name from a nil pointer.

By adding these checks, the failed asset now returns the following error message:

<img width="912" alt="Screenshot 2025-05-06 at 12 59 54" src="https://github.com/user-attachments/assets/b157bf60-5502-4777-8de6-8847eb16d25a" />

However if we run the entire pipeline, the asset is ignored for validation (there are actually 39 well-formed assets + 1 mal-formed asset in this pipeline) and the pipeline executes: 

<img width="641" alt="Screenshot 2025-05-06 at 13 01 15" src="https://github.com/user-attachments/assets/e73c5958-67d7-403f-be57-31aba2872d39" />

Stopping the pipeline at this point and returning an error message would involve rewriting some of the unit tests.






