### PR TITLE
Add Pinterest connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -210,6 +210,7 @@ export default withMermaid({
                             {text: "Personio", link: "/ingestion/personio"},
                             {text: "PhantomBuster", link: "/ingestion/phantombuster"},
                             {text: "Pipedrive", link: "/ingestion/pipedrive"},
+                            {text: "Pinterest", link: "/ingestion/pinterest"},
                             {text: "QuickBooks", link: "/ingestion/quickbooks"},
                             {text: "Zoom", link: "/ingestion/zoom"},
                             {text: "Salesforce", link: "/ingestion/salesforce"},

--- a/docs/ingestion/pinterest.md
+++ b/docs/ingestion/pinterest.md
@@ -1,0 +1,45 @@
+# Pinterest
+[Pinterest](https://www.pinterest.com/) is a social media platform for discovering and sharing ideas using visual bookmarks.
+
+Bruin supports Pinterest as a source for [Ingestr assets](/assets/ingestr), allowing you to ingest data from Pinterest into your data warehouse.
+
+To connect to Pinterest you must add a configuration item to the `.bruin.yml` file and the asset file. You will need `access_token`.
+
+Follow the steps below to correctly set up Pinterest as a data source and run ingestion.
+
+### Step 1: Add a connection to .bruin.yml file
+Add the connection configuration to the connections section of `.bruin.yml`:
+
+```yaml
+connections:
+  pinterest:
+    - name: "pinterest"
+      access_token: "your-token"
+```
+
+- `access_token`: The token used for authentication with the Pinterest API. You can obtain an access token from the [official Pinterest documentation](https://developers.pinterest.com/docs/getting-started/connect-app/).
+
+### Step 2: Create an asset file for data ingestion
+Create an [asset configuration](/assets/ingestr#asset-structure) file to define the data flow:
+
+```yaml
+name: public.pinterest_pins
+type: ingestr
+
+parameters:
+  source_connection: pinterest
+  source_table: 'pins'
+
+  destination: postgres
+```
+
+- `source_connection`: name of the Pinterest connection defined in `.bruin.yml`.
+- `source_table`: Pinterest table to ingest. Available tables are listed in the [Ingestr documentation](https://github.com/bruin-data/ingestr/blob/main/docs/supported-sources/pinterest.md#tables).
+- `destination`: name of the destination connection.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+```
+bruin run assets/pinterest_asset.yml
+```
+
+Executing this command ingests data from Pinterest into your Postgres database.

--- a/integration-tests/expected_connections_schema.json
+++ b/integration-tests/expected_connections_schema.json
@@ -539,6 +539,12 @@
           },
           "type": "array"
         },
+        "pinterest": {
+          "items": {
+            "$ref": "#/$defs/PinterestConnection"
+          },
+          "type": "array"
+        },
         "quickbooks": {
           "items": {
             "$ref": "#/$defs/QuickBooksConnection"
@@ -1509,6 +1515,22 @@
         "client_id",
         "client_secret",
         "refresh_token"
+      ]
+    },
+    "PinterestConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "access_token": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "access_token"
       ]
     },
     "RedshiftConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -649,6 +649,15 @@ func (c MixpanelConnection) GetName() string {
 	return c.Name
 }
 
+type PinterestConnection struct {
+	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	AccessToken string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token"`
+}
+
+func (c PinterestConnection) GetName() string {
+	return c.Name
+}
+
 type QuickBooksConnection struct {
 	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	CompanyID    string `yaml:"company_id,omitempty" json:"company_id" mapstructure:"company_id"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -67,6 +67,7 @@ type Connections struct {
 	Kinesis             []KinesisConnection             `yaml:"kinesis,omitempty" json:"kinesis,omitempty" mapstructure:"kinesis"`
 	Pipedrive           []PipedriveConnection           `yaml:"pipedrive,omitempty" json:"pipedrive,omitempty" mapstructure:"pipedrive"`
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
+	Pinterest           []PinterestConnection           `yaml:"pinterest,omitempty" json:"pinterest,omitempty" mapstructure:"pinterest"`
 	QuickBooks          []QuickBooksConnection          `yaml:"quickbooks,omitempty" json:"quickbooks,omitempty" mapstructure:"quickbooks"`
 	Zoom                []ZoomConnection                `yaml:"zoom,omitempty" json:"zoom,omitempty" mapstructure:"zoom"`
 	EMRServerless       []EMRServerlessConnection       `yaml:"emr_serverless,omitempty" json:"emr_serverless,omitempty" mapstructure:"emr_serverless"`
@@ -735,6 +736,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Mixpanel = append(env.Connections.Mixpanel, conn)
+	case "pinterest":
+		var conn PinterestConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Pinterest = append(env.Connections.Pinterest, conn)
 	case "quickbooks":
 		var conn QuickBooksConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -982,6 +990,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Pipedrive = removeConnection(env.Connections.Pipedrive, connectionName)
 	case "mixpanel":
 		env.Connections.Mixpanel = removeConnection(env.Connections.Mixpanel, connectionName)
+	case "pinterest":
+		env.Connections.Pinterest = removeConnection(env.Connections.Pinterest, connectionName)
 	case "quickbooks":
 		env.Connections.QuickBooks = removeConnection(env.Connections.QuickBooks, connectionName)
 	case "zoom":

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -396,6 +396,12 @@ func TestLoadFromFile(t *testing.T) {
 					RefreshToken: "rtoken",
 				},
 			},
+			Pinterest: []PinterestConnection{
+				{
+					Name:        "pinterest-1",
+					AccessToken: "token",
+				},
+			},
 			Mixpanel: []MixpanelConnection{
 				{
 					Name:      "mixpanel-1",

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -248,6 +248,9 @@ environments:
           password: "secret-123"
           project_id: "12345"
           server: "eu"
+      pinterest:
+        - name: "pinterest-1"
+          access_token: "token"
       quickbooks:
         - name: "quickbooks-1"
           company_id: "123456"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -249,6 +249,9 @@ environments:
           password: "secret-123"
           project_id: "12345"
           server: "eu"
+      pinterest:
+        - name: "pinterest-1"
+          access_token: "token"
       quickbooks:
         - name: "quickbooks-1"
           company_id: "123456"

--- a/pkg/pinterest/client.go
+++ b/pkg/pinterest/client.go
@@ -1,0 +1,16 @@
+package pinterest
+
+// Client provides access to Pinterest via ingestr.
+type Client struct {
+	config Config
+}
+
+// NewClient initializes a Pinterest client with given configuration.
+func NewClient(c Config) (*Client, error) {
+	return &Client{config: c}, nil
+}
+
+// GetIngestrURI returns the ingestr URI for the client.
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}

--- a/pkg/pinterest/config.go
+++ b/pkg/pinterest/config.go
@@ -1,0 +1,15 @@
+package pinterest
+
+import "net/url"
+
+// Config holds credentials for Pinterest connection.
+type Config struct {
+	AccessToken string `yaml:"access_token" json:"access_token" mapstructure:"access_token"`
+}
+
+// GetIngestrURI builds an ingestr URI for Pinterest.
+func (c *Config) GetIngestrURI() string {
+	u := url.Values{}
+	u.Set("access_token", c.AccessToken)
+	return "pinterest://?" + u.Encode()
+}


### PR DESCRIPTION
## Summary
- add Pinterest source docs
- support Pinterest connections in config and manager
- handle Pinterest in connection manager
- expose schema for Pinterest connections

## Testing
- `make format` *(fails: unsupported version of the configuration)*
- `make test` *(fails: forbidden downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68625b62fadc83248aefc7bbb2a2d567