### PR TITLE
Add Trustpilot connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -211,6 +211,7 @@ export default withMermaid({
                             {text: "PhantomBuster", link: "/ingestion/phantombuster"},
                             {text: "Pipedrive", link: "/ingestion/pipedrive"},
                             {text: "Pinterest", link: "/ingestion/pinterest"},
+                            {text: "Trustpilot", link: "/ingestion/trustpilot"},
                             {text: "QuickBooks", link: "/ingestion/quickbooks"},
                             {text: "Salesforce", link: "/ingestion/salesforce"},
                             {text: "SAP HANA", link: "/ingestion/sap_hana"},

--- a/docs/ingestion/trustpilot.md
+++ b/docs/ingestion/trustpilot.md
@@ -1,0 +1,41 @@
+# Trustpilot
+[Trustpilot](https://www.trustpilot.com/) provides a platform for collecting and sharing customer reviews.
+
+Bruin supports Trustpilot as a source for [Ingestr assets](/assets/ingestr), allowing you to ingest reviews into your data platform.
+
+To connect to Trustpilot you must define a connection in the `.bruin.yml` file and reference it from your asset configuration. The connection requires `business_unit_id` and `api_key`.
+
+Follow the steps below to configure Trustpilot and run ingestion.
+
+### Step 1: Add a connection to the `.bruin.yml` file
+```yaml
+connections:
+  trustpilot:
+    - name: "trustpilot"
+      business_unit_id: "<business-unit-id>"
+      api_key: "<api-key>"
+```
+- `business_unit_id`: Identifier of the business unit to fetch reviews for.
+- `api_key`: Trustpilot API key.
+
+### Step 2: Create an asset file for data ingestion
+Create an [asset configuration](/assets/ingestr#asset-structure) file to define the data flow:
+```yaml
+name: public.trustpilot_reviews
+type: ingestr
+
+parameters:
+  source_connection: trustpilot
+  source_table: 'reviews'
+
+  destination: postgres
+```
+- `source_connection`: The Trustpilot connection name defined in `.bruin.yml`.
+- `source_table`: Table to ingest. Currently only `reviews` is supported.
+- `destination`: Destination connection name.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+```
+bruin run assets/trustpilot_asset.yml
+```
+Executing this command ingests data from Trustpilot into your Postgres database.

--- a/integration-tests/expected_connections_schema.json
+++ b/integration-tests/expected_connections_schema.json
@@ -539,6 +539,12 @@
           },
           "type": "array"
         },
+        "trustpilot": {
+          "items": {
+            "$ref": "#/$defs/TrustpilotConnection"
+          },
+          "type": "array"
+        },
         "pinterest": {
           "items": {
             "$ref": "#/$defs/PinterestConnection"
@@ -1228,6 +1234,26 @@
         "username",
         "password",
         "project_id"
+      ]
+    },
+    "TrustpilotConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "business_unit_id": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "business_unit_id",
+        "api_key"
       ]
     },
     "MongoConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -658,6 +658,16 @@ func (c PinterestConnection) GetName() string {
 	return c.Name
 }
 
+type TrustpilotConnection struct {
+	Name           string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	BusinessUnitID string `yaml:"business_unit_id,omitempty" json:"business_unit_id" mapstructure:"business_unit_id"`
+	APIKey         string `yaml:"api_key,omitempty" json:"api_key" mapstructure:"api_key"`
+}
+
+func (c TrustpilotConnection) GetName() string {
+	return c.Name
+}
+
 type QuickBooksConnection struct {
 	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	CompanyID    string `yaml:"company_id,omitempty" json:"company_id" mapstructure:"company_id"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -68,6 +68,7 @@ type Connections struct {
 	Pipedrive           []PipedriveConnection           `yaml:"pipedrive,omitempty" json:"pipedrive,omitempty" mapstructure:"pipedrive"`
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
 	Pinterest           []PinterestConnection           `yaml:"pinterest,omitempty" json:"pinterest,omitempty" mapstructure:"pinterest"`
+	Trustpilot          []TrustpilotConnection          `yaml:"trustpilot,omitempty" json:"trustpilot,omitempty" mapstructure:"trustpilot"`
 	QuickBooks          []QuickBooksConnection          `yaml:"quickbooks,omitempty" json:"quickbooks,omitempty" mapstructure:"quickbooks"`
 	Zoom                []ZoomConnection                `yaml:"zoom,omitempty" json:"zoom,omitempty" mapstructure:"zoom"`
 	EMRServerless       []EMRServerlessConnection       `yaml:"emr_serverless,omitempty" json:"emr_serverless,omitempty" mapstructure:"emr_serverless"`
@@ -743,6 +744,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Pinterest = append(env.Connections.Pinterest, conn)
+	case "trustpilot":
+		var conn TrustpilotConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Trustpilot = append(env.Connections.Trustpilot, conn)
 	case "quickbooks":
 		var conn QuickBooksConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -992,6 +1000,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Mixpanel = removeConnection(env.Connections.Mixpanel, connectionName)
 	case "pinterest":
 		env.Connections.Pinterest = removeConnection(env.Connections.Pinterest, connectionName)
+	case "trustpilot":
+		env.Connections.Trustpilot = removeConnection(env.Connections.Trustpilot, connectionName)
 	case "quickbooks":
 		env.Connections.QuickBooks = removeConnection(env.Connections.QuickBooks, connectionName)
 	case "zoom":

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -411,6 +411,13 @@ func TestLoadFromFile(t *testing.T) {
 					Server:    "eu",
 				},
 			},
+			Trustpilot: []TrustpilotConnection{
+				{
+					Name:            "trustpilot-1",
+					BusinessUnitID:  "unit123",
+					APIKey:          "apikey",
+				},
+			},
 			EMRServerless: []EMRServerlessConnection{
 				{
 					Name:          "emr_serverless-test",

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -413,9 +413,9 @@ func TestLoadFromFile(t *testing.T) {
 			},
 			Trustpilot: []TrustpilotConnection{
 				{
-					Name:            "trustpilot-1",
-					BusinessUnitID:  "unit123",
-					APIKey:          "apikey",
+					Name:           "trustpilot-1",
+					BusinessUnitID: "unit123",
+					APIKey:         "apikey",
 				},
 			},
 			EMRServerless: []EMRServerlessConnection{

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -251,6 +251,10 @@ environments:
       pinterest:
         - name: "pinterest-1"
           access_token: "token"
+      trustpilot:
+        - name: "trustpilot-1"
+          business_unit_id: "unit123"
+          api_key: "apikey"
       quickbooks:
         - name: "quickbooks-1"
           company_id: "123456"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -252,6 +252,10 @@ environments:
       pinterest:
         - name: "pinterest-1"
           access_token: "token"
+      trustpilot:
+        - name: "trustpilot-1"
+          business_unit_id: "unit123"
+          api_key: "apikey"
       quickbooks:
         - name: "quickbooks-1"
           company_id: "123456"

--- a/pkg/trustpilot/client.go
+++ b/pkg/trustpilot/client.go
@@ -1,0 +1,16 @@
+package trustpilot
+
+// Client provides access to Trustpilot via ingestr.
+type Client struct {
+	config Config
+}
+
+// NewClient initializes a Trustpilot client with the given configuration.
+func NewClient(c Config) (*Client, error) {
+	return &Client{config: c}, nil
+}
+
+// GetIngestrURI returns the ingestr URI for the client.
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}

--- a/pkg/trustpilot/config.go
+++ b/pkg/trustpilot/config.go
@@ -1,0 +1,16 @@
+package trustpilot
+
+import "net/url"
+
+// Config holds credentials for Trustpilot connection.
+type Config struct {
+	BusinessUnitID string `yaml:"business_unit_id" json:"business_unit_id" mapstructure:"business_unit_id"`
+	APIKey         string `yaml:"api_key" json:"api_key" mapstructure:"api_key"`
+}
+
+// GetIngestrURI builds the ingestr URI for Trustpilot.
+func (c *Config) GetIngestrURI() string {
+	params := url.Values{}
+	params.Set("api_key", c.APIKey)
+	return "trustpilot://" + c.BusinessUnitID + "?" + params.Encode()
+}


### PR DESCRIPTION
Below changes are made in this PR:
- create Trustpilot client and config
- wire Trustpilot connection into connection manager and configuration handling
- document Trustpilot ingestion usage
- add Trustpilot examples to sample config files
- expose Trustpilot docs link in navigation
