### PR TITLE
Fix/sql end comment

### DIFF
--- a/pkg/bigquery/materialization.go
+++ b/pkg/bigquery/materialization.go
@@ -492,5 +492,3 @@ FROM (
 
 	return strings.TrimSpace(stmt), nil
 }
-
-


### PR DESCRIPTION
```
`/* @bruin
materialization:
  type: table
  strategy: time_interval
@bruin */

select 3 --todo: fix it`
was previously being rendered as
```

```
`BEGIN TRANSACTION;
DELETE FROM analytics_469253130.parse_version WHERE col1 BETWEEN '2025-07-22' AND '2025-07-22';
INSERT INTO analytics_469253130.parse_version select 3 --todo: fix it;
COMMIT TRANSACTION;`
```

Now all final open inline comments in bigquery are converted to closed inlined comments:

```
`BEGIN TRANSACTION;
DELETE FROM analytics_469253130.parse_version WHERE col1 BETWEEN '2025-07-22' AND '2025-07-22';
INSERT INTO analytics_469253130.parse_version select 3 --todo: fix it
;
COMMIT TRANSACTION;`
```

