### PR TITLE
Fix: improve test logging for debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ integration-test: build
 	@mkdir -p integration-tests/logs/runs
 	@echo "$(OK_COLOR)==> Running integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
-	@cd integration-tests && go test -tags="no_duckdb_arrow" -v -count=1 .
+	@cd integration-tests && env SILENT=1 go test -tags="no_duckdb_arrow" -v -count=1 .
 
 integration-test-light: build
 	@rm -rf integration-tests/duckdb-files  # Clean up the directory if it exists
@@ -57,7 +57,7 @@ integration-test-light: build
 	@mkdir -p integration-tests/logs/runs
 	@echo "$(OK_COLOR)==> Running integration tests (skipping ingestr tasks)...$(NO_COLOR)"
 	@cd integration-tests && git init
-	@cd integration-tests && go test -tags="no_duckdb_arrow" -v -count=1 -run "^(TestIndividualTasks|TestWorkflowTasks)" .
+	@cd integration-tests && env SILENT=1 go test -tags="no_duckdb_arrow" -v -count=1 -run "^(TestIndividualTasks|TestWorkflowTasks)" .
 
 integration-test-cloud: build
 	@touch integration-tests/cloud-integration-tests/.git
@@ -66,7 +66,7 @@ integration-test-cloud: build
 	@rm integration-tests/cloud-integration-tests/bruin
 	@echo "$(OK_COLOR)==> Running cloud integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
-	@cd integration-tests/cloud-integration-tests && go test -count=1 -v .
+	@cd integration-tests/cloud-integration-tests && env SILENT=1 go test -count=1 -v .
 
 clean:
 	@rm -rf ./bin

--- a/pkg/e2e/task.go
+++ b/pkg/e2e/task.go
@@ -40,6 +40,10 @@ func (s *Task) Run() error {
 	if s.Retries == 0 {
 		s.Retries = 1
 	}
+	silent := os.Getenv("SILENT") == "1"
+	if !silent {
+		log.Printf("Running task: %s", s.Name)
+	}
 
 	for attempt := 1; attempt <= s.Retries; attempt++ {
 		if s.Retries > 1 {

--- a/pkg/e2e/workflow.go
+++ b/pkg/e2e/workflow.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/google/uuid"
 )
@@ -23,8 +24,17 @@ type Workflow struct {
 }
 
 func (w *Workflow) Run() error {
+
+	silent := os.Getenv("SILENT") == "1"
+	if !silent {
+		log.Printf("Starting workflow: %s", w.Name)
+	}
+
 	if w.Name == "" {
 		w.Name = "workflow-" + uuid.New().String()
+		if !silent {
+			log.Printf("Generated new workflow name: %s", w.Name)
+		}
 	}
 
 	for _, task := range w.Steps {
@@ -39,5 +49,8 @@ func (w *Workflow) Run() error {
 		}
 	}
 
+	if !silent {
+		log.Printf("Completed workflow: %s", w.Name)
+	}
 	return nil
 }

--- a/pkg/e2e/workflow.go
+++ b/pkg/e2e/workflow.go
@@ -24,7 +24,6 @@ type Workflow struct {
 }
 
 func (w *Workflow) Run() error {
-
 	silent := os.Getenv("SILENT") == "1"
 	if !silent {
 		log.Printf("Starting workflow: %s", w.Name)


### PR DESCRIPTION
In a previous PR I deleted the test logs are we were no longer using the for the `make integration-test` command output. They are however still useful when debugging single tests, as you can more clearly see in which step a workflow failed etc. So I re-implemented the comments but added a flag to silence them on running the `make integration-test` command. 