### PR TITLE
feat: add domain parameter to Salesforce connection

### DIFF
--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -3,7 +3,7 @@
 
 Bruin supports Salesforce as a source for [ingestr assets](/assets/ingestr), and you can use it to ingest data from Salesforce into your data platform.
 
-To set up a Salesforce connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `username`, `password` and `token`. You can obtain your security token by logging into your Salesforce account and navigating to the user settings under "Reset My Security Token."
+To set up a Salesforce connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `username`, `password` and `token`. Optionally, you can specify a `domain` for custom Salesforce domains. You can obtain your security token by logging into your Salesforce account and navigating to the user settings under "Reset My Security Token."
 
 Follow the steps below to set up Salesforce correctly as a data source and run ingestion.
 ### Step 1: Add a connection to the .bruin.yml file
@@ -14,10 +14,12 @@ connections:
               username: "user_123"
               password: "pass_123"
               token: "token_123"
+              domain: "your-domain.my.salesforce.com"  # optional
 ```
 - `username` is your Salesforce account username.
 - `password` is your Salesforce account password.
 - `token` is your Salesforce security token.
+- `domain` is your custom Salesforce domain (optional). If not specified, login.salesforce.com will be used.
 
 ### Step 2: Create an asset file for data ingestion
 To ingest data from Salesforce, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., salesforce_ingestion.yml) inside the assets folder and add the following content:

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -790,6 +790,7 @@ type SalesforceConnection struct {
 	Username string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
 	Password string `yaml:"password,omitempty" json:"password" mapstructure:"password"`
 	Token    string `yaml:"token,omitempty" json:"token" mapstructure:"token"`
+	Domain   string `yaml:"domain,omitempty" json:"domain" mapstructure:"domain"`
 }
 
 func (c SalesforceConnection) GetName() string {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -491,6 +491,7 @@ func TestLoadFromFile(t *testing.T) {
 					Username: "username-123",
 					Password: "password-123",
 					Token:    "token-123",
+					Domain:   "mydomain.my.salesforce.com",
 				},
 			},
 			SQLite: []SQLiteConnection{

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -305,6 +305,7 @@ environments:
           username: "username-123"
           password: "password-123"
           token: "token-123"
+          domain: "mydomain.my.salesforce.com"
       sqlite:
         - name: "sqlite-1"
           path: "C:\\path\\to\\sqlite.db"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -305,6 +305,7 @@ environments:
           username: "username-123"
           password: "password-123"
           token: "token-123"
+          domain: "mydomain.my.salesforce.com"
       sqlite:
         - name: "sqlite-1"
           path: "C:\\path\\to\\sqlite.db"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1680,6 +1680,7 @@ func (m *Manager) AddSalesforceConnectionFromConfig(connection *config.Salesforc
 		Username: connection.Username,
 		Password: connection.Password,
 		Token:    connection.Token,
+		Domain:   connection.Domain,
 	})
 	if err != nil {
 		return err

--- a/pkg/salesforce/config.go
+++ b/pkg/salesforce/config.go
@@ -8,14 +8,18 @@ type Config struct {
 	Username string
 	Password string
 	Token    string
+	Domain   string
 }
 
 func (c *Config) GetIngestrURI() string {
-	// salesforce://?username=<your_username>&password=<your_password>&token=<your_token>
+	// salesforce://?username=<your_username>&password=<your_password>&token=<your_token>&domain=<your_domain>
 	baseURL := "salesforce://"
 	params := url.Values{}
 	params.Add("username", c.Username)
 	params.Add("password", c.Password)
 	params.Add("token", c.Token)
+	if c.Domain != "" {
+		params.Add("domain", c.Domain)
+	}
 	return baseURL + "?" + params.Encode()
 }


### PR DESCRIPTION
## Summary
- Add optional domain parameter to Salesforce integration
- Support custom Salesforce domains in connection configuration
- Maintain backward compatibility with existing configurations

## Changes
- **Salesforce Config**: Added `Domain` field to config struct with conditional URI building
- **Connection Configuration**: Added domain field with proper YAML/JSON tags
- **Connection Manager**: Updated to pass domain parameter to Salesforce client
- **Documentation**: Updated with domain parameter usage examples
- **Tests**: Updated test configurations and expectations

## Test plan
- [x] All existing tests pass
- [x] Go vet passes without errors
- [x] Code compiles successfully
- [x] Test configurations updated to include domain parameter
- [x] Backward compatibility maintained (domain is optional)

🤖 Generated with [Claude Code](https://claude.ai/code)