### PR TITLE
feat/add jinja rendering for ingestr tables

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -897,7 +897,7 @@ func setupExecutors(
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeIngestr) || estimateCustomCheckType == pipeline.AssetTypeIngestr {
-		ingestrOperator, err := ingestr.NewBasicOperator(conn)
+		ingestrOperator, err := ingestr.NewBasicOperator(conn, renderer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -774,6 +774,7 @@ func (m *Manager) GetSolidgateConnectionWithoutDefault(name string) (*solidgate.
 
 	return db, nil
 }
+
 func (m *Manager) GetAdjustConnection(name string) (*adjust.Client, error) {
 	db, err := m.GetAdjustConnectionWithoutDefault(name)
 	if err == nil {

--- a/pythonsrc/main.py
+++ b/pythonsrc/main.py
@@ -53,7 +53,7 @@ def main():
             elif cmd["command"] == "add-limit":
                 logging.info("got add-limit command")
                 c = cmd["contents"]
-                result = add_limit(c["query"], c["limit"],c["dialect"])
+                result = add_limit(c["query"], c["limit"], c["dialect"])
             elif cmd["command"] == "exit":
                 logging.info("got exit command amx")
                 break

--- a/pythonsrc/parser/main_test.py
+++ b/pythonsrc/parser/main_test.py
@@ -2048,7 +2048,5 @@ def test_add_limit_with_convert_timezone():
     """
 
     result = add_limit(query, 10, dialect="snowflake")
-    print(f"result: {result}")
-
-
- 
+    assert "query" in result
+    assert parse_one(result["query"]).sql() == parse_one(expected_query).sql()


### PR DESCRIPTION
This PR introduces the ability to render jinja in `source_table` parameters for ingestr assets so that the users can do templating for tables.

This makes it possible to build assets like this:
```yaml
name: dest.my_table
type: ingestr

parameters:
    source_table: my-bucket/{{ end_timestamp | date_format('%Y-%m-%d') }}/**/*.csv
    source_connection: s3
    destination: bigquery
```

See the `source_table` field.