### PR TITLE
feat add polling for job status

### DIFF
--- a/pkg/tableau/client.go
+++ b/pkg/tableau/client.go
@@ -171,7 +171,9 @@ func (c *Client) pollJobStatus(ctx context.Context, jobID string) error {
 			writer = wr
 		}
 	}
-	writer.Write([]byte(fmt.Sprintf("Refresh started asynchronously, waiting for job to complete, job ID: %s\n", jobID)))
+	if _, err := writer.Write([]byte(fmt.Sprintf("Refresh started asynchronously, waiting for job to complete, job ID: %s\n", jobID))); err != nil {
+		return errors.Wrap(err, "failed to write log output")
+	}
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Tableau refresh endpoints return a **202 Accepted** response, meaning the refresh runs asynchronously. This PR adds logic to track the job status after initiating a refresh to ensure it completes successfully.