### PR TITLE
lint: GetRules(): remove seed assets validator.

### DIFF
--- a/cmd/const.go
+++ b/cmd/const.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/glossary"
 	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/lint"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/fatih/color"
 	"github.com/spf13/afero"
@@ -40,6 +41,13 @@ var (
 	}
 
 	DefaultPipelineBuilder = pipeline.NewBuilder(builderConfig, pipeline.CreateTaskFromYamlDefinition(fs), pipeline.CreateTaskFromFileComments(fs), fs, DefaultGlossaryReader)
+	SeedAssetsValidator    = &lint.SimpleRule{
+		Identifier:       "assets-seed-validation",
+		Fast:             true,
+		Severity:         lint.ValidatorSeverityCritical,
+		AssetValidator:   lint.ValidateAssetSeedValidation,
+		ApplicableLevels: []lint.Level{lint.LevelAsset},
+	}
 )
 
 func renderAssetParamsMutator(renderer jinja.RendererInterface) pipeline.AssetMutator {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -174,6 +174,7 @@ func Lint(isDebug *bool) *cli.Command {
 
 			rules = append(rules, queryValidatorRules(logger, cm, connectionManager)...)
 			rules = append(rules, lint.GetCustomCheckQueryDryRunRule(connectionManager, renderer))
+			rules = append(rules, SeedAssetsValidator)
 
 			if c.Bool("fast") {
 				rules = lint.FilterRulesBySpeed(rules, true)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -596,6 +596,7 @@ func CheckLint(ctx context.Context, foundPipeline *pipeline.Pipeline, pipelinePa
 		errorPrinter.Printf("An error occurred while linting the pipelines: %v\n", err)
 		return err
 	}
+	rules = append(rules, SeedAssetsValidator)
 
 	rules = lint.FilterRulesBySpeed(rules, true)
 


### PR DESCRIPTION
The validator is still available and used, but isn't part of the static rule list anymore. Instead it's added to the rule list in the CLI code.

This change disable this rule in SDK clients.