### PR TITLE
Add readonly option to postgres connections

### DIFF
--- a/pkg/postgres/config_test.go
+++ b/pkg/postgres/config_test.go
@@ -22,6 +22,41 @@ func TestConfig_ToDBConnectionURI(t *testing.T) {
 	assert.Equal(t, "postgres://user:password@localhost:5432/database?sslmode=disable&pool_max_conns=10&search_path=schema", c.ToDBConnectionURI())
 }
 
+func TestConfig_ToDBConnectionURI_WithReadOnly(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Username:     "user",
+		Password:     "password",
+		Host:         "localhost",
+		Port:         5432,
+		Database:     "database",
+		Schema:       "schema",
+		PoolMaxConns: 10,
+		SslMode:      "disable",
+		ReadOnly:     true,
+	}
+
+	expected := "postgres://user:password@localhost:5432/database?sslmode=disable&pool_max_conns=10&search_path=schema&options=-c+default_transaction_read_only%3Don"
+	assert.Equal(t, expected, c.ToDBConnectionURI())
+}
+
+func TestConfig_ToDBConnectionURI_ReadOnlyWithoutSchema(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Username:     "user",
+		Password:     "password",
+		Host:         "localhost",
+		Port:         5432,
+		Database:     "database",
+		PoolMaxConns: 10,
+		SslMode:      "disable",
+		ReadOnly:     true,
+	}
+
+	expected := "postgres://user:password@localhost:5432/database?sslmode=disable&pool_max_conns=10&options=-c+default_transaction_read_only%3Don"
+	assert.Equal(t, expected, c.ToDBConnectionURI())
+}
+
 func TestConfig_ToIngestr(t *testing.T) {
 	t.Parallel()
 	c := Config{
@@ -36,4 +71,71 @@ func TestConfig_ToIngestr(t *testing.T) {
 	}
 
 	assert.Equal(t, "postgresql://user:password@localhost:5432/database?sslmode=disable", c.GetIngestrURI())
+}
+
+func TestConfig_GetIngestrURI_WithReadOnly(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Username:     "user",
+		Password:     "password",
+		Host:         "localhost",
+		Port:         5432,
+		Database:     "database",
+		Schema:       "schema",
+		PoolMaxConns: 10,
+		SslMode:      "disable",
+		ReadOnly:     true,
+	}
+
+	expected := "postgresql://user:password@localhost:5432/database?sslmode=disable&options=-c+default_transaction_read_only%3Don"
+	assert.Equal(t, expected, c.GetIngestrURI())
+}
+
+func TestConfig_GetIngestrURI_ReadOnlyWithoutSSL(t *testing.T) {
+	t.Parallel()
+	c := Config{
+		Username:     "user",
+		Password:     "password",
+		Host:         "localhost",
+		Port:         5432,
+		Database:     "database",
+		PoolMaxConns: 10,
+		ReadOnly:     true,
+	}
+
+	expected := "postgresql://user:password@localhost:5432/database?options=-c+default_transaction_read_only%3Don"
+	assert.Equal(t, expected, c.GetIngestrURI())
+}
+
+func TestRedShiftConfig_ToDBConnectionURI_WithReadOnly(t *testing.T) {
+	t.Parallel()
+	c := RedShiftConfig{
+		Username: "user",
+		Password: "password",
+		Host:     "localhost",
+		Port:     5439,
+		Database: "database",
+		Schema:   "schema",
+		SslMode:  "require",
+		ReadOnly: true,
+	}
+
+	expected := "postgres://user:password@localhost:5439/database?sslmode=require&search_path=schema&options=-c+default_transaction_read_only%3Don"
+	assert.Equal(t, expected, c.ToDBConnectionURI())
+}
+
+func TestRedShiftConfig_GetIngestrURI_WithReadOnly(t *testing.T) {
+	t.Parallel()
+	c := RedShiftConfig{
+		Username: "user",
+		Password: "password",
+		Host:     "localhost",
+		Port:     5439,
+		Database: "database",
+		SslMode:  "require",
+		ReadOnly: true,
+	}
+
+	expected := "redshift://user:password@localhost:5439/database?sslmode=require&options=-c+default_transaction_read_only%3Don"
+	assert.Equal(t, expected, c.GetIngestrURI())
 }


### PR DESCRIPTION
Add a `ReadOnly` option to PostgreSQL and RedShift connection configurations to enable read-only database access.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbbb3e34-5d32-4a05-9796-b14ddb22ff29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbbb3e34-5d32-4a05-9796-b14ddb22ff29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

