### PR TITLE
Fix table comparison row count error

### DIFF
--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -572,6 +573,13 @@ func (d *Client) GetTableSummary(ctx context.Context, tableName string, schemaOn
 				rowCount = int64(val)
 			case float64:
 				rowCount = int64(val)
+			case string:
+				// Handle string representation of numbers (common with BigQuery)
+				parsed, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse row count string '%s' for table '%s': %w", val, tableName, err)
+				}
+				rowCount = parsed
 			default:
 				return nil, fmt.Errorf("unexpected row count type for table '%s': got %T with value %v", tableName, val, val)
 			}

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/diff"
@@ -198,6 +199,13 @@ func (c *Client) GetTableSummary(ctx context.Context, tableName string, schemaOn
 				rowCount = int64(val)
 			case float64:
 				rowCount = int64(val)
+			case string:
+				// Handle string representation of numbers
+				parsed, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse row count string '%s' for table '%s': %w", val, tableName, err)
+				}
+				rowCount = parsed
 			default:
 				return nil, fmt.Errorf("unexpected row count type for table '%s': got %T with value %v", tableName, val, val)
 			}

--- a/pkg/postgres/db.go
+++ b/pkg/postgres/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -435,6 +436,13 @@ func (c *Client) GetTableSummary(ctx context.Context, tableName string, schemaOn
 				rowCount = int64(val)
 			case float64:
 				rowCount = int64(val)
+			case string:
+				// Handle string representation of numbers
+				parsed, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse row count string '%s' for table '%s': %w", val, tableName, err)
+				}
+				rowCount = parsed
 			default:
 				return nil, fmt.Errorf("unexpected row count type for table '%s': got %T with value %v", tableName, val, val)
 			}

--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -460,6 +461,13 @@ func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly 
 				rowCount = int64(val)
 			case float64:
 				rowCount = int64(val)
+			case string:
+				// Handle string representation of numbers (common with Snowflake)
+				parsed, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse row count string '%s' for table '%s': %w", val, tableName, err)
+				}
+				rowCount = parsed
 			default:
 				return nil, fmt.Errorf("unexpected row count type for table '%s': got %T with value %v", tableName, val, val)
 			}


### PR DESCRIPTION
Add string parsing for row counts in `GetTableSummary` across all database clients to resolve table diff errors when row counts are returned as strings.

Previously, databases like Snowflake could return row counts as strings (e.g., '2363249'), which was not handled by the `GetTableSummary` function. This led to an 'unexpected row count type' error, preventing the table diff feature from working. This change makes the function more robust by converting string-represented numbers to `int64`.

---
[Slack Thread](https://bruintalk.slack.com/archives/C066JBNP3U2/p1758099191746639?thread_ts=1758099191.746639&cid=C066JBNP3U2)

<a href="https://cursor.com/background-agent?bcId=bc-f6d06415-c171-4821-8b9a-50c7572ba7af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6d06415-c171-4821-8b9a-50c7572ba7af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

