### PR TITLE
patch: improve performance for lineage via prebuilding scope

### DIFF
--- a/cmd/const.go
+++ b/cmd/const.go
@@ -43,7 +43,7 @@ var (
 
 func variableOverridesMutator(variables []string) pipeline.PipelineMutator {
 	return func(ctx context.Context, p *pipeline.Pipeline) (*pipeline.Pipeline, error) {
-		var overrides = map[string]any{}
+		overrides := map[string]any{}
 		for _, variable := range variables {
 			parsed, err := parseVariable(variable)
 			if err != nil {

--- a/internal/requirements.txt
+++ b/internal/requirements.txt
@@ -1,1 +1,1 @@
-sqlglot[rs]==26.11.1
+sqlglot[rs]==26.19.0

--- a/pkg/lineage/lineage_test.go
+++ b/pkg/lineage/lineage_test.go
@@ -36,8 +36,15 @@ func SetupSQLParser() error {
 	return nil
 }
 
-func getBasicLineageTestCase() []TestCase {
-	return []TestCase{
+func TestParseLineageRecursively(t *testing.T) { //nolint
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		pipeline *pipeline.Pipeline
+		after    *pipeline.Pipeline
+		want     error
+	}{
 		{
 			name: "successful recursive lineage parsing",
 			pipeline: &pipeline.Pipeline{
@@ -524,11 +531,6 @@ func getBasicLineageTestCase() []TestCase {
 			},
 			want: nil,
 		},
-	}
-}
-
-func GetAdvancedSQLTestCase() []TestCase {
-	return []TestCase{
 		{
 			name: "advanced SQL functions and aggregations",
 			pipeline: &pipeline.Pipeline{
@@ -734,7 +736,6 @@ func GetAdvancedSQLTestCase() []TestCase {
 			},
 			want: nil,
 		},
-
 		{
 			name: "postgres specific syntax",
 			pipeline: &pipeline.Pipeline{
@@ -872,28 +873,25 @@ func GetAdvancedSQLTestCase() []TestCase {
 			want: nil,
 		},
 	}
-}
-
-func TestParseLineageRecursively(t *testing.T) {
-	t.Parallel()
-
-	tests := append(getBasicLineageTestCase(), GetAdvancedSQLTestCase()...)
-
-	for _, tt := range tests {
-		runSingleLineageTest(t, tt.pipeline, tt.after, tt.want)
-	}
-}
-
-func runSingleLineageTest(t *testing.T, p, after *pipeline.Pipeline, want error) {
-	t.Helper()
 
 	extractor := NewLineageExtractor(SQLParser)
-	for _, asset := range p.Assets {
-		err := extractor.ColumnLineage(p, asset, make(map[string]bool))
-		assertLineageError(t, err, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			for _, asset := range tt.pipeline.Assets {
+				err := extractor.ColumnLineage(tt.pipeline, asset, make(map[string]bool))
+				assertLineageError(t, err, tt.want)
 
-		assertColumns(t, asset.Columns, after.GetAssetByName(asset.Name).Columns)
-		assertAssetExists(t, after, asset)
+				if tt.want == nil {
+					if len(err.Issues) > 0 {
+						t.Errorf("assertLineageError() error = %v, want nil", err)
+					}
+				}
+
+				assertColumns(t, asset.Columns, tt.after.GetAssetByName(asset.Name).Columns)
+				assertAssetExists(t, tt.after, asset)
+			}
+		})
 	}
 }
 
@@ -985,13 +983,6 @@ func assertColumns(t *testing.T, got, want []pipeline.Column) {
 			t.Errorf("Column %s checks mismatch: got %d, want %d", col.Name, len(col.Checks), len(wantCol.Checks))
 		}
 	}
-}
-
-type TestCase struct {
-	name     string
-	pipeline *pipeline.Pipeline
-	after    *pipeline.Pipeline
-	want     error
 }
 
 func TestAddColumnToAsset(t *testing.T) {

--- a/pythonsrc/parser/main_test.py
+++ b/pythonsrc/parser/main_test.py
@@ -1842,8 +1842,8 @@ ORDER BY 1, 2, 3
 )
 def test_get_column_lineage(query, schema, expected, expected_non_selected, dialect):
     result = get_column_lineage(query, schema, dialect)
-    assert expected == result["columns"]
-    assert expected_non_selected == result["non_selected_columns"]
+    assert result["columns"] == expected
+    assert result["non_selected_columns"] == expected_non_selected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces two changes:
- it removes certain optimizations that are heavy in large queries
- it calculates and reuses a scope in lineage

based on my benchmarks, it improves the basic cases ~30% while allowing 4-5x improvement in some pathological queries.

```
Benchmark 1: before
  Time (mean ± σ):      3.630 s ±  0.022 s    [User: 0.054 s, System: 0.017 s]
  Range (min … max):    3.604 s …  3.680 s    10 runs
 
Benchmark 2: after
  Time (mean ± σ):     910.2 ms ±   9.8 ms    [User: 52.7 ms, System: 23.7 ms]
  Range (min … max):   902.0 ms … 932.8 ms    10 runs
 
Summary
  after ran
    3.99 ± 0.05 times faster than before
```

My understanding is that the larger the query, the bigger the difference. There still is a linear growth of the latency though, I couldn't solve that yet.