### PR TITLE
Add parent domain field and validation

### DIFF
--- a/pkg/glossary/entity.go
+++ b/pkg/glossary/entity.go
@@ -17,11 +17,12 @@ type Contact struct {
 }
 
 type Domain struct {
-	Name        string     `json:"name" yaml:"name,omitempty"`
-	Description string     `json:"description" yaml:"description,omitempty"`
-	Owners      []string   `json:"owners" yaml:"owners,omitempty"`
-	Tags        []string   `json:"tags" yaml:"tags,omitempty"`
-	Contact     []*Contact `json:"contact" yaml:"contact,omitempty"`
+	Name         string     `json:"name" yaml:"name,omitempty"`
+	Description  string     `json:"description" yaml:"description,omitempty"`
+	ParentDomain string     `json:"parent_domain" yaml:"parent_domain,omitempty"`
+	Owners       []string   `json:"owners" yaml:"owners,omitempty"`
+	Tags         []string   `json:"tags" yaml:"tags,omitempty"`
+	Contact      []*Contact `json:"contact" yaml:"contact,omitempty"`
 }
 
 type Attribute struct {

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -149,6 +149,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser *sqlp
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "valid-parent-domains",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			Validator:        gr.EnsureParentDomainsExistInGlossary,
+			ApplicableLevels: []Level{LevelPipeline},
+		},
+		&SimpleRule{
 			Identifier:       "duplicate-column-names",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -2210,11 +2210,11 @@ func TestGlossaryChecker_EnsureParentDomainsExistInGlossary_WithCache(t *testing
 	t.Parallel()
 
 	tests := []struct {
-		name           string
+		name            string
 		initialGlossary *glossary.Glossary
-		cacheGlossary  bool
-		want           []string
-		wantErr        assert.ErrorAssertionFunc
+		cacheGlossary   bool
+		want            []string
+		wantErr         assert.ErrorAssertionFunc
 	}{
 		{
 			name: "uses cached glossary when available",
@@ -2227,8 +2227,8 @@ func TestGlossaryChecker_EnsureParentDomainsExistInGlossary_WithCache(t *testing
 				Entities: []*glossary.Entity{},
 			},
 			cacheGlossary: true,
-			want:         []string{"Parent domain 'missing' for domain 'orphan' does not exist in the glossary"},
-			wantErr:      assert.NoError,
+			want:          []string{"Parent domain 'missing' for domain 'orphan' does not exist in the glossary"},
+			wantErr:       assert.NoError,
 		},
 		{
 			name: "handles empty cached glossary",
@@ -2237,8 +2237,8 @@ func TestGlossaryChecker_EnsureParentDomainsExistInGlossary_WithCache(t *testing
 				Entities: []*glossary.Entity{},
 			},
 			cacheGlossary: true,
-			want:         []string{},
-			wantErr:      assert.NoError,
+			want:          []string{},
+			wantErr:       assert.NoError,
 		},
 	}
 


### PR DESCRIPTION
Adds `parent_domain` field to `Domain` struct and a validation rule to ensure its existence in the glossary.

---
[Slack Thread](https://bruintalk.slack.com/archives/C0971BSNJ14/p1754490189034449?thread_ts=1754490189.034449&cid=C0971BSNJ14)

<a href="https://cursor.com/background-agent?bcId=bc-32fd5fd1-07c9-432c-a24b-ad6c83ea066c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32fd5fd1-07c9-432c-a24b-ad6c83ea066c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

