### PR TITLE
Fix get_tables for blank statements

### DIFF
--- a/pythonsrc/parser/main.py
+++ b/pythonsrc/parser/main.py
@@ -47,6 +47,9 @@ def extract_non_selected_columns(parsed: exp.Select) -> list[Column]:
 
 
 def extract_tables(parsed):
+    if parsed is None:
+        return []
+
     def get_cte_names(parsed_stmt):
         """Get all CTE names from the parsed statement"""
         cte_names = set()
@@ -140,6 +143,8 @@ def get_tables(query: str, dialect: str):
 
     tables = []
     for parsedSingle in parsed:
+        if parsedSingle is None:
+            continue
         try:
             extracted = extract_tables(parsedSingle)
             tables.extend(extracted)

--- a/pythonsrc/parser/main_test.py
+++ b/pythonsrc/parser/main_test.py
@@ -1936,6 +1936,18 @@ SELECT * from my_cte
     assert get_tables(query, dialect) == expected
 
 
+def test_get_tables_trailing_semicolon():
+    dialect = "bigquery"
+
+    query = "SELECT * FROM table1;"
+    expected = {"tables": ["table1"]}
+    assert get_tables(query, dialect) == expected
+
+    query = "SELECT * FROM table1;;"
+    expected = {"tables": ["table1"]}
+    assert get_tables(query, dialect) == expected
+
+
 def test_add_limit():
     query = """
     SELECT DISTINCT product_id, product_name, price, stock, created_at


### PR DESCRIPTION
## Summary
- handle `None` statements when collecting tables
- skip `None` entries from `sqlglot.parse`
- test trailing semicolons for `get_tables`

## Testing
- `ruff format pythonsrc`
- `ruff check --fix pythonsrc`
- `pytest pythonsrc/parser/main_test.py::test_get_tables_trailing_semicolon -q`
- `pytest -q` *(fails: test_get_column_lineage[failing scenario for CTEs and case-sensitive fields])*

------
https://chatgpt.com/codex/tasks/task_e_686cdae4e1d0832084d911f9018e1fc9