### PR TITLE
Fix: add temp dir to postgres integration tests

### DIFF
--- a/integration-tests/cloud-integration-tests/postgres/postgres_test.go
+++ b/integration-tests/cloud-integration-tests/postgres/postgres_test.go
@@ -64,9 +64,9 @@ func TestPostgresWorkflows(t *testing.T) {
 			},
 		},
 		{
-			name: "scd2_by_column",
+			name: "scd2-by-column",
 			workflow: e2e.Workflow{
-				Name: "scd2_by_column",
+				Name: "scd2-by-column",
 				Steps: []e2e.Task{
 					{
 						Name:    "scd2-by-column: create test directory",
@@ -103,18 +103,6 @@ func TestPostgresWorkflows(t *testing.T) {
 							e2e.AssertByExitCode,
 						},
 					},
-					// {
-					// 	Name:    "scd2-by-column: restore menu asset to initial state",
-					// 	Command: "cp",
-					// 	Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/menu_original.sql"), filepath.Join(tempDir, "test-scd2-by-column/scd2-by-column-pipeline/assets/menu.sql")},
-					// 	Env:     []string{},
-					// 	Expected: e2e.Output{
-					// 		ExitCode: 0,
-					// 	},
-					// 	Asserts: []func(*e2e.Task) error{
-					// 		e2e.AssertByExitCode,
-					// 	},
-					// },
 					{
 						Name:    "scd2-by-column: create the initial table",
 						Command: binary,
@@ -122,9 +110,11 @@ func TestPostgresWorkflows(t *testing.T) {
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
+							Contains: []string{"Finished: test.menu"},
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
+							e2e.AssertByContains,
 						},
 					},
 					{
@@ -160,9 +150,11 @@ func TestPostgresWorkflows(t *testing.T) {
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
+							Contains: []string{"Finished: test.menu"},
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
+							e2e.AssertByContains,
 						},
 					},
 					{
@@ -198,9 +190,11 @@ func TestPostgresWorkflows(t *testing.T) {
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
+							Contains: []string{"Finished: test.menu"},
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
+							e2e.AssertByContains,
 						},
 					},
 					{
@@ -245,15 +239,14 @@ func TestPostgresWorkflows(t *testing.T) {
 			},
 		},
 		{
-			name: "SCD2 by time",
+			name: "scd2-by-time",
 			workflow: e2e.Workflow{
-				Name: "SCD2 by time",
+				Name: "scd2-by-time",
 				Steps: []e2e.Task{
 					{
-						Name:    "scd2-by-time: restore products asset to initial state",
-						Command: "cp",
-						Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/products_original.sql"), filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql")},
-						Env:     []string{},
+						Name:    "scd2-by-time: create test directory",
+						Command: "mkdir",
+						Args:    []string{"-p", filepath.Join(tempDir, "test-scd2-by-time")},
 						Expected: e2e.Output{
 							ExitCode: 0,
 						},
@@ -262,25 +255,63 @@ func TestPostgresWorkflows(t *testing.T) {
 						},
 					},
 					{
-						Name:    "scd2-by-time: create the initial products table",
-						Command: binary,
-						Args:    append(append([]string{"run"}, configFlags...), "--full-refresh", "--env", "default", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline")),
-						Env:     []string{},
+						Name:    "scd2-by-time: initialize git repository",
+						Command: "git",
+						Args:    []string{"init"},
+						WorkingDir: filepath.Join(tempDir, "test-scd2-by-time"),
 						Expected: e2e.Output{
 							ExitCode: 0,
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
+						},
+					},	
+					{
+						Name:       "scd2-by-time: copy pipeline files",
+						Command:    "cp",
+						Args:       []string{"-a", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline"), filepath.Join(tempDir, "test-scd2-by-time")},
+						WorkingDir: filepath.Join(tempDir, "test-scd2-by-time"),
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					// {
+					// 	Name:    "scd2-by-time: restore products asset to initial state",
+					// 	Command: "cp",
+					// 	Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/products_original.sql"), filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/assets/products.sql")},
+					// 	Env:     []string{},
+					// 	Expected: e2e.Output{
+					// 		ExitCode: 0,
+					// 	},
+					// 	Asserts: []func(*e2e.Task) error{
+					// 		e2e.AssertByExitCode,
+					// 	},
+					// },
+					{
+						Name:    "scd2-by-time: create the initial products table",
+						Command: binary,
+						Args:    append(append([]string{"run"}, configFlags...), "--full-refresh", "--env", "default", filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/assets/products.sql")),
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							Contains: []string{"Finished: test.products"},
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByContains,
 						},
 					},
 					{
 						Name:    "scd2-by-time: query the initial table",
 						Command: binary,
-						Args:    append(append([]string{"query"}, configFlags...), "--env", "default", "--asset", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql"), "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"),
+						Args:    append(append([]string{"query"}, configFlags...), "--connection", "postgres-default", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"),
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
-							CSVFile:  filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/expectations/scd2_by_time_expected_initial.csv"),
+							CSVFile:  filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/expectations/scd2_by_time_expected_initial.csv"),
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
@@ -290,7 +321,7 @@ func TestPostgresWorkflows(t *testing.T) {
 					{
 						Name:    "scd2-by-time: copy products_updated_01.sql to products.sql",
 						Command: "cp",
-						Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/products_updated_01.sql"), filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql")},
+						Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/products_updated_01.sql"), filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/assets/products.sql")},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -302,23 +333,25 @@ func TestPostgresWorkflows(t *testing.T) {
 					{
 						Name:    "scd2-by-time: run products_updated_01.sql with SCD2 materialization",
 						Command: binary,
-						Args:    append(append([]string{"run"}, configFlags...), "--env", "default", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql")),
+						Args:    append(append([]string{"run"}, configFlags...), "--env", "default", filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/assets/products.sql")),
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
+							Contains: []string{"Finished: test.products"},
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
+							e2e.AssertByContains,
 						},
 					},
 					{
 						Name:    "scd2-by-time: query the updated table 01",
 						Command: binary,
-						Args:    append(append([]string{"query"}, configFlags...), "--env", "default", "--asset", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql"), "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"),
+						Args:    append(append([]string{"query"}, configFlags...), "--connection", "postgres-default", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"),
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
-							CSVFile:  filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/expectations/scd2_by_time_expected_update_01.csv"),
+							CSVFile:  filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/expectations/scd2_by_time_expected_update_01.csv"),
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
@@ -328,7 +361,7 @@ func TestPostgresWorkflows(t *testing.T) {
 					{
 						Name:    "scd2-by-time: copy products_updated_02.sql to products.sql",
 						Command: "cp",
-						Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/products_updated_02.sql"), filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql")},
+						Args:    []string{filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/resources/products_updated_02.sql"), filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/assets/products.sql")},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -340,23 +373,25 @@ func TestPostgresWorkflows(t *testing.T) {
 					{
 						Name:    "scd2-by-time: run products_updated_02.sql with SCD2 materialization",
 						Command: binary,
-						Args:    append(append([]string{"run"}, configFlags...), "--env", "default", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql")),
+						Args:    append(append([]string{"run"}, configFlags...), "--env", "default", filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/assets/products.sql")),
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
+							Contains: []string{"Finished: test.products"},
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
+							e2e.AssertByContains,
 						},
 					},
 					{
 						Name:    "scd2-by-time: query the updated table 02",
 						Command: binary,
-						Args:    append(append([]string{"query"}, configFlags...), "--env", "default", "--asset", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql"), "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"),
+						Args:    append(append([]string{"query"}, configFlags...), "--connection", "postgres-default", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"),
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
-							CSVFile:  filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/expectations/scd2_by_time_expected_update_02.csv"),
+							CSVFile:  filepath.Join(tempDir, "test-scd2-by-time/scd2-by-time-pipeline/expectations/scd2_by_time_expected_update_02.csv"),
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
@@ -366,7 +401,7 @@ func TestPostgresWorkflows(t *testing.T) {
 					{
 						Name:    "scd2-by-time: drop the table",
 						Command: binary,
-						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, "../.bruin.cloud.yml"), "--asset", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql"), "--query", "DROP TABLE IF EXISTS test.products;"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, "../.bruin.cloud.yml"), "--query", "DROP TABLE IF EXISTS test.products;"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 1, // Expect failure due to "field descriptions not available for DDL statements" - specific to PostgresSQL driver
@@ -378,7 +413,7 @@ func TestPostgresWorkflows(t *testing.T) {
 					{
 						Name:    "scd2-by-time: confirm the table is dropped",
 						Command: binary,
-						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, "../.bruin.cloud.yml"), "--asset", filepath.Join(currentFolder, "test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql"), "--query", "SELECT * FROM test.products;"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, "../.bruin.cloud.yml"), "--query", "SELECT * FROM test.products;"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 1,

--- a/integration-tests/cloud-integration-tests/postgres/postgres_test.go
+++ b/integration-tests/cloud-integration-tests/postgres/postgres_test.go
@@ -80,9 +80,9 @@ func TestPostgresWorkflows(t *testing.T) {
 						},
 					},
 					{
-						Name:    "scd2-by-column: initialize git repository",
-						Command: "git",
-						Args:    []string{"init"},
+						Name:       "scd2-by-column: initialize git repository",
+						Command:    "git",
+						Args:       []string{"init"},
 						WorkingDir: filepath.Join(tempDir, "test-scd2-by-column"),
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -255,9 +255,9 @@ func TestPostgresWorkflows(t *testing.T) {
 						},
 					},
 					{
-						Name:    "scd2-by-time: initialize git repository",
-						Command: "git",
-						Args:    []string{"init"},
+						Name:       "scd2-by-time: initialize git repository",
+						Command:    "git",
+						Args:       []string{"init"},
 						WorkingDir: filepath.Join(tempDir, "test-scd2-by-time"),
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -265,7 +265,7 @@ func TestPostgresWorkflows(t *testing.T) {
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
 						},
-					},	
+					},
 					{
 						Name:       "scd2-by-time: copy pipeline files",
 						Command:    "cp",

--- a/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
+++ b/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-column-pipeline/assets/menu.sql
@@ -1,6 +1,6 @@
 /* @bruin
 name: test.menu
-type: pg.sql
+type: pg.sql 
 materialization:
   type: table
   strategy: scd2_by_column
@@ -25,4 +25,9 @@ columns:
 @bruin */
 
 
-SELECT 1 AS ID, 'Cola' AS Name, 0.99 AS Price
+
+SELECT 1 AS ID, 'Cola' AS Name, 3.99 AS Price
+UNION ALL
+SELECT 2 AS ID, 'Tea' AS Name, 4.99 AS Price
+UNION ALL
+SELECT 3 AS ID, 'Coffee' AS Name, 5.99 AS Price

--- a/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
+++ b/integration-tests/cloud-integration-tests/postgres/test-pipelines/scd2-pipelines/scd2-by-time-pipeline/assets/products.sql
@@ -14,7 +14,6 @@ columns:
     primary_key: true
   - name: product_name
     type: VARCHAR
-    description: "Name of the product"
     primary_key: true
   - name: dt
     type: DATE
@@ -23,11 +22,27 @@ columns:
     type: INTEGER
     description: "Number of units in stock"
 @bruin */
+SELECT
+    1 AS product_id,
+    'Laptop' AS product_name,
+    100 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    2 AS product_id,
+    'Smartphone' AS product_name,
 
+    150 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
 SELECT
     3 AS product_id,
     'Headphones' AS product_name,
-    1200 AS stock,
-    DATE '2025-06-10' AS dt
-
-
+    175 AS stock,
+    DATE '2025-04-02' AS dt
+UNION ALL
+SELECT
+    4 AS product_id,
+    'Monitor' AS product_name,
+    25 AS stock,
+    DATE '2025-04-02' AS dt


### PR DESCRIPTION
Tests now run using a temp directory, which avoids file clean up after running tests. 

