### PR TITLE
Fix verbose test output

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1104,7 +1104,7 @@ func TestApplyFilters(t *testing.T) { //nolint
 				taskNames := []string{}
 				for _, task := range markedTasks {
 					taskNames = append(taskNames, task.GetHumanID()) // Use HumanID for accurate matching
-					print(task.GetHumanID())
+					t.Log(task.GetHumanID())
 				}
 
 				// Check if each expected task is present in the marked tasks


### PR DESCRIPTION
## Summary
- switch `print(task.GetHumanID())` to `t.Log(task.GetHumanID())` in `cmd/run_test.go`

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68415712dc78832082078f9bf020bf98