### PR TITLE
Policy: resolve config dynamically

### DIFF
--- a/integration-tests/integration-test.go
+++ b/integration-tests/integration-test.go
@@ -520,6 +520,19 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			},
 		},
 		{
+			Name:    "policy-validate-single-asset",
+			Command: binary,
+			Args:    []string{"validate", filepath.Join(currentFolder, "test-pipelines/policies-validate-single-asset/assets/target.sql")},
+			Env:     []string{},
+			Expected: e2e.Output{
+				ExitCode: 0,
+			},
+			WorkingDir: currentFolder,
+			Asserts: []func(*e2e.Task) error{
+				e2e.AssertByExitCode,
+			},
+		},
+		{
 			Name:          "parse-whole-pipeline",
 			Command:       binary,
 			Args:          []string{"internal", "parse-pipeline", filepath.Join(currentFolder, "test-pipelines/parse-whole-pipeline")},

--- a/integration-tests/policy.yml
+++ b/integration-tests/policy.yml
@@ -85,3 +85,9 @@ rulesets:
       - asset: "^non_compliant.tertiary$"
     rules:
       - asset-has-owner
+  
+  - name: validate-single-asset
+    selector:
+      - pipeline: policies-validate-single-asset
+    rules:
+      - asset-name-contains-public

--- a/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
+++ b/integration-tests/test-pipelines/policies-builtin/assets/standard.sql
@@ -9,6 +9,7 @@ columns:
     type: string
     primary_key: true
     description: The contents of the message
+
 tags:
   - layer:raw
 

--- a/integration-tests/test-pipelines/policies-validate-single-asset/assets/target.sql
+++ b/integration-tests/test-pipelines/policies-validate-single-asset/assets/target.sql
@@ -1,0 +1,6 @@
+/* @bruin
+name: public.standalone
+type: bq.sql
+@bruin */
+
+select "I walk a lonely road, the only one that I have ever known ..." as msg

--- a/integration-tests/test-pipelines/policies-validate-single-asset/pipeline.yml
+++ b/integration-tests/test-pipelines/policies-validate-single-asset/pipeline.yml
@@ -1,0 +1,3 @@
+name: policies-validate-single-asset
+schedule: hourly
+start_date: "1970-01-01"

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -168,7 +168,15 @@ func (l *Linter) LintAsset(rootPath string, pipelineDefinitionFileName []string,
 		return nil, fmt.Errorf("failed to load policy: %w", err)
 	}
 	if len(policyRules) > 0 {
-		rules = slices.Concat([]Rule{}, rules, policyRules)
+		assetRules := []Rule{}
+
+		// suboptimal, but works.
+		for _, rule := range policyRules {
+			if slices.Contains(rule.GetApplicableLevels(), LevelAsset) {
+				assetRules = append(assetRules, rule)
+			}
+		}
+		rules = slices.Concat([]Rule{}, rules, assetRules)
 	}
 
 	// now the actual validation starts

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -331,6 +331,14 @@ func RunLintRulesOnPipeline(p *pipeline.Pipeline, rules []Rule) (*PipelineIssues
 		ctx = context.Background()
 	)
 
+	policyRules, err := loadPolicy(p.DefinitionFile.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load policy: %w", err)
+	}
+	if len(policyRules) > 0 {
+		rules = slices.Concat([]Rule{}, rules, policyRules)
+	}
+
 	for _, rule := range rules {
 		levels := rule.GetApplicableLevels()
 		if slices.Contains(levels, LevelPipeline) {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -162,8 +162,17 @@ func (l *Linter) LintAsset(rootPath string, pipelineDefinitionFileName []string,
 		Issues:   make(map[Rule][]*Issue),
 	}
 
+	rules := l.rules
+	policyRules, err := loadPolicy(assetPipeline.DefinitionFile.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load policy: %w", err)
+	}
+	if len(policyRules) > 0 {
+		rules = slices.Concat([]Rule{}, rules, policyRules)
+	}
+
 	// now the actual validation starts
-	for _, rule := range l.rules {
+	for _, rule := range rules {
 		issues, err := rule.ValidateAsset(context.TODO(), assetPipeline, asset)
 		if err != nil {
 			return nil, err

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -1,7 +1,6 @@
 package lint
 
 import (
-	"fmt"
 	"slices"
 
 	"github.com/bruin-data/bruin/pkg/git"
@@ -190,14 +189,6 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser *sqlp
 			Validator:        yamlFileValidator.WarnRegularYamlFilesInRepo,
 			ApplicableLevels: []Level{LevelPipeline},
 		},
-	}
-
-	policyRules, err := loadPolicy(fs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load policy: %w", err)
-	}
-	if len(policyRules) > 0 {
-		rules = append(rules, policyRules...)
 	}
 
 	if parser != nil {

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -343,7 +343,6 @@ func addBoundaryAnchors(pattern string) string {
 }
 
 func loadPolicy(path string) (rules []Rule, err error) {
-
 	repo, err := git.FindRepoFromPath(path)
 	if errors.Is(err, git.ErrNoGitRepoFound) {
 		return nil, nil

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -343,6 +343,7 @@ func addBoundaryAnchors(pattern string) string {
 }
 
 func loadPolicy(path string) (rules []Rule, err error) {
+	// TODO(turtledev): utilize cached FS to improve performance
 	repo, err := git.FindRepoFromPath(path)
 	if errors.Is(err, git.ErrNoGitRepoFound) {
 		return nil, nil


### PR DESCRIPTION
## Summary

This PR changes how and when policies are loaded.

In the current version of Bruin, policies are loaded during startup once, and then reused during the lifecycle of the application. However, the policy file resolver would always look for a git directory as a proxy for the bruin project. This is error-prone and can break in unexpected ways.

The new version resolves the git directory relative to the target resource (`pipeline`/`asset`) and is more robust. The policy file is loaded only when the `lint.*` family of functions are called. 

## Notes
This change doesn't utilize file system caching, so it may have a negative impact on lint performance. A future change will address this.