### PR TITLE
codex: Add materialization type validator

### DIFF
--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -204,6 +204,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser *sqlp
 			AssetValidator:   ValidateCustomCheckQueryDryRun(connectionManager),
 			ApplicableLevels: []Level{LevelAsset},
 		},
+		&SimpleRule{
+			Identifier:       "materialization-type-match",
+			Fast:             false,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   ValidateMaterializationTypeMatches(connectionManager),
+			ApplicableLevels: []Level{LevelAsset},
+		},
 	}
 
 	if parser != nil {

--- a/pkg/lint/materialization.go
+++ b/pkg/lint/materialization.go
@@ -1,0 +1,67 @@
+package lint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+)
+
+// materializationTypeValidator represents a connection capable of
+// checking if the materialization type of an asset matches the
+// existing object in the database.
+type materializationTypeValidator interface {
+	MaterializationTypeMatches(ctx context.Context, asset *pipeline.Asset) (bool, error)
+}
+
+// ValidateMaterializationTypeMatches validates that the materialization
+// type defined for an asset matches the object type in the destination
+// data platform. It returns an issue if a mismatch is detected.
+func ValidateMaterializationTypeMatches(connections connectionManager) AssetValidator {
+	return func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		issues := make([]*Issue, 0)
+
+		if asset.Materialization.Type == pipeline.MaterializationTypeNone {
+			return issues, nil
+		}
+
+		connName, err := p.GetConnectionNameForAsset(asset)
+		if err != nil {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Cannot get connection for asset: %v", err),
+			})
+			return issues, nil
+		}
+
+		conn, err := connections.GetConnection(connName)
+		if err != nil {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Cannot get connection for asset: %v", err),
+			})
+			return issues, nil
+		}
+
+		validator, ok := conn.(materializationTypeValidator)
+		if !ok {
+			return issues, nil
+		}
+
+		match, err := validator.MaterializationTypeMatches(ctx, asset)
+		if err != nil {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Failed to validate materialization type: %v", err),
+			})
+			return issues, nil
+		}
+		if !match {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "Materialization type mismatch between asset and destination", // simple message
+			})
+		}
+		return issues, nil
+	}
+}


### PR DESCRIPTION
## Summary
- enforce that asset materialization type matches existing table/view
- add BigQuery implementation for materialization type check
- validate mismatch through new linter rule
- cover new logic with unit tests

## Testing
- `go test ./...` *(fails: Forbidden - unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848c59b916c832bbeb61817e51af608