### PR TITLE
EMR Serverless: Enable Quality Checks

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -965,13 +965,13 @@ func setupExecutors(
 		if s.WillRunTaskOfType(typ) {
 			emrServerlessOperator, err := emr_serverless.NewBasicOperator(conn)
 			emrCheckRunner := emr_serverless.NewColumnCheckOperator(conn)
+			emrCustomCheckRunner := emr_serverless.NewCustomCheckOperator(conn)
 			if err != nil {
 				return nil, err
 			}
 			mainExecutors[typ][scheduler.TaskInstanceTypeMain] = emrServerlessOperator
 			mainExecutors[typ][scheduler.TaskInstanceTypeColumnCheck] = emrCheckRunner
-			// todo(turtledev): test custom check runner
-			// mainExecutors[typ][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+			mainExecutors[typ][scheduler.TaskInstanceTypeCustomCheck] = emrCustomCheckRunner
 		}
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -964,10 +964,14 @@ func setupExecutors(
 	for _, typ := range emrServerlessAssetTypes {
 		if s.WillRunTaskOfType(typ) {
 			emrServerlessOperator, err := emr_serverless.NewBasicOperator(conn)
+			emrCheckRunner := emr_serverless.NewColumnCheckOperator(conn)
 			if err != nil {
 				return nil, err
 			}
 			mainExecutors[typ][scheduler.TaskInstanceTypeMain] = emrServerlessOperator
+			mainExecutors[typ][scheduler.TaskInstanceTypeColumnCheck] = emrCheckRunner
+			// todo(turtledev): test custom check runner
+			// mainExecutors[typ][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 		}
 	}
 

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -45,13 +45,13 @@ In order to stream logs, one of the following conditions must be met:
 > [!NOTE]
 > Python assets stream logs out-of-the-box. You don't need to specify `parameters.logs` for them.
 
-## Asset Types
+## EMR Serverless Assets
 
 Bruin supports two different ways of defining a Spark asset:
 - what we call a "managed" PySpark asset where Bruin takes care of delivering the code to the cluster as well
 - as an external asset defined with YAML where Bruin simply orchestrates
 
-### Python Asset
+### `emr_serverless.pyspark`
 A fully managed option where Bruin takes care of job setup, configuration, and execution. You only need to define the workload logic.
 
 * Supports only PySpark scripts.
@@ -150,7 +150,7 @@ Bruin uses this for:
 
 ![workspace diagram](media/pyspark-workspace.svg)
 
-### YAML Asset
+### `emr_serverless.spark`
 A lightweight option that only supports triggering a job. 
 
 * Supports both PySpark scripts and JARs.

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -349,6 +349,18 @@ if __name__ == "__main__":
 ```
 :::
 
+::: tip
+If all your Assets share the same `type` and `parameters.athena_connection`, you can set them as [defaults](/getting-started/concepts.html#defaults) in your `pipeline.yml` to avoid repeating them for each Asset.
+
+
+```yaml 
+name: my-pipeline
+default:
+  type: emr_serverless.pyspark
+  parameters:
+    athena_connection: quality-checks
+```
+:::
 Now when we run our bruin pipeline again, our quality checks should run after our Asset run finishes.
 ```sh
 bruin run ./quality-checks-example

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -397,6 +397,10 @@ parameters:
   # path where logs are stored or should be stored (optional)
   logs: s3://amzn-test-bucket/logs
 
+  # name of your athena connection (optional, defaults to "athena-default")
+  # used for quality checks
+  athena_connection: athena-conn
+
   # args to pass to the entrypoint (optional)
   args: arg1 arg2
 

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -197,7 +197,7 @@ To demonstrate quality checks, we're going to write a simple pyspark script that
 
 #### Initial Setup
 
-We're going to start by creating a pipeline called `quality-checks-example`. We first run bruin to create the skeleton structure.
+We're going to start by creating a pipeline called `quality-checks-example`. We first run `bruin init` to create the skeleton structure.
 ```sh
 bruin init default quality-checks-example
 ```
@@ -284,8 +284,11 @@ STORED AS TEXTFILE
 LOCATION 's3://acme/user/list' 
 ```
 
+> [!TIP]
+> For more information on creating Athena tables, see [Create tables in Athena](https://docs.aws.amazon.com/athena/latest/ug/creating-tables.html) and [Use SerDe](https://docs.aws.amazon.com/athena/latest/ug/serde-reference.html) in the AWS Athena Documentation.
+
 Next, update your `bruin.yml` file with an athena connection.
-::: code-block
+
 ```yaml [bruin.yml]
 environments:
   default:
@@ -299,7 +302,7 @@ environments:
         execution_role: IAM_ROLE_ARN
         workspace: s3://acme/bruin-pyspark-workspace/
       athena:                                           # [!code ++]
-      - name:  athena-qc                                # [!code ++]
+      - name: quality-tests                             # [!code ++]
         access_key_id: AWS_ACCESS_KEY_ID                # [!code ++]
         secret_access_key: AWS_SECRET_ACCESS_KEY        # [!code ++]
         region: eu-north-1                              # [!code ++]
@@ -322,9 +325,9 @@ columns:              # [!code ++]
 custom_checks: # [!code ++] 
   - name: users are adults # [!code ++]
     query: SELECT count(*) from users where age < 18 # [!code ++]
-    value: 1 # [!code ++]
+    value: 0 # [!code ++]
 parameters: # [!code ++]
-  athena_connection: athena-qc # [!code ++]
+  athena_connection: quality-tests # [!code ++]
 @bruin """
 
 from pyspark.sql import SparkSession

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -179,6 +179,58 @@ This defines an asset that runs a spark job on an EMR Serverless Application def
 > * YAML-style assets: `emr_serverless.spark` 
 > * Python assets:  `emr_serverless.pyspark`.
 
+## Quality Checks
+[Quality checks](/quality/overview.md) for EMR Serverless are powered via [AWS Athena](/platforms/athena.md). 
+
+> [!WARNING]
+> Bruin currently requires a few extra steps in order to be able to run quality checks for your EMR Serverless Assets.
+> Future versions of Bruin will automate this process for you. 
+
+### Prerequisites
+* Configure an [athena connection](/platforms/athena.html#connection) in your `bruin.yml`.
+* Set `parameters.athena_connection` to the name of your Athena connection.
+* Create an `athena` table on top of your data with the same name as your Asset's name.
+
+### Example
+
+To illustrate quality checks, we're going to write a simple pyspark script that writes static data as CSV to a bucket in S3.
+
+::: code-group
+```bruin-python [users.py]
+""" @bruin
+name: raw.users
+type: emr_serverless.pyspark
+connection: emr-stage
+parameters:
+  athena_connection: athena-stage
+columns:
+  - name: id
+    type: integer
+  - name: name
+    type: string
+  - name: age
+    type: integer
+@bruin """
+
+from pyspark.sql import SparkSession
+
+USERS = [
+  (1, "Alice", 29),
+  (2, "Bob", 31),
+  (3, "Cathy", 25),
+  (4, "David", 35),
+  (5, "Eva", 28),
+]
+
+if __name__ == "__main__":
+  spark_session = SparkSession.builder.appName("users").getOrCreate()
+  df = spark.createDataFrame(USERS, ["id", "name", "age"])
+  df.write.csv("output", header=True, mode="overwrite")
+  spark.stop()
+```
+:::
+
+
 ## Asset Schema
 
 Here's the full schema of the `emr_serverless.spark` asset along with a brief explanation:

--- a/pkg/athena/checks.go
+++ b/pkg/athena/checks.go
@@ -12,8 +12,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+type checksConnectionFetcher interface {
+	GetConnection(string) (interface{}, error)
+}
+
 type AcceptedValuesCheck struct {
-	conn connectionFetcher
+	conn checksConnectionFetcher
 }
 
 func (c *AcceptedValuesCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
@@ -48,12 +52,12 @@ func (c *AcceptedValuesCheck) Check(ctx context.Context, ti *scheduler.ColumnChe
 	}).Check(ctx, ti)
 }
 
-func NewAcceptedValuesCheck(conn connectionFetcher) *AcceptedValuesCheck {
+func NewAcceptedValuesCheck(conn checksConnectionFetcher) *AcceptedValuesCheck {
 	return &AcceptedValuesCheck{conn: conn}
 }
 
 type PatternCheck struct {
-	conn connectionFetcher
+	conn checksConnectionFetcher
 }
 
 func (c *PatternCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
@@ -73,6 +77,6 @@ func (c *PatternCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInsta
 	}).Check(ctx, ti)
 }
 
-func NewPatternCheck(conn connectionFetcher) *PatternCheck {
+func NewPatternCheck(conn checksConnectionFetcher) *PatternCheck {
 	return &PatternCheck{conn: conn}
 }

--- a/pkg/athena/checks.go
+++ b/pkg/athena/checks.go
@@ -48,6 +48,10 @@ func (c *AcceptedValuesCheck) Check(ctx context.Context, ti *scheduler.ColumnChe
 	}).Check(ctx, ti)
 }
 
+func NewAcceptedValuesCheck(conn connectionFetcher) *AcceptedValuesCheck {
+	return &AcceptedValuesCheck{conn: conn}
+}
+
 type PatternCheck struct {
 	conn connectionFetcher
 }
@@ -67,4 +71,8 @@ func (c *PatternCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInsta
 	return ansisql.NewCountableQueryCheck(c.conn, 0, &query.Query{Query: qq}, "pattern", func(count int64) error {
 		return errors.Errorf("column %s has %d values that don't satisfy the pattern %s", ti.Column.Name, count, *ti.Check.Value.String)
 	}).Check(ctx, ti)
+}
+
+func NewPatternCheck(conn connectionFetcher) *PatternCheck {
+	return &PatternCheck{conn: conn}
 }

--- a/pkg/athena/checks.go
+++ b/pkg/athena/checks.go
@@ -13,7 +13,7 @@ import (
 )
 
 type checksConnectionFetcher interface {
-	GetConnection(string) (interface{}, error)
+	GetConnection(name string) (interface{}, error)
 }
 
 type AcceptedValuesCheck struct {

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -1,6 +1,7 @@
 package emr_serverless //nolint
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"strings"
@@ -87,7 +88,10 @@ func (cr *connectionRemapper) GetConnection(string) (interface{}, error) {
 	asset := cr.ti.GetAsset()
 	connectionName := asset.Parameters["athena_connection"]
 	if strings.TrimSpace(connectionName) == "" {
-		connectionName = "athena-default"
+		connectionName = cmp.Or(
+			cr.ti.GetPipeline().DefaultConnections["athena"],
+			"athena-default",
+		)
 	}
 	return cr.connectionFetcher.GetConnection(connectionName)
 }

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/athena"
@@ -85,14 +84,11 @@ type connectionRemapper struct {
 }
 
 func (cr *connectionRemapper) GetConnection(string) (interface{}, error) {
-	asset := cr.ti.GetAsset()
-	connectionName := asset.Parameters["athena_connection"]
-	if strings.TrimSpace(connectionName) == "" {
-		connectionName = cmp.Or(
-			cr.ti.GetPipeline().DefaultConnections["athena"],
-			"athena-default",
-		)
-	}
+	connectionName := cmp.Or(
+		cr.ti.GetAsset().Parameters["athena_connection"],
+		cr.ti.GetPipeline().DefaultConnections["athena"],
+		"athena-default",
+	)
 	return cr.connectionFetcher.GetConnection(connectionName)
 }
 

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -1,4 +1,4 @@
-package emr_serverless
+package emr_serverless //nolint
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 type CheckRunner interface {
 	Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error
 }
+
 type CustomCheckRunner interface {
 	Check(ctx context.Context, ti *scheduler.CustomCheckInstance) error
 }

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -2,17 +2,72 @@ package emr_serverless
 
 import (
 	"context"
+	"errors"
+	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/athena"
 	"github.com/bruin-data/bruin/pkg/scheduler"
 )
 
+type CheckRunner interface {
+	Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error
+}
+
+type checkBuilder func(conn connectionFetcher) CheckRunner
+
 type ColumnCheckOperator struct {
+	checks map[string]checkBuilder
+	conn   connectionFetcher
 }
 
 func (o *ColumnCheckOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error {
-	return nil
+	test, ok := ti.(*scheduler.ColumnCheckInstance)
+	if !ok {
+		return errors.New("cannot run a non-column check instance")
+	}
+
+	executor, ok := o.checks[test.Check.Name]
+	if !ok {
+		return errors.New("there is no executor configured for the check type, check cannot be run: " + test.Check.Name)
+	}
+
+	conn := newConnectionRemapper(o.conn, ti)
+	return executor(conn).Check(ctx, test)
 }
 
-func NewColumnCheckOperator(manager connectionFetcher) *ColumnCheckOperator {
-	return &ColumnCheckOperator{}
+func NewColumnCheckOperator(conn connectionFetcher) *ColumnCheckOperator {
+	return &ColumnCheckOperator{
+		conn: conn,
+		checks: map[string]checkBuilder{
+			"not_null":        func(c connectionFetcher) CheckRunner { return ansisql.NewNotNullCheck(c) },
+			"unique":          func(c connectionFetcher) CheckRunner { return ansisql.NewUniqueCheck(c) },
+			"positive":        func(c connectionFetcher) CheckRunner { return ansisql.NewPositiveCheck(c) },
+			"non_negative":    func(c connectionFetcher) CheckRunner { return ansisql.NewNonNegativeCheck(c) },
+			"negative":        func(c connectionFetcher) CheckRunner { return ansisql.NewNegativeCheck(c) },
+			"accepted_values": func(c connectionFetcher) CheckRunner { return athena.NewAcceptedValuesCheck(c) },
+			"pattern":         func(c connectionFetcher) CheckRunner { return athena.NewPatternCheck(c) },
+		},
+	}
+}
+
+type connectionRemapper struct {
+	connectionFetcher
+	ti scheduler.TaskInstance
+}
+
+func (cr *connectionRemapper) GetConnection(string) (interface{}, error) {
+	asset := cr.ti.GetAsset()
+	connectionName := asset.Parameters["athena_connection"]
+	if strings.TrimSpace(connectionName) == "" {
+		connectionName = "athena-default"
+	}
+	return cr.connectionFetcher.GetConnection(connectionName)
+}
+
+func newConnectionRemapper(conn connectionFetcher, ti scheduler.TaskInstance) *connectionRemapper {
+	return &connectionRemapper{
+		connectionFetcher: conn,
+		ti:                ti,
+	}
 }

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -1,0 +1,18 @@
+package emr_serverless
+
+import (
+	"context"
+
+	"github.com/bruin-data/bruin/pkg/scheduler"
+)
+
+type ColumnCheckOperator struct {
+}
+
+func (o *ColumnCheckOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error {
+	return nil
+}
+
+func NewColumnCheckOperator(manager connectionFetcher) *ColumnCheckOperator {
+	return &ColumnCheckOperator{}
+}

--- a/pkg/emr_serverless/operator.go
+++ b/pkg/emr_serverless/operator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless"
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/bruin-data/bruin/pkg/athena"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -35,6 +36,12 @@ var terminalJobRunStates = []types.JobRunState{
 }
 
 type connectionFetcher interface {
+
+	// TODO(turtledev): we add these so that we can leverage
+	// athena checks, We should find a way to clean this up.
+	GetAthenaConnectionWithoutDefault(name string) (athena.Client, error)
+	GetConnection(name string) (interface{}, error)
+
 	GetEMRServerlessConnection(name string) (*Client, error)
 }
 

--- a/pkg/emr_serverless/operator.go
+++ b/pkg/emr_serverless/operator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless"
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/bruin-data/bruin/pkg/athena"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -35,7 +36,7 @@ var terminalJobRunStates = []types.JobRunState{
 }
 
 type connectionFetcher interface {
-	GetConnection(name string) (interface{}, error)
+	GetAthenaConnection(name string) (athena.Client, error)
 	GetEMRServerlessConnection(name string) (*Client, error)
 }
 

--- a/pkg/emr_serverless/operator.go
+++ b/pkg/emr_serverless/operator.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless"
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/bruin-data/bruin/pkg/athena"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -36,12 +35,7 @@ var terminalJobRunStates = []types.JobRunState{
 }
 
 type connectionFetcher interface {
-
-	// TODO(turtledev): we add these so that we can leverage
-	// athena checks, We should find a way to clean this up.
-	GetAthenaConnectionWithoutDefault(name string) (athena.Client, error)
 	GetConnection(name string) (interface{}, error)
-
 	GetEMRServerlessConnection(name string) (*Client, error)
 }
 


### PR DESCRIPTION

This PR adds support for running quality checks on EMR Serverless assets using AWS Athena. You can now define column and custom checks for your Spark jobs.

**How to enable:**
1. Create an Athena table over your output data.
2. Add an Athena connection in your `bruin.yml`.
3. Set `parameters.athena_connection` in your asset.

**Example asset:**
```yaml
name: users
type: emr_serverless.spark
columns:
  - name: id
    type: integer
    checks:
      - non_negative
custom_checks:
  - name: users are adults
    query: SELECT count(*) from users where age < 18
    value: 0
parameters:
  athena_connection: athena-default
```
