### PR TITLE
Add date range log to pipeline start

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -431,7 +431,8 @@ func Run(isDebug *bool) *cli.Command {
 			}
 			sendTelemetry(s, c)
 			infoPrinter.Printf("\n%s\n", executionStartLog)
-			infoPrinter.Println()
+			infoPrinter.Printf("Start date: %s\n", startDate.Format(time.RFC3339))
+			infoPrinter.Printf("End date:   %s\n\n", endDate.Format(time.RFC3339))
 			if runConfig.SensorMode != "" {
 				if !(runConfig.SensorMode == "skip" || runConfig.SensorMode == "once" || runConfig.SensorMode == "wait") {
 					errorPrinter.Printf("invalid value for '--mode' flag: '%s', valid options are --skip ,--once, --wait", runConfig.SensorMode)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -430,9 +430,9 @@ func Run(isDebug *bool) *cli.Command {
 				return nil
 			}
 			sendTelemetry(s, c)
+			infoPrinter.Printf("\nStart date: %s\n", startDate.Format(time.RFC3339))
+			infoPrinter.Printf("End date:   %s\n", endDate.Format(time.RFC3339))
 			infoPrinter.Printf("\n%s\n", executionStartLog)
-			infoPrinter.Printf("Start date: %s\n", startDate.Format(time.RFC3339))
-			infoPrinter.Printf("End date:   %s\n\n", endDate.Format(time.RFC3339))
 			if runConfig.SensorMode != "" {
 				if !(runConfig.SensorMode == "skip" || runConfig.SensorMode == "once" || runConfig.SensorMode == "wait") {
 					errorPrinter.Printf("invalid value for '--mode' flag: '%s', valid options are --skip ,--once, --wait", runConfig.SensorMode)


### PR DESCRIPTION
## Summary
- print start and end date when running pipeline via CLI

## Testing
- `go test ./...` *(fails: unable to finish due to environment or dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_68512578948c832283511bb2da517aa8