### PR TITLE
chore/make rendering more maintainable

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -544,7 +544,6 @@ func GetPipeline(ctx context.Context, inputPath string, runConfig *scheduler.Run
 
 	if runningForAnAsset {
 		task, err = DefaultPipelineBuilder.CreateAssetFromFile(inputPath, foundPipeline)
-
 		if err != nil {
 			errorPrinter.Printf("Failed to build asset: %v. Are you sure you used the correct path?\n", err.Error())
 			return &PipelineInfo{
@@ -737,7 +736,7 @@ func setupExecutors(
 		Fs:       fs,
 		Renderer: renderer,
 	}
-	customCheckRunner := ansisql.NewCustomCheckOperator(conn, wholeFileExtractor)
+	customCheckRunner := ansisql.NewCustomCheckOperator(conn, renderer)
 	if s.WillRunTaskOfType(pipeline.AssetTypeBigqueryQuery) || estimateCustomCheckType == pipeline.AssetTypeBigqueryQuery || s.WillRunTaskOfType(pipeline.AssetTypeBigquerySeed) || s.WillRunTaskOfType(pipeline.AssetTypeBigqueryQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeBigqueryTableSensor) || s.WillRunTaskOfType(pipeline.AssetTypeBigqueryDDL) {
 		bqOperator := bigquery.NewBasicOperator(conn, wholeFileExtractor, bigquery.NewMaterializer(fullRefresh))
 		bqCheckRunner, err := bigquery.NewColumnCheckOperator(conn)

--- a/pkg/ansisql/checks.go
+++ b/pkg/ansisql/checks.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
-	"github.com/spf13/afero"
 )
 
 type connectionFetcher interface {
@@ -187,28 +186,26 @@ func (c *NegativeCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInst
 }
 
 type CustomCheck struct {
-	conn      connectionFetcher
-	extractor query.QueryExtractor
+	conn     connectionFetcher
+	renderer jinja.RendererInterface
 }
 
 func NewCustomCheck(conn connectionFetcher) *CustomCheck {
-	queryExtractor := query.WholeFileExtractor{
-		Fs:       afero.NewOsFs(),
-		Renderer: jinja.NewRendererWithYesterday("your-pipeline-name", "your-run-id"),
-	}
-	return &CustomCheck{conn: conn, extractor: &queryExtractor}
+	// TODO: this needs to use an actual renderer instead of the yesterday, since this `NewRendererWithYesterday` does not honor
+	// the parameters passed to the `bruin run` command.
+	return &CustomCheck{conn: conn, renderer: jinja.NewRendererWithYesterday("your-pipeline-name", "your-run-id")}
 }
 
 func (c *CustomCheck) Check(ctx context.Context, ti *scheduler.CustomCheckInstance) error {
 	qq := ti.Check.Query
-	if c.extractor != nil {
-		extractor := c.extractor.CloneForAsset(ctx, ti.GetAsset())
-		qry, err := extractor.ExtractQueriesFromString(qq)
+	if c.renderer != nil {
+		r := c.renderer.CloneForAsset(ctx, ti.GetAsset())
+		qry, err := r.Render(qq)
 		if err != nil {
 			return errors.Wrap(err, "failed to render custom check query")
 		}
 
-		qq = qry[0].Query
+		qq = qry
 	}
 	return NewCountableQueryCheck(c.conn, ti.Check.Value, &query.Query{Query: qq}, ti.Check.Name, func(count int64) error {
 		return errors.Errorf("custom check '%s' has returned %d instead of the expected %d", ti.Check.Name, count, ti.Check.Value)
@@ -251,9 +248,9 @@ type CustomCheckOperator struct {
 	checkRunner CustomCheckRunner
 }
 
-func NewCustomCheckOperator(manager connectionFetcher, extractor query.QueryExtractor) *CustomCheckOperator {
+func NewCustomCheckOperator(manager connectionFetcher, r jinja.RendererInterface) *CustomCheckOperator {
 	return &CustomCheckOperator{
-		checkRunner: &CustomCheck{conn: manager, extractor: extractor},
+		checkRunner: &CustomCheck{conn: manager, renderer: r},
 	}
 }
 

--- a/pkg/ansisql/checks_test.go
+++ b/pkg/ansisql/checks_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/scheduler"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -279,11 +278,7 @@ func TestCustomCheck(t *testing.T) {
 
 			conn := new(mockConnectionFetcher)
 			conn.On("GetConnection", "test").Return(q, nil)
-			extractor := query.WholeFileExtractor{
-				Fs:       afero.NewOsFs(),
-				Renderer: jinja.NewRendererWithYesterday("your-pipeline-name", "your-run-id"),
-			}
-			n := &CustomCheck{conn: conn, extractor: &extractor}
+			n := &CustomCheck{conn: conn, renderer: jinja.NewRendererWithYesterday("your-pipeline-name", "your-run-id")}
 
 			testInstance := &scheduler.CustomCheckInstance{
 				AssetInstance: &scheduler.AssetInstance{

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -425,7 +425,6 @@ var builtinRules = map[string]validators{
 					Description: "Pipeline must have a start date",
 				},
 			}, nil
-
 		},
 	},
 	"pipeline-has-metadata-push": {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -255,8 +255,10 @@ func (n Notifications) MarshalJSON() ([]byte, error) {
 	})
 }
 
-type MaterializationType string
-type DDLStrategy string
+type (
+	MaterializationType string
+	DDLStrategy         string
+)
 
 const (
 	MaterializationTypeNone  MaterializationType = ""

--- a/pkg/query/extract.go
+++ b/pkg/query/extract.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -79,16 +78,12 @@ func (q Query) String() string {
 
 var queryCommentRegex = regexp.MustCompile(`(?m)(?s)\/\*.*?\*\/|(^|\s)--.*?\n`)
 
-type renderer interface {
-	Render(query string) (string, error)
-}
-
 // FileQuerySplitterExtractor is a regular file extractor, but it splits the queries in the given file into multiple
 // instances. For usecases that require EXPLAIN statements, such as validating Snowflake queries, it is not possible
-// to EXPLAIN a multi-query string directly, therefore we have to split them.
+// to use a single query with multiple statements, so we need to split them into multiple queries.
 type FileQuerySplitterExtractor struct {
 	Fs       afero.Fs
-	Renderer renderer
+	Renderer jinja.RendererInterface
 }
 
 func (f FileQuerySplitterExtractor) ExtractQueriesFromString(content string) ([]*Query, error) {
@@ -146,7 +141,7 @@ func splitQueries(fileContent string) []*Query {
 // for cases where the whole file content can be treated as a single query, such as validating GoogleCloudPlatform queries via dry-run.
 type WholeFileExtractor struct {
 	Fs       afero.Fs
-	Renderer renderer
+	Renderer jinja.RendererInterface
 }
 
 func (f *WholeFileExtractor) ExtractQueriesFromString(content string) ([]*Query, error) {
@@ -176,20 +171,8 @@ func (f *WholeFileExtractor) ReextractQueriesFromSlice(content []string) ([]stri
 }
 
 func (f *WholeFileExtractor) CloneForAsset(ctx context.Context, t *pipeline.Asset) QueryExtractor {
-	applyModifiers, ok := ctx.Value(pipeline.RunConfigApplyIntervalModifiers).(bool)
-	if !ok || !applyModifiers {
-		return f
-	}
-	startDate := ctx.Value(pipeline.RunConfigStartDate).(time.Time)
-	endDate := ctx.Value(pipeline.RunConfigEndDate).(time.Time)
-	pipelineName := ctx.Value(pipeline.RunConfigPipelineName).(string)
-	runID := ctx.Value(pipeline.RunConfigRunID).(string)
-	startDate = pipeline.ModifyDate(startDate, t.IntervalModifiers.Start)
-	endDate = pipeline.ModifyDate(endDate, t.IntervalModifiers.End)
-	newRenderer := jinja.NewRendererWithStartEndDates(&startDate, &endDate, pipelineName, runID)
-
 	return &WholeFileExtractor{
-		Renderer: newRenderer,
+		Renderer: f.Renderer.CloneForAsset(ctx, t),
 		Fs:       f.Fs,
 	}
 }

--- a/pkg/query/extract_test.go
+++ b/pkg/query/extract_test.go
@@ -1,8 +1,11 @@
 package query
 
 import (
+	"context"
 	"testing"
 
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -22,16 +25,21 @@ func (m *mockNoOpRenderer) Render(template string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+func (m *mockNoOpRenderer) CloneForAsset(ctx context.Context, asset *pipeline.Asset) jinja.RendererInterface { //nolint:ireturn
+	args := m.Called(ctx, asset)
+	return args.Get(0).(jinja.RendererInterface)
+}
+
 func TestFileExtractor_ExtractQueriesFromString(t *testing.T) {
 	t.Parallel()
 
-	noOpRenderer := func(mr renderer) {
+	noOpRenderer := func(mr jinja.RendererInterface) {
 		mr.(*mockNoOpRenderer).On("Render", mock.Anything).Return("default", nil)
 	}
 
 	tests := []struct {
 		name          string
-		setupRenderer func(mr renderer)
+		setupRenderer func(mr jinja.RendererInterface)
 		content       string
 		want          []*Query
 		wantErr       bool
@@ -55,7 +63,7 @@ func TestFileExtractor_ExtractQueriesFromString(t *testing.T) {
 		{
 			name:    "single query, rendered properly",
 			content: "select * from users-{{ds}};",
-			setupRenderer: func(mr renderer) {
+			setupRenderer: func(mr jinja.RendererInterface) {
 				mr.(*mockNoOpRenderer).
 					On("Render", mock.Anything).
 					Return("select * from users-2022-01-01", nil)
@@ -187,13 +195,13 @@ set min_level_req = 22;
 func TestWholeFileExtractor_ExtractQueriesFromString(t *testing.T) {
 	t.Parallel()
 
-	noOpRenderer := func(mr renderer) {
+	noOpRenderer := func(mr jinja.RendererInterface) {
 		mr.(*mockNoOpRenderer).On("Render", mock.Anything).Return("default", nil)
 	}
 
 	tests := []struct {
 		name          string
-		setupRenderer func(mr renderer)
+		setupRenderer func(mr jinja.RendererInterface)
 		content       string
 		want          []*Query
 		wantErr       bool
@@ -221,7 +229,7 @@ func TestWholeFileExtractor_ExtractQueriesFromString(t *testing.T) {
 		{
 			name:    "single query, rendered properly",
 			content: "select * from users-{{ds}};",
-			setupRenderer: func(mr renderer) {
+			setupRenderer: func(mr jinja.RendererInterface) {
 				mr.(*mockNoOpRenderer).
 					On("Render", mock.Anything).
 					Return("select * from users-2022-01-01", nil)


### PR DESCRIPTION
- **move CloneForAsset from extractor into renderer**
- **use renderer instead of extractor in custom checks**
- **chore: format**
