### PR TITLE
Improve quality docs with examples

### DIFF
--- a/docs/assets/seed.md
+++ b/docs/assets/seed.md
@@ -38,3 +38,23 @@ B,LinkedIn,SDE 2,2024-01-01
 ```
 
 This operation will load the CSV into a table called `seed.raw` in the DuckDB database.
+
+### Adding quality checks
+You can attach quality checks to seed assets the same way you do for other assets.
+
+```yaml
+name: dashboard.hello
+type: duckdb.seed
+
+parameters:
+    path: hello.csv
+
+columns:
+  - name: name
+    type: string
+    checks:
+      - name: not_null
+      - name: unique
+```
+
+The example above ensures that the `name` column contains unique and non-null values after the CSV is loaded.

--- a/docs/assets/sensor.md
+++ b/docs/assets/sensor.md
@@ -64,6 +64,24 @@ parameters:
 
 This asset will wait until the query returns any result.
 
+### Adding quality checks
+Sensors also support quality checks. You can use them to validate the external data once the sensor succeeds.
+
+```yaml
+name: raw.external_asset
+type: bq.sensor.query
+parameters:
+    query: select count(*) > 0 from `your-project-id.raw.external_asset`
+
+columns:
+  - name: count
+    type: integer
+    checks:
+      - name: positive
+```
+
+The snippet above ensures the `raw.external_asset` table exposes a `count` column and that the values are positive. The sensor waits until the query returns true, and then the quality check validates the data before downstream assets run.
+
 
 
 

--- a/docs/assets/sql.md
+++ b/docs/assets/sql.md
@@ -76,4 +76,31 @@ where dt between '{{ start_datetime }}' and '{{ end_datetime }}'
 
 This example will incrementally update the data in the destination table using this query. Read more about [materialization here](./materialization.md). 
 
-This example also uses Jinja templates, you can read more about [Jinja here](./templating/templating.md). 
+This example also uses Jinja templates, you can read more about [Jinja here](./templating/templating.md).
+
+### Adding quality checks
+SQL assets can define quality checks on the columns produced by the query.
+
+```bruin-sql
+/* @bruin
+
+name: dashboard.hello_bq
+type: bq.sql
+
+materialization:
+    type: table
+
+columns:
+  - name: one
+    type: integer
+    checks:
+      - name: positive
+      - name: unique
+@bruin */
+
+select 1 as one
+union all
+select -1 as one
+```
+
+In this example the `one` column is validated to be positive and unique after the query runs.

--- a/docs/quality/custom.md
+++ b/docs/quality/custom.md
@@ -29,6 +29,9 @@ FROM dataset.players
 GROUP BY 1
 ```
 
+> [!INFO]
+> Non-blocking checks are useful for long-running or expensive quality checks. It means the downstream assets will not be waiting for this quality check to finish.
+
 There are a few fields to configure the check behavior:
 - `name`: required, give a name to the check.
 - `query`: required, the query to run as the quality check
@@ -81,7 +84,6 @@ SELECT name, count(*)
 FROM dataset.players
 GROUP BY 1
 ```
-
 > [!INFO]
 > Non-blocking checks are useful for long-running or expensive quality checks. It means the downstream assets will not be waiting for this quality check to finish.
 

--- a/docs/quality/overview.md
+++ b/docs/quality/overview.md
@@ -1,24 +1,30 @@
 # Quality checks
 
-Quality checks are tests you can perform on your Bruin assets after they run to verify that the asset's data satisfies your expectations. 
+Quality checks are tests you can perform on your Bruin assets **after** they run to verify that the produced data satisfies your expectations. They are a great way to ensure your data is accurate, complete and consistent.
 
-You can use quality checks to ensure that your data is accurate, complete, and consistent. Quality checks are a powerful tool for ensuring that your data is reliable and trustworthy.
+Quality checks run after the asset has been executed. If a check fails and its
+`blocking` attribute is `true`, the rest of the checks are skipped and the asset
+is marked as failed. When `blocking` is `false` the asset still fails but the
+remaining checks continue to run. `blocking` defaults to `true`.
 
-Quality checks run **after** the asset has been executed. If an asset fails a quality check and the `blocking` attribute of that check is `true`, the remaining checks won't be executed. 
-If `blocking` is `false`, the asset will be marked as failed, but the remaining checks will be executed.
-
-See example below:
+Below is a short example of attaching checks to columns:
 
 ```yaml
 columns:
-  - name: one
+  - name: id
     type: integer
-    description: "Just a number"
-    checks:
-        - name: unique
-          blocking: true
+    description: "Primary key"
+    checks:            # run built-in checks
+      - name: unique
+      - name: not_null
 ```
 
-`blocking` is `true` by default.
+If any of those checks fails the asset will be marked as failed and any
+downstream assets will not be executed.
 
-If any of the checks fails, the asset will be marked as failed and any of the downstream assets will not be executed.
+Quality checks can also be executed on their own without running the asset
+again:
+
+```bash
+bruin run --only checks assets/my_asset.sql
+```


### PR DESCRIPTION
## Summary
- expand sensor asset documentation with correct quality check info
- restore missing info callout in custom quality checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bd71fdfc883209dc57db0e46ceec1