### PR TITLE
Fix diff column formatting in data-diff command

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -392,6 +393,9 @@ func abs(x float64) float64 {
 func formatDiffValue(rawDiff float64, percentageDiff string) string {
 	if percentageDiff == "-" {
 		return "-"
+	}
+	if rawDiff == math.Trunc(rawDiff) {
+		return strconv.FormatInt(int64(rawDiff), 10)
 	}
 	return fmt.Sprintf("%.4g", rawDiff)
 }


### PR DESCRIPTION
## Summary
- avoid scientific notation when showing the diff column in `data-diff`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685afa3c887c8320b579732a13e8f084