### PR TITLE
Implement LogIfFullRefreshAndDDL for athena

### DIFF
--- a/pkg/athena/materializer.go
+++ b/pkg/athena/materializer.go
@@ -2,10 +2,12 @@ package athena
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/pkg/errors"
 )
 
 // The other packages all use a materializer that renders the query to a single string. Due to the quirks of athena
@@ -66,4 +68,25 @@ func (r *Renderer) Render(asset *pipeline.Asset, query string) (string, error) {
 
 	result := strings.Join(queries, ";")
 	return result, nil
+}
+
+func (m *Materializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
+	if !m.fullRefresh {
+		return nil
+	}
+
+	if asset.Materialization.Strategy != pipeline.MaterializationStrategyDDL {
+		return nil
+	}
+	if writer == nil {
+		return errors.New("no writer found in context, please create an issue for this: https://github.com/bruin-data/bruin/issues")
+	}
+	message := "Full refresh detected, but DDL strategy is in use — table will NOT be dropped or recreated.\n"
+	writerObj, ok := writer.(io.Writer)
+	if !ok {
+		return errors.New("writer is not an io.Writer")
+	}
+	_, _ = writerObj.Write([]byte(message))
+
+	return nil
 }

--- a/pkg/athena/materializer_test.go
+++ b/pkg/athena/materializer_test.go
@@ -1,0 +1,75 @@
+package athena
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogIfFullRefreshAndDDL(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name         string
+		fullRefresh  bool
+		strategy     pipeline.MaterializationStrategy
+		writer       interface{}
+		expectErr    string
+		expectOutput string
+	}{
+		{
+			name:        "fullRefresh false",
+			fullRefresh: false,
+			strategy:    pipeline.MaterializationStrategyDDL,
+			writer:      &bytes.Buffer{},
+		},
+		{
+			name:        "strategy not DDL",
+			fullRefresh: true,
+			strategy:    pipeline.MaterializationStrategyCreateReplace,
+			writer:      &bytes.Buffer{},
+		},
+		{
+			name:        "writer is nil",
+			fullRefresh: true,
+			strategy:    pipeline.MaterializationStrategyDDL,
+			writer:      nil,
+			expectErr:   "no writer found in context",
+		},
+		{
+			name:        "writer not io.Writer",
+			fullRefresh: true,
+			strategy:    pipeline.MaterializationStrategyDDL,
+			writer:      123,
+			expectErr:   "writer is not an io.Writer",
+		},
+		{
+			name:         "all conditions met",
+			fullRefresh:  true,
+			strategy:     pipeline.MaterializationStrategyDDL,
+			writer:       &bytes.Buffer{},
+			expectOutput: "Full refresh detected, but DDL strategy is in use — table will NOT be dropped or recreated.\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mat := pipeline.Materialization{Strategy: tc.strategy}
+			asset := &pipeline.Asset{Materialization: mat}
+			m := &Materializer{fullRefresh: tc.fullRefresh}
+
+			err := m.LogIfFullRefreshAndDDL(tc.writer, asset)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+				if buf, ok := tc.writer.(*bytes.Buffer); ok && tc.expectOutput != "" {
+					require.Equal(t, tc.expectOutput, buf.String())
+				}
+			}
+		})
+	}
+}

--- a/pkg/athena/operator_test.go
+++ b/pkg/athena/operator_test.go
@@ -38,6 +38,10 @@ func (m *mockMaterializer) Render(t *pipeline.Asset, query, location string) ([]
 	return res.Get(0).([]string), res.Error(1)
 }
 
+func (m *mockMaterializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
+	return nil
+}
+
 func TestBasicOperator_RunTask(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
As with the destinations that use pipeline/materializer (e.g. bigquery), I implemented the function logiffullrefreshandDDL for DDL materialization for Athena. The function logs to console if the user was trying to run full-refresh with a DDL asset and reports that the table will not be dropped.

Created units tests to test functionality.
