### PR TITLE
validate: propogate context to lint validators.

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/manifoldco/promptui"
@@ -109,4 +111,12 @@ func printError(err error, output string, message string) {
 	} else {
 		errorPrinter.Printf("%s: %v\n", message, err)
 	}
+}
+
+func NewRunID() string {
+	runID := time.Now().Format("2006_01_02_15_04_05")
+	if os.Getenv("BRUIN_RUN_ID") != "" {
+		runID = os.Getenv("BRUIN_RUN_ID")
+	}
+	return runID
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -172,18 +173,23 @@ func Lint(isDebug *bool) *cli.Command {
 			rules = append(rules, queryValidatorRules(logger, cm, connectionManager)...)
 			rules = append(rules, lint.GetCustomCheckQueryDryRunRule(connectionManager))
 
+			lintCtx := context.Background()
+			lintCtx = context.WithValue(lintCtx, pipeline.RunConfigStartDate, defaultStartDate)
+			lintCtx = context.WithValue(lintCtx, pipeline.RunConfigEndDate, defaultEndDate)
+			lintCtx = context.WithValue(lintCtx, pipeline.RunConfigRunID, NewRunID())
+
 			var result *lint.PipelineAnalysisResult
 			var errr error
 			if asset == "" {
 				linter := lint.NewLinter(path.GetPipelinePaths, DefaultPipelineBuilder, rules, logger)
 				logger.Debugf("running %d rules for pipeline validation", len(rules))
 				infoPrinter.Printf("Validating pipelines in '%s' for '%s' environment...\n", rootPath, cm.SelectedEnvironmentName)
-				result, errr = linter.Lint(rootPath, PipelineDefinitionFiles, c)
+				result, errr = linter.Lint(lintCtx, rootPath, PipelineDefinitionFiles, c)
 			} else {
 				rules = lint.FilterRulesByLevel(rules, lint.LevelAsset)
 				logger.Debugf("running %d rules for asset-only validation", len(rules))
 				linter := lint.NewLinter(path.GetPipelinePaths, DefaultPipelineBuilder, rules, logger)
-				result, errr = linter.LintAsset(rootPath, PipelineDefinitionFiles, asset, c)
+				result, errr = linter.LintAsset(lintCtx, rootPath, PipelineDefinitionFiles, asset, c)
 			}
 
 			printer := lint.Printer{RootCheckPath: rootPath}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1272,6 +1272,7 @@ func TestCheckLintFunc(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logger := zaptest.NewLogger(t).Sugar()
@@ -1308,7 +1309,7 @@ func TestCheckLintFunc(t *testing.T) {
 				SelectedEnvironment:     defaultEnv,
 			}
 			connectionManager, _ := connection.NewManagerFromConfig(cfg)
-			err := CheckLint(tt.foundPipeline, tt.pipelinePath, logger, nil, connectionManager)
+			err := CheckLint(ctx, tt.foundPipeline, tt.pipelinePath, logger, nil, connectionManager)
 			require.NoError(t, err, "Expected no error but got one")
 		})
 	}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -95,7 +95,7 @@ func NewLinter(findPipelines pipelineFinder, builder pipelineBuilder, rules []Ru
 }
 
 func (l *Linter) Lint(ctx context.Context, rootPath string, pipelineDefinitionFileName []string, c *cli.Context) (*PipelineAnalysisResult, error) {
-	pipelines, err := l.extractPipelinesFromPath(rootPath, pipelineDefinitionFileName)
+	pipelines, err := l.extractPipelinesFromPath(ctx, rootPath, pipelineDefinitionFileName)
 
 	excludeTag := ""
 	if c != nil {
@@ -137,7 +137,7 @@ func (l *Linter) Lint(ctx context.Context, rootPath string, pipelineDefinitionFi
 }
 
 func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinitionFileName []string, assetNameOrPath string, c *cli.Context) (*PipelineAnalysisResult, error) {
-	pipelines, err := l.extractPipelinesFromPath(rootPath, pipelineDefinitionFileName)
+	pipelines, err := l.extractPipelinesFromPath(ctx, rootPath, pipelineDefinitionFileName)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinit
 	}, nil
 }
 
-func (l *Linter) extractPipelinesFromPath(rootPath string, pipelineDefinitionFileName []string) ([]*pipeline.Pipeline, error) {
+func (l *Linter) extractPipelinesFromPath(ctx context.Context, rootPath string, pipelineDefinitionFileName []string) ([]*pipeline.Pipeline, error) {
 	pipelinePaths, err := l.findPipelines(rootPath, pipelineDefinitionFileName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -245,7 +245,7 @@ func (l *Linter) extractPipelinesFromPath(rootPath string, pipelineDefinitionFil
 	for _, pipelinePath := range pipelinePaths {
 		l.logger.Debugf("creating pipeline from path '%s'", pipelinePath)
 
-		p, err := l.builder.CreatePipelineFromPath(context.Background(), pipelinePath, pipeline.WithMutate())
+		p, err := l.builder.CreatePipelineFromPath(ctx, pipelinePath, pipeline.WithMutate())
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating pipeline from path '%s'", pipelinePath)
 		}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -18,7 +18,7 @@ import (
 
 type (
 	pipelineFinder    func(root string, pipelineDefinitionFile []string) ([]string, error)
-	PipelineValidator func(pipeline *pipeline.Pipeline) ([]*Issue, error)
+	PipelineValidator func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error)
 	AssetValidator    func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error)
 )
 
@@ -35,7 +35,7 @@ type Issue struct {
 type Rule interface {
 	Name() string
 	IsFast() bool
-	Validate(pipeline *pipeline.Pipeline) ([]*Issue, error)
+	Validate(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error)
 	ValidateAsset(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error)
 	GetApplicableLevels() []Level
 	GetSeverity() ValidatorSeverity
@@ -50,8 +50,8 @@ type SimpleRule struct {
 	Severity         ValidatorSeverity
 }
 
-func (g *SimpleRule) Validate(pipeline *pipeline.Pipeline) ([]*Issue, error) {
-	return g.Validator(pipeline)
+func (g *SimpleRule) Validate(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
+	return g.Validator(ctx, pipeline)
 }
 
 func (g *SimpleRule) IsFast() bool {
@@ -94,7 +94,7 @@ func NewLinter(findPipelines pipelineFinder, builder pipelineBuilder, rules []Ru
 	}
 }
 
-func (l *Linter) Lint(rootPath string, pipelineDefinitionFileName []string, c *cli.Context) (*PipelineAnalysisResult, error) {
+func (l *Linter) Lint(ctx context.Context, rootPath string, pipelineDefinitionFileName []string, c *cli.Context) (*PipelineAnalysisResult, error) {
 	pipelines, err := l.extractPipelinesFromPath(rootPath, pipelineDefinitionFileName)
 
 	excludeTag := ""
@@ -133,10 +133,10 @@ func (l *Linter) Lint(rootPath string, pipelineDefinitionFileName []string, c *c
 		return nil, err
 	}
 
-	return l.LintPipelines(pipelines)
+	return l.LintPipelines(ctx, pipelines)
 }
 
-func (l *Linter) LintAsset(rootPath string, pipelineDefinitionFileName []string, assetNameOrPath string, c *cli.Context) (*PipelineAnalysisResult, error) {
+func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinitionFileName []string, assetNameOrPath string, c *cli.Context) (*PipelineAnalysisResult, error) {
 	pipelines, err := l.extractPipelinesFromPath(rootPath, pipelineDefinitionFileName)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (l *Linter) LintAsset(rootPath string, pipelineDefinitionFileName []string,
 
 	// now the actual validation starts
 	for _, rule := range rules {
-		issues, err := rule.ValidateAsset(context.TODO(), assetPipeline, asset)
+		issues, err := rule.ValidateAsset(ctx, assetPipeline, asset)
 		if err != nil {
 			return nil, err
 		}
@@ -341,11 +341,11 @@ func (p *PipelineIssues) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (l *Linter) LintPipelines(pipelines []*pipeline.Pipeline) (*PipelineAnalysisResult, error) {
+func (l *Linter) LintPipelines(ctx context.Context, pipelines []*pipeline.Pipeline) (*PipelineAnalysisResult, error) {
 	result := &PipelineAnalysisResult{}
 
 	for _, p := range pipelines {
-		pipelineResult, err := l.LintPipeline(p)
+		pipelineResult, err := l.LintPipeline(ctx, p)
 		if err != nil {
 			return nil, err
 		}
@@ -355,17 +355,15 @@ func (l *Linter) LintPipelines(pipelines []*pipeline.Pipeline) (*PipelineAnalysi
 	return result, nil
 }
 
-func (l *Linter) LintPipeline(p *pipeline.Pipeline) (*PipelineIssues, error) {
-	return RunLintRulesOnPipeline(p, l.rules)
+func (l *Linter) LintPipeline(ctx context.Context, p *pipeline.Pipeline) (*PipelineIssues, error) {
+	return RunLintRulesOnPipeline(ctx, p, l.rules)
 }
 
-func RunLintRulesOnPipeline(p *pipeline.Pipeline, rules []Rule) (*PipelineIssues, error) {
+func RunLintRulesOnPipeline(ctx context.Context, p *pipeline.Pipeline, rules []Rule) (*PipelineIssues, error) {
 	pipelineResult := &PipelineIssues{
 		Pipeline: p,
 		Issues:   make(map[Rule][]*Issue),
 	}
-	ctx := context.Background()
-
 	policyRules, err := loadPolicy(p.DefinitionFile.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load policy: %w", err)
@@ -377,7 +375,7 @@ func RunLintRulesOnPipeline(p *pipeline.Pipeline, rules []Rule) (*PipelineIssues
 	for _, rule := range rules {
 		levels := rule.GetApplicableLevels()
 		if slices.Contains(levels, LevelPipeline) {
-			issues, err := rule.Validate(p)
+			issues, err := rule.Validate(ctx, p)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -28,14 +28,16 @@ func TestLinter_Lint(t *testing.T) {
 	t.Parallel()
 
 	errorRule := &SimpleRule{
-		Identifier:       "errorRule",
-		Validator:        func(p *pipeline.Pipeline) ([]*Issue, error) { return nil, errors.New("first rule failed") },
+		Identifier: "errorRule",
+		Validator: func(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
+			return nil, errors.New("first rule failed")
+		},
 		ApplicableLevels: []Level{LevelPipeline},
 	}
 
 	successRule := &SimpleRule{
 		Identifier:       "successRule",
-		Validator:        func(p *pipeline.Pipeline) ([]*Issue, error) { return nil, nil },
+		Validator:        func(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) { return nil, nil },
 		ApplicableLevels: []Level{LevelPipeline},
 	}
 
@@ -193,6 +195,7 @@ func TestLinter_Lint(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -209,7 +212,7 @@ func TestLinter_Lint(t *testing.T) {
 				logger:        logger.Sugar(),
 			}
 
-			_, err := l.Lint(tt.args.rootPath, tt.args.pipelineDefinitionFileName, cli.NewContext(nil, nil, nil))
+			_, err := l.Lint(ctx, tt.args.rootPath, tt.args.pipelineDefinitionFileName, cli.NewContext(nil, nil, nil))
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -459,6 +462,7 @@ func TestLinter_LintAsset(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -475,7 +479,7 @@ func TestLinter_LintAsset(t *testing.T) {
 				logger:        logger.Sugar(),
 			}
 
-			_, err := l.LintAsset(tt.args.rootPath, tt.args.pipelineDefinitionFileName, "my-asset", cli.NewContext(nil, nil, nil))
+			_, err := l.LintAsset(ctx, tt.args.rootPath, tt.args.pipelineDefinitionFileName, "my-asset", cli.NewContext(nil, nil, nil))
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Equal(t, tt.errorMessage, err.Error())

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -240,7 +240,7 @@ func assetValidatorFromRuleDef(def *RuleDefinition) AssetValidator {
 }
 
 func pipelineValidatorFromRuleDef(def *RuleDefinition) PipelineValidator {
-	return func(pipe *pipeline.Pipeline) ([]*Issue, error) {
+	return func(ctx context.Context, pipe *pipeline.Pipeline) ([]*Issue, error) {
 		env := pipelineValidatorEnv{pipe, pipe.Variables.Value()}
 		result, err := expr.Run(def.evalutor, env)
 		if err != nil {
@@ -262,7 +262,7 @@ func pipelineValidatorFromRuleDef(def *RuleDefinition) PipelineValidator {
 func withSelector(selector []map[string]any, downstream validators) validators {
 	middleware := validators{}
 	if downstream.Pipeline != nil {
-		middleware.Pipeline = func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+		middleware.Pipeline = func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 			match, err := doesSelectorMatch(selector, pipeline, nil)
 			if err != nil {
 				return nil, fmt.Errorf("error matching selector: %w", err)
@@ -272,7 +272,7 @@ func withSelector(selector []map[string]any, downstream validators) validators {
 				return nil, nil
 			}
 
-			return downstream.Pipeline(pipeline)
+			return downstream.Pipeline(ctx, pipeline)
 		}
 	}
 	if downstream.Asset != nil {

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -390,7 +390,7 @@ var builtinRules = map[string]validators{
 		},
 	},
 	"pipeline-has-notifications": {
-		Pipeline: func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+		Pipeline: func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 			notifs := pipeline.Notifications
 			if len(notifs.Discord) > 0 || len(notifs.MSTeams) > 0 || len(notifs.Slack) > 0 {
 				return nil, nil
@@ -403,7 +403,7 @@ var builtinRules = map[string]validators{
 		},
 	},
 	"pipeline-has-retries": {
-		Pipeline: func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+		Pipeline: func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 			if pipeline.Retries > 0 {
 				return nil, nil
 			}
@@ -416,7 +416,7 @@ var builtinRules = map[string]validators{
 		},
 	},
 	"pipeline-has-start-date": {
-		Pipeline: func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+		Pipeline: func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 			if strings.TrimSpace(pipeline.StartDate) != "" {
 				return nil, nil
 			}
@@ -428,7 +428,7 @@ var builtinRules = map[string]validators{
 		},
 	},
 	"pipeline-has-metadata-push": {
-		Pipeline: func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+		Pipeline: func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 			if pipeline.MetadataPush.HasAnyEnabled() {
 				return nil, nil
 			}

--- a/pkg/lint/query.go
+++ b/pkg/lint/query.go
@@ -154,7 +154,7 @@ func (q *QueryValidatorRule) ValidateAsset(ctx context.Context, p *pipeline.Pipe
 	return issues, nil
 }
 
-func (q *QueryValidatorRule) validateTask(p *pipeline.Pipeline, task *pipeline.Asset, done chan<- []*Issue) {
+func (q *QueryValidatorRule) validateTask(ctx context.Context, p *pipeline.Pipeline, task *pipeline.Asset, done chan<- []*Issue) {
 	issues := make([]*Issue, 0)
 
 	q.Logger.Debugf("validating pipeline '%s' task '%s'", p.Name, task.Name)
@@ -255,7 +255,7 @@ func (q *QueryValidatorRule) validateTask(p *pipeline.Pipeline, task *pipeline.A
 
 				return
 			}
-			valid, err := valll.IsValid(context.Background(), foundQuery)
+			valid, err := valll.IsValid(ctx, foundQuery)
 			if err != nil {
 				mu.Lock()
 				issues = append(issues, &Issue{
@@ -312,7 +312,7 @@ func (q *QueryValidatorRule) Validate(ctx context.Context, p *pipeline.Pipeline)
 	for range q.WorkerCount {
 		go func(taskChannel <-chan *pipeline.Asset, results chan<- []*Issue) {
 			for task := range taskChannel {
-				q.validateTask(p, task, results)
+				q.validateTask(ctx, p, task, results)
 			}
 		}(taskChannel, results)
 	}

--- a/pkg/lint/query.go
+++ b/pkg/lint/query.go
@@ -295,7 +295,7 @@ func (q *QueryValidatorRule) bufferSize() int {
 	return 256
 }
 
-func (q *QueryValidatorRule) Validate(p *pipeline.Pipeline) ([]*Issue, error) {
+func (q *QueryValidatorRule) Validate(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
 	// skip if there are no workers defined

--- a/pkg/lint/query_test.go
+++ b/pkg/lint/query_test.go
@@ -283,6 +283,7 @@ func TestQueryValidatorRule_Validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -309,7 +310,7 @@ func TestQueryValidatorRule_Validate(t *testing.T) {
 				Materializer: mat,
 			}
 
-			got, err := q.Validate(tt.p)
+			got, err := q.Validate(ctx, tt.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -84,7 +84,7 @@ func EnsureTaskNameIsValidForASingleAsset(ctx context.Context, p *pipeline.Pipel
 	return issues, nil
 }
 
-func EnsureTaskNameIsUnique(p *pipeline.Pipeline) ([]*Issue, error) {
+func EnsureTaskNameIsUnique(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	nameFileMapping := make(map[string][]*pipeline.Asset)
 	for _, task := range p.Assets {
 		if task.Name == "" {
@@ -203,7 +203,7 @@ func EnsureExecutableFileIsValidForASingleAsset(fs afero.Fs) AssetValidator {
 	}
 }
 
-func EnsurePipelineNameIsValid(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+func EnsurePipelineNameIsValid(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 	if pipeline.Name == "" {
 		issues = append(issues, &Issue{
@@ -222,11 +222,11 @@ func EnsurePipelineNameIsValid(pipeline *pipeline.Pipeline) ([]*Issue, error) {
 	return issues, nil
 }
 
-func CallFuncForEveryAsset(callable AssetValidator) func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
-	return func(pipeline *pipeline.Pipeline) ([]*Issue, error) {
+func CallFuncForEveryAsset(callable AssetValidator) func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
+	return func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
 		issues := make([]*Issue, 0)
 		for _, task := range pipeline.Assets {
-			assetIssues, err := callable(context.TODO(), pipeline, task)
+			assetIssues, err := callable(ctx, pipeline, task)
 			if err != nil {
 				return issues, err
 			}
@@ -316,7 +316,7 @@ func EnsureDependencyExistsForASingleAsset(ctx context.Context, p *pipeline.Pipe
 	return issues, nil
 }
 
-func EnsurePipelineScheduleIsValidCron(p *pipeline.Pipeline) ([]*Issue, error) {
+func EnsurePipelineScheduleIsValidCron(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 	if p.Schedule == "" {
 		return issues, nil
@@ -345,7 +345,7 @@ type WarnRegularYamlFiles struct {
 	fs afero.Fs
 }
 
-func (w *WarnRegularYamlFiles) WarnRegularYamlFilesInRepo(p *pipeline.Pipeline) ([]*Issue, error) {
+func (w *WarnRegularYamlFiles) WarnRegularYamlFilesInRepo(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
 	if p.DefinitionFile.Path == "" {
@@ -411,7 +411,7 @@ func (w *WarnRegularYamlFiles) WarnRegularYamlFilesInRepo(p *pipeline.Pipeline) 
 	return issues, nil
 }
 
-func EnsurePipelineStartDateIsValid(p *pipeline.Pipeline) ([]*Issue, error) {
+func EnsurePipelineStartDateIsValid(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 	if p.StartDate == "" {
 		return issues, nil
@@ -662,7 +662,7 @@ func ValidateDuplicateColumnNames(ctx context.Context, p *pipeline.Pipeline, ass
 	return issues, nil
 }
 
-func ValidateAssetDirectoryExist(p *pipeline.Pipeline) ([]*Issue, error) {
+func ValidateAssetDirectoryExist(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	var issues []*Issue
 
 	parentDir := filepath.Dir(p.DefinitionFile.Path)
@@ -700,7 +700,7 @@ func EnsureTypeIsCorrectForASingleAsset(ctx context.Context, p *pipeline.Pipelin
 // Since the pipelines are directed graphs, strongly connected components mean cycles, therefore
 // they would be considered invalid for our pipelines.
 // Strong connectivity wouldn't work for tasks that depend on themselves, therefore there's a specific check for that.
-func EnsurePipelineHasNoCycles(p *pipeline.Pipeline) ([]*Issue, error) {
+func EnsurePipelineHasNoCycles(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
 	for _, task := range p.Assets {
@@ -777,7 +777,7 @@ func isStringInArray(arr []string, str string) bool {
 	return false
 }
 
-func EnsureSlackFieldInPipelineIsValid(p *pipeline.Pipeline) ([]*Issue, error) {
+func EnsureSlackFieldInPipelineIsValid(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
 	slackChannels := make([]string, 0, len(p.Notifications.Slack))
@@ -802,7 +802,7 @@ func EnsureSlackFieldInPipelineIsValid(p *pipeline.Pipeline) ([]*Issue, error) {
 	return issues, nil
 }
 
-func EnsureMSTeamsFieldInPipelineIsValid(p *pipeline.Pipeline) ([]*Issue, error) {
+func EnsureMSTeamsFieldInPipelineIsValid(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
 	MSTeamsConnections := make([]string, 0, len(p.Notifications.MSTeams))
@@ -1202,8 +1202,8 @@ func (u UsedTableValidatorRule) GetSeverity() ValidatorSeverity {
 	return ValidatorSeverityWarning
 }
 
-func (u UsedTableValidatorRule) Validate(p *pipeline.Pipeline) ([]*Issue, error) {
-	return CallFuncForEveryAsset(u.ValidateAsset)(p)
+func (u UsedTableValidatorRule) Validate(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
+	return CallFuncForEveryAsset(u.ValidateAsset)(ctx, p)
 }
 
 func (u UsedTableValidatorRule) ValidateAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -1231,7 +1231,7 @@ func (u UsedTableValidatorRule) ValidateAsset(ctx context.Context, p *pipeline.P
 	return issues, nil
 }
 
-func ValidateVariables(p *pipeline.Pipeline) ([]*Issue, error) {
+func ValidateVariables(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
 	if p.Variables == nil {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -90,11 +90,12 @@ func TestEnsureTaskNameIsNotEmpty(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureTaskNameIsValidForASingleAsset)(tt.args.pipeline)
+			got, err := CallFuncForEveryAsset(EnsureTaskNameIsValidForASingleAsset)(ctx, tt.args.pipeline)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -392,6 +393,7 @@ func TestEnsureExecutableFileIsValid(t *testing.T) {
 			want: noIssues,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -403,7 +405,7 @@ func TestEnsureExecutableFileIsValid(t *testing.T) {
 
 			checker := CallFuncForEveryAsset(EnsureExecutableFileIsValidForASingleAsset(fs))
 
-			got, err := checker(&tt.args.pipeline)
+			got, err := checker(ctx, &tt.args.pipeline)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -535,11 +537,12 @@ func TestEnsureDependencyExists(t *testing.T) {
 			},
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureDependencyExistsForASingleAsset)(tt.args.p)
+			got, err := CallFuncForEveryAsset(EnsureDependencyExistsForASingleAsset)(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -613,11 +616,12 @@ func TestEnsurePipelineScheduleIsValidCron(t *testing.T) {
 			want: noIssues,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := EnsurePipelineScheduleIsValidCron(tt.args.p)
+			got, err := EnsurePipelineScheduleIsValidCron(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -693,11 +697,12 @@ func TestEnsureOnlyAcceptedTaskTypesAreThere(t *testing.T) {
 			want: noIssues,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureTypeIsCorrectForASingleAsset)(tt.args.p)
+			got, err := CallFuncForEveryAsset(EnsureTypeIsCorrectForASingleAsset)(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -770,11 +775,12 @@ func TestEnsureTaskNameIsUnique(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := EnsureTaskNameIsUnique(tt.p)
+			got, err := EnsureTaskNameIsUnique(ctx, tt.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -958,11 +964,12 @@ func TestEnsurePipelineNameIsValid(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := EnsurePipelineNameIsValid(tt.args.p)
+			got, err := EnsurePipelineNameIsValid(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1051,11 +1058,12 @@ func TestEnsurePipelineHasNoCycles(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := EnsurePipelineHasNoCycles(tt.args.p)
+			got, err := EnsurePipelineHasNoCycles(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1175,10 +1183,11 @@ func TestEnsureSlackFieldInPipelineIsValid(t *testing.T) {
 			},
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := EnsureSlackFieldInPipelineIsValid(tt.args.p)
+			got, err := EnsureSlackFieldInPipelineIsValid(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1257,10 +1266,11 @@ func TestMSTeamsFieldInPipelineIsValid(t *testing.T) {
 			},
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := EnsureMSTeamsFieldInPipelineIsValid(tt.args.p)
+			got, err := EnsureMSTeamsFieldInPipelineIsValid(ctx, tt.args.p)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1481,11 +1491,12 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureMaterializationValuesAreValidForSingleAsset)(&pipeline.Pipeline{
+			got, err := CallFuncForEveryAsset(EnsureMaterializationValuesAreValidForSingleAsset)(ctx, &pipeline.Pipeline{
 				Assets: tt.assets,
 			})
 
@@ -1562,11 +1573,12 @@ func TestEnsureSnowflakeSensorHasQueryParameter(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureSnowflakeSensorHasQueryParameterForASingleAsset)(tt.p)
+			got, err := CallFuncForEveryAsset(EnsureSnowflakeSensorHasQueryParameterForASingleAsset)(ctx, tt.p)
 			if !tt.wantErr(t, err) {
 				return
 			}
@@ -1640,11 +1652,12 @@ func TestEnsureBigqueryQuerySensorHasQueryParameter(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureBigQueryQuerySensorHasTableParameterForASingleAsset)(tt.p)
+			got, err := CallFuncForEveryAsset(EnsureBigQueryQuerySensorHasTableParameterForASingleAsset)(ctx, tt.p)
 			if !tt.wantErr(t, err) {
 				return
 			}
@@ -1733,11 +1746,12 @@ func TestEnsureBigQueryTableSensorHasTableParameter(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CallFuncForEveryAsset(EnsureBigQueryTableSensorHasTableParameterForASingleAsset)(tt.p)
+			got, err := CallFuncForEveryAsset(EnsureBigQueryTableSensorHasTableParameterForASingleAsset)(ctx, tt.p)
 			if !tt.wantErr(t, err) {
 				return
 			}
@@ -1911,11 +1925,12 @@ func TestEnsurePipelineStartDateIsValid(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := EnsurePipelineStartDateIsValid(tt.p)
+			got, err := EnsurePipelineStartDateIsValid(ctx, tt.p)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -2400,6 +2415,8 @@ func TestWarnRegularYamlFiles_WarnRegularYamlFilesInRepo(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 	}
+
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -2407,7 +2424,7 @@ func TestWarnRegularYamlFiles_WarnRegularYamlFilesInRepo(t *testing.T) {
 			w := &WarnRegularYamlFiles{
 				fs: afero.NewOsFs(),
 			}
-			got, err := w.WarnRegularYamlFilesInRepo(tt.p)
+			got, err := w.WarnRegularYamlFilesInRepo(ctx, tt.p)
 			if !tt.wantErr(t, err, fmt.Sprintf("WarnRegularYamlFilesInRepo(%v)", tt.p)) {
 				return
 			}

--- a/pkg/pipeline/variables.go
+++ b/pkg/pipeline/variables.go
@@ -19,6 +19,9 @@ func (v Variables) Validate() error {
 	// TODO(turtledev):
 	// - validate the defaults actually satisfy the schema
 	// - make "properties" a required field for object types
+	//
+	// BUG: Schema compiler fetches the schema from the spec URL, which may break
+	// in environments where internet access is restricted.
 	_, err := varSchemaLoader().Compile(gojsonschema.NewGoLoader(v.Schema()))
 	if err != nil {
 		return fmt.Errorf("invalid variables schema: %w", err)


### PR DESCRIPTION
This change fixes a bug with variables not being inherited by lint rules.