### PR TITLE
Feature: initialise template in place 

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -262,6 +262,7 @@ func Init() *cli.Command {
 
 			var bruinYmlPath string
 			repoRoot, err := git.FindRepoFromPath(".")
+			//nolint:nestif
 			if err != nil {
 				var targetDir string
 
@@ -290,8 +291,15 @@ func Init() *cli.Command {
 					return cli.Exit("", 1)
 				}
 
-				bruinYmlPath = filepath.Join("bruin", ".bruin.yml")
-				inputPath = filepath.Join("bruin", inputPath)
+				if c.IsSet("in-place") {
+					// When using --in-place, use current directory for .bruin.yml and inputPath.
+					bruinYmlPath = filepath.Join(targetDir, ".bruin.yml")
+					inputPath = filepath.Join(targetDir, inputPath)
+				} else {
+					// When not using --in-place, use bruin subdirectory.
+					bruinYmlPath = filepath.Join("bruin", ".bruin.yml")
+					inputPath = filepath.Join("bruin", inputPath)
+				}
 			} else {
 				bruinYmlPath = filepath.Join(repoRoot.Path, ".bruin.yml")
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -266,13 +266,8 @@ func Init() *cli.Command {
 				var targetDir string
 
 				if c.IsSet("in-place") {
-					// Initialize in current directory
-					var err error
-					targetDir, err = os.Getwd()
-					if err != nil {
-						errorPrinter.Printf("Failed to get current directory: %v\n", err)
-						return cli.Exit("", 1)
-					}
+					// Initialize in given directory
+					targetDir = inputPath
 				} else {
 					// Create a bruin root directory
 					if err := os.MkdirAll("bruin", 0o755); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -267,7 +267,11 @@ func Init() *cli.Command {
 
 				if c.IsSet("in-place") {
 					// Initialize in given directory
-					targetDir = inputPath
+					targetDir, err = os.Getwd()
+					if err != nil {
+						errorPrinter.Printf("Failed to get current working directory: %v\n", err)
+						return cli.Exit("", 1)
+					}
 				} else {
 					// Create a bruin root directory
 					if err := os.MkdirAll("bruin", 0o755); err != nil {


### PR DESCRIPTION
The command bruin init --in-place {template-name} now creates the template in an unitialised repo without creating the bruin parent folder. 