### PR TITLE
Add Zoom integration

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -210,6 +210,7 @@ export default withMermaid({
                             {text: "PhantomBuster", link: "/ingestion/phantombuster"},
                             {text: "Pipedrive", link: "/ingestion/pipedrive"},
                             {text: "QuickBooks", link: "/ingestion/quickbooks"},
+                            {text: "Zoom", link: "/ingestion/zoom"},
                             {text: "Salesforce", link: "/ingestion/salesforce"},
                             {text: "SAP HANA", link: "/ingestion/sap_hana"},
                             {text: "S3", link: "/ingestion/s3"},

--- a/docs/ingestion/zoom.md
+++ b/docs/ingestion/zoom.md
@@ -1,0 +1,49 @@
+# Zoom
+[Zoom](https://zoom.us/) is a video conferencing platform used for online meetings and webinars.
+
+Bruin supports Zoom as a source for [Ingestr assets](/assets/ingestr), so you can ingest data from Zoom into your data warehouse.
+
+To connect to Zoom you must add a configuration item to the `.bruin.yml` file and the asset file. You will need `client_id`, `client_secret` and `account_id`.
+
+Follow the steps below to correctly set up Zoom as a data source and run ingestion.
+
+### Step 1: Add a connection to .bruin.yml file
+Add the connection configuration to the connections section of `.bruin.yml`:
+
+```yaml
+connections:
+  zoom:
+    - name: "zoom"
+      client_id: "cid"
+      client_secret: "csecret"
+      account_id: "accid"
+```
+
+- `client_id`: OAuth client id from your Zoom application.
+- `client_secret`: OAuth client secret.
+- `account_id`: Zoom account id.
+
+### Step 2: Create an asset file for data ingestion
+Create an [asset configuration](/assets/ingestr#asset-structure) file to define the data flow:
+
+```yaml
+name: public.zoom_meetings
+type: ingestr
+
+parameters:
+  source_connection: zoom
+  source_table: 'meetings'
+
+  destination: duckdb
+```
+
+- `source_connection`: name of the Zoom connection defined in `.bruin.yml`.
+- `source_table`: Zoom table to ingest.
+- `destination`: name of the destination connection.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+```
+bruin run assets/zoom_asset.yml
+```
+
+Executing this command ingests data from Zoom into your DuckDB database.

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -663,6 +663,17 @@ func (c QuickBooksConnection) GetName() string {
 	return c.Name
 }
 
+type ZoomConnection struct {
+	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	ClientID     string `yaml:"client_id,omitempty" json:"client_id" mapstructure:"client_id"`
+	ClientSecret string `yaml:"client_secret,omitempty" json:"client_secret" mapstructure:"client_secret"`
+	AccountID    string `yaml:"account_id,omitempty" json:"account_id" mapstructure:"account_id"`
+}
+
+func (c ZoomConnection) GetName() string {
+	return c.Name
+}
+
 type EMRServerlessConnection struct {
 	Name          string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	AccessKey     string `yaml:"access_key" json:"access_key" mapstructure:"access_key"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -68,6 +68,7 @@ type Connections struct {
 	Pipedrive           []PipedriveConnection           `yaml:"pipedrive,omitempty" json:"pipedrive,omitempty" mapstructure:"pipedrive"`
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
 	QuickBooks          []QuickBooksConnection          `yaml:"quickbooks,omitempty" json:"quickbooks,omitempty" mapstructure:"quickbooks"`
+	Zoom                []ZoomConnection                `yaml:"zoom,omitempty" json:"zoom,omitempty" mapstructure:"zoom"`
 	EMRServerless       []EMRServerlessConnection       `yaml:"emr_serverless,omitempty" json:"emr_serverless,omitempty" mapstructure:"emr_serverless"`
 	GoogleAnalytics     []GoogleAnalyticsConnection     `yaml:"googleanalytics,omitempty" json:"googleanalytics,omitempty" mapstructure:"googleanalytics"`
 	AppLovin            []AppLovinConnection            `yaml:"applovin,omitempty" json:"applovin,omitempty" mapstructure:"applovin"`
@@ -740,6 +741,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.QuickBooks = append(env.Connections.QuickBooks, conn)
+	case "zoom":
+		var conn ZoomConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Zoom = append(env.Connections.Zoom, conn)
 	case "emr_serverless":
 		var conn EMRServerlessConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -968,6 +976,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Mixpanel = removeConnection(env.Connections.Mixpanel, connectionName)
 	case "quickbooks":
 		env.Connections.QuickBooks = removeConnection(env.Connections.QuickBooks, connectionName)
+	case "zoom":
+		env.Connections.Zoom = removeConnection(env.Connections.Zoom, connectionName)
 	case "emr_serverless":
 		env.Connections.EMRServerless = removeConnection(env.Connections.EMRServerless, connectionName)
 	case "googleanalytics":

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -254,6 +254,11 @@ environments:
           client_id: "cid"
           client_secret: "csecret"
           refresh_token: "rtoken"
+      zoom:
+        - name: "zoom-1"
+          client_id: "zid"
+          client_secret: "zsecret"
+          account_id: "accid"
       emr_serverless:
         - name: emr_serverless-test
           access_key: AKIAEXAMPLE

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -255,6 +255,11 @@ environments:
           client_id: "cid"
           client_secret: "csecret"
           refresh_token: "rtoken"
+      zoom:
+        - name: "zoom-1"
+          client_id: "zid"
+          client_secret: "zsecret"
+          account_id: "accid"
       emr_serverless:
         - name: emr_serverless-test
           access_key: AKIAEXAMPLE

--- a/pkg/zoom/client.go
+++ b/pkg/zoom/client.go
@@ -1,0 +1,16 @@
+package zoom
+
+// Client provides access to Zoom via ingestr.
+type Client struct {
+	config Config
+}
+
+// NewClient initializes a Zoom client with given configuration.
+func NewClient(c Config) (*Client, error) {
+	return &Client{config: c}, nil
+}
+
+// GetIngestrURI returns the ingestr URI for the client.
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}

--- a/pkg/zoom/config.go
+++ b/pkg/zoom/config.go
@@ -1,0 +1,19 @@
+package zoom
+
+import "net/url"
+
+// Config holds credentials for Zoom connection.
+type Config struct {
+	ClientID     string `yaml:"client_id" json:"client_id" mapstructure:"client_id"`
+	ClientSecret string `yaml:"client_secret" json:"client_secret" mapstructure:"client_secret"`
+	AccountID    string `yaml:"account_id" json:"account_id" mapstructure:"account_id"`
+}
+
+// GetIngestrURI builds an ingestr URI for Zoom.
+func (c *Config) GetIngestrURI() string {
+	u := url.Values{}
+	u.Set("client_id", c.ClientID)
+	u.Set("client_secret", c.ClientSecret)
+	u.Set("account_id", c.AccountID)
+	return "zoom://?" + u.Encode()
+}


### PR DESCRIPTION
## Summary
- add zoom config and client
- support zoom connection in connection manager and config
- document Zoom ingestion setup
- include Zoom in example configs and docs navigation

## Testing
- `go test ./...` *(fails: Forbidden when downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d507101208324a62a9ea4e9a6a205