### PR TITLE
Add concurrency field to Pipeline struct

### DIFF
--- a/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
+++ b/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
@@ -113,5 +113,6 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
@@ -462,5 +462,6 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -237,6 +237,7 @@
     "bigquery": false
   },
   "retries": 0,
+  "concurrency": 0,
   "default": {
     "type": "ingestr",
     "parameters": {

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
@@ -206,5 +206,6 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }

--- a/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
@@ -464,5 +464,6 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }

--- a/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
@@ -208,5 +208,6 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1196,6 +1196,7 @@ type Pipeline struct {
 	Catchup            bool                   `json:"catchup" yaml:"catchup" mapstructure:"catchup"`
 	MetadataPush       MetadataPush           `json:"metadata_push" yaml:"metadata_push" mapstructure:"metadata_push"`
 	Retries            int                    `json:"retries" yaml:"retries" mapstructure:"retries"`
+	Concurrency        int                    `json:"concurrency" yaml:"concurrency" mapstructure:"concurrency"`
 	DefaultValues      *DefaultValues         `json:"default,omitempty" yaml:"default,omitempty" mapstructure:"default,omitempty"`
 	Commit             string                 `json:"commit"`
 	Snapshot           string                 `json:"snapshot"`

--- a/pkg/pipeline/testdata/pipeline/first-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/first-pipeline_unix.json
@@ -2,18 +2,21 @@
     "legacy_id": "first-pipeline",
     "name": "first-pipeline",
     "schedule": "",
-    "snapshot": "",
     "start_date": "",
+    "snapshot": "",
     "agent": false,
     "definition_file": {
         "name": "pipeline.yml",
         "path": "__BASEDIR__/testdata/pipeline/first-pipeline/pipeline.yml"
     },
+    "variables": null,
     "default_connections": {
         "gcpConnectionId": "gcp-connection-id-here",
         "slack": "slack-connection"
     },
-    "variables": null,
+    "metadata_push": {
+        "bigquery": false
+    },
     "assets": [
         {
             "id": "943be81e20336c53de2c8ab40991839ca3b88bcb4f854f03cdbd69825eb369b6",
@@ -24,7 +27,6 @@
             "connection": "conn1",
             "tags": [],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [
                 {
                     "type": "asset",
@@ -56,7 +58,8 @@
             "custom_checks": [],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         },
         {
             "id": "c69409a1840ddb3639a4acbaaec46c238c63b6431cc74ee5254b6dcef7b88c4b",
@@ -67,7 +70,6 @@
             "connection": "",
             "tags": [],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [],
             "image": "",
             "instance": "",
@@ -93,7 +95,8 @@
             "custom_checks": [],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         },
         {
             "id": "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
@@ -104,7 +107,6 @@
             "connection": "first-connection",
             "tags": [],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [
                 {
                     "type": "asset",
@@ -167,7 +169,8 @@
             "custom_checks": [],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         },
         {
             "id": "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
@@ -178,7 +181,6 @@
             "connection": "conn2",
             "tags": [],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [
                 {
                     "type": "asset",
@@ -240,7 +242,8 @@
             "custom_checks": [],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         }
     ],
     "notifications": {
@@ -268,8 +271,6 @@
     },
     "catchup": false,
     "commit": "",
-    "metadata_push": {
-        "bigquery": false
-    },
-    "retries": 3
+    "retries": 3,
+    "concurrency": 0
 }

--- a/pkg/pipeline/testdata/pipeline/first-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/first-pipeline_windows.json
@@ -271,5 +271,6 @@
   },
   "catchup": false,
   "commit": "",
-  "retries": 3
+  "retries": 3,
+  "concurrency": 0
 }

--- a/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_unix.json
+++ b/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_unix.json
@@ -2,14 +2,11 @@
     "legacy_id": "",
     "name": "pipeline-with-no-assets",
     "schedule": "",
-    "snapshot": "",
     "start_date": "",
-    "agent": false,
     "definition_file": {
         "name": "pipeline.yml",
         "path": "__BASEDIR__/testdata/pipeline/pipeline-with-no-assets/pipeline.yml"
     },
-    "variables": null,
     "default_connections": {
         "gcpConnectionId": "gcp-connection-id-here",
         "slack": "slack-connection"
@@ -21,9 +18,13 @@
         "discord": []
     },
     "catchup": false,
-    "commit": "",
     "metadata_push": {
         "bigquery": false
     },
-    "retries": 0
+    "retries": 0,
+    "concurrency": 0,
+    "commit": "",
+    "snapshot": "",
+    "agent": false,
+    "variables": null
 }

--- a/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_windows.json
+++ b/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_windows.json
@@ -25,5 +25,6 @@
   },
   "catchup": false,
   "commit": "",
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
@@ -3,13 +3,10 @@
     "name": "first-pipeline",
     "schedule": "",
     "start_date": "",
-    "snapshot": "",
-    "agent": false,
     "definition_file": {
         "name": "pipeline.yml",
         "path": "__BASEDIR__/testdata/pipeline/second-pipeline/pipeline.yml"
     },
-    "variables": null,
     "default_connections": {
         "gcpConnectionId": "gcp-connection-id-here",
         "slack": "slack-connection"
@@ -24,7 +21,6 @@
             "connection": "",
             "tags": [],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [],
             "image": "",
             "instance": "",
@@ -50,7 +46,8 @@
             "custom_checks": [],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         },
         {
             "id": "a01e7580b118b5fbbdc1f7c8de6b8c377c684727e4e8ad574e9153a3dbd46dd1",
@@ -61,7 +58,6 @@
             "connection": "",
             "tags": [],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [],
             "image": "",
             "instance": "",
@@ -87,7 +83,8 @@
             "custom_checks": [],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         },
         {
             "id": "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
@@ -101,7 +98,6 @@
                 "tag2:value2"
             ],
             "materialization": null,
-            "interval_modifiers": null,
             "upstreams": [
                 {
                     "type": "asset",
@@ -230,12 +226,12 @@
                     "value": 16,
                     "blocking": false,
                     "query": "select 5"
-
                 }
             ],
             "metadata": {},
             "snowflake": null,
-            "athena": null
+            "athena": null,
+            "interval_modifiers": null
         }
     ],
     "notifications": {
@@ -244,9 +240,13 @@
         "discord": []
     },
     "catchup": false,
-    "commit": "",
     "metadata_push": {
         "bigquery": false
     },
-    "retries": 0
+    "retries": 0,
+    "concurrency": 0,
+    "commit": "",
+    "snapshot": "",
+    "agent": false,
+    "variables": null
 }

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
@@ -247,5 +247,6 @@
   },
   "catchup": false,
   "commit": "",
-  "retries": 0
+  "retries": 0,
+  "concurrency": 0
 }


### PR DESCRIPTION
A `Concurrency` field was added to the `Pipeline` struct in `pkg/pipeline/pipeline.go`.

*   The new field is an `int` type.
*   It includes `json`, `yaml`, and `mapstructure` tags, ensuring proper serialization and deserialization consistent with other struct fields.
*   The field's addition enables specifying the number of concurrent runs for a pipeline, directly addressing the need for controlling execution concurrency, as indicated by the context of enabling "5 concurrent runs" for a specific pipeline.
*   The field was logically placed after the `Retries` field within the struct definition.