### PR TITLE
feat: add timeout to sqlparser

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -102,9 +102,9 @@ func Query() *cli.Command {
 				if err != nil {
 					return handleError(c.String("output"), errors.Wrap(err, "failed to initialize SQL parser"))
 				}
-				defer parser.Close()
+				defer parser.Close(context.Background())
 
-				err = parser.Start()
+				err = parser.Start(context.Background())
 				if err != nil {
 					return handleError(c.String("output"), errors.Wrap(err, "failed to start SQL parser"))
 				}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -433,7 +433,7 @@ func Run(isDebug *bool) *cli.Command {
 				}
 
 				go func() {
-					err := parser.Start()
+					err := parser.Start(context.Background())
 					if err != nil {
 						printError(err, c.String("output"), "Could not start sql parser")
 					}

--- a/pkg/lineage/lineage_test.go
+++ b/pkg/lineage/lineage_test.go
@@ -1,6 +1,7 @@
 package lineage
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
@@ -27,7 +28,7 @@ func SetupSQLParser() error {
 		if err != nil {
 			return err
 		}
-		err = sqlParser.Start()
+		err = sqlParser.Start(context.Background())
 		if err != nil {
 			return err
 		}

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -1,6 +1,7 @@
 package sqlparser
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,7 +10,7 @@ import (
 func TestGetLineageForRunner(t *testing.T) {
 	lineage, err := NewSQLParser(true)
 	require.NoError(t, err)
-	require.NoError(t, lineage.Start())
+	require.NoError(t, lineage.Start(context.Background()))
 
 	tests := []struct {
 		name    string
@@ -638,7 +639,7 @@ func TestSqlParser_GetTables(t *testing.T) {
 	s, err := NewSQLParser(true)
 	require.NoError(t, err)
 
-	err = s.Start()
+	err = s.Start(context.Background())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -773,7 +774,7 @@ COMMIT;`,
 	})
 
 	// wg.Wait()
-	s.Close()
+	s.Close(context.Background())
 	require.NoError(t, err)
 }
 
@@ -781,7 +782,7 @@ func TestSqlParser_RenameTables(t *testing.T) {
 	s, err := NewSQLParser(true)
 	require.NoError(t, err)
 
-	err = s.Start()
+	err = s.Start(context.Background())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -827,7 +828,7 @@ func TestSqlParser_RenameTables(t *testing.T) {
 	})
 
 	// wg.Wait()
-	s.Close()
+	s.Close(context.Background())
 	require.NoError(t, err)
 }
 
@@ -883,10 +884,10 @@ func TestSqlParser_AddLimit(t *testing.T) { //nolint
 			s, err := NewSQLParser(true)
 			require.NoError(t, err)
 			defer func() {
-				s.Close()
+				s.Close(context.Background())
 			}()
 
-			err = s.Start()
+			err = s.Start(context.Background())
 			require.NoError(t, err)
 
 			got, err := s.AddLimit(tt.query, tt.limit, tt.dialect)


### PR DESCRIPTION
Add a timeout on the Go side so the lineage request doesn't hang forever.

Ensure that if a timeout occurs, the Python code also stops processing and does not continue running in the background.