### PR TITLE
Fix run command end-date help text

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -603,7 +603,7 @@ func ParseDate(startDateStr, endDateStr string, logger logger.Logger) (time.Time
 	endDate, err := date.ParseTime(endDateStr)
 	logger.Debug("given end date: ", endDate)
 	if err != nil {
-		errorPrinter.Printf("Please give a valid end date: bruin run --start-date <start date>)\n")
+		errorPrinter.Printf("Please give a valid end date: bruin run --end-date <end date>)\n")
 		errorPrinter.Printf("A valid start date can be in the YYYY-MM-DD or YYYY-MM-DD HH:MM:SS formats. \n")
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02"))
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02 15:04:05"))


### PR DESCRIPTION
## Summary
- correct the end-date flag in run command error message
- fix indentation to match surrounding lines

## Testing
- `make test` *(fails: go not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841570d7c2c832084a742386deeed12