### PR TITLE
Fix: Remove name tag from convertToBruinAsset

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -454,9 +454,9 @@ func convertToBruinAsset(fs afero.Fs, filePath string) error {
 
 	switch ext {
 	case ".sql":
-		bruinHeader = fmt.Sprintf("/* @bruin\nname: %s\ntype: bq.sql\n@bruin */\n\n", assetName)
+		bruinHeader = fmt.Sprintf("/* @bruin\ntype: bq.sql\n@bruin */\n\n")
 	case ".py":
-		bruinHeader = fmt.Sprintf("\"\"\" @bruin\nname: %s\n@bruin \"\"\"\n\n", assetName)
+		bruinHeader = fmt.Sprintf("\"\"\" @bruin\n@bruin \"\"\"\n\n")
 	default:
 		return nil // unsupported file types
 	}


### PR DESCRIPTION
The convertToBruinAsset command was incorrectly adding a 'name:' tag to the YAML part of the asset. This change removes the 'name:' tag from the Bruin header for both SQL and Python files.

A new test has been added to verify that the 'name:' tag is not present in the Bruin header after converting a file to a Bruin asset.