### PR TITLE
Handle malformed bruin.yml gracefully

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 	path2 "path"
-
+	
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
+	bruinpath "github.com/bruin-data/bruin/pkg/path"
 	"github.com/jedib0t/go-pretty/v6/table"
 	errors2 "github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -272,6 +273,11 @@ func (r *ConnectionsCommand) ListConnections(pathToProject, output, environment,
 
 	cm, err := config.LoadOrCreate(afero.NewOsFs(), configFilePath)
 	if err != nil {
+		if _, ok := err.(*bruinpath.YamlParseError); ok {
+			printErrorForOutput(output, fmt.Errorf("failed to parse Bruin config at %s: %s", configFilePath, err.Error()))
+			return cli.Exit("", 1)
+		}
+
 		errorPrinter.Printf("Failed to load or create the config file: %v\n", err)
 		return cli.Exit("", 1)
 	}

--- a/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
+++ b/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
@@ -1,6 +1,6 @@
 /* @bruin
 name: test.menu
-type: pg.sql
+type: pg.sql 
 materialization:
   type: table
   strategy: scd2_by_column
@@ -25,4 +25,9 @@ columns:
 @bruin */
 
 
-SELECT 1 AS ID, 'Cola' AS Name, 0.99 AS Price
+
+SELECT 1 AS ID, 'Cola' AS Name, 3.99 AS Price
+UNION ALL
+SELECT 2 AS ID, 'Tea' AS Name, 4.99 AS Price
+UNION ALL
+SELECT 3 AS ID, 'Coffee' AS Name, 5.99 AS Price

--- a/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
+++ b/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
@@ -14,7 +14,6 @@ columns:
     primary_key: true
   - name: product_name
     type: VARCHAR
-    description: "Name of the product"
     primary_key: true
   - name: dt
     type: DATE
@@ -23,11 +22,27 @@ columns:
     type: INTEGER
     description: "Number of units in stock"
 @bruin */
+SELECT
+    1 AS product_id,
+    'Laptop' AS product_name,
+    100 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    2 AS product_id,
+    'Smartphone' AS product_name,
 
+    150 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
 SELECT
     3 AS product_id,
     'Headphones' AS product_name,
-    1200 AS stock,
-    DATE '2025-06-10' AS dt
-
-
+    175 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    4 AS product_id,
+    'Monitor' AS product_name,
+    25 AS stock,
+    DATE '2025-04-02' AS dt

--- a/integration-tests/cloud-integration-tests/redshift/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
+++ b/integration-tests/cloud-integration-tests/redshift/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
@@ -1,6 +1,6 @@
 /* @bruin
 name: test.menu
-type: rs.sql
+type: rs.sql 
 materialization:
   type: table
   strategy: scd2_by_column
@@ -25,4 +25,9 @@ columns:
 @bruin */
 
 
-SELECT 1 AS ID, 'Cola' AS Name, 0.99 AS Price
+
+SELECT 1 AS ID, 'Cola' AS Name, 3.99 AS Price
+UNION ALL
+SELECT 2 AS ID, 'Tea' AS Name, 4.99 AS Price
+UNION ALL
+SELECT 3 AS ID, 'Coffee' AS Name, 5.99 AS Price

--- a/integration-tests/cloud-integration-tests/redshift/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
+++ b/integration-tests/cloud-integration-tests/redshift/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
@@ -14,7 +14,6 @@ columns:
     primary_key: true
   - name: product_name
     type: VARCHAR
-    description: "Name of the product"
     primary_key: true
   - name: dt
     type: DATE
@@ -23,11 +22,27 @@ columns:
     type: INTEGER
     description: "Number of units in stock"
 @bruin */
+SELECT
+    1 AS product_id,
+    'Laptop' AS product_name,
+    100 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    2 AS product_id,
+    'Smartphone' AS product_name,
 
+    150 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
 SELECT
     3 AS product_id,
     'Headphones' AS product_name,
-    1200 AS stock,
-    DATE '2025-06-10' AS dt
-
-
+    175 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    4 AS product_id,
+    'Monitor' AS product_name,
+    25 AS stock,
+    DATE '2025-04-02' AS dt

--- a/integration-tests/cloud-integration-tests/snowflake/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
+++ b/integration-tests/cloud-integration-tests/snowflake/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
@@ -1,6 +1,6 @@
 /* @bruin
 name: test.menu
-type: sf.sql
+type: sf.sql 
 materialization:
   type: table
   strategy: scd2_by_column
@@ -25,4 +25,9 @@ columns:
 @bruin */
 
 
-SELECT 1 AS ID, 'Cola' AS Name, 0.99 AS Price
+
+SELECT 1 AS ID, 'Cola' AS Name, 3.99 AS Price
+UNION ALL
+SELECT 2 AS ID, 'Tea' AS Name, 4.99 AS Price
+UNION ALL
+SELECT 3 AS ID, 'Coffee' AS Name, 5.99 AS Price

--- a/integration-tests/cloud-integration-tests/snowflake/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
+++ b/integration-tests/cloud-integration-tests/snowflake/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
@@ -14,20 +14,35 @@ columns:
     primary_key: true
   - name: product_name
     type: VARCHAR
-    description: "Name of the product"
     primary_key: true
   - name: dt
     type: DATE
     description: "incremental key"
   - name: stock
-    type: INTEGER
+    type: NUMBER
     description: "Number of units in stock"
 @bruin */
+SELECT
+    1 AS product_id,
+    'Laptop' AS product_name,
+    100 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    2 AS product_id,
+    'Smartphone' AS product_name,
 
+    150 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
 SELECT
     3 AS product_id,
     'Headphones' AS product_name,
-    120 AS stock,
-    DATE '2025-06-10' AS dt
-
-
+    175 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    4 AS product_id,
+    'Monitor' AS product_name,
+    25 AS stock,
+    DATE '2025-04-02' AS dt

--- a/integration-tests/test-pipelines/continue-pipeline/assets/shipping_providers.sql
+++ b/integration-tests/test-pipelines/continue-pipeline/assets/shipping_providers.sql
@@ -1,0 +1,33 @@
+/* @bruin
+name: shipping_providers
+type: duckdb.sql
+materialization:
+  type: table
+columns:
+  - name: provider_id
+    type: INTEGER
+    description: "Unique identifier for each shipping provider"
+    primary_key: true
+  - name: provider_name
+    type: VARCHAR
+    description: "Name of the fictional shipping provider"
+  - name: delivery_speed
+    type: VARCHAR
+    description: "Average delivery time (e.g., '2-day', 'Standard')"
+  - name: service_areas
+    type: VARCHAR
+    description: "Regions or countries where the provider operates"
+
+@bruin */
+
+SELECT
+    1 AS provider_id, 'SwiftCourier' AS provider_name, '2-day' AS delivery_speed, 'North America, Asia' AS service_areas
+UNION ALL
+SELECT
+    2 AcdsS provider_id, 'GlobalFreight' AS provider_name, 'Standard' AS delivery_speed, 'Worldwide' AS service_areas
+UNION ALL -- THIS ASSET IS BROKEN FOR TESTING PURPOSES DON'T FIX IT
+SELECT
+    3 AS provider_id, 'BudgetShip' AS provider_name, 'Economy' AS delivery_speed, 'Europe, Africa' AS service_areas
+UNION ALL
+SELECT
+    4 AS provider_id, 'ApexLogistics' AS provider_name, 'Overnight' AS delivery_speed, 'North America' AS service_areas;


### PR DESCRIPTION
Handle malformed `.bruin.yml` to prevent panics and provide clearer error messages for `bruin connections list`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b26348c0-4555-4173-bfcc-6a1b1f417e9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b26348c0-4555-4173-bfcc-6a1b1f417e9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

