### PR TITLE
patch/improve run output

### DIFF
--- a/cmd/const.go
+++ b/cmd/const.go
@@ -23,6 +23,7 @@ var (
 
 	faint          = color.New(color.Faint).SprintFunc()
 	infoPrinter    = color.New(color.Bold)
+	summaryPrinter = color.New()
 	errorPrinter   = color.New(color.FgRed, color.Bold)
 	warningPrinter = color.New(color.FgYellow, color.Bold)
 	successPrinter = color.New(color.FgGreen, color.Bold)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -151,7 +151,7 @@ func printExecutionTable(results []*scheduler.TaskExecutionResult, s *scheduler.
 		return
 	}
 	
-	fmt.Println()
+	fmt.Println("\n" + strings.Repeat("=", 50) + "\n")
 	
 	for _, assetName := range assetOrder {
 		results := assetResults[assetName]
@@ -817,8 +817,7 @@ func Run(isDebug *bool) *cli.Command {
 				return nil
 			}
 			sendTelemetry(s, c)
-			infoPrinter.Printf("\nStart date: %s\n", startDate.Format(time.RFC3339))
-			infoPrinter.Printf("End date:   %s\n", endDate.Format(time.RFC3339))
+			infoPrinter.Printf("\nInterval: %s - %s\n", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339))
 			infoPrinter.Printf("\n%s\n", executionStartLog)
 			if runConfig.SensorMode != "" {
 				if !(runConfig.SensorMode == "skip" || runConfig.SensorMode == "once" || runConfig.SensorMode == "wait") {
@@ -1024,29 +1023,19 @@ func printErrorsInResults(errorsInTaskResults []*scheduler.TaskExecutionResult, 
 	for assetName, results := range data {
 		assetBranch := tree.AddBranch(color.New(color.FgYellow).Sprint(assetName))
 
-		columnBranches := make(map[string]treeprint.Tree, len(results))
-
 		for _, result := range results {
 			switch instance := result.Instance.(type) {
 			case *scheduler.ColumnCheckInstance:
-				colBranch, exists := columnBranches[instance.Column.Name]
-				if !exists {
-					colBranch = assetBranch.AddBranch(fmt.Sprintf("%s %s", 
-						color.New(color.FgCyan).Sprint(instance.Column.Name),
-						faint("column")))
-					columnBranches[instance.Column.Name] = colBranch
-				}
-
-				checkBranch := colBranch.AddBranch(fmt.Sprintf("%s %s", 
+				assetBranch.AddNode(fmt.Sprintf("%s.%s - %s", 
+					color.New(color.FgCyan).Sprint(instance.Column.Name),
 					color.New(color.FgMagenta).Sprint(instance.Check.Name),
-					faint("check")))
-				checkBranch.AddNode(color.New(color.FgRed).Sprintf("%s", result.Error))
+					color.New(color.FgRed).Sprintf("%s", result.Error)))
 
 			case *scheduler.CustomCheckInstance:
-				customBranch := assetBranch.AddBranch(fmt.Sprintf("%s %s", 
+				assetBranch.AddNode(fmt.Sprintf("%s %s - %s", 
 					color.New(color.FgMagenta).Sprint(instance.Check.Name),
-					faint("custom check")))
-				customBranch.AddNode(color.New(color.FgRed).Sprintf("%s", result.Error))
+					faint("custom check"),
+					color.New(color.FgRed).Sprintf("%s", result.Error)))
 
 			default:
 				assetBranch.AddNode(color.New(color.FgRed).Sprintf("%s", result.Error))

--- a/integration-tests/integration-test.go
+++ b/integration-tests/integration-test.go
@@ -843,7 +843,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Executed 3 tasks", "Finished: shipping_provider", "Finished: products", "Finished: products:price:positive"},
+				Contains: []string{"bruin run completed", "Finished: shipping_provider", "Finished: products", "Finished: products:price:positive"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -870,7 +870,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Executed 2 tasks", "Finished: shipping_provider", "Finished: products"},
+				Contains: []string{"bruin run completed", "Finished: shipping_provider", "Finished: products"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -884,7 +884,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Executed 5 tasks", "Finished: products", "Finished: products:price:positive", "Finished: product_price_summary", "Finished: product_price_summary:product_count:non_negative", "Finished: product_price_summary:total_stock:non_negative"},
+				Contains: []string{"bruin run completed", "Finished: products", "Finished: products:price:positive", "Finished: product_price_summary", "Finished: product_price_summary:product_count:non_negative", "Finished: product_price_summary:total_stock:non_negative"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -898,7 +898,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Executed 2 tasks", "Finished: products", "Finished: product_price_summary"},
+				Contains: []string{"bruin run completed", "Finished: products", "Finished: product_price_summary"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1081,7 +1081,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 
 			Expected: e2e.Output{
 				ExitCode: 1,
-				Contains: []string{"Parser Error: syntax error at or near \"S_ELECT_\"", "Failed assets 1"},
+				Contains: []string{"Parser Error: syntax error at or near \"S_ELECT_\"", "1 failed"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1155,7 +1155,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Executed 5 tasks"},
+				Contains: []string{"bruin run completed"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1184,7 +1184,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Successfully validated 4 assets", "Executed 5 tasks", "Finished: chess_playground.player_summary", "Finished: chess_playground.games", "Finished: python_asset"},
+				Contains: []string{"Successfully validated 4 assets", "bruin run completed", "Finished: chess_playground.player_summary", "Finished: chess_playground.games", "Finished: python_asset"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1258,7 +1258,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Successfully validated 1 assets", "Executed 1 tasks", "Finished: materialize.country"},
+				Contains: []string{"Successfully validated 1 assets", "bruin run completed", "Finished: materialize.country"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1286,7 +1286,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Successfully validated 2 assets", "Executed 4 tasks", "Finished: render_this.my_asset_2"},
+				Contains: []string{"Successfully validated 2 assets", "bruin run completed", "Finished: render_this.my_asset_2"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1300,7 +1300,7 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Successfully validated 2 assets", "Executed 8 tasks", "Finished: my_schema.table_check"},
+				Contains: []string{"Successfully validated 2 assets", "bruin run completed", "Finished: my_schema.table_check"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
@@ -1548,7 +1548,7 @@ func getIngestrTasks(binary string, currentFolder string) []e2e.Task {
 			Env:     []string{},
 			Expected: e2e.Output{
 				ExitCode: 0,
-				Contains: []string{"Executed 4 tasks", "Finished: chess_playground.profiles", "Finished: chess_playground.games", "Finished: chess_playground.player_summary", "Finished: chess_playground.player_summary:total_games:positive"},
+				Contains: []string{"bruin run completed", "Finished: chess_playground.profiles", "Finished: chess_playground.games", "Finished: chess_playground.player_summary", "Finished: chess_playground.player_summary:total_games:positive"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"os"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/bigquery"
@@ -423,7 +424,7 @@ func TestNewManagerFromConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			for k, v := range tt.env {
-				t.Setenv(k, v)
+				os.Setenv(k, v) //nolint
 			}
 			got, errors := NewManagerFromConfig(tt.cm)
 			assert.Equalf(t, tt.want, got, "NewManagerFromConfig(%v)", tt.cm)

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"os"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/bigquery"
@@ -424,7 +423,7 @@ func TestNewManagerFromConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			got, errors := NewManagerFromConfig(tt.cm)
 			assert.Equalf(t, tt.want, got, "NewManagerFromConfig(%v)", tt.cm)

--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -26,6 +26,8 @@ var (
 	faint        = color.New(color.Faint).SprintFunc()
 	whitePrinter = color.New(color.FgWhite, color.Faint).SprintfFunc()
 	plainColor   = color.New()
+	greenColor   = color.New(color.FgGreen)
+	redColor     = color.New(color.FgRed)
 )
 
 type contextKey int
@@ -97,13 +99,15 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 		w.printLock.Lock()
 
 		timestampStr := whitePrinter("[%s]", time.Now().Format(timeFormat))
-		if w.formatOpts.NoColor {
-			w.printer = plainColor
+		w.printer = plainColor
+		runningPrinter := w.printer
+		if !w.formatOpts.NoColor {
+			runningPrinter = color.New(color.Faint)
 		}
 		if w.formatOpts.DoNotLogTimestamp {
-			fmt.Printf("%s\n", w.printer.Sprintf("Running:  %s", task.GetHumanID()))
+			fmt.Printf("%s\n", runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
 		} else {
-			fmt.Printf("%s %s\n", timestampStr, w.printer.Sprintf("Running:  %s", task.GetHumanID()))
+			fmt.Printf("%s %s\n", timestampStr, runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
 		}
 		w.printLock.Unlock()
 
@@ -124,16 +128,25 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 		durationString := fmt.Sprintf("(%s)", duration.Truncate(time.Millisecond).String())
 		w.printLock.Lock()
 
+		printerInstance := w.printer
+		if !w.formatOpts.NoColor {
+			if err != nil {
+				printerInstance = redColor
+			} else {
+				printerInstance = greenColor
+			}
+		}
+
 		res := "Finished"
 		if err != nil {
 			res = "Failed"
 		}
 
 		if w.formatOpts.DoNotLogTimestamp {
-			fmt.Printf("%s\n", w.printer.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+			fmt.Printf("%s\n", printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
 		} else {
 			timestampStr = whitePrinter("[%s]", time.Now().Format(timeFormat))
-			fmt.Printf("%s %s\n", timestampStr, w.printer.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+			fmt.Printf("%s %s\n", timestampStr, printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
 		}
 		w.printLock.Unlock()
 		results <- &scheduler.TaskExecutionResult{

--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -99,7 +99,9 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 		w.printLock.Lock()
 
 		timestampStr := whitePrinter("[%s]", time.Now().Format(timeFormat))
-		w.printer = plainColor
+		if w.formatOpts.NoColor {
+			w.printer = plainColor
+		}
 		runningPrinter := w.printer
 		if !w.formatOpts.NoColor {
 			runningPrinter = color.New(color.Faint)

--- a/templates/duckdb-example/assets/product_categories.sql
+++ b/templates/duckdb-example/assets/product_categories.sql
@@ -11,7 +11,7 @@ columns:
     primary_key: true
     checks:
       - name: not_null
-      - name: positive
+      - name: negative
   - name: category_name
     type: VARCHAR
     description: "Name of the product category"


### PR DESCRIPTION
This PR cleans the output of the `bruin run` command a bit to make it more user friendly.

- Replace execution logs with actual status colors
- Print a pytest-like list of assets at the end
- Print a simple summary with the numbers
- List error logs nicely

## Before
<img width="589" height="519" alt="image" src="https://github.com/user-attachments/assets/7384a5f4-6df0-4e62-a1c1-9b671dccd18f" />


## After
<img width="1090" height="594" alt="image" src="https://github.com/user-attachments/assets/6918fa68-67f4-4629-86b6-1355942348f6" />
