### PR TITLE
Fix typos and update 'bruin' to 'Bruin' in documentation

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -49,7 +49,7 @@ Assets that are defined as YAML files have to have file names as `<name>.asset.y
 :::
 
 ## `name`
-The name of the asset, used for many things including dependencies, materialiation and more. Corresponds to the `schema.table` convention.
+The name of the asset, used for many things including dependencies, materialization and more. Corresponds to the `schema.table` convention.
 Must consist of letters and dot `.` character.
 - **Type:** `String`
 

--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -1,6 +1,6 @@
 # Materialization
 
-Materialization is the idea taking a simple `SELECT` query, and applying the necessary logic to materialize the results into a table or view. This is a common pattern in data engineering, where you have a query that is expensive to run, and you want to store the results in a table for faster access.
+Materialization is the idea of taking a simple `SELECT` query, and applying the necessary logic to materialize the results into a table or view.
 
 Bruin supports various materialization strategies catered to different use cases.
 

--- a/docs/assets/seed.md
+++ b/docs/assets/seed.md
@@ -19,7 +19,7 @@ You can see the "Data Platforms" on the left sidebar to see supported types.
 The `parameters` key in the configuration defines the parameters for the seed asset. The `path` parameter is the path to the CSV file that will be loaded into the data platform. path is relative to the asset definition file.
 
 ##  Examples
-The examples below show how load a csv into a Duckdb & bigquery database.
+The examples below show how to load a CSV into a DuckDB & BigQuery database.
 
 ### Simplest: Load csv into a Duckdb
 ```yaml
@@ -37,4 +37,4 @@ Y,LinkedIn,SDE,2024-01-01
 B,LinkedIn,SDE 2,2024-01-01
 ```
 
-This operation will load the csv into a table called `seed.raw` in the Duckdb database.
+This operation will load the CSV into a table called `seed.raw` in the DuckDB database.

--- a/docs/assets/sensor.md
+++ b/docs/assets/sensor.md
@@ -2,7 +2,7 @@
 
 Sensor assets are a special type of asset that allows you to wait until a certain external event has occurred.
 
-The most common usecase of a sensor is when a piece of data is being produced by external systems, and you want to wait until that data is available before you start processing it. For example, you may want to wait until a file is available in a certain location, or until a certain database table has been populated with data.
+The most common use case of a sensor is when a piece of data is being produced by external systems, and you want to wait until that data is available before you start processing it.
 
 Sensors are implemented on a per-platform basis, therefore some platforms may have more sensors than others.
 
@@ -28,7 +28,7 @@ Sensors are a crucial part of integrating Bruin with external systems, and we ar
 
 ### Poking Interval
 
-Sensor work as a poking mechanism, they will check the status of the external event every few minutes until the event has occurred.
+Sensors work as a poking mechanism, they will check the status of the external event every few minutes until the event has occurred.
 
 You can control how often the poking occurs via the `poke_interval` parameter, value being in seconds.
 

--- a/docs/assets/templating/templating.md
+++ b/docs/assets/templating/templating.md
@@ -82,7 +82,7 @@ variables:
       tenant: acme
 ```
 :::
-All user-defined variables are accessible via the `var` namespace. For example, if you define a variable called `src`, it will be available as `{{ var.src }}` in your Assets.
+All user-defined variables are accessible via the `var` namespace. For example, if you define a variable called `src`, it will be available as <code>&lbrace;&lbrace; var.src &rbrace;&rbrace;</code> in your assets.
 
 Additionally all top level variables must define a `default` value. This will be used to render your assets in absence of values supplied on the commandline.
 

--- a/docs/assets/templating/templating.md
+++ b/docs/assets/templating/templating.md
@@ -56,7 +56,7 @@ You can read more about [Jinja here](https://jinja.palletsprojects.com/en/3.1.x/
 ## Adding variables
 
 You can add variables in your `pipeline.yml` file. We support all YAML data types to give you the
-maximum flexiblity in your variable configuration. `variables` are declared as [JSON Schema object](https://json-schema.org/draft-07/draft-handrews-json-schema-01#rfc.section.4.2.1). Here's a comprehensive example:
+maximum flexibility in your variable configuration. `variables` are declared as [JSON Schema object](https://json-schema.org/draft-07/draft-handrews-json-schema-01#rfc.section.4.2.1). Here's a comprehensive example:
 
 ::: code-group 
 ```yaml [pipeline.yml]
@@ -82,7 +82,7 @@ variables:
       tenant: acme
 ```
 :::
-All user defined variables are accessibe via `var` namespace. For example, if you define a variable called `src` it will be available as  <code>&lbrace;&lbrace; var.src &rbrace;&rbrace;</code> in your Assets.
+All user-defined variables are accessible via the `var` namespace. For example, if you define a variable called `src`, it will be available as `{{ var.src }}` in your Assets.
 
 Additionally all top level variables must define a `default` value. This will be used to render your assets in absence of values supplied on the commandline.
 
@@ -99,7 +99,7 @@ $ bruin run --var key=value
 $ bruin run --var '{"key": "value"}'
 ```
 
-The `--var` flag can be specified multiple times. However beware that if you specify the same key multiple times, the latter one will overwrite the previous one.
+The `--var` flag can be specified multiple times. However, beware that if you specify the same key multiple times, the latter one will overwrite the previous one.
 
 ## Builtin variables
 

--- a/docs/cloud/cross-pipeline.md
+++ b/docs/cloud/cross-pipeline.md
@@ -8,7 +8,7 @@ Bruin considers assets unique; however, asset names often do not fulfill the uni
 
 However, even if they have assets with the same name, in reality they have separate tables in their data warehouse.
 
-In order to uniquely identify where the individual assets contain, Bruin has a concept of a URI. A URI is a unique identifier for an asset, and it is expected to be unique across all pipelines and repos of the customer.
+In order to uniquely identify what the individual assets contain or where they are located, Bruin has a concept of a URI. A URI is a unique identifier for an asset, and it is expected to be unique across all pipelines and repos of the customer.
 
 
 > [!WARNING]
@@ -50,7 +50,7 @@ depends:
 The new `uri` key in the `depends` array allows you to define a dependency on an asset that lives in a different pipeline. This allows you to define cross-pipeline dependencies without having to know what pipeline or repo the asset lives in.
 
 > [!INFO]
-> Bruin required `depends` to be a string array previously, whereas now it can accept an object with the `uri` key as well.
+> Bruin previously required `depends` to be a string array, whereas now it can also accept an object with the `uri` key.
 
 
 ## How it works?
@@ -74,15 +74,15 @@ This approach has a couple of advantages:
 ## Dependencies with different schemas
 
 When the upstream and downstream both have the same schedule, it's easy to determine when does the downstream need to run. 
-E.g if both every 5 minutes, then if downstream has a data interval from `2025-10-11 15:30:00`to `2025-10-11 15:35:00`,
+E.g., if both run every 5 minutes, then if downstream has a data interval from `2025-10-11 15:30:00`to `2025-10-11 15:35:00`,
 then the upstream should have a successful run for the same interval.
 
 In the case of mixed schedules it's a bit more complicated but still possible.
 Imagine we have a downstream that runs every 5 minutes and we have a run with the data interval  `2025-10-11 15:30:00`to `2025-10-11 15:35:00`.
 This downstream has an external dependency that runs every 2 minutes.
 
-The in order to run the downstream we will wait until the upstream has successful runs with data intervals covering fully the downstream data interval.
-For example for the aforementioned `2025-10-11 15:30:00`to `2025-10-11 15:35:00`, we would need downstream to have for example.
+Then, in order to run the downstream, we will wait until the upstream has successful runs with data intervals covering fully the downstream data interval.
+For example for the aforementioned `2025-10-11 15:30:00`to `2025-10-11 15:35:00`, we would need the downstream to have, for example:
 
  * `2025-10-11 15:30:00`to `2025-10-11 15:32:00`
  * `2025-10-11 15:32:00`to `2025-10-11 15:34:00`

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -47,7 +47,7 @@ table td:first-child {
 
 ### Continue from the last failed asset
 
-If you want to continue from the last failed task, you can use the `--continue` flag. This will run the pipeline/asset from the last failed task. Bruin will automatically retrive all the flags used in the last run. 
+If you want to continue from the last failed task, you can use the `--continue` flag. This will run the pipeline/asset from the last failed task. Bruin will automatically retrieve all the flags used in the last run. 
 
 ```bash
 bruin run --continue 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -133,7 +133,7 @@ default:
       end: 2h
 ```
 
-For more detail, Please check the example from the template [here](https://github.com/bruin-data/bruin/blob/main/templates/chess/pipeline.yml).
+For more details, please check the example from the template [here](https://github.com/bruin-data/bruin/blob/main/templates/chess/pipeline.yml).
 
 ## Sensors
 Sensors are a special type of assets that are used to wait on certain external signals. Sensors are useful to wait on external signals such as a table being created in an external database, or a file being uploaded to S3. A common usecase for sensors is when there are datasets/files/tables that are created by a separate process and you need to wait for them to be created before running your assets.

--- a/docs/getting-started/devenv.md
+++ b/docs/getting-started/devenv.md
@@ -134,8 +134,8 @@ flowchart LR
 
 
 When you run this asset in a schema-prefixed environments, Bruin will do a few things:
-- First of all, it will analyze if the query, and identify the used tables. 
-  - In this example, it will identify `chess.players` is found.
+- First of all, it will analyze the query and identify the used tables. 
+  - In this example, it will identify that `chess.players` is found.
 - In parallel, it will gather a list of available schemas and tables within the given database.
 - It will check which of the referenced schemas and tables exist with the prefix.
 - For each table that has a copy in a prefixed schema, Bruin will rewrite the query and the asset to use the prefixed schema names instead.

--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -1,6 +1,6 @@
 # Policies
 
-Bruin supports **policies** to verify that data transformation jobs follow best practices and organisation wide conventions. In addition to built-in lint rules, Bruin also allows users to define **custom lint rules** using a `policy.yml` file.
+Bruin supports **policies** to verify that data transformation jobs follow best practices and organization-wide conventions. In addition to built-in lint rules, Bruin also allows users to define **custom lint rules** using a `policy.yml` file.
 
 This document explains how to define, configure, and use custom linting policies.
 

--- a/docs/getting-started/telemetry.md
+++ b/docs/getting-started/telemetry.md
@@ -3,10 +3,10 @@ outline: deep
 ---
 
 # Telemetry
-bruin uses a very basic form of **anonymous telemetry** to be able to keep track of the usage on a high-level.
+Bruin uses a very basic form of **anonymous telemetry** to be able to keep track of the usage on a high-level.
 - It uses anonymous machine IDs that are hashed to keep track of the number of unique users.
 - It sends the following information:
-    - bruin version
+    - Bruin version
     - machine ID (Anomymous)
     - OS info: OS, architecture
     - command executed

--- a/docs/getting-started/templates-docs/athena-README.md
+++ b/docs/getting-started/templates-docs/athena-README.md
@@ -22,7 +22,7 @@ The pipeline includes the following SQL assets located in the `assets/` folder:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 bruin --start-date 2024-01-01 run ./athena/pipeline.yml

--- a/docs/getting-started/templates-docs/chess-README.md
+++ b/docs/getting-started/templates-docs/chess-README.md
@@ -32,7 +32,7 @@ You can simply switch the environment using the `--environment` flag, e.g.:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 bruin run ./chess/pipeline.yml
@@ -57,4 +57,4 @@ Executed 1 tasks in 103ms
 
 You can optionally pass a `--downstream` flag to run the task with all of its downstreams.
 
-That's it, good luc
+That's it, good luck!

--- a/docs/getting-started/templates-docs/clickhouse-README.md
+++ b/docs/getting-started/templates-docs/clickhouse-README.md
@@ -31,7 +31,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 

--- a/docs/getting-started/templates-docs/duckdb-README.md
+++ b/docs/getting-started/templates-docs/duckdb-README.md
@@ -22,7 +22,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 

--- a/docs/getting-started/templates-docs/firebase-README.md
+++ b/docs/getting-started/templates-docs/firebase-README.md
@@ -38,7 +38,7 @@ Review TODOs: The SQL files events/events.sql, user_model/users_daily.sql, and e
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 bruin run ./firebase/pipeline.yml

--- a/docs/getting-started/templates-docs/gorgias-README.md
+++ b/docs/getting-started/templates-docs/gorgias-README.md
@@ -31,7 +31,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 # this will get all the satisfaction surveys starting from 2024-01-01

--- a/docs/getting-started/templates-docs/gsheet-bigquery-README.md
+++ b/docs/getting-started/templates-docs/gsheet-bigquery-README.md
@@ -29,7 +29,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 ❯ bruin run ./templates/gsheet-bigquery/                                                       (bruin) 

--- a/docs/getting-started/templates-docs/gsheet-duckdb-README.md
+++ b/docs/getting-started/templates-docs/gsheet-duckdb-README.md
@@ -28,7 +28,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 
 ```shell

--- a/docs/getting-started/templates-docs/notion-README.md
+++ b/docs/getting-started/templates-docs/notion-README.md
@@ -27,7 +27,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 bruin run assets/notion.asset.yml

--- a/docs/getting-started/templates-docs/shopify-bigquery-README.md
+++ b/docs/getting-started/templates-docs/shopify-bigquery-README.md
@@ -28,7 +28,7 @@ environments:
 
 ## Running the pipeline
 
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 
 ```shell
 bruin run assets/shopify.asset.yml

--- a/docs/getting-started/templates-docs/shopify-duckdb-README.md
+++ b/docs/getting-started/templates-docs/shopify-duckdb-README.md
@@ -25,7 +25,7 @@ environments:
                   url: "******.myshopify.com"
 ```
 ## Running the pipeline
-bruin CLI can run the whole pipeline or any task with the downstreams:
+Bruin CLI can run the whole pipeline or any task with the downstreams:
 ```shell
 bruin run assets/shopify.asset.yml
 ```

--- a/docs/ingestion/adjust.md
+++ b/docs/ingestion/adjust.md
@@ -18,7 +18,7 @@ To connect to Adjust, you need to add a configuration item to the connections se
           api_key: "abc123"
 ```
 - `api_key`: The API key for the Adjust account.
-- `lookback_days`: Optional. The number of days to go back than the given start date for data. Defaults to 30 days. To know more about it, please refer [here](https://bruin-data.github.io/ingestr/supported-sources/adjust.html#lookback-days)
+- `lookback_days`: Optional. The number of days to go back from the given start date for data. Defaults to 30 days. To know more about it, please refer [here](https://bruin-data.github.io/ingestr/supported-sources/adjust.html#lookback-days)
 
 ### Step 2: Create an asset file for data ingestion
 

--- a/docs/ingestion/applovin.md
+++ b/docs/ingestion/applovin.md
@@ -3,7 +3,7 @@
 
 Bruin supports AppLovin as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from AppLovin into your data platform.
 
-To set up a AppLovin connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `api_key` that is report key. You can generate a report key from your [analytics dashboard](https://dash.applovin.com/login#keys).
+To set up an AppLovin connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `api_key` that is report key. You can generate a report key from your [analytics dashboard](https://dash.applovin.com/login#keys).
 
 Follow the steps below to set up AppLovin correctly as a data source and run ingestion.
 ### Step 1: Add a connection to the .bruin.yml file

--- a/docs/ingestion/applovin_max.md
+++ b/docs/ingestion/applovin_max.md
@@ -3,7 +3,7 @@
 
 Bruin supports AppLovin Max as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from AppLovin Max into your data platform.
 
-To set up a AppLovin Max connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `api_key` that is report key and `application`. For details on how to obtain these credentials, please refer [here](https://developers.applovin.com/en/max/max-dashboard/account/account-info/#keys)
+To set up an AppLovin Max connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `api_key` that is report key and `application`. For details on how to obtain these credentials, please refer [here](https://developers.applovin.com/en/max/max-dashboard/account/account-info/#keys)
 
 Follow the steps below to set up AppLovin Max correctly as a data source and run ingestion.
 ### Step 1: Add a connection to the .bruin.yml file

--- a/docs/ingestion/appsflyer.md
+++ b/docs/ingestion/appsflyer.md
@@ -3,7 +3,7 @@
 
 Bruin supports Appsflyer as a source, and you can use it to ingest data from Appsflyer into your data warehouse.
 
-In order to have set up Appsflyer connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema. For more information on how to get these credentials check the Appsflyer section in [Ingestr documentation](https://bruin-data.github.io/ingestr/getting-started/quickstart.html)
+In order to set up an Appsflyer connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema. For more information on how to get these credentials check the Appsflyer section in [Ingestr documentation](https://bruin-data.github.io/ingestr/getting-started/quickstart.html)
 
 
 ```yaml

--- a/docs/ingestion/dynamodb.md
+++ b/docs/ingestion/dynamodb.md
@@ -22,7 +22,7 @@ To connect to DynamoDB, you need to add a configuration item to the connections 
           
 ```
 
-* `access_key_id`: Identifes an IAM account.
+* `access_key_id`: Identifies an IAM account.
 * `secret_access_key`: Password for the IAM account.
 * `region`: AWS region in which your DynamoDB table exists.
 

--- a/docs/ingestion/facebook-ads.md
+++ b/docs/ingestion/facebook-ads.md
@@ -3,7 +3,7 @@ Facebook Ads is the advertising platform that helps users to create targeted ads
 
 Bruin supports Facebook Ads as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Facebook Ads into your data warehouse.
 
-In order to set up Facebook Ads connection, you need to add a configuration item in the `.bruin.yml` file and `asset` file. You need `access_token` and `accound_id`. For details on how to obtain these credentials, please refer [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/facebook_ads#grab-credentials)
+In order to set up Facebook Ads connection, you need to add a configuration item in the `.bruin.yml` file and `asset` file. You need `access_token` and `account_id`. For details on how to obtain these credentials, please refer [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/facebook_ads#grab-credentials)
 
 Follow the steps below to correctly set up Facebook Ads as a data source and run ingestion.
 

--- a/docs/ingestion/google_analytics.md
+++ b/docs/ingestion/google_analytics.md
@@ -21,7 +21,7 @@ Follow the steps below to correctly set up Google Analytics as a data source and
 
 ### Step 2: Create an asset file for data ingestion
 To ingest data from Google Analytics, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., gAnalytics_ingestion.yml) inside the assets folder and add the following content:
-s
+
 ```yaml
 name: public.googleanalyticss
 type: ingestr
@@ -34,7 +34,7 @@ parameters:
   destination: postgres
 ```
 - `name`: The name of the asset.
-- `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For Pipedrive, it will be always `ingestr`.
+- `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For Google Analytics, it will be always `ingestr`.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
 - `source_connection`: The name of the Google Analytics connection defined in .bruin.yml.
 - `source_table`: The name of the data table in Google Analytics to ingest data from.

--- a/docs/ingestion/klaviyo.md
+++ b/docs/ingestion/klaviyo.md
@@ -1,5 +1,5 @@
 # Klaviyo
-[Klaviyo](https://www.Klaviyo.com/) is a marketing automation platform that helps businesses build and manage digital relationships with their customers by connecting through personalized email and enhancing customer loyality.
+[Klaviyo](https://www.Klaviyo.com/) is a marketing automation platform that helps businesses build and manage digital relationships with their customers by connecting through personalized email and enhancing customer loyalty.
 
 Bruin supports Klaviyo as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Klaviyo into your data warehouse.
 

--- a/docs/ingestion/notion.md
+++ b/docs/ingestion/notion.md
@@ -32,7 +32,7 @@ parameters:
   source_connection: my_notion
   source_table: 'd8ee2d159ac34cfc85827ba5a0a8ae71'
 
-  destination: postgress
+  destination: postgres
 ```
 
 - `name`: The name of the asset.

--- a/docs/ingestion/phantombuster.md
+++ b/docs/ingestion/phantombuster.md
@@ -1,5 +1,5 @@
 # PhantomBuster
-[PhantomBuster](https://phantombuster.com/) is a cloud-based data automation and web scraping platform that allows users to extract data from websites, automate action.
+[PhantomBuster](https://phantombuster.com/) is a cloud-based data automation and web scraping platform that allows users to extract data from websites, automate actions.
 
 Bruin supports PhantomBuster as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from PhantomBuster into your data warehouse.
 

--- a/docs/ingestion/s3.md
+++ b/docs/ingestion/s3.md
@@ -1,5 +1,5 @@
 # S3
-Amazon Simple Storage Service [S3](https://aws.amazon.com/s3/) is a service offered by Amazon Web Services (AWS) that provides object storage through a web service interface.Amazon S3 uses the same scalable storage infrastructure that Amazon.com uses to run its e-commerce network. Amazon S3 can store any type of object, which allows uses like storage for Internet applications, backups, disaster recovery, data archives, data lakes for analytics, and hybrid cloud storage.
+Amazon Simple Storage Service [S3](https://aws.amazon.com/s3/) is a service offered by Amazon Web Services (AWS) that provides object storage through a web service interface.Amazon S3 uses the same scalable storage infrastructure that Amazon.com uses to run its e-commerce network. Amazon S3 can store any type of object, which allows use cases like storage for Internet applications, backups, disaster recovery, data archives, data lakes for analytics, and hybrid cloud storage.
 
 Bruin supports S3 as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from S3 into your data warehouse.
 

--- a/docs/ingestion/shopify.md
+++ b/docs/ingestion/shopify.md
@@ -8,6 +8,7 @@ In order to set up Shopify connection, you need to add a configuration item in t
 Follow the steps below to correctly set up Shopify as a data source and run ingestion:
 
 ### Step 1: Add a connection to .bruin.yml file
+To ingest data from Shopify, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., shopify_ingestion.yml) inside the assets folder and add the following content:
 
 ```yaml
    connections:

--- a/docs/ingestion/shopify.md
+++ b/docs/ingestion/shopify.md
@@ -8,7 +8,6 @@ In order to set up Shopify connection, you need to add a configuration item in t
 Follow the steps below to correctly set up Shopify as a data source and run ingestion:
 
 ### Step 1: Add a connection to .bruin.yml file
-To ingest data from Shopify, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., shopify_ingestion.yml) inside the assets folder and add the following content:
 
 ```yaml
    connections:

--- a/docs/ingestion/shopify.md
+++ b/docs/ingestion/shopify.md
@@ -5,7 +5,7 @@ Bruin supports Shopify as a source for [Ingestr assets](/assets/ingestr), and yo
 
 In order to set up Shopify connection, you need to add a configuration item in the `.bruin.yml` file and in `asset` file. You need the `url` of your Shopify store and the `api_key`. For details on how to obtain these credentials, please refer [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/shopify#setup-guide).
 
-Follow the steps below to correctly set up shopify as a data source and run ingestion:
+Follow the steps below to correctly set up Shopify as a data source and run ingestion:
 
 ### Step 1: Add a connection to .bruin.yml file
 To ingest data from Shopify, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., shopify_ingestion.yml) inside the assets folder and add the following content:
@@ -36,7 +36,7 @@ parameters:
 - `type`: Specifies the type of the asset. It will be always ingestr type for Shopify.
 - `connection`: This is the destination connection.
 - `source_connection`: The name of the Shopify connection defined in .bruin.yml.
-- `source_table`: The name of the data table in shopify you want to ingest. For example, "order" would ingest data related to order.You can find the available source tables in Shopify [here](https://bruin-data.github.io/ingestr/supported-sources/shopify.html#available-tables)
+- `source_table`: The name of the data table in Shopify you want to ingest. For example, "order" would ingest data related to order.You can find the available source tables in Shopify [here](https://bruin-data.github.io/ingestr/supported-sources/shopify.html#available-tables)
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 ```     

--- a/docs/ingestion/slack.md
+++ b/docs/ingestion/slack.md
@@ -5,7 +5,7 @@ Bruin supports Slack as a source for [Ingestr assets](/assets/ingestr), and you 
 
 In order to set up Slack connection, you need to add a configuration item in the `.bruin.yml` file and in `asset` file. You need the `api_key`. For details on how to obtain these credentials, please refer [here](https://dlthub.com/docs/dlt-ecosystem/verified-sources/slack#setup-guide).
 
-Follow the steps below to correctly set up slack as a data source and run ingestion:
+Follow the steps below to correctly set up Slack as a data source and run ingestion:
 
 ### Step 1: Add a connection to .bruin.yml file
 
@@ -35,10 +35,10 @@ parameters:
 ```
 
 - name: The name of the asset.
-- type: Specifies the type of the asset. It will be always ingestr type for slack.
+- type: Specifies the type of the asset. It will be always ingestr type for Slack.
 - connection: This is the destination connection.
-- source_connection: The name of the slack connection defined in .bruin.yml.
-- source_table: The name of the data table in slack you want to ingest.
+- source_connection: The name of the Slack connection defined in .bruin.yml.
+- source_table: The name of the data table in Slack you want to ingest.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 ```

--- a/docs/ingestion/sqlite.md
+++ b/docs/ingestion/sqlite.md
@@ -1,8 +1,6 @@
 # SQLite
 SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine.
 
-ingestr supports SQLite as a source.
-
 Bruin supports SQLite as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from SQLite into your data warehouse. 
 
 In order to set up SQLite connection, you need to add a configuration item in the `.bruin.yml` file and in `asset` file.

--- a/docs/ingestion/tiktokads.md
+++ b/docs/ingestion/tiktokads.md
@@ -48,7 +48,7 @@ Custom Table Format:
 `custom:<dimensions>:<metrics>[:<filter_name,filter_values>]`
 Parameters:
 `dimensions`(required): A comma-separated list of dimensions to retrieve.
-`metrics(required): A comma-separated list of metrics to retrieve.
+`metrics` (required): A comma-separated list of metrics to retrieve.
 `filters (optional): Filters are specified in the format <filter_name=filter_values>.
 `filter_name`: The name of the filter (e.g. campaign_ids).
 `filter_values`: A comma-separated list of one or more values associated with the filter name (e.g., camp_id123,camp_id456). Only the IN filter type is supported. Learn more about filters [here](https://business-api.tiktok.com/portal/docs?id=1751443975608321).

--- a/docs/ingestion/zendesk.md
+++ b/docs/ingestion/zendesk.md
@@ -5,7 +5,7 @@ Bruin supports Zendesk as a source for [Ingestr assets](/assets/ingestr), and yo
 
 In order to set up Zendesk connection, you need to add a configuration item to `connections` in the `.bruin.yml` file and in `asset` file. Depending on the data you are ingesting (source_table), you will need to use either `API Token authentication` or `OAuth Token authentication`. Choose the appropriate method based on your source table. For more details, please refer to the [Ingestr documentation](https://bruin-data.github.io/ingestr/supported-sources/zendesk.html)
 
-Follow the steps below to correctly set up zendesk as a data source and run ingestion.
+Follow the steps below to correctly set up Zendesk as a data source and run ingestion.
 ### Step 1: Add a connection to .bruin.yml file
 
 To connect to Zendesk, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
@@ -35,7 +35,7 @@ OAuth Token Authentication:
 - `oauth_token`: the OAuth token used for authentication with Zendesk
 
 ### Step 2: Create an asset file for data ingestion
-To ingest data from zendesk, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., zendesk_ingestion.yml) inside the assets folder and add the following content:
+To ingest data from Zendesk, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., zendesk_ingestion.yml) inside the assets folder and add the following content:
 
 ```yaml
 name: public.zendesk
@@ -52,13 +52,13 @@ parameters:
 - `name`: The name of the asset.
 - `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
-- `source_connection`: The name of the zendesk connection defined in .bruin.yml.
-- `source_table`: The name of the data table in zendesk that you want to ingest. You can find the available source tables in Zendesk [here](https://bruin-data.github.io/ingestr/supported-sources/zendesk.html#tables)
+- `source_connection`: The name of the Zendesk connection defined in .bruin.yml.
+- `source_table`: The name of the data table in Zendesk that you want to ingest. You can find the available source tables in Zendesk [here](https://bruin-data.github.io/ingestr/supported-sources/zendesk.html#tables)
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 ```     
 bruin run assets/zendesk_ingestion.yml
 ```
-As a result of this command, Bruin will ingest data from the given zendesk table into your Postgres database.
+As a result of this command, Bruin will ingest data from the given Zendesk table into your Postgres database.
 
 <img width="1082" alt="zendesk" src="https://github.com/user-attachments/assets/b4cb54eb-dc05-4b6e-a113-e07316be9bff">

--- a/docs/platforms/athena.md
+++ b/docs/platforms/athena.md
@@ -95,7 +95,7 @@ group by order_date;
 
 
 ### `athena.seed`
-`athena.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your athena database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the athena database.
+`athena.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Athena database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Athena database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -112,7 +112,7 @@ parameters:
 
 ####  Examples: Load csv into a Athena database
 
-The examples below show how load a csv into a athena database.
+The examples below show how to load a CSV into an Athena database.
 ```yaml
 name: dashboard.hello
 type: athena.seed

--- a/docs/platforms/bigquery.md
+++ b/docs/platforms/bigquery.md
@@ -142,7 +142,7 @@ parameters:
 ```
 
 ### `bq.seed`
-`bq.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your bigquery database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the bigquery database.
+`bq.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your BigQuery database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the BigQuery database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -159,7 +159,7 @@ parameters:
 
 ####  Examples: Load csv into a BigQuery database
 
-The examples below show how load a csv into a bigquery database.
+The examples below show how to load a CSV into a BigQuery database.
 ```yaml
 name: dashboard.hello
 type: bq.seed

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -3,7 +3,7 @@
 Bruin supports Clickhouse as both a source and a destination.
 
 ## Connection
-In order to have set up a Clickhouse connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema:
+In order to set up a Clickhouse connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema:
 
 ```yaml
 connections:
@@ -93,7 +93,7 @@ ORDER BY average_rating DESC;
 
 
 ### `clickhouse.seed`
-`clickhouse.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your clickhouse database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the clickhouse database.
+`clickhouse.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Clickhouse database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Clickhouse database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -110,7 +110,7 @@ parameters:
 
 ####  Examples: Load csv into a Clickhouse database
 
-The examples below show how to load a csv into a clickhouse database:
+The examples below show how to load a CSV into a Clickhouse database:
 ```yaml
 name: dashboard.hello
 type: clickhouse.seed

--- a/docs/platforms/databricks.md
+++ b/docs/platforms/databricks.md
@@ -69,7 +69,7 @@ join marketing.attribution as a
 ```
 
 ### `databricks.seed`
-`databricks.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your databricks database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the databricks database.
+`databricks.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Databricks database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Databricks database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -86,7 +86,7 @@ parameters:
 
 ####  Examples: Load csv into a Databricks database
 
-The examples below show how load a csv into a databricks database.
+The examples below show how to load a CSV into a Databricks database.
 ```yaml
 name: dashboard.hello
 type: databricks.seed

--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -60,7 +60,7 @@ FROM events.customers
 
 
 ### `duckdb.seed`
-`duckdb.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your duckdb database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the duckdb database.
+`duckdb.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your DuckDB database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the DuckDB database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -77,7 +77,7 @@ parameters:
 
 ####  Examples: Load csv into a Duckdb database
 
-The examples below show how load a csv into a duckdb database.
+The examples below show how to load a CSV into a DuckDB database.
 ```yaml
 name: dashboard.hello
 type: duckdb.seed

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -143,8 +143,8 @@ Bruin internally sets the [`PYTHONPATH`](https://docs.python.org/3/using/cmdline
 #### Workspace
 Python assets require `workspace` to be configured in your `emr_serverless` connection. Workspace is a S3 path that is used by Bruin as working storage for jobs that run on `emr_serverless`.
 
-Bruin uses this S3 path for several purposes:
-* Storing logs.
+Bruin uses this S3 path for:
+* Storing Logs.
 * Staging your entrypoint file.
 * Uploading bundled dependencies.
 

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -143,8 +143,8 @@ Bruin internally sets the [`PYTHONPATH`](https://docs.python.org/3/using/cmdline
 #### Workspace
 Python assets require `workspace` to be configured in your `emr_serverless` connection. Workspace is a S3 path that is used by Bruin as working storage for jobs that run on `emr_serverless`.
 
-Bruin uses this S3 path for:
-* Storing Logs.
+Bruin uses this S3 path for several purposes:
+* Storing logs.
 * Staging your entrypoint file.
 * Uploading bundled dependencies.
 

--- a/docs/platforms/emr_serverless.md
+++ b/docs/platforms/emr_serverless.md
@@ -5,7 +5,7 @@ Bruin supports EMR Serverless as a data platform. You can use Bruin to integrate
 
 ## Connection
 
-In order to use bruin to run spark jobs in EMR Serverless, you need to define an `emr_serverless` connection in your `.bruin.yml` file. Here's a sample `.bruin.yml` with the required fields defined.
+In order to use Bruin to run Spark jobs in EMR Serverless, you need to define an `emr_serverless` connection in your `.bruin.yml` file. Here's a sample `.bruin.yml` with the required fields defined.
 
 ```yaml 
 environments:
@@ -93,7 +93,7 @@ Advanced Spark users often package core logic into reusable libraries to improve
 
 Bruin has seamless support for pyspark modules.
 
-For this example, let's assume this is how your bruin pipeline is structured:
+For this example, let's assume this is how your Bruin pipeline is structured:
 ```
 acme_pipeline/
 ├── assets
@@ -103,13 +103,13 @@ acme_pipeline/
 └── pipeline.yml
 ```
 
-Let's say that `acme_pipeline/lib/core.py` stores some common routines used throughout your jobs. For this example, we'll create a function called `sanitize` that takes in a Spark DataFrame and sanitize it's columns (A common operation in Data Analytics).
+Let's say that `acme_pipeline/lib/core.py` stores some common routines used throughout your jobs. For this example, we'll create a function called `sanitize` that takes in a Spark DataFrame and sanitize its columns (A common operation in Data Analytics).
 
 ::: code-group
 ```python [acme_pipeline/lib/core.py]
 from pyspark.sql import DataFrame
 
-def sanitize(df: DateFrame):
+def sanitize(df: DataFrame):
   """
   sanitize a dataframe
   """
@@ -141,11 +141,11 @@ if __name__ == "__main__":
 Bruin internally sets the [`PYTHONPATH`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH) to the root of your pipeline. So you'll always have to use the fully qualified package name to import any internal packages. 
 
 #### Workspace
-Python assets require `workspace` to be configured in your `emr_serverless` connection. Workspace is a S3 path that is used by bruin as working storage for jobs that run on `emr_serverless`.
+Python assets require `workspace` to be configured in your `emr_serverless` connection. Workspace is a S3 path that is used by Bruin as working storage for jobs that run on `emr_serverless`.
 
-Bruin uses this for:
-* Storing Logs
-* Staging your entrypoint file
+Bruin uses this S3 path for:
+* Storing Logs.
+* Staging your entrypoint file.
 * Uploading bundled dependencies.
 
 ![workspace diagram](media/pyspark-workspace.svg)
@@ -350,7 +350,7 @@ if __name__ == "__main__":
 :::
 
 ::: tip
-If all your Assets share the same `type` and `parameters.athena_connection`, you can set them as [defaults](/getting-started/concepts.html#defaults) in your `pipeline.yml` to avoid repeating them for each Asset.
+If all your assets share the same `type` and `parameters.athena_connection`, you can set them as [defaults](/getting-started/concepts.html#defaults) in your `pipeline.yml` to avoid repeating them for each asset.
 
 
 ```yaml 
@@ -361,7 +361,7 @@ default:
     athena_connection: quality-checks
 ```
 :::
-Now when we run our bruin pipeline again, our quality checks should run after our Asset run finishes.
+Now when we run our Bruin pipeline again, our quality checks should run after our Asset run finishes.
 ```sh
 bruin run ./quality-checks-example
 ```

--- a/docs/platforms/materialization.md
+++ b/docs/platforms/materialization.md
@@ -1,6 +1,6 @@
 # Materialization
 
-Materialization is the idea taking a simple `SELECT` query, and applying the necessary logic to materialize the results into a table or view. This is a common pattern in data engineering, where you have a query that is expensive to run, and you want to store the results in a table for faster access.
+Materialization is the idea of taking a simple `SELECT` query, and applying the necessary logic to materialize the results into a table or view. This is a common pattern in data engineering, where you have a query that is expensive to run, and you want to store the results in a table for faster access.
 
 Bruin supports various materialization strategies catered to different use cases.
 

--- a/docs/platforms/mssql.md
+++ b/docs/platforms/mssql.md
@@ -7,7 +7,7 @@ Bruin supports Microsoft SQL Server as a data platform.
 
 
 ## Connection
-In order to have set up a SQL Server connection on Bruin, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema.
+In order to set up a SQL Server connection in Bruin, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema.
 
 ```yaml
     connections:
@@ -55,7 +55,7 @@ order by order_year, order_month;
 ```
 
 ### `ms.seed`
-`ms.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your mssql database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the mssql database.
+`ms.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your MSSQL database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the MSSQL database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -72,7 +72,7 @@ parameters:
 
 ####  Examples: Load csv into a MSSQL database
 
-The examples below show how load a csv into a mssql database.
+The examples below show how to load a CSV into an MSSQL database.
 ```yaml
 name: dashboard.hello
 type: ms.seed

--- a/docs/platforms/postgres.md
+++ b/docs/platforms/postgres.md
@@ -3,7 +3,7 @@
 Bruin supports PostgreSQL as a data platform.
 
 ## Connection
-In order to have set up a Postgres connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema.
+In order to set up a PostgreSQL connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema.
 
 ```yaml
     connections:
@@ -72,7 +72,7 @@ join marketing.attribution as a
 ```
 
 ### `pg.seed`
-`pg.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your postgres database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the postgres database.
+`pg.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your PostgreSQL database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the PostgreSQL database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -89,7 +89,7 @@ parameters:
 
 ####  Examples: Load csv into a Postgres database
 
-The examples below show how load a csv into a postgres database.
+The examples below show how to load a CSV into a PostgreSQL database.
 ```yaml
 name: dashboard.hello
 type: pg.seed

--- a/docs/platforms/redshift.md
+++ b/docs/platforms/redshift.md
@@ -3,7 +3,7 @@
 Bruin supports AWS Redshift as a data platform, which means you can use Bruin to build tables and views in your Redshift data warehouse.
 
 ## Connection
-In order to have set up a Redshift connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema
+In order to set up a Redshift connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema
 Mind that, despite the connection being at all effects a Postgres connection, the default `port` field of Amazon Redshift is `5439`.
 
 ```yaml
@@ -24,11 +24,11 @@ Mind that, despite the connection being at all effects a Postgres connection, th
 
 ### Making Redshift publicly accessible
 
-Before the connection works properly, you need to ensure that the Redshift cluster can be access from the outside. In order to do that you must mark the configuration option in your redshift cluster
+Before the connection works properly, you need to ensure that the Redshift cluster can be accessed from the outside. In order to do that you must mark the configuration option in your Redshift cluster
 
 ![Make publicly available](/publicly-accessible.png)
 
-In addition to this, you must configure the inbound rules of the security group your redshift cluster belongs to, to accept inbound connections. In the example below we enabled access for all origins but you can set more restrictive rules for this.
+In addition to this, you must configure the inbound rules of the security group your Redshift cluster belongs to, to accept inbound connections. In the example below we enabled access for all origins but you can set more restrictive rules for this.
 
 ![Inbound Rules](/inbound-rules.png)
 
@@ -79,7 +79,7 @@ commit transaction;
 
 
 ### `rs.seed`
-`rs.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your redshift database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the redshift database.
+`rs.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Redshift database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Redshift database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -96,7 +96,7 @@ parameters:
 
 ####  Examples: Load csv into a Redshift database
 
-The examples below show how load a csv into a redshift database.
+The examples below show how to load a CSV into a Redshift database.
 ```yaml
 name: dashboard.hello
 type: rs.seed

--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -3,9 +3,7 @@
 Bruin supports Snowflake as a data platform. 
 
 ## Connection
-In order to have set up a Snowflake connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema.
-
-In order to have set up a Snowflake connection, you need to add a configuration item to `connections` in the `.bruin.yml` file.
+In order to set up a Snowflake connection, you need to add a configuration item to `connections` in the `.bruin.yml` file.
 
 There's 2 different ways to fill it in
 
@@ -119,7 +117,7 @@ parameters:
 ```
 
 ### `sf.seed`
-`sf.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your snowflake database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the snowflake database.
+`sf.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Snowflake database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Snowflake database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -136,7 +134,7 @@ parameters:
 
 ####  Examples: Load csv into a Snowflake database
 
-The examples below show how load a csv into a snowflake database.
+The examples below show how to load a CSV into a Snowflake database.
 ```yaml
 name: dashboard.hello
 type: sf.seed

--- a/docs/platforms/synapse.md
+++ b/docs/platforms/synapse.md
@@ -54,7 +54,7 @@ group by customer_id;
 ```
 
 ### `synapse.seed`
-`synapse.seed` are a special type of assets that are used to represent are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your synapse database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the synapse database.
+`synapse.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Synapse database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Synapse database.
 
 You can define seed assets in a file ending with `.yaml`:
 ```yaml
@@ -71,7 +71,7 @@ parameters:
 
 ####  Examples: Load csv into a Synapse database
 
-The examples below show how load a csv into a synapse database.
+The examples below show how to load a CSV into a Synapse database.
 ```yaml
 name: dashboard.hello
 type: synapse.seed

--- a/docs/quality/available_checks.md
+++ b/docs/quality/available_checks.md
@@ -4,8 +4,8 @@ Bruin provides the following checks to validate assets, ensuring that asset data
 
 - [**Accepted Values**](#accepted-values)
 - [**Negative**](#negative)
-- [**Non-negative**](#non-negative)
-- [**Not Null**](#not-null)
+- [**Non-Negative**](#non-negative)
+- [**Not-Null**](#not-null)
 - [**Pattern**](#pattern)
 - [**Positive**](#positive)
 - [**Unique**](#unique)
@@ -35,7 +35,7 @@ columns:
     checks:
       - name: negative
 ```
-## Non negative
+## Non-Negative
 This check will verify that the values of the column are all non negative (positive or zero)
 ```yaml
 columns:
@@ -46,7 +46,7 @@ columns:
       - name: non_negative
 ```
 
-## Not Null
+## Not-Null
 This check will verify that none of the values of the checked column are null.
 ```yaml
 columns:

--- a/docs/quality/overview.md
+++ b/docs/quality/overview.md
@@ -4,8 +4,8 @@ Quality checks are tests you can perform on your Bruin assets after they run to 
 
 You can use quality checks to ensure that your data is accurate, complete, and consistent. Quality checks are a powerful tool for ensuring that your data is reliable and trustworthy.
 
-Quality checks run **after** the asset has been executed. If an asset fails a quality check and the `blocking` attribute of that check is `true` the remaining checks won't be executed. 
-If `blocking` is `false` the asset will be marked as failed but the remaining checks will be executed.
+Quality checks run **after** the asset has been executed. If an asset fails a quality check and the `blocking` attribute of that check is `true`, the remaining checks won't be executed. 
+If `blocking` is `false`, the asset will be marked as failed, but the remaining checks will be executed.
 
 See example below:
 
@@ -21,4 +21,4 @@ columns:
 
 `blocking` is `true` by default.
 
-If any of the checks fails, the asset will be marked as failed and any of the downstream assets won't be executed
+If any of the checks fails, the asset will be marked as failed and any of the downstream assets will not be executed

--- a/docs/quality/overview.md
+++ b/docs/quality/overview.md
@@ -21,4 +21,4 @@ columns:
 
 `blocking` is `true` by default.
 
-If any of the checks fails, the asset will be marked as failed and any of the downstream assets will not be executed
+If any of the checks fails, the asset will be marked as failed and any of the downstream assets will not be executed.

--- a/docs/vscode-extension/configuration.md
+++ b/docs/vscode-extension/configuration.md
@@ -1,6 +1,6 @@
 ## Configuration
 
-You can configure the Bruin VSCode extension to suit your preferences, adjusting settings for folding behavior and the default path separator.
+You can configure the Bruin VS Code extension to suit your preferences, adjusting settings for folding behavior and the default path separator.
 
 ### Folding Behavior
 
@@ -18,7 +18,7 @@ Set your preferred path separator in the extension settings under `Bruin > Path 
 
 To access and modify the Bruin extension settings:
 
-1. Open Visual Studio Code.
+1. Open VS Code.
 2. Click the **Settings** gear icon in the lower-left corner.
 3. In the search bar, type "Bruin" to filter the Bruin extension settings.
 4. Adjust the settings for **Default Folding State** and **Path Separator** as needed.

--- a/docs/vscode-extension/getting-started.md
+++ b/docs/vscode-extension/getting-started.md
@@ -1,10 +1,10 @@
 # Getting Started
 
-Once you’ve installed the Bruin VSCode extension and configured your settings, you’re ready to start using its features. Follow these steps to get started:
+Once you’ve installed the Bruin VS Code extension and configured your settings, you’re ready to start using its features. Follow these steps to get started:
 
 ## 1. Open a Supported File
 
-The Bruin extension works with SQL, Python and YAML files. Open a file with one of these extensions in VSCode, or create a new one to get started.
+The Bruin extension works with SQL, Python, and YAML files. Open a file with one of these extensions in VS Code, or create a new one to get started.
 
 ## 2. Create a Bruin Section
 
@@ -27,7 +27,7 @@ To access Bruin features, add a Bruin section in your code. You can do this manu
 
 ## 3. Use Syntax Highlighting and Autocompletion
 
-Syntax highlighting is automatic in a Bruin section. If the section is written without formatting errors, the syntax should be highlighted in YAML colors. If it appears as a comment instead, check the structure to ensure there are no errors. Autocompletion is also available in `pipeline.yaml` and `.bruin.yml` files, allowing you to access relevant properties and values as you type, with a JSON schema to maintain accuracy and completeness.
+Syntax highlighting is automatic in a Bruin section. If the section is written without formatting errors, the syntax should be highlighted in YAML colors. If it appears as a comment instead, check the structure to ensure there are no errors. Autocompletion is also available in `pipeline.yml` and `.bruin.yml` files, allowing you to access relevant properties and values as you type, with a JSON schema to maintain accuracy and completeness.
 
 ![Bruin Autocomplete](../public/vscode-extension/snippets/autocomplete-postgres.gif)
 
@@ -45,6 +45,6 @@ Run Bruin CLI commands directly from the extension:
 The Bruin extension provides two main panels :
 
 - **Side Panel**: Displays the current asset’s details with tabs for viewing asset information, columns, and settings.
-- **Lineage Panel**: Found at the bottom of VSCode, near the terminal, this panel shows the asset lineage, giving you a visual of how the asset connects to other assets.
-- **Query Preview Panel**: Found near the `Lineage` panel, this panel allows you to preview query results directly within VSCode. When running a query, results will be displayed in this panel, enabling quick debugging and verification without switching to an external database tool.
+- **Lineage Panel**: Found at the bottom of VS Code, near the terminal, this panel shows the asset lineage, giving you a visual overview of how the asset connects to other assets.
+- **Query Preview Panel**: Found near the `Lineage` panel, this panel allows you to preview query results directly within VS Code. When running a query, results will be displayed in this panel, enabling quick debugging and verification without switching to an external database tool.
 

--- a/docs/vscode-extension/overview.md
+++ b/docs/vscode-extension/overview.md
@@ -1,30 +1,30 @@
-# Bruin VSCode Extension
+# Bruin VS Code Extension
 
-The Bruin VSCode extension complements the Bruin CLI by offering a more visual and interactive approach to managing data pipelines. Integrated directly into VSCode, it simplifies tasks like building, managing, and deploying pipelines, making it easier for developers to interact with their projects.
+The Bruin VS Code extension complements the Bruin CLI by offering a more visual and interactive approach to managing data pipelines. Integrated directly into VS Code, it simplifies tasks like building, managing, and deploying pipelines, making it easier for developers to interact with their projects.
 
 ![Bruin Action Buttons](/vscode-extension/render-asset.gif)
 
 
 ## Syntax highlighting
 
-Bruin has its own syntax for defining asset metadata, inside special markers. In order to make the experience of building Bruin pipelines easier, VS Code extension includes a built-in syntax highlighter, allowing you to easily navigate the configuration & code.
+Bruin has its own syntax for defining asset metadata, inside special markers. In order to make the experience of building Bruin pipelines easier, the VS Code extension includes a built-in syntax highlighter, allowing you to easily navigate the configuration & code.
 
 ![Syntaxe Coloring](../public/vscode-extension/syntaxe-coloring.png)
 
 ## Autocompletion & Snippets
 
-Bruin VS Code extension includes autocompletion for Bruin [definitions](../assets/definition-schema), and validates the configuration. This allows you to quickly build models & easily identify mistakes in your asset definitions.
+The Bruin VS Code extension includes autocompletion for Bruin [definitions](../assets/definition-schema), and validates the configuration. This allows you to quickly build models & easily identify mistakes in your asset definitions.
 
 In addition, Bruin VS Code extension includes snippets to auto-generate full or partial configurations. Simply type `!fullsqlasset` and get a ready-to-go asset with all the fields filled out.
 
 ## Data Lineage
 
-VS Code includes a built-in lineage panel that allows you to get a clear view of how data assets connect and interact.
+The VS Code extension includes a built-in lineage panel that allows you to get a clear view of how data assets connect and interact.
 
 ![Lineage Overview](../public/vscode-extension/panels/lineage-panel/lineage-overview.png)
 
 ## Rendered Jinja queries
-Bruin supports [Jinja](../assets/templating/templating) out of the box, and while Jinja is powerful, it is often tricky to understand the resulting query. VS Code extension includes a built-in query renderer, which shows you the rendered version of the query, not just for Jinja but also [materialized](../assets/materialization.md) versions of any query.
+Bruin supports [Jinja](../assets/templating/templating) out of the box, and while Jinja is powerful, it is often tricky to understand the resulting query. The VS Code extension includes a built-in query renderer, which shows you the rendered version of the query, not just for Jinja but also [materialized](../assets/materialization.md) versions of any query.
 
 ![Bruin Action Buttons](/vscode-extension/render-asset.gif)
 
@@ -32,12 +32,12 @@ Bruin supports [Jinja](../assets/templating/templating) out of the box, and whil
 
 ## Local data catalog
 
-VS Code extension visualizes Bruin definitions, including asset & column documentation. This means that you can simply view an asset file, and on the right side you can see all the relevant details about an asset, its columns, quality checks, and lineage.
+The VS Code extension visualizes Bruin definitions, including asset & column documentation. This means that you can simply view an asset file, and on the right side you can see all the relevant details about an asset, its columns, quality checks, and lineage.
 
 
 ## Bruin CLI integration
 
-VS Code extension gives a visual way of working with Bruin pipelines. It integrates seamlessly with Bruin CLI, and allows you to validate, run and manage your assets from the interface.
+The VS Code extension gives a visual way of working with Bruin pipelines. It integrates seamlessly with Bruin CLI, and allows you to validate, run and manage your assets from the interface.
 
 ![CLI Integration](../public/vscode-extension/action-buttons.gif)
 

--- a/docs/vscode-extension/panel-overview.md
+++ b/docs/vscode-extension/panel-overview.md
@@ -1,6 +1,6 @@
 # Panels Overview  
 
-The Bruin VSCode extension provides three main panels that help streamline your workflow: the Side Panel, the Lineage Panel, and the Query Preview Panel. 
+The Bruin VS Code extension provides three main panels that help streamline your workflow: the Side Panel, the Lineage Panel, and the Query Preview Panel. 
 Each panel offers specific functionality to enhance asset management, data lineage tracking, and query result visualization.
 
 ![Bruin Panels](../public/vscode-extension/panels/bruin-panels.png)

--- a/docs/vscode-extension/panels/lineage-panel.md
+++ b/docs/vscode-extension/panels/lineage-panel.md
@@ -1,6 +1,6 @@
 # Lineage Panel
 
-The Lineage Panel is located at the bottom of the VSCode interface, near the terminal tab. It provides a visual representation of the current asset's lineage.
+The Lineage Panel is located at the bottom of the VS Code interface, near the terminal tab. It provides a visual representation of the current asset's lineage.
 
 ## Functionality
 - **Display Asset Lineage**

--- a/docs/vscode-extension/panels/query-preview.md
+++ b/docs/vscode-extension/panels/query-preview.md
@@ -1,5 +1,5 @@
 # Query Preview Panel
-The Query Preview Panel is located at the bottom of the VSCode interface, near the `Lineage` Panel. It offers a visual representation of the query output, displayed as a table.
+The Query Preview Panel is located at the bottom of the VS Code interface, near the `Lineage` Panel. It offers a visual representation of the query output, displayed as a table.
 
 ## Functionality
 - **Display Query Output**  


### PR DESCRIPTION
This commit addresses multiple documentation files to:
- Correct various typographical errors.
- Ensure consistent capitalization of 'Bruin' when referring to the product/company name outside of code blocks, command examples, or configuration settings.
- Improve clarity in several passages.