### PR TITLE
patch/make ephemeral connection not ping

### DIFF
--- a/integration-tests/integration-test.go
+++ b/integration-tests/integration-test.go
@@ -1475,20 +1475,6 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			},
 		},
 		{
-			Name:    "run-seed-data",
-			Command: binary,
-			Args:    []string{"run", "--env", "env-run-seed-data", filepath.Join(currentFolder, "test-pipelines/run-seed-data/assets/seed.asset.yml")},
-			Env:     []string{},
-			Expected: e2e.Output{
-				ExitCode: 0,
-				Contains: []string{"bruin run completed"},
-			},
-			Asserts: []func(*e2e.Task) error{
-				e2e.AssertByExitCode,
-				e2e.AssertByContains,
-			},
-		},
-		{
 			Name:          "parse-asset-seed-data",
 			Command:       binary,
 			Args:          []string{"internal", "parse-asset", filepath.Join(currentFolder, "test-pipelines/run-seed-data/assets/seed.asset.yml")},
@@ -1501,20 +1487,6 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
 				e2e.AssertByOutputJSON,
-			},
-		},
-		{
-			Name:    "run-asset-default-option-pipeline",
-			Command: binary,
-			Args:    []string{"run", "--env", "env-run-default-option", filepath.Join(currentFolder, "test-pipelines/parse-default-option")},
-			Env:     []string{},
-			Expected: e2e.Output{
-				ExitCode: 0,
-				Contains: []string{"Successfully validated 4 assets", "bruin run completed", "Finished: chess_playground.player_summary", "Finished: chess_playground.games", "Finished: python_asset"},
-			},
-			Asserts: []func(*e2e.Task) error{
-				e2e.AssertByExitCode,
-				e2e.AssertByContains,
 			},
 		},
 		{
@@ -1575,20 +1547,6 @@ func getTasks(binary string, currentFolder string) []e2e.Task {
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,
 				e2e.AssertByOutputJSON,
-			},
-		},
-		{
-			Name:    "run-python-materialization",
-			Command: binary,
-			Args:    []string{"run", "--env", "env-run-python-materialization", filepath.Join(currentFolder, "test-pipelines/run-python-materialization")},
-			Env:     []string{},
-			Expected: e2e.Output{
-				ExitCode: 0,
-				Contains: []string{"Successfully validated 1 assets", "bruin run completed", "Finished: materialize.country"},
-			},
-			Asserts: []func(*e2e.Task) error{
-				e2e.AssertByExitCode,
-				e2e.AssertByContains,
 			},
 		},
 		{
@@ -1657,6 +1615,48 @@ func getIngestrTasks(binary string, currentFolder string) []e2e.Task {
 			Expected: e2e.Output{
 				ExitCode: 0,
 				Contains: []string{"bruin run completed", "Finished: chess_playground.profiles", "Finished: chess_playground.games", "Finished: chess_playground.player_summary", "Finished: chess_playground.player_summary:total_games:positive"},
+			},
+			Asserts: []func(*e2e.Task) error{
+				e2e.AssertByExitCode,
+				e2e.AssertByContains,
+			},
+		},
+		{
+			Name:    "run-seed-data",
+			Command: binary,
+			Args:    []string{"run", "--env", "env-run-seed-data", filepath.Join(currentFolder, "test-pipelines/run-seed-data/assets/seed.asset.yml")},
+			Env:     []string{},
+			Expected: e2e.Output{
+				ExitCode: 0,
+				Contains: []string{"bruin run completed"},
+			},
+			Asserts: []func(*e2e.Task) error{
+				e2e.AssertByExitCode,
+				e2e.AssertByContains,
+			},
+		},
+		{
+			Name:    "run-asset-default-option-pipeline",
+			Command: binary,
+			Args:    []string{"run", "--env", "env-run-default-option", filepath.Join(currentFolder, "test-pipelines/parse-default-option")},
+			Env:     []string{},
+			Expected: e2e.Output{
+				ExitCode: 0,
+				Contains: []string{"Successfully validated 4 assets", "bruin run completed", "Finished: chess_playground.player_summary", "Finished: chess_playground.games", "Finished: python_asset"},
+			},
+			Asserts: []func(*e2e.Task) error{
+				e2e.AssertByExitCode,
+				e2e.AssertByContains,
+			},
+		},
+		{
+			Name:    "run-python-materialization",
+			Command: binary,
+			Args:    []string{"run", "--env", "env-run-python-materialization", filepath.Join(currentFolder, "test-pipelines/run-python-materialization")},
+			Env:     []string{},
+			Expected: e2e.Output{
+				ExitCode: 0,
+				Contains: []string{"Successfully validated 1 assets", "bruin run completed", "Finished: materialize.country"},
 			},
 			Asserts: []func(*e2e.Task) error{
 				e2e.AssertByExitCode,

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -14,21 +14,6 @@ type EphemeralConnection struct {
 }
 
 func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
-	conn, err := sqlx.Open("duckdb", c.ToDBConnectionURI())
-	if err != nil {
-		return nil, err
-	}
-	defer func(conn *sqlx.DB) {
-		if err := conn.Close(); err != nil {
-			panic(err)
-		}
-	}(conn)
-
-	err = conn.Ping()
-	if err != nil {
-		return nil, err
-	}
-
 	return &EphemeralConnection{config: c}, nil
 }
 


### PR DESCRIPTION
This PR removes the `sqlx.Open` from the ephemeral DB struct initialization.

This struct has been primarily used with local DuckDB files, in which opening the database was reasonably fast. However, with the introduction of Motherduck, this suddenly started making network calls even though Motherduck connection was not being used in the current execution, slowing down the whole application time significantly, up to 20 seconds in my tests. 

This PR makes the connection fully lazy.