### PR TITLE
feat: make integration-test-clean command to clean up logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ integration-test: build
 	@touch integration-tests/bruin
 	@rm -rf integration-tests/.git
 	@rm integration-tests/bruin
+	@rm -rf integration-tests/logs
+	@mkdir -p integration-tests/logs
+	@mkdir -p integration-tests/logs/exports
+	@mkdir -p integration-tests/logs/runs
 	@echo "$(OK_COLOR)==> Running integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
 	@cd integration-tests && go test -tags="no_duckdb_arrow" -v -count=1 .
@@ -47,6 +51,10 @@ integration-test-individual: build
 	@touch integration-tests/bruin
 	@rm -rf integration-tests/.git
 	@rm integration-tests/bruin
+	@rm -rf integration-tests/logs
+	@mkdir -p integration-tests/logs
+	@mkdir -p integration-tests/logs/exports
+	@mkdir -p integration-tests/logs/runs
 	@echo "$(OK_COLOR)==> Running integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
 	@cd integration-tests && go test -tags="no_duckdb_arrow" -v -count=1 -run ^TestIndividualTasks github.com/bruin-data/bruin/integration-tests
@@ -58,6 +66,10 @@ integration-test-workflow: build
 	@touch integration-tests/bruin
 	@rm -rf integration-tests/.git
 	@rm integration-tests/bruin
+	@rm -rf integration-tests/logs
+	@mkdir -p integration-tests/logs
+	@mkdir -p integration-tests/logs/exports
+	@mkdir -p integration-tests/logs/runs
 	@echo "$(OK_COLOR)==> Running integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
 	@cd integration-tests && go test -tags="no_duckdb_arrow" -v -count=1 -run ^TestWorkflowTasks github.com/bruin-data/bruin/integration-tests
@@ -69,6 +81,10 @@ integration-test-ingestr: build
 	@touch integration-tests/bruin
 	@rm -rf integration-tests/.git
 	@rm integration-tests/bruin
+	@rm -rf integration-tests/logs
+	@mkdir -p integration-tests/logs
+	@mkdir -p integration-tests/logs/exports
+	@mkdir -p integration-tests/logs/runs
 	@echo "$(OK_COLOR)==> Running integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
 	@cd integration-tests && INCLUDE_INGESTR=1 go test -tags="no_duckdb_arrow" -v -count=1 -run ^TestIngestrTasks github.com/bruin-data/bruin/integration-tests
@@ -81,12 +97,6 @@ integration-test-cloud: build
 	@echo "$(OK_COLOR)==> Running cloud integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
 	@cd integration-tests/cloud-integration-tests && go test -count=1 -v .
-
-integration-test-clean:
-	@rm -rf integration-tests/logs
-	@mkdir -p integration-tests/logs
-	@mkdir -p integration-tests/logs/exports
-	@mkdir -p integration-tests/logs/runs
 
 clean:
 	@rm -rf ./bin

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,12 @@ integration-test-cloud: build
 	@cd integration-tests && git init
 	@cd integration-tests/cloud-integration-tests && go test -count=1 -v .
 
+integration-test-clean:
+	@rm -rf integration-tests/logs
+	@mkdir -p integration-tests/logs
+	@mkdir -p integration-tests/logs/exports
+	@mkdir -p integration-tests/logs/runs
+
 clean:
 	@rm -rf ./bin
 


### PR DESCRIPTION
The logs folder was getting filled with thousands of files over time as dozens of tests are run on each integration test run. The make integration-test commands now cleans up the integration-test directory. 