### PR TITLE
feat: add optional failure flag to data diff

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -71,6 +71,7 @@ func DataDiffCmd() *cli.Command {
 	var configFilePath string
 	var tolerance float64
 	var schemaOnly bool
+	var failIfDiff bool
 
 	return &cli.Command{
 		Name:    "data-diff",
@@ -101,6 +102,11 @@ func DataDiffCmd() *cli.Command {
 				Name:        "schema-only",
 				Usage:       "Compare only table schemas without analyzing row counts or column distributions",
 				Destination: &schemaOnly,
+			},
+			&cli.BoolFlag{
+				Name:        "fail-if-diff",
+				Usage:       "Return a non-zero exit code if differences are found",
+				Destination: &failIfDiff,
 			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
@@ -178,8 +184,8 @@ func DataDiffCmd() *cli.Command {
 
 			if schemaComparison != nil {
 				hasDifferences := printSchemaComparisonOutput(*schemaComparison, table1Identifier, table2Identifier, tolerance, schemaOnly, c.Writer)
-				if hasDifferences {
-					return cli.Exit("", 1) // Exit with code 1 when differences are found
+				if hasDifferences && failIfDiff {
+					return cli.Exit("", 1) // Exit with code 1 when differences are found and flag is set
 				}
 			} else {
 				fmt.Fprintf(c.ErrWriter, "\nUnable to compare summaries - the comparison result is nil\n")

--- a/cmd/mcp/docs/overview.md
+++ b/cmd/mcp/docs/overview.md
@@ -41,12 +41,15 @@ bruin data-diff [command options]
 
 Compares data between two environments or sources. Table names can be provided as 'connection:table' or just 'table' if a default connection is set via --connection flag.
 
+By default, the command exits with code 0 even when differences are detected. Use --fail-if-diff to exit with a non-zero code when differences are found.
+
 Flags:
 Flag	Alias	Description
 --connection value	-c value	Name of the default connection to use, if not specified in the table argument (e.g. conn:table)
 --config-file value		The path to the .bruin.yml file [$BRUIN_CONFIG_FILE]
 --tolerance value	-t value	Tolerance percentage for considering values equal (default: 0.001%). Values with percentage difference below this threshold are considered equal. (default: 0.001)
 --schema-only		Compare only table schemas without analyzing row counts or column distributions (default: false)
+--fail-if-diff                          Return a non-zero exit code if differences are found (default: false)
 --help	-h	Show help
 
 ------

--- a/docs/commands/data-diff.md
+++ b/docs/commands/data-diff.md
@@ -14,6 +14,8 @@ This command is particularly useful for:
 bruin data-diff [FLAGS] <table1> <table2>
 ```
 
+By default, this command exits with a status code of `0` even when differences are found. Use `--fail-if-diff` to exit with a non-zero code when differences are detected.
+
 **Arguments:**
 
 - **table1:** The first table to compare. Can be specified as `connection:table` or just `table` if using a default connection.
@@ -36,6 +38,7 @@ table td:first-child {
 | `--connection`, `-c` | str | - | Name of the default connection to use when connection is not specified in table arguments |
 | `--tolerance`, `-t` | float | `0.001` | Tolerance percentage for considering values equal. Values with percentage difference below this threshold are considered equal |
 | `--config-file` | str | `.bruin.yml` | The path to the .bruin.yml configuration file |
+| `--fail-if-diff` | bool | `false` | Return a non-zero exit code if differences are found |
 
 ## Table Identifier Format
 


### PR DESCRIPTION
## Summary
- add `--fail-if-diff` flag to `data-diff` so differences default to exit 0
- document new flag and default exit behavior

## Testing
- `make format`
- `make test` *(fails: Timeout exceeded: try increasing it by passing --timeout option)*


------
https://chatgpt.com/codex/tasks/task_e_68a413ed1a148320a9e64d7fb151d5b9