### PR TITLE
Add 'create' subcommand for environments

### DIFF
--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -19,6 +19,7 @@ func Environments(isDebug *bool) *cli.Command {
 		Usage: "manage environments defined in .bruin.yml",
 		Subcommands: []*cli.Command{
 			ListEnvironments(isDebug),
+			CreateEnvironment(isDebug),
 		},
 	}
 }
@@ -111,4 +112,73 @@ func (r *EnvironmentListCommand) Run(output, configFilePath string) error {
 	}
 
 	return nil
+}
+
+func CreateEnvironment(isDebug *bool) *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "create a new environment",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "name",
+				Aliases:  []string{"n"},
+				Usage:    "the name of the environment",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "schema-prefix",
+				Aliases: []string{"s"},
+				Usage:   "schema prefix for schema-based environments",
+			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Usage:   "the output type, possible values are: plain, json",
+			},
+			&cli.StringFlag{
+				Name:    "config-file",
+				EnvVars: []string{"BRUIN_CONFIG_FILE"},
+				Usage:   "the path to the .bruin.yml file",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			envName := c.String("name")
+			schemaPrefix := c.String("schema-prefix")
+			output := strings.ToLower(c.String("output"))
+
+			configFilePath := c.String("config-file")
+			if configFilePath == "" {
+				repoRoot, err := git.FindRepoFromPath(path2.Clean("."))
+				if err != nil {
+					printError(errors.Wrap(err, "Failed to find the git repository root"), output, "")
+					return cli.Exit("", 1)
+				}
+				configFilePath = path2.Join(repoRoot.Path, ".bruin.yml")
+			}
+
+			cm, err := config.LoadOrCreate(afero.NewOsFs(), configFilePath)
+			if err != nil {
+				printError(err, output, "Failed to load the config file at "+configFilePath)
+				return cli.Exit("", 1)
+			}
+
+			if _, exists := cm.Environments[envName]; exists {
+				printError(fmt.Errorf("environment '%s' already exists", envName), output, "")
+				return cli.Exit("", 1)
+			}
+
+			if err := cm.AddEnvironment(envName, schemaPrefix); err != nil {
+				printError(err, output, "failed to add environment")
+				return cli.Exit("", 1)
+			}
+
+			if err := cm.Persist(); err != nil {
+				printError(err, output, "failed to persist config")
+				return cli.Exit("", 1)
+			}
+
+			printSuccessForOutput(output, fmt.Sprintf("Successfully created environment: %s", envName))
+			return nil
+		},
+	}
 }

--- a/docs/commands/environments.md
+++ b/docs/commands/environments.md
@@ -1,7 +1,7 @@
 # `environments` Command
 
-The `environments` command allows you to manage environments defined in the `.bruin.yml` configuration file. 
-It currently supports listing all available environments in the current Git repository.
+The `environments` command allows you to manage environments defined in the `.bruin.yml` configuration file.
+It supports listing all available environments in the current Git repository and creating new ones.
 
 ### Usage
 ```bash
@@ -22,4 +22,22 @@ Displays the environments defined in the `.bruin.yml` configuration file in the 
 
 ```bash
 bruin environments list [flags]
+```
+
+## `create` Subcommand
+
+Creates a new environment entry in the `.bruin.yml` configuration file.
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--name` | str | - | Name of the environment to create. |
+| `--schema-prefix` | str | - | Optional schema prefix to use for the environment. |
+| `--config-file` | str | - | The path to the `.bruin.yml` file. |
+
+### Usage
+
+```bash
+bruin environments create --name dev [--schema-prefix my_prefix]
 ```

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -1186,3 +1186,29 @@ func populateAwsConfigAliases(creds map[string]any) map[string]any {
 
 	return creds
 }
+
+// AddEnvironment adds a new environment to the configuration.
+// If an environment with the given name already exists an error is returned.
+// The schemaPrefix argument is optional and can be left empty.
+func (c *Config) AddEnvironment(name, schemaPrefix string) error {
+	if name == "" {
+		return fmt.Errorf("environment name cannot be empty")
+	}
+
+	if c.Environments == nil {
+		c.Environments = make(map[string]Environment)
+	}
+
+	if _, exists := c.Environments[name]; exists {
+		return fmt.Errorf("environment '%s' already exists", name)
+	}
+
+	env := Environment{
+		Connections:  &Connections{},
+		SchemaPrefix: schemaPrefix,
+	}
+
+	c.Environments[name] = env
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- allow creating environments via `bruin environments create`
- implement `AddEnvironment` helper in config manager
- document new CLI usage in environments command docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686bdb1c21448320a89970b2c385250f