### PR TITLE
Ensure BRUIN_VARS always set

### DIFF
--- a/docs/assets/python.md
+++ b/docs/assets/python.md
@@ -144,7 +144,7 @@ The following environment variables are available in every Python asset executio
 
 ### Pipeline
 
-Bruin supports user-defined variables at a pipeline level. These become available as a JSON document in your python asset as `BRUIN_VARS`. See [pipeline variables](/getting-started/pipeline-variables) for more information on how to define and override them.
+Bruin supports user-defined variables at a pipeline level. These become available as a JSON document in your python asset as `BRUIN_VARS`. When no variables exist, `BRUIN_VARS` is set to `{}`. See [pipeline variables](/getting-started/pipeline-variables) for more information on how to define and override them.
 
 Here's a short example:
 ::: code-group

--- a/docs/getting-started/pipeline-variables.md
+++ b/docs/getting-started/pipeline-variables.md
@@ -23,7 +23,7 @@ variables:
 
 All variables are accessible in SQL, `seed`, `sensor`, and `ingestr` assets via the `var` namespace.
 
-In Python assets, variables are exposed under `BRUIN_VARS` environment variable.
+In Python assets, variables are exposed under `BRUIN_VARS` environment variable. When a pipeline defines no variables, this environment variable contains `{}`.
 ::: code-group
 ```sql [asset.sql]
 SELECT * FROM events

--- a/pkg/env/variables.go
+++ b/pkg/env/variables.go
@@ -59,12 +59,15 @@ func envMutateIntervals(ctx context.Context, p *pipeline.Pipeline, t *pipeline.A
 
 func envInjectVariables(env map[string]string, variables map[string]any) (map[string]string, error) {
 	if len(variables) == 0 {
+		env["BRUIN_VARS"] = "{}"
 		return env, nil
 	}
+
 	doc, err := json.Marshal(variables)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling variables to JSON: %w", err)
 	}
+
 	env["BRUIN_VARS"] = string(doc)
 	return env, nil
 }

--- a/pkg/env/variables_test.go
+++ b/pkg/env/variables_test.go
@@ -33,7 +33,10 @@ func TestSetupVariables(t *testing.T) {
 			},
 			asset:       &pipeline.Asset{},
 			existingEnv: map[string]string{"EXISTING": "value"},
-			expectedEnv: map[string]string{"EXISTING": "value"},
+			expectedEnv: map[string]string{
+				"EXISTING":   "value",
+				"BRUIN_VARS": "{}",
+			},
 		},
 		{
 			name: "with days modifier",
@@ -61,6 +64,7 @@ func TestSetupVariables(t *testing.T) {
 				"BRUIN_PIPELINE":        "test-pipeline",
 				"BRUIN_RUN_ID":          "test-run",
 				"BRUIN_FULL_REFRESH":    "1",
+				"BRUIN_VARS":            "{}",
 			},
 		},
 		{
@@ -89,6 +93,7 @@ func TestSetupVariables(t *testing.T) {
 				"BRUIN_PIPELINE":        "test-pipeline",
 				"BRUIN_RUN_ID":          "test-run",
 				"BRUIN_FULL_REFRESH":    "1",
+				"BRUIN_VARS":            "{}",
 			},
 		},
 		{
@@ -129,6 +134,7 @@ func TestSetupVariables(t *testing.T) {
 				"BRUIN_PIPELINE":        "test-pipeline",
 				"BRUIN_RUN_ID":          "test-run",
 				"BRUIN_FULL_REFRESH":    "1",
+				"BRUIN_VARS":            "{}",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- default `BRUIN_VARS` to `{}` when pipeline has no variables
- document that `BRUIN_VARS` is always defined
- update tests for new behaviour

## Testing
- `go test ./pkg/...`


------
https://chatgpt.com/codex/tasks/task_e_6860f1c11e8c832b8cb916a594ab9f4c