### PR TITLE
feat/format with sqlfluff

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -188,6 +188,10 @@ func formatAsset(path string) (*pipeline.Asset, error) {
 		return nil, errors2.Wrap(err, "failed to build the asset")
 	}
 
+	if asset == nil {
+		return nil, errors2.New("no valid asset found in the file")
+	}
+
 	return asset, asset.Persist(afero.NewOsFs())
 }
 
@@ -205,6 +209,10 @@ func shouldFileChange(path string) (bool, error) {
 	asset, err := DefaultPipelineBuilder.CreateAssetFromFile(path, nil)
 	if err != nil {
 		return false, errors2.Wrap(err, "failed to build the asset")
+	}
+
+	if asset == nil {
+		return false, errors2.New("no valid asset found in the file")
 	}
 
 	// Generate the new content without persisting

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -2,13 +2,18 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/bruin-data/bruin/pkg/executor"
+	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/python"
 	errors2 "github.com/pkg/errors"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/spf13/afero"
@@ -31,6 +36,11 @@ func Format(isDebug *bool) *cli.Command {
 				Usage: "fail the command if any of the assets need reformatting",
 				Value: false,
 			},
+			&cli.BoolFlag{
+				Name:  "sqlfluff",
+				Usage: "run sqlfluff to format SQL files",
+				Value: false,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			logger := makeLogger(*isDebug)
@@ -42,6 +52,7 @@ func Format(isDebug *bool) *cli.Command {
 
 			output := c.String("output")
 			checkLint := c.Bool("fail-if-changed")
+			runSqlfluff := c.Bool("sqlfluff")
 
 			if isPathReferencingAsset(repoOrAsset) {
 				if checkLint {
@@ -125,38 +136,85 @@ func Format(isDebug *bool) *cli.Command {
 				}
 				return cli.Exit("", 1)
 			}
-			if !checkLint && len(errorList) == 0 {
+
+			if checkLint || len(errorList) > 0 {
 				if output == "json" {
-					return nil
+					jsMessage, err := json.Marshal(errorList)
+					if err != nil {
+						printErrorJSON(err)
+					}
+					fmt.Println(jsMessage)
+					return cli.Exit("", 1)
 				}
 
-				if processedAssetCount == 0 {
-					infoPrinter.Println("no actual assets were found in the given path, nothing has changed.")
-					return nil
+				errorPrinter.Println("Some errors occurred:")
+				for _, err := range errorList {
+					errorPrinter.Println("  - " + err.Error())
 				}
 
-				assetStr := "asset"
-				if processedAssetCount > 1 {
-					assetStr += "s"
-				}
-				infoPrinter.Printf("Successfully formatted %d %s.\n", processedAssetCount, assetStr)
-				return nil
-			}
-			if output == "json" {
-				jsMessage, err := json.Marshal(errorList)
-				if err != nil {
-					printErrorJSON(err)
-				}
-				fmt.Println(jsMessage)
 				return cli.Exit("", 1)
 			}
 
-			errorPrinter.Println("Some errors occurred:")
-			for _, err := range errorList {
-				errorPrinter.Println("  - " + err.Error())
+			if output == "json" {
+				return nil
 			}
 
-			return cli.Exit("", 1)
+			if processedAssetCount == 0 {
+				infoPrinter.Println("no actual assets were found in the given path, nothing has changed.")
+				return nil
+			}
+
+			assetStr := "asset"
+			if processedAssetCount > 1 {
+				assetStr += "s"
+			}
+			infoPrinter.Printf("Successfully formatted %d %s.\n", processedAssetCount, assetStr)
+
+			// Run sqlfluff if requested
+			if runSqlfluff {
+				no
+				var err error
+				infoPrinter.Println("Running sqlfluff...")
+				// For single asset formatting, we need to handle it differently
+				if isPathReferencingAsset(repoOrAsset) {
+					// Find the repository root for the single asset
+					// Use the directory containing the asset to find the repo
+					repoFinder := &git.RepoFinder{}
+					assetDir := filepath.Dir(repoOrAsset)
+					repo, repoErr := repoFinder.Repo(assetDir)
+					if repoErr != nil {
+						if output == "json" {
+							jsMessage, err := json.Marshal([]error{repoErr})
+							if err != nil {
+								printErrorJSON(err)
+							}
+							fmt.Println(jsMessage)
+							return cli.Exit("", 1)
+						}
+						errorPrinter.Printf("Error finding repository for sqlfluff: %v\n", repoErr)
+						return cli.Exit("", 1)
+					}
+					err = runSqlfluffFormattingForSingleAsset(repoOrAsset, repo, logger)
+				} else {
+					err = runSqlfluffFormatting(repoOrAsset, output, logger)
+				}
+
+				if err != nil {
+					if output == "json" {
+						jsMessage, jsonErr := json.Marshal([]error{err})
+						if jsonErr != nil {
+							printErrorJSON(jsonErr)
+						}
+						fmt.Println(jsMessage)
+						return cli.Exit("", 1)
+					}
+					errorPrinter.Printf("Error running sqlfluff: %v\n", err)
+					return cli.Exit("", 1)
+				}
+				infoPrinter.Println("Successfully formatted SQL files with sqlfluff.")
+			}
+
+			return nil
 		},
 	}
 }
@@ -221,4 +279,142 @@ func checkChangesForSingleAsset(repoOrAsset, output string) error {
 func normalizeLineEndings(content []byte) []byte {
 	content = bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 	return bytes.ReplaceAll(content, []byte("\r"), []byte("\n"))
+}
+
+func runSqlfluffFormatting(repoPath, output string, logger interface{}) error {
+	// Find all SQL files with their asset information
+	sqlFilesWithDialects, err := findSqlFilesWithDialects(repoPath)
+	if err != nil {
+		return errors2.Wrap(err, "failed to find SQL files")
+	}
+
+	if len(sqlFilesWithDialects) == 0 {
+		return nil // No SQL files to format
+	}
+
+	// Find the git repo
+	repoFinder := &git.RepoFinder{}
+	repo, err := repoFinder.Repo(repoPath)
+	if err != nil {
+		return errors2.Wrap(err, "failed to find git repository")
+	}
+
+	// Create sqlfluff runner
+	sqlfluffRunner := &python.SqlfluffRunner{
+		UvInstaller: &python.UvChecker{},
+	}
+
+	// Run sqlfluff on all SQL files
+	ctx := context.WithValue(context.Background(), executor.ContextLogger, logger)
+	return sqlfluffRunner.RunSqlfluffWithDialects(ctx, sqlFilesWithDialects, repo)
+}
+
+func runSqlfluffFormattingForSingleAsset(assetPath string, repo *git.Repo, logger interface{}) error {
+	// Parse the single asset to get its type
+	asset, err := DefaultPipelineBuilder.CreateAssetFromFile(assetPath, nil)
+	if err != nil {
+		return errors2.Wrap(err, "failed to parse asset")
+	}
+
+	if asset == nil {
+		return nil // Not a valid asset
+	}
+
+	// Detect dialect from asset type
+	dialect := python.DetectDialectFromAssetType(string(asset.Type))
+
+	// Convert to absolute path for now since we're working in a nested repo structure
+	absolutePath, err := filepath.Abs(assetPath)
+	if err != nil {
+		return errors2.Wrap(err, "failed to get absolute path")
+	}
+
+	sqlFileInfo := python.SQLFileInfo{
+		FilePath: absolutePath,
+		Dialect:  dialect,
+	}
+
+	// Create sqlfluff runner
+	sqlfluffRunner := &python.SqlfluffRunner{
+		UvInstaller: &python.UvChecker{},
+	}
+
+	// Run sqlfluff on the single file
+	ctx := context.WithValue(context.Background(), executor.ContextLogger, logger)
+	return sqlfluffRunner.RunSqlfluffWithDialects(ctx, []python.SQLFileInfo{sqlFileInfo}, repo)
+}
+
+func findSqlFilesWithDialects(repoPath string) ([]python.SQLFileInfo, error) {
+	// Check if we're formatting a single asset
+	if isPathReferencingAsset(repoPath) {
+		// Single asset - detect dialect from the asset itself
+		asset, err := DefaultPipelineBuilder.CreateAssetFromFile(repoPath, nil)
+		if err != nil {
+			return nil, errors2.Wrap(err, "failed to parse asset")
+		}
+
+		if asset != nil {
+			dialect := python.DetectDialectFromAssetType(string(asset.Type))
+			return []python.SQLFileInfo{{
+				FilePath: repoPath,
+				Dialect:  dialect,
+			}}, nil
+		}
+		return []python.SQLFileInfo{}, nil
+	}
+
+	// Full pipeline - analyze all SQL files and detect dialects in parallel
+	sqlPaths := path.GetAllPossibleAssetPaths(repoPath, assetsDirectoryNames, []string{".sql"})
+
+	if len(sqlPaths) == 0 {
+		return []python.SQLFileInfo{}, nil
+	}
+
+	// Use conc pool to process assets in parallel with max 30 goroutines
+	assetPool := pool.New().WithMaxGoroutines(30)
+	sqlFilesWithDialects := make([]python.SQLFileInfo, len(sqlPaths))
+	errorList := make([]error, 0)
+
+	for i, sqlPath := range sqlPaths {
+		assetPool.Go(func() {
+			index := i
+			// Check if file exists
+			if _, err := os.Stat(sqlPath); err != nil {
+				return
+			}
+
+			// Try to parse asset to get type information
+			asset, err := DefaultPipelineBuilder.CreateAssetFromFile(sqlPath, nil)
+			if err != nil || asset == nil {
+				// If we can't parse the asset, use ANSI as fallback
+				sqlFilesWithDialects[index] = python.SQLFileInfo{
+					FilePath: sqlPath,
+					Dialect:  "ansi",
+				}
+				return
+			}
+
+			dialect := python.DetectDialectFromAssetType(string(asset.Type))
+			sqlFilesWithDialects[index] = python.SQLFileInfo{
+				FilePath: sqlPath,
+				Dialect:  dialect,
+			}
+		})
+	}
+
+	assetPool.Wait()
+
+	// Filter out empty entries (from files that didn't exist)
+	result := make([]python.SQLFileInfo, 0, len(sqlFilesWithDialects))
+	for _, sqlFile := range sqlFilesWithDialects {
+		if sqlFile.FilePath != "" {
+			result = append(result, sqlFile)
+		}
+	}
+
+	if len(errorList) > 0 {
+		return result, errorList[0] // Return first error if any occurred
+	}
+
+	return result, nil
 }

--- a/docs/commands/format.md
+++ b/docs/commands/format.md
@@ -23,4 +23,49 @@ Specifies the output format for the command.
 Possible values:
 - `plain` (default): Prints human-readable messages.
 - `json`: Prints errors (if any) in JSON format.  
-- `fail-if-changed`: fail the command if any of the assets need reformatting
+
+**--fail-if-changed** (optional):  
+Fail the command if any of the assets need reformatting.
+
+**--sqlfluff** (optional):  
+Run SQLFluff to format SQL files in addition to formatting Bruin asset definitions. SQLFluff is a SQL linting and formatting tool that ensures consistent SQL code style across your project.
+
+## SQLFluff Integration
+
+When the `--sqlfluff` flag is used, Bruin automatically:
+
+1. **Detects SQL dialects** based on asset types (e.g., `sf.sql` → Snowflake, `bq.sql` → BigQuery)
+2. **Formats SQL files** using the appropriate dialect-specific rules
+3. **Processes files in parallel** for improved performance (up to 30 concurrent operations)
+
+### Supported Database Dialects
+
+| Asset Type Prefix | SQLFluff Dialect | Database |
+|-------------------|------------------|----------|
+| `sf.` | snowflake | Snowflake |
+| `bq.` | bigquery | BigQuery |
+| `pg.` | postgres | PostgreSQL |
+| `rs.` | redshift | Amazon Redshift |
+| `athena.` | athena | Amazon Athena |
+| `ms.` | tsql | Microsoft SQL Server |
+| `databricks.` | sparksql | Databricks |
+| `synapse.` | tsql | Azure Synapse |
+| `duckdb.` | duckdb | DuckDB |
+| `clickhouse.` | clickhouse | ClickHouse |
+
+### Examples
+
+Format all assets including SQL files:
+```bash
+bruin format --sqlfluff
+```
+
+Format a single SQL asset:
+```bash
+bruin format assets/sf.my_table.sql --sqlfluff
+```
+
+Format with JSON output:
+```bash
+bruin format --sqlfluff --output json
+```

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.2
 
 require (
 	cloud.google.com/go/bigquery v1.69.0
+	github.com/BurntSushi/toml v1.5.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.37.1
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/alecthomas/chroma/v2 v2.18.0
@@ -66,7 +67,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1 // indirect
-	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/ClickHouse/ch-go v0.66.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/apache/arrow-go/v18 v18.3.0 // indirect

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -491,6 +491,7 @@ func TestLinter_LintAsset(t *testing.T) {
 		})
 	}
 }
+
 func TestPipelineAnalysisResult_ErrorCount(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -474,7 +474,7 @@ type SQLFileInfo struct {
 }
 
 // DetectDialectFromAssetType extracts the dialect from an asset's type field
-// by splitting on the first dot and mapping the prefix
+// by splitting on the first dot and mapping the prefix.
 func DetectDialectFromAssetType(assetType string) string {
 	parts := strings.Split(assetType, ".")
 	if len(parts) == 0 {
@@ -512,7 +512,8 @@ func (s *SqlfluffRunner) RunSqlfluffWithDialects(ctx context.Context, sqlFiles [
 		err = s.formatSQLFileWithDialect(ctx, sqlFileInfo.FilePath, sqlFileInfo.Dialect, repo)
 		if err != nil {
 			// Check if it's a non-critical exit code (1 = unfixable violations)
-			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 				// Exit code 1 means there were unfixable violations but fixes were applied
 				// This is acceptable, so we continue
 				return nil
@@ -534,7 +535,8 @@ func (s *SqlfluffRunner) RunSqlfluffWithDialects(ctx context.Context, sqlFiles [
 			err := s.formatSQLFileWithDialect(ctx, fileInfo.FilePath, fileInfo.Dialect, repo)
 			if err != nil {
 				// Check if it's a non-critical exit code (1 = unfixable violations)
-				if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 					// Exit code 1 means there were unfixable violations but fixes were applied
 					// This is acceptable, so we continue
 					return

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -611,7 +612,15 @@ func parsePyprojectToml(filePath string) (map[string]any, error) {
 func convertTomlConfigToIni(config map[string]any, prefix string) string {
 	var result strings.Builder
 
-	for key, value := range config {
+	// Sort keys to ensure deterministic output
+	keys := make([]string, 0, len(config))
+	for key := range config {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := config[key]
 		sectionName := key
 		if prefix != "" {
 			sectionName = prefix + ":" + key

--- a/pkg/python/uv_pyproject_test.go
+++ b/pkg/python/uv_pyproject_test.go
@@ -1,0 +1,136 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePyprojectToml(t *testing.T) {
+	tests := []struct {
+		name         string
+		tomlContent  string
+		expected     map[string]any
+		wantErr      bool
+	}{
+		{
+			name: "valid_pyproject_toml_with_sqlfluff_config",
+			tomlContent: `[tool.sqlfluff.core]
+dialect = "duckdb"
+max_line_length = 120
+exclude_rules = ["LT05", "ST06"]
+
+[tool.sqlfluff.indentation]
+indented_joins = false
+indented_using_on = true`,
+			expected: map[string]any{
+				"core": map[string]any{
+					"dialect":         "duckdb",
+					"max_line_length": int64(120),
+					"exclude_rules":   []any{"LT05", "ST06"},
+				},
+				"indentation": map[string]any{
+					"indented_joins":   false,
+					"indented_using_on": true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "empty_pyproject_toml",
+			tomlContent:  "",
+			expected:     nil,
+			wantErr:      false,
+		},
+		{
+			name:         "pyproject_toml_without_sqlfluff_section",
+			tomlContent:  `[tool.other]
+value = "test"`,
+			expected:     nil,
+			wantErr:      false,
+		},
+		{
+			name:         "non_existent_file",
+			tomlContent:  "", 
+			expected:     nil,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for each test
+			testTempDir, err := os.MkdirTemp("", "test-pyproject-*")
+			require.NoError(t, err)
+			defer os.RemoveAll(testTempDir)
+
+			var filePath string
+			if tt.name == "non_existent_file" {
+				filePath = filepath.Join(testTempDir, "nonexistent.toml")
+				// Don't create the file for this test case
+			} else {
+				filePath = filepath.Join(testTempDir, "test.toml")
+				err := os.WriteFile(filePath, []byte(tt.tomlContent), 0644)
+				require.NoError(t, err)
+			}
+
+			result, err := parsePyprojectToml(filePath)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestConvertTomlConfigToIni(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]any
+		prefix   string
+		expected string
+	}{
+		{
+			name: "simple_config_values",
+			config: map[string]any{
+				"core": map[string]any{
+					"dialect":         "duckdb",
+					"max_line_length": int64(120),
+					"exclude_rules":   []any{"LT05", "ST06"},
+				},
+			},
+			prefix:   "",
+			expected: "[sqlfluff:core]\ndialect = duckdb\nmax_line_length = 120\nexclude_rules = LT05,ST06\n\n",
+		},
+		{
+			name: "nested_config_with_boolean",
+			config: map[string]any{
+				"indentation": map[string]any{
+					"indented_joins":   false,
+					"indented_using_on": true,
+				},
+			},
+			prefix:   "",
+			expected: "[sqlfluff:indentation]\nindented_joins = false\nindented_using_on = true\n\n",
+		},
+		{
+			name:     "empty_config",
+			config:   map[string]any{},
+			prefix:   "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertTomlConfigToIni(tt.config, tt.prefix)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/python/uv_pyproject_test.go
+++ b/pkg/python/uv_pyproject_test.go
@@ -109,7 +109,7 @@ func TestConvertTomlConfigToIni(t *testing.T) {
 				},
 			},
 			prefix:   "",
-			expected: "[sqlfluff:core]\ndialect = duckdb\nmax_line_length = 120\nexclude_rules = LT05,ST06\n\n",
+			expected: "[sqlfluff:core]\ndialect = duckdb\nexclude_rules = LT05,ST06\nmax_line_length = 120\n\n",
 		},
 		{
 			name: "nested_config_with_boolean",

--- a/pkg/python/uv_pyproject_test.go
+++ b/pkg/python/uv_pyproject_test.go
@@ -65,7 +65,7 @@ value = "test"`,
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			testTempDir := t.TempDir()
 
 			var filePath string

--- a/pkg/python/uv_pyproject_test.go
+++ b/pkg/python/uv_pyproject_test.go
@@ -10,11 +10,13 @@ import (
 )
 
 func TestParsePyprojectToml(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name         string
-		tomlContent  string
-		expected     map[string]any
-		wantErr      bool
+		name        string
+		tomlContent string
+		expected    map[string]any
+		wantErr     bool
 	}{
 		{
 			name: "valid_pyproject_toml_with_sqlfluff_config",
@@ -33,39 +35,38 @@ indented_using_on = true`,
 					"exclude_rules":   []any{"LT05", "ST06"},
 				},
 				"indentation": map[string]any{
-					"indented_joins":   false,
+					"indented_joins":    false,
 					"indented_using_on": true,
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name:         "empty_pyproject_toml",
-			tomlContent:  "",
-			expected:     nil,
-			wantErr:      false,
+			name:        "empty_pyproject_toml",
+			tomlContent: "",
+			expected:    nil,
+			wantErr:     false,
 		},
 		{
-			name:         "pyproject_toml_without_sqlfluff_section",
-			tomlContent:  `[tool.other]
+			name: "pyproject_toml_without_sqlfluff_section",
+			tomlContent: `[tool.other]
 value = "test"`,
-			expected:     nil,
-			wantErr:      false,
+			expected: nil,
+			wantErr:  false,
 		},
 		{
-			name:         "non_existent_file",
-			tomlContent:  "", 
-			expected:     nil,
-			wantErr:      false,
+			name:        "non_existent_file",
+			tomlContent: "",
+			expected:    nil,
+			wantErr:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a temporary directory for each test
-			testTempDir, err := os.MkdirTemp("", "test-pyproject-*")
-			require.NoError(t, err)
-			defer os.RemoveAll(testTempDir)
+			t.Parallel()
+			
+			testTempDir := t.TempDir()
 
 			var filePath string
 			if tt.name == "non_existent_file" {
@@ -73,16 +74,16 @@ value = "test"`,
 				// Don't create the file for this test case
 			} else {
 				filePath = filepath.Join(testTempDir, "test.toml")
-				err := os.WriteFile(filePath, []byte(tt.tomlContent), 0644)
+				err := os.WriteFile(filePath, []byte(tt.tomlContent), 0o644)
 				require.NoError(t, err)
 			}
 
 			result, err := parsePyprojectToml(filePath)
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
 		})
@@ -90,6 +91,8 @@ value = "test"`,
 }
 
 func TestConvertTomlConfigToIni(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		config   map[string]any
@@ -112,7 +115,7 @@ func TestConvertTomlConfigToIni(t *testing.T) {
 			name: "nested_config_with_boolean",
 			config: map[string]any{
 				"indentation": map[string]any{
-					"indented_joins":   false,
+					"indented_joins":    false,
 					"indented_using_on": true,
 				},
 			},
@@ -129,6 +132,8 @@ func TestConvertTomlConfigToIni(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := convertTomlConfigToIni(tt.config, tt.prefix)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/templates/duckdb/assets/example.sql
+++ b/templates/duckdb/assets/example.sql
@@ -1,42 +1,59 @@
 /* @bruin
-name: example
+
 materialization:
-   type: table
+  type: table
 
 columns:
   - name: id
     type: integer
-    description: "Just a number"
+    description: Just a number
     primary_key: true
     checks:
-        - name: not_null
-        - name: positive
-        - name: non_negative
+      - name: not_null
+      - name: positive
+      - name: non_negative
   - name: country
     type: varchar
-    description: "the country"
+    description: the country
     primary_key: true
     checks:
-        - name: not_null
+      - name: not_null
   - name: name
     type: varchar
+    description: Just a name
     update_on_merge: true
-    description: "Just a name"
     checks:
-        - name: unique
-        - name: not_null
-#        - name: pattern
-#        value: "^[A-Z][a-z]*$"
-   @bruin */
+      - name: unique
+      - name: not_null
 
-SELECT 1 as id, 'spain' as country , 'alberto' as name
-union all
-SELECT 2 as id, 'germany' as country , 'frank' as name
-union all
-SELECT 3 as id, 'germany' as country , 'franz' as name
-union all
-SELECT 4 as id, 'france' as country , 'jean' as name
-union all
-SELECT 5 as id, 'poland' as country , 'maciej' as name
-union all
-SELECT 6 as id, 'india' as country , 'yuvraj' as name
+@bruin */
+
+SELECT
+    1 AS id,
+    'spain' AS country,
+    'alberto' AS name
+UNION ALL
+SELECT
+    2 AS id,
+    'germany' AS country,
+    'frank' AS name
+UNION ALL
+SELECT
+    3 AS id,
+    'germany' AS country,
+    'franz' AS name
+UNION ALL
+SELECT
+    4 AS id,
+    'france' AS country,
+    'jean' AS name
+UNION ALL
+SELECT
+    5 AS id,
+    'poland' AS country,
+    'maciej' AS name
+UNION ALL
+SELECT
+    6 AS id,
+    'india' AS country,
+    'yuvraj' AS name

--- a/templates/duckdb/assets/seed.asset.yml
+++ b/templates/duckdb/assets/seed.asset.yml
@@ -1,16 +1,19 @@
 name: raw.seed
 type: duckdb.seed
-
 description: This asset loads a CSV file into a DuckDB database.
+
+parameters:
+  path: ./seed.csv
+
 columns:
   - name: name
     type: varchar
-    description: "Contact person's full name"
+    description: Contact person's full name
     checks:
       - name: not_null
   - name: networking_through
     type: varchar
-    description: "Source or connection through which contact was made"
+    description: Source or connection through which contact was made
     checks:
       - name: not_null
       - name: accepted_values
@@ -21,13 +24,9 @@ columns:
           - Instagram
   - name: position
     type: varchar
-    description: "Contact's job position or title"
+    description: Contact's job position or title
     checks:
       - name: not_null
   - name: contact_date
     type: varchar
-    description: "Date when contact was established"
-
-
-parameters:
-  path: ./seed.csv
+    description: Date when contact was established


### PR DESCRIPTION
This PR introduces a new `--sqlfluff` parameter into `bruin format` command that will automatically run SQLFluff on the SQL assets based on their dialects. 