### PR TITLE
Fix/init menu resize

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -55,7 +55,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		visibleCount := m.height - templateHeaderHeight
-		if visibleCount >= len(choices) {
+		if visibleCount >= len(choices) { // nolint:gocritic
 			m.pageStart = 0
 		} else if m.cursor < m.pageStart {
 			m.pageStart = m.cursor
@@ -228,7 +228,6 @@ func Init() *cli.Command {
 					if m.choice != "" {
 						templateName = m.choice
 					} else if m.quitting {
-						fmt.Printf("Quitting... Goodbye!\n")
 						return nil
 					}
 				}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -52,7 +52,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
-		visibleCount := m.height - 6
+		visibleCount := m.height - 7
 		if visibleCount >= len(choices) {
 			m.pageStart = 0
 		} else if m.cursor < m.pageStart {
@@ -62,7 +62,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyMsg:
-		visibleCount := m.height - 6
+		visibleCount := m.height - 7
 		if visibleCount < 1 {
 			visibleCount = 1
 		}
@@ -104,18 +104,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m model) View() string {
 	s := strings.Builder{}
-	s.WriteString("Please select a template below\n\n")
-	visibleCount := m.height - 6
-	if visibleCount < 1 {
-		visibleCount = 1
+	s.WriteString("Please select a template below:\n\n")
+	visibleCount := m.height - 7
+	maxStart := len(choices) - visibleCount
+	if maxStart < 0 {
+		maxStart = 0
 	}
-	if visibleCount >= len(choices) {
-		m.pageStart = 0
+	if m.pageStart > maxStart {
+		m.pageStart = maxStart
 	}
 	end := m.pageStart + visibleCount
 	if end > len(choices) {
 		end = len(choices)
 	}
+
 	for i := m.pageStart; i < end; i++ {
 		if m.cursor == i {
 			s.WriteString(" [x] ")
@@ -126,11 +128,6 @@ func (m model) View() string {
 		s.WriteString("\n")
 	}
 
-	if visibleCount == 0 {
-		s.WriteString("\n(press q to quit)\n")
-	}
-
-	// Updated display message to show the exact range of options
 	if visibleCount == 1 {
 		s.WriteString(fmt.Sprintf(
 			"\ndisplaying options %d of %d\n",

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.15.0
+	golang.org/x/term v0.32.0
 	google.golang.org/api v0.237.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -193,7 +194,6 @@ require (
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect


### PR DESCRIPTION
The template menu  list (cmd: bruin init) was being cut off when the terminal size too small:

<img width="829" alt="Screenshot 2025-06-06 at 13 22 42" src="https://github.com/user-attachments/assets/f58d4e51-2507-4d3a-a9b1-12555a81a95e" />

Changes:

- Fixed header size so that "Please select a template below:" and "(Press 'q' to quit )" are always visible
- Menu is now numerated e.g. "Displaying options 3-8 of 17"

