### PR TITLE
Add docs for pipeline variables

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -161,6 +161,7 @@ export default withMermaid({
                     {text: "Credentials", link: "/getting-started/credentials"},
                     {text: "Interval Modifiers", link: "/assets/interval-modifiers"},
                     {text: "Materialization", link: "/assets/materialization"},
+                    {text: "Pipeline Variables", link: "/pipeline-variables"},
                     {
                         text: " Jinja Templating",
                         link: "/assets/templating/templating",

--- a/docs/assets/python.md
+++ b/docs/assets/python.md
@@ -98,8 +98,7 @@ The following environment variables are available in every Python asset executio
 
 ### Pipeline
 
-<!--TODO: update variables reference to point to dedicated docs section, once it's ready -->
-Bruin supports user-defined variables at a pipeline level. These become available as a JSON document in your python asset as `BRUIN_VARS`. See [variables](/assets/templating/templating#adding-variables) for more information on how to define variables for your assets.
+Bruin supports user-defined variables at a pipeline level. These become available as a JSON document in your python asset as `BRUIN_VARS`. See [pipeline variables](../pipeline-variables.md) for more information on how to define and override them.
 
 Here's a short example:
 ::: code-group

--- a/docs/assets/templating/templating.md
+++ b/docs/assets/templating/templating.md
@@ -56,7 +56,7 @@ You can read more about [Jinja here](https://jinja.palletsprojects.com/en/3.1.x/
 ## Adding variables
 
 You can add variables in your `pipeline.yml` file. We support all YAML data types to give you the
-maximum flexibility in your variable configuration. `variables` are declared as [JSON Schema object](https://json-schema.org/draft-07/draft-handrews-json-schema-01#rfc.section.4.2.1). Here's a comprehensive example:
+maximum flexibility in your variable configuration. `variables` are declared as [JSON Schema object](https://json-schema.org/draft-07/draft-handrews-json-schema-01#rfc.section.4.2.1). See [pipeline variables](../../pipeline-variables.md) for a dedicated guide. Here's a comprehensive example:
 
 ::: code-group 
 ```yaml [pipeline.yml]

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -55,6 +55,8 @@ table td:first-child {
 | `--minimal-logs` | bool | `false` | Skip initial pipeline analysis logs for this run. |
 | `--var` | []str | - | Override pipeline variables with custom values. |
 
+See [pipeline variables](../pipeline-variables.md) for details on declaring and using variables.
+
 
 ### Continue from the last failed asset
 

--- a/docs/pipeline-variables.md
+++ b/docs/pipeline-variables.md
@@ -1,0 +1,74 @@
+# Pipeline Variables
+
+Bruin lets you parameterize your pipelines with custom variables. These variables are defined in `pipeline.yml` using [JSON Schema](https://json-schema.org/) and are available in your assets during execution.
+
+## Defining variables
+
+Add a `variables` section to your `pipeline.yml` and describe each variable with JSON Schema keywords. Every variable must provide a `default` value so Bruin can render assets without command line overrides.
+
+```yaml [pipeline.yml]
+name: var-pipeline
+variables:
+  env:
+    type: string
+    default: dev
+  users:
+    type: array
+    items:
+      type: string
+    default: ["alice", "bob"]
+```
+
+## Referencing variables in assets
+
+All variables are accessible in SQL, Python, **sensor**, and **ingestr** assets via the `var` namespace:
+
+```sql [asset.sql]
+SELECT * FROM events
+WHERE user_id IN ({{ ','.join(var.users) }})
+```
+
+```python [asset.py]
+import os, json
+vars = json.loads(os.environ["BRUIN_VARS"])
+print(vars["env"])
+```
+
+Sensor and ingestr assets, defined as YAML files, can embed variables in the same way:
+
+```yaml [sensor.asset.yml]
+name: wait_for_table
+type: bq.sensor.query
+parameters:
+  query: select count(*) > 0 from `{{ var.table }}`
+```
+
+## Built-in variables
+
+Bruin injects several variables automatically:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `start_date` | The start date in YYYY-MM-DD format | "2023-12-01" |
+| `start_datetime` | The start date and time in YYYY-MM-DDThh:mm:ss format | "2023-12-01T15:30:00" |
+| `start_timestamp` | The start timestamp in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) format | "2023-12-01T15:30:00.000000+07:00" |
+| `end_date` | The end date in YYYY-MM-DD format | "2023-12-02" |
+| `end_datetime` | The end date and time in YYYY-MM-DDThh:mm:ss format | "2023-12-02T15:30:00" |
+| `end_timestamp` | The end timestamp in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) format | "2023-12-02T15:30:00.000000Z07:00" |
+| `pipeline` | The name of the currently executing pipeline | `my_pipeline` |
+| `run_id` | The unique identifier for the current pipeline run | `run_1234567890` |
+
+In Python assets these built-ins are exposed as environment variables (e.g. `BRUIN_START_DATE`). User-defined variables are available as the JSON string `BRUIN_VARS`.
+
+Sensor and ingestr processes receive the same environment variables, enabling any custom scripts they execute to access `BRUIN_VARS` as well.
+
+## Overriding variables
+
+During `bruin run` you can override variable values with the `--var` flag:
+
+```bash
+bruin run --var env=prod --var '{"users": ["alice", "bob"]}'
+```
+
+The flag may be used multiple times. If the same key is specified more than once, the last value wins.
+


### PR DESCRIPTION
## Summary
- document pipeline variables
- link python, templating and run docs to the new page
- add pipeline variables page to the sidebar
- expand pipeline variables doc with info about sensors and ingestr assets

## Testing
- `npm install`
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_6851258f0e9883228431353ac40695af