### PR TITLE
Fix ingestr version update in action

### DIFF
--- a/.github/workflows/update-ingestr.yml
+++ b/.github/workflows/update-ingestr.yml
@@ -34,14 +34,36 @@ jobs:
           if version_gt "$latest" "$current"; then
               echo "new=true" >> "$GITHUB_OUTPUT"
               echo "version=$latest" >> "$GITHUB_OUTPUT"
-              sed -i -E "s|(ingestrVersion\s*=\s*\")[^\"]+(\" )|\1$latest\2|" pkg/python/uv.go
           else
               echo "new=false" >> "$GITHUB_OUTPUT"
           fi
-          # echo "Script completed"
+
+      - name: Update ingestr version in code
+        if: steps.check.outputs.new == 'true'
+        run: |
+          set -euo pipefail
+          
+          # Update the version using sed with a more robust pattern
+          sed -i -E 's/(ingestrVersion[[:space:]]*=[[:space:]]*)"[^"]+"/\1"${{ steps.check.outputs.version }}"/' pkg/python/uv.go
+          
+          # Verify the change was made
+          echo "Updated version in pkg/python/uv.go:"
+          grep -n "ingestrVersion" pkg/python/uv.go
+          
+          # Stage the changes
+          git add pkg/python/uv.go
+          
+          # Check if there are actually changes to commit
+          if git diff --cached --quiet; then
+            echo "No changes detected after update"
+            exit 1
+          fi
+          
+          echo "Changes staged successfully"
 
       - name: Check if branch exists
         id: check-branch-exists
+        if: steps.check.outputs.new == 'true'
         run: |
             if [[ -n $(git ls-remote --heads origin update-ingestr-${{ steps.check.outputs.version }}) ]]; then
                 echo "exists=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `.github/workflows/update-ingestr.yml` workflow was updated to correctly modify the `ingestrVersion` in `pkg/python/uv.go` before creating a pull request.

Key changes include:

*   **Dedicated Update Step**: The version update logic was moved from the `Check ingestr version` step into a new, dedicated `Update ingestr version in code` step.
*   **Corrected `sed` Regex**: The `sed` command's regex pattern was updated from `s|(ingestrVersion\s*=\s*\")[^\"]+(\" )|\1$latest\2|` to `s/(ingestrVersion[[:space:]]*=[[:space:]]*)"[^"]+"/\1"${{ steps.check.outputs.version }}"/`. This change correctly handles varying whitespace (tabs/spaces) around the equals sign in the Go constant definition.
*   **Explicit Staging and Verification**:
    *   `git add pkg/python/uv.go` was added to explicitly stage the file changes.
    *   Verification steps, including `grep` to show the updated line and `git diff --cached --quiet` to confirm changes were made, were introduced to ensure the update was successful.
*   **Conditional Execution**: The new update step and subsequent PR creation logic are now conditionally executed only when a new version is detected.