### PR TITLE
Add exclude paths option to lint command

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -28,6 +28,13 @@ import (
 
 var ErrExcludeTagNotSupported = errors.New("exclude-tag flag is not supported for asset-only validation")
 
+// createPipelineFinderWithExclusions creates a pipeline finder function that excludes specified paths
+func createPipelineFinderWithExclusions(excludePaths []string) func(string, []string) ([]string, error) {
+	return func(root string, pipelineDefinitionFile []string) ([]string, error) {
+		return path.GetPipelinePathsWithExclusions(root, pipelineDefinitionFile, excludePaths)
+	}
+}
+
 type jinjaRenderedMaterializer struct {
 	renderer     *jinja.Renderer
 	materializer queryMaterializer
@@ -83,6 +90,10 @@ func Lint(isDebug *bool) *cli.Command {
 			&cli.BoolFlag{
 				Name:  "fast",
 				Usage: "run only fast validation rules, excludes some important rules such as query validation",
+			},
+			&cli.StringSliceFlag{
+				Name:  "exclude-paths",
+				Usage: "exclude the given list of paths from the folders that are searched during validation",
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -190,10 +201,14 @@ func Lint(isDebug *bool) *cli.Command {
 			lintCtx = context.WithValue(lintCtx, pipeline.RunConfigEndDate, defaultEndDate)
 			lintCtx = context.WithValue(lintCtx, pipeline.RunConfigRunID, NewRunID())
 
+			// Create a pipeline finder that respects exclude paths
+			excludePaths := c.StringSlice("exclude-paths")
+			pipelineFinder := createPipelineFinderWithExclusions(excludePaths)
+
 			var result *lint.PipelineAnalysisResult
 			var errr error
 			if asset == "" {
-				linter := lint.NewLinter(path.GetPipelinePaths, DefaultPipelineBuilder, rules, logger, parser)
+				linter := lint.NewLinter(pipelineFinder, DefaultPipelineBuilder, rules, logger, parser)
 				logger.Debugf("running %d rules for pipeline validation", len(rules))
 				infoPrinter.Printf("Validating pipelines in '%s' for '%s' environment...\n", rootPath, cm.SelectedEnvironmentName)
 				result, errr = linter.Lint(lintCtx, rootPath, PipelineDefinitionFiles, c)
@@ -205,7 +220,7 @@ func Lint(isDebug *bool) *cli.Command {
 				}
 				rules = lint.FilterRulesByLevel(rules, lint.LevelAsset)
 				logger.Debugf("running %d rules for asset-only validation", len(rules))
-				linter := lint.NewLinter(path.GetPipelinePaths, DefaultPipelineBuilder, rules, logger, parser)
+				linter := lint.NewLinter(pipelineFinder, DefaultPipelineBuilder, rules, logger, parser)
 				result, errr = linter.LintAsset(lintCtx, rootPath, PipelineDefinitionFiles, asset, c)
 			}
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -28,7 +28,7 @@ import (
 
 var ErrExcludeTagNotSupported = errors.New("exclude-tag flag is not supported for asset-only validation")
 
-// createPipelineFinderWithExclusions creates a pipeline finder function that excludes specified paths
+// createPipelineFinderWithExclusions creates a pipeline finder function that excludes specified paths.
 func createPipelineFinderWithExclusions(excludePaths []string) func(string, []string) ([]string, error) {
 	return func(root string, pipelineDefinitionFile []string) ([]string, error) {
 		return path.GetPipelinePathsWithExclusions(root, pipelineDefinitionFile, excludePaths)

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -26,7 +26,7 @@ Defaults to the current directory (".") if not provided.
 | `--config-file`          |            | The path to the `.bruin.yml` file.                                           |
 | `--exclude-tag`          |            | Excludes assets with the given tag from validation.                          |
 | `--fast`                 |            | Runs only fast validation rules, excludes some important rules such as query validation. |
-
+| `--exclude-paths`        |            | Excludes the given paths from the folders that are searched during validation. |
 
 
 ### Dry-run Validation
@@ -61,4 +61,10 @@ bruin validate --output json
 ```bash
 bruin validate path/to/specific-asset
 
+```
+
+**4. Validate while excluding specific paths:**
+
+```bash
+bruin validate --exclude-paths path/to/exclude1 --exclude-paths path/to/exclude2
 ```

--- a/pkg/path/walk.go
+++ b/pkg/path/walk.go
@@ -12,8 +12,54 @@ import (
 
 var SkipDirs = []string{".git", ".github", ".vscode", "node_modules", "dist", "build", "target", "vendor", ".venv", ".env", "env", "venv", "dbt_packages"}
 
+// shouldExcludePath checks if a given path should be excluded based on the exclude patterns
+func shouldExcludePath(path string, excludePaths []string) bool {
+	if len(excludePaths) == 0 {
+		return false
+	}
+
+	// Convert path to absolute path for consistent comparison
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		// If we can't get absolute path, fall back to original path
+		absPath = path
+	}
+
+	for _, excludePattern := range excludePaths {
+		// Convert exclude pattern to absolute path
+		absExcludePattern, err := filepath.Abs(excludePattern)
+		if err != nil {
+			// If we can't get absolute path, use original pattern
+			absExcludePattern = excludePattern
+		}
+
+		// Check if the path starts with the exclude pattern (prefix match)
+		// This allows excluding entire directory trees
+		if strings.HasPrefix(absPath, absExcludePattern) {
+			// Ensure we're matching complete path components to avoid false positives
+			// e.g., "/foo/bar" should not match "/foo/barbaz"
+			if absPath == absExcludePattern || strings.HasPrefix(absPath, absExcludePattern+string(filepath.Separator)) {
+				return true
+			}
+		}
+
+		// Also check relative path matching for convenience
+		if strings.HasPrefix(path, excludePattern) {
+			if path == excludePattern || strings.HasPrefix(path, excludePattern+string(filepath.Separator)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func GetPipelinePaths(root string, pipelineDefinitionFile []string) ([]string, error) {
-	var pipelinePaths []string
+	return GetPipelinePathsWithExclusions(root, pipelineDefinitionFile, nil)
+}
+
+func GetPipelinePathsWithExclusions(root string, pipelineDefinitionFile []string, excludePaths []string) ([]string, error) {
+	pipelinePaths := make([]string, 0)
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -25,6 +71,16 @@ func GetPipelinePaths(root string, pipelineDefinitionFile []string) ([]string, e
 				return filepath.SkipDir
 			}
 
+			// Check if this directory path should be excluded
+			if shouldExcludePath(path, excludePaths) {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		// Check if the parent directory should be excluded before processing files
+		if shouldExcludePath(filepath.Dir(path), excludePaths) {
 			return nil
 		}
 
@@ -36,7 +92,11 @@ func GetPipelinePaths(root string, pipelineDefinitionFile []string) ([]string, e
 					return errors.Wrapf(err, "failed to get absolute path for %s", path)
 				}
 
-				pipelinePaths = append(pipelinePaths, filepath.Dir(abs))
+				pipelineDir := filepath.Dir(abs)
+				// Double-check that the pipeline directory itself isn't excluded
+				if !shouldExcludePath(pipelineDir, excludePaths) {
+					pipelinePaths = append(pipelinePaths, pipelineDir)
+				}
 				break // Stop checking other file names if one matches
 			}
 		}

--- a/pkg/path/walk.go
+++ b/pkg/path/walk.go
@@ -12,7 +12,7 @@ import (
 
 var SkipDirs = []string{".git", ".github", ".vscode", "node_modules", "dist", "build", "target", "vendor", ".venv", ".env", "env", "venv", "dbt_packages"}
 
-// shouldExcludePath checks if a given path should be excluded based on the exclude patterns
+// shouldExcludePath checks if a given path should be excluded based on the exclude patterns.
 func shouldExcludePath(path string, excludePaths []string) bool {
 	if len(excludePaths) == 0 {
 		return false


### PR DESCRIPTION
Add `--exclude-paths` option to the `validate` command to exclude specified directories from pipeline discovery.

---
[Slack Thread](https://bruintalk.slack.com/archives/C066JBNP3U2/p1753966738843219?thread_ts=1753966738.843219&cid=C066JBNP3U2)

<a href="https://cursor.com/background-agent?bcId=bc-5e1cdd6b-ab02-432d-9d58-fa4ca7be433a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e1cdd6b-ab02-432d-9d58-fa4ca7be433a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>