### PR TITLE
patch: make jinja rendering support more robust

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -208,10 +208,18 @@ func prepareQueryExecution(c *cli.Context, fs afero.Fs) (string, interface{}, st
 	if err != nil {
 		return "", nil, "", err
 	}
+	pipelineInfo, err := GetPipelineAndAsset(c.Context, assetPath, fs, c.String("config-file"))
+	if err != nil {
+		return "", nil, "", err
+	}
+	var pipelineName string
+	if pipelineInfo != nil && pipelineInfo.Pipeline != nil {
+		pipelineName = pipelineInfo.Pipeline.Name
+	}
 	extractor := &query.WholeFileExtractor{
 		Fs: fs,
 		// note: we don't support variables for now
-		Renderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, "your-pipeline-name", "your-run-id", nil),
+		Renderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, pipelineName, "your-run-id", nil),
 	}
 
 	// Direct query mode (no asset path)
@@ -246,7 +254,7 @@ func prepareQueryExecution(c *cli.Context, fs afero.Fs) (string, interface{}, st
 		return connName, conn, queryStr, nil
 	}
 	// Asset query mode (only asset path)
-	pipelineInfo, err := GetPipelineAndAsset(c.Context, assetPath, fs, c.String("config-file"))
+	pipelineInfo, err = GetPipelineAndAsset(c.Context, assetPath, fs, c.String("config-file"))
 	if err != nil {
 		return "", nil, "", errors.Wrap(err, "failed to get pipeline info")
 	}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -197,7 +197,7 @@ func Render() *cli.Command {
 			r := RenderCommand{
 				extractor: &query.WholeFileExtractor{
 					Fs:       fs,
-					Renderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, "your-pipeline-name", "your-run-id", pl.Variables.Value()),
+					Renderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, pl.Name, "your-run-id", pl.Variables.Value()),
 				},
 				materializers: map[pipeline.AssetType]queryMaterializer{
 					pipeline.AssetTypeBigqueryQuery:   bigquery.NewMaterializer(fullRefresh),
@@ -364,7 +364,7 @@ func getPipelineDefinitionFullPath(pipelinePath string) (string, error) {
 func modifyExtractor(ctx ModifierInfo, p *pipeline.Pipeline, t *pipeline.Asset) queryExtractor {
 	newStartDate := pipeline.ModifyDate(ctx.StartDate, t.IntervalModifiers.Start)
 	newEnddate := pipeline.ModifyDate(ctx.EndDate, t.IntervalModifiers.End)
-	newRenderer := jinja.NewRendererWithStartEndDates(&newStartDate, &newEnddate, "your-pipeline-name", "your-run-id", p.Variables.Value())
+	newRenderer := jinja.NewRendererWithStartEndDates(&newStartDate, &newEnddate, p.Name, "your-run-id", p.Variables.Value())
 
 	return &query.WholeFileExtractor{
 		Renderer: newRenderer,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -754,7 +754,7 @@ func setupExecutors(
 
 		metadataPushOperator := bigquery.NewMetadataPushOperator(conn)
 		bqQuerySensor := bigquery.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
-		bqTableSensor := bigquery.NewTableSensor(conn, sensorMode)
+		bqTableSensor := bigquery.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeBigqueryQuery][scheduler.TaskInstanceTypeMain] = bqOperator
 		mainExecutors[pipeline.AssetTypeBigqueryQuery][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner


### PR DESCRIPTION
This pr aims to make our jinja rendering support more robust by 

- enabling  support of pipeline names in the vscode query rendering UI 
- Jinja rendering in table sensor assets 
- enabling support of pipeline names in the query command 