### PR TITLE
Check for DDL for full refresh in Clickhouse materializer

### DIFF
--- a/pkg/athena/materialization.go
+++ b/pkg/athena/materialization.go
@@ -166,5 +166,6 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string, location string
 		fmt.Sprintf(`INSERT INTO %s %s`,
 			asset.Name, query),
 	}
+
 	return queries, nil
 }

--- a/pkg/athena/materialization.go
+++ b/pkg/athena/materialization.go
@@ -166,6 +166,5 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string, location string
 		fmt.Sprintf(`INSERT INTO %s %s`,
 			asset.Name, query),
 	}
-
 	return queries, nil
 }

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -362,6 +362,7 @@ func TestMaterializer_Render(t *testing.T) {
 					PartitionBy: "timestamp, location",
 				},
 			},
+			fullRefresh: true,
 			want: []string{
 				"CREATE TABLE IF NOT EXISTS my_composite_partitioned_table (\n" +
 					"id INT64,\n" +

--- a/pkg/clickhouse/materializer.go
+++ b/pkg/clickhouse/materializer.go
@@ -25,7 +25,9 @@ func (m *Materializer) Render(asset *pipeline.Asset, query string) ([]string, er
 
 	strategy := mat.Strategy
 	if m.fullRefresh && mat.Type == pipeline.MaterializationTypeTable {
-		strategy = pipeline.MaterializationStrategyCreateReplace
+		if mat.Strategy != pipeline.MaterializationStrategyDDL {
+			strategy = pipeline.MaterializationStrategyCreateReplace
+		}
 	}
 
 	query = strings.TrimSuffix(strings.TrimSpace(query), ";")


### PR DESCRIPTION
This correction makes sure that the Clickhouse assets using the DDL materialization strategy ignore the full-refresh flag.

DDL materialization should always as be rendered as CREATE TABLE IF NOT EXIST (....) and should not drop the table or be rendered as CREATE OR REPLACE TABLE  (...) etc. 

Added unit test for testing.

