### PR TITLE
Jinja {{this}}

### DIFF
--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -16,6 +16,10 @@ type Renderer struct {
 	queryRenderLock *sync.Mutex
 }
 
+func (r *Renderer) GetContext() *exec.Context {
+	return r.context
+}
+
 func init() { //nolint: gochecknoinits
 	gonja.DefaultConfig.StrictUndefined = true
 }
@@ -68,6 +72,30 @@ func NewRendererWithStartEndDates(startDate, endDate *time.Time, pipelineName, r
 		"pipeline":          pipelineName,
 		"run_id":            runID,
 	})
+
+	return &Renderer{
+		context:         ctx,
+		queryRenderLock: &sync.Mutex{},
+	}
+}
+
+func NewRendererWithAssetName(assetName string) *Renderer {
+	ctx := exec.NewContext(map[string]any{
+		"this": assetName,
+	})
+
+	return &Renderer{
+		context:         ctx,
+		queryRenderLock: &sync.Mutex{},
+	}
+}
+
+func EnrichContextWithAssetName(ctx *exec.Context, assetName string) *Renderer {
+	newCtx := exec.NewContext(map[string]any{
+		"this": assetName,
+	})
+
+	ctx.Update(newCtx)
 
 	return &Renderer{
 		context:         ctx,

--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -103,6 +103,16 @@ func EnrichContextWithAssetName(ctx *exec.Context, assetName string) *Renderer {
 	}
 }
 
+func EnrichContext(ctx *exec.Context, data map[string]any) *Renderer {
+	newCtx := exec.NewContext(data)
+	ctx.Update(newCtx)
+
+	return &Renderer{
+		context:         ctx,
+		queryRenderLock: &sync.Mutex{},
+	}
+}
+
 func NewRendererWithYesterday(pipelineName, runID string) *Renderer {
 	yesterday := time.Now().AddDate(0, 0, -1)
 	startDate := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Implementing a new variable in jinja {{this}} which returns the name of the asset.

We can then use this in custom checks:

/* @bruin

name: events.buscheckout2
type: athena.sql

custom_checks:
  - name: sum of x should be 5
    value: 5
    query: select sum(x) from {{ this }}

@bruin */

select *
from source_table
where ts >= (select max(ts) from events.buscheckout2)