### PR TITLE
fixed makefile to skip cloud-integration-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test: test-unit
 
 test-unit:
 	@echo "$(OK_COLOR)==> Running the unit tests$(NO_COLOR)"
-	@go test -tags="no_duckdb_arrow" -race -cover -timeout 10m $(shell go list ./... | grep -v '/cloud-integration-tests/') 
+	@go test -tags="no_duckdb_arrow" -race -cover -timeout 10m $(shell go list ./... | grep -v 'integration-tests/cloud-integration-tests') 
 
 format: tools lint-python
 	@echo "$(OK_COLOR)>> [go vet] running$(NO_COLOR)" & \


### PR DESCRIPTION
Fixed make test to exclude cloud integration tests as intended.