### PR TITLE
feat:  ColumnMatchDBValidatorRule

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -176,6 +176,7 @@ func Lint(isDebug *bool) *cli.Command {
 
 			rules = append(rules, queryValidatorRules(logger, cm, connectionManager)...)
 			rules = append(rules, lint.GetCustomCheckQueryDryRunRule(connectionManager, renderer))
+			rules = append(rules, lint.GetColumnMatchDBValidatorRule(connectionManager, renderer))
 			rules = append(rules, SeedAssetsValidator)
 
 			if c.Bool("fast") {


### PR DESCRIPTION
### Summary
This PR adds a new validation rule that checks for missing columns in the database compared to the asset metadata. This helps users identify when their database schema has columns that aren't reflected in their asset definitions.
What it does
The ColumnMatchDBValidatorRule validates table assets by:
Querying the database schema to get actual column names
Comparing them against the columns defined in the asset metadata
Reporting any columns that exist in the database but are missing from the metadata
### Things to note

1. this is marked as isFast: false 
2. its a non blocking warning level validation 