### PR TITLE
feat: add duplicate tag lint rule

### DIFF
--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -163,6 +163,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser *sqlp
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "duplicate-tags",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   ValidateDuplicateTags,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "custom-check-query-exists",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -674,6 +674,44 @@ func ValidateDuplicateColumnNames(ctx context.Context, p *pipeline.Pipeline, ass
 	return issues, nil
 }
 
+// ValidateDuplicateTags checks for duplicate tags within an asset and its columns.
+// It performs case-insensitive comparisons to find duplicates and returns issues
+// for any repeated tags found either on the asset itself or within individual
+// columns.
+func ValidateDuplicateTags(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	var issues []*Issue
+
+	tagSet := make(map[string]bool)
+	for _, tag := range asset.Tags {
+		key := strings.ToLower(tag)
+		if tagSet[key] {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Duplicate asset tag '%s' found", tag),
+			})
+		} else {
+			tagSet[key] = true
+		}
+	}
+
+	for _, column := range asset.Columns {
+		columnTagSet := make(map[string]bool)
+		for _, tag := range column.Tags {
+			key := strings.ToLower(tag)
+			if columnTagSet[key] {
+				issues = append(issues, &Issue{
+					Task:        asset,
+					Description: fmt.Sprintf("Duplicate tag '%s' found in column '%s'", tag, column.Name),
+				})
+			} else {
+				columnTagSet[key] = true
+			}
+		}
+	}
+
+	return issues, nil
+}
+
 func ValidateAssetDirectoryExist(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
 	var issues []*Issue
 


### PR DESCRIPTION
## Summary
- flag duplicate asset tags
- detect duplicate tags on column definitions

## Testing
- `make format`
- `make test-unit`


------
https://chatgpt.com/codex/tasks/task_e_6899d6208f088320a9d165c106be8c6c