### PR TITLE
Support inline Snowflake private key

### DIFF
--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -19,7 +19,12 @@ There's 2 different ways to fill it in
           warehouse: "warehouse_name" # optional
           role: "data_analyst" # optional
           region: "eu-west1" # optional
+          # specify either private_key or private_key_path for key-based authentication
           private_key_path: "path/to/private_key" # optional
+          # private_key: |
+          #   -----BEGIN PRIVATE KEY-----
+          #   ...
+          #   -----END PRIVATE KEY-----
 ```
 
 Where account is the identifier that you can copy here:
@@ -29,7 +34,7 @@ Where account is the identifier that you can copy here:
 
 ### Key-based Authentication
 
-Snowflake currently supports both password-based authentication as well as key-based authentication. In order to use key-based authentication, you need to provide a path to the private key file as the `private_key_path` parameter. See [this guide](https://select.dev/docs/snowflake-developer-guide/snowflake-key-pair) to create a key-pair if you haven't done that before.
+Snowflake currently supports both password-based authentication as well as key-based authentication. For key-based auth you can either embed the key directly using the `private_key` option or reference it with `private_key_path`. See [this guide](https://select.dev/docs/snowflake-developer-guide/snowflake-key-pair) to create a key-pair if you haven't done that before.
 
 
 ## Snowflake Assets

--- a/integration-tests/expected_connections_schema.json
+++ b/integration-tests/expected_connections_schema.json
@@ -173,6 +173,22 @@
         "region"
       ]
     },
+    "AttioConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "api_key"
+      ]
+    },
     "AwsConnection": {
       "properties": {
         "name": {
@@ -577,28 +593,27 @@
           },
           "type": "array"
         },
-        "spanner": {
-          "items": {
-            "$ref": "#/$defs/SpannerConnection"
-          },
-          "type": "array"
-        },
-        "attio": {
-          "items": {
-            "$ref": "#/$defs/AttioConnection"
-          },
-          "type": "array"
-        },
-
         "solidgate": {
           "items": {
             "$ref": "#/$defs/SolidgateConnection"
           },
           "type": "array"
         },
+        "spanner": {
+          "items": {
+            "$ref": "#/$defs/SpannerConnection"
+          },
+          "type": "array"
+        },
         "smartsheet": {
           "items": {
             "$ref": "#/$defs/SmartsheetConnection"
+          },
+          "type": "array"
+        },
+        "attio": {
+          "items": {
+            "$ref": "#/$defs/AttioConnection"
           },
           "type": "array"
         }
@@ -1541,6 +1556,22 @@
         "api_key"
       ]
     },
+    "SmartsheetConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "access_token": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "access_token"
+      ]
+    },
     "SnowflakeConnection": {
       "oneOf": [
         {
@@ -1551,9 +1582,15 @@
         },
         {
           "required": [
-            "private_key_path"
+            "private_key"
           ],
           "title": "private_key"
+        },
+        {
+          "required": [
+            "private_key_path"
+          ],
+          "title": "private_key_path"
         }
       ],
       "properties": {
@@ -1584,6 +1621,9 @@
         "warehouse": {
           "type": "string"
         },
+        "private_key": {
+          "type": "string"
+        },
         "private_key_path": {
           "type": "string"
         }
@@ -1595,6 +1635,26 @@
         "account",
         "username",
         "region"
+      ]
+    },
+    "SolidgateConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "public_key": {
+          "type": "string"
+        },
+        "secret_key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "public_key",
+        "secret_key"
       ]
     },
     "SpannerConnection": {
@@ -1611,10 +1671,10 @@
         "database": {
           "type": "string"
         },
-        "service_account_file": {
+        "service_account_json": {
           "type": "string"
         },
-        "service_account_json": {
+        "service_account_file": {
           "type": "string"
         }
       },
@@ -1625,42 +1685,6 @@
         "project_id",
         "instance_id",
         "database"
-      ]
-    },
-    "SolidgateConnection": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "secret_key": {
-          "type": "string"
-        },
-        "public_key": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name",
-        "public_key",
-        "secret_key"
-      ]
-    },
-    "SmartsheetConnection": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "access_token": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name",
-        "access_token"
       ]
     },
     "StripeConnection": {
@@ -1762,19 +1786,6 @@
         "oauth_token",
         "sub_domain"
       ]
-    },
-    "AttioConnection": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "api_key": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": ["name", "api_key"] 
     }
   }
 }

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -268,22 +268,30 @@ type SnowflakeConnection struct {
 	Database       string `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
 	Schema         string `yaml:"schema,omitempty" json:"schema,omitempty" mapstructure:"schema"`
 	Warehouse      string `yaml:"warehouse,omitempty" json:"warehouse,omitempty" mapstructure:"warehouse"`
-	PrivateKeyPath string `yaml:"private_key_path,omitempty" json:"private_key_path,omitempty" jsonschema:"oneof_required=private_key" mapstructure:"private_key_path"`
+	PrivateKey     string `yaml:"private_key,omitempty" json:"private_key,omitempty" jsonschema:"oneof_required=private_key" mapstructure:"private_key"`
+	PrivateKeyPath string `yaml:"private_key_path,omitempty" json:"private_key_path,omitempty" jsonschema:"oneof_required=private_key_path" mapstructure:"private_key_path"`
 }
 
 func (c SnowflakeConnection) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]string{
-		"name":             c.Name,
-		"account":          c.Account,
-		"username":         c.Username,
-		"password":         c.Password,
-		"region":           c.Region,
-		"role":             c.Role,
-		"database":         c.Database,
-		"schema":           c.Schema,
-		"warehouse":        c.Warehouse,
-		"private_key_path": c.PrivateKeyPath,
-	})
+	m := map[string]string{
+		"name":      c.Name,
+		"account":   c.Account,
+		"username":  c.Username,
+		"password":  c.Password,
+		"region":    c.Region,
+		"role":      c.Role,
+		"database":  c.Database,
+		"schema":    c.Schema,
+		"warehouse": c.Warehouse,
+	}
+
+	if c.PrivateKey != "" {
+		m["private_key"] = c.PrivateKey
+	} else {
+		m["private_key_path"] = c.PrivateKeyPath
+	}
+
+	return json.Marshal(m)
 }
 
 func (c SnowflakeConnection) GetName() string {

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnowflakeConnection_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		conn      SnowflakeConnection
+		wantKey   string
+		wantNoKey string
+	}{
+		{
+			name: "inline private key",
+			conn: SnowflakeConnection{
+				Name:       "conn1",
+				Account:    "acc",
+				Username:   "usr",
+				Region:     "region",
+				PrivateKey: "some-key",
+			},
+			wantKey:   "private_key",
+			wantNoKey: "private_key_path",
+		},
+		{
+			name: "private key path",
+			conn: SnowflakeConnection{
+				Name:           "conn1",
+				Account:        "acc",
+				Username:       "usr",
+				Region:         "region",
+				PrivateKeyPath: "path/to/key",
+			},
+			wantKey:   "private_key_path",
+			wantNoKey: "private_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := tt.conn.MarshalJSON()
+			require.NoError(t, err)
+
+			var got map[string]string
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			_, ok := got[tt.wantKey]
+			require.True(t, ok)
+			_, ok = got[tt.wantNoKey]
+			require.False(t, ok)
+		})
+	}
+}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -292,9 +292,9 @@ func LoadFromFile(fs afero.Fs, path string) (*Config, error) {
 			}
 		}
 
-		// Make Snowflake private key path absolute
+		// Make Snowflake private key path absolute when using a path
 		for i, conn := range env.Connections.Snowflake {
-			if conn.PrivateKeyPath == "" {
+			if conn.PrivateKey != "" || conn.PrivateKeyPath == "" {
 				continue
 			}
 

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1578,8 +1578,8 @@ func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnecti
 	}
 	m.mutex.Unlock()
 
-	privateKey := ""
-	if connection.PrivateKeyPath != "" {
+	privateKey := connection.PrivateKey
+	if privateKey == "" && connection.PrivateKeyPath != "" {
 		privateKeyBytes, err := os.ReadFile(connection.PrivateKeyPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- add inline `private_key` for Snowflake connections
- adjust connection manager to use either the key or path
- update docs for Snowflake authentication options
- regenerate connection schema
- add unit tests for Snowflake private key handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68496d40782c832b9428e7153316c3c8