### PR TITLE
Fix: duckdb float

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -124,6 +124,7 @@ func Query() *cli.Command {
 
 				queryStr = addLimitToQuery(queryStr, c.Int64("limit"), conn, parser, dialect)
 			}
+			//nolint:nestif
 			if querier, ok := conn.(interface {
 				SelectWithSchema(ctx context.Context, q *query.Query) (*query.QueryResult, error)
 			}); ok {

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -139,8 +139,6 @@ func Query() *cli.Command {
 				if err != nil {
 					return handleError(c.String("output"), errors.Wrap(err, "query execution failed"))
 				}
-				// Determine connection type from asset type (more reliable than reflection)
-				// Fall back to reflection if assetType is empty (direct query mode)
 				var connectionType string
 				if assetType != "" {
 					connectionType = getConnectionTypeFromAssetType(string(assetType))

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -138,8 +138,14 @@ func Query() *cli.Command {
 				if err != nil {
 					return handleError(c.String("output"), errors.Wrap(err, "query execution failed"))
 				}
-				// Determine connection type once
-				connectionType := getConnectionType(conn)
+				// Determine connection type from asset type (more reliable than reflection)
+				// Fall back to reflection if assetType is empty (direct query mode)
+				var connectionType string
+				if assetType != "" {
+					connectionType = getConnectionTypeFromAssetType(string(assetType))
+				} else {
+					connectionType = getConnectionType(conn)
+				}
 
 				// Output result based on format specified
 				inputPath := c.String("asset")

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/big"
 	"os"
+	"reflect"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"time"
 
@@ -170,5 +173,221 @@ func printWarningForOutput(output string, message string) {
 		fmt.Println(string(jsonData))
 	} else {
 		warningPrinter.Printf("%s\n", message)
+	}
+}
+
+// connectionTypeMap maps package paths to connection type names
+var connectionTypeMap = map[string]string{
+	"duckdb":     "duckdb",
+	"bigquery":   "bigquery",
+	"postgres":   "postgres",
+	"snowflake":  "snowflake",
+	"mysql":      "mysql",
+	"mssql":      "mssql",
+	"clickhouse": "clickhouse",
+	"athena":     "athena",
+	"databricks": "databricks",
+	"oracle":     "oracle",
+	"sqlite":     "sqlite",
+	"trino":      "trino",
+	"synapse":    "synapse",
+	"hana":       "hana",
+	"spanner":    "spanner",
+}
+
+// getConnectionType determines the connection type from the connection object
+func getConnectionType(conn interface{}) string {
+	if conn == nil {
+		return "unknown"
+	}
+
+	// Use reflection to determine the connection type
+	connType := reflect.TypeOf(conn)
+	if connType == nil {
+		return "unknown"
+	}
+
+	// If it's a pointer, get the element type
+	if connType.Kind() == reflect.Ptr {
+		connType = connType.Elem()
+	}
+
+	// Get the package name to determine the connection type
+	pkgPath := connType.PkgPath()
+
+	// Check each known connection type
+	for pkgName, connTypeName := range connectionTypeMap {
+		if strings.Contains(pkgPath, pkgName) {
+			return connTypeName
+		}
+	}
+
+	return "unknown"
+}
+
+// formatValue properly formats values based on the connection type
+// Handles platform-specific value formatting (e.g., DuckDB float tuples, etc.)
+func formatValue(val interface{}, connectionType string) string {
+	if val == nil {
+		return ""
+	}
+
+	// Only apply DuckDB-specific formatting for DuckDB connections
+	if connectionType != "duckdb" {
+		// For non-DuckDB connections, use standard formatting
+		switch v := val.(type) {
+		case float64:
+			return fmt.Sprintf("%g", v)
+		case float32:
+			return fmt.Sprintf("%g", v)
+		case int64:
+			return fmt.Sprintf("%d", v)
+		case int32:
+			return fmt.Sprintf("%d", v)
+		case int:
+			return fmt.Sprintf("%d", v)
+		case string:
+			return v
+		case bool:
+			return fmt.Sprintf("%t", v)
+		default:
+			return fmt.Sprintf("%v", val)
+		}
+	}
+
+	// Handle different types that DuckDB might return
+	switch v := val.(type) {
+	case float64:
+		// Format float64 with appropriate precision
+		return fmt.Sprintf("%g", v)
+	case float32:
+		// Format float32 with appropriate precision
+		return fmt.Sprintf("%g", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case int32:
+		return fmt.Sprintf("%d", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case string:
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	default:
+		// Try to handle DuckDB decimal types using reflection
+		// DuckDB might return a struct that implements certain methods
+		rv := reflect.ValueOf(val)
+		if rv.Kind() == reflect.Struct {
+			// Try to access fields by index (DuckDB structs might have fields in order: Width, Scale, Value)
+			if rv.NumField() >= 3 {
+				widthField := rv.Field(0)
+				scaleField := rv.Field(1)
+				valueField := rv.Field(2)
+
+				if widthField.IsValid() && scaleField.IsValid() && valueField.IsValid() {
+					// This might be a DuckDB decimal struct
+					if valueField.CanInterface() && scaleField.CanInterface() {
+						value := valueField.Interface()
+						scale := scaleField.Interface()
+
+						// Convert value to float64
+						var floatValue float64
+						switch v := value.(type) {
+						case *big.Int:
+							// Convert big.Int to float64
+							floatValue, _ = new(big.Float).SetInt(v).Float64()
+						case int64:
+							floatValue = float64(v)
+						case int32:
+							floatValue = float64(v)
+						case int:
+							floatValue = float64(v)
+						case float64:
+							floatValue = v
+						case float32:
+							floatValue = float64(v)
+						default:
+							// Fallback to string representation
+							return fmt.Sprintf("%v", val)
+						}
+
+						// Convert scale to int
+						var scaleInt int
+						switch s := scale.(type) {
+						case uint8:
+							scaleInt = int(s)
+						case int64:
+							scaleInt = int(s)
+						case int32:
+							scaleInt = int(s)
+						case int:
+							scaleInt = s
+						default:
+							// Fallback: assume scale of 1
+							scaleInt = 1
+						}
+
+						// Convert using the scale: divide by 10^scale
+						divisor := 1.0
+						for i := 0; i < scaleInt; i++ {
+							divisor *= 10
+						}
+						return fmt.Sprintf("%g", floatValue/divisor)
+					}
+				}
+			}
+		}
+
+		// For other types, try to extract the actual value
+		valStr := fmt.Sprintf("%v", val)
+
+		// Check if it's a DuckDB tuple-like string (contains braces)
+		// DuckDB returns floats as {width scale value} format
+		// Examples: {2 1 15} for 1.5, {6 5 314159} for 3.14159
+		if strings.HasPrefix(valStr, "{") && strings.HasSuffix(valStr, "}") {
+			// Remove braces and split by spaces
+			inner := strings.Trim(valStr, "{}")
+			parts := strings.Fields(inner)
+			if len(parts) >= 3 {
+				// For DuckDB float tuples, the format is {width scale value}
+				// where the second part is the scale and the last part is the value
+				scaleStr := parts[1]
+				valueStr := parts[2]
+
+				if scale, err := strconv.Atoi(scaleStr); err == nil {
+					if value, err := strconv.ParseFloat(valueStr, 64); err == nil {
+						// Convert using the scale: divide by 10^scale
+						divisor := 1.0
+						for i := 0; i < scale; i++ {
+							divisor *= 10
+						}
+						return fmt.Sprintf("%g", value/divisor)
+					}
+				}
+			}
+		}
+
+		// Check if it's a tuple-like string (contains parentheses)
+		if strings.Contains(valStr, "(") && strings.Contains(valStr, ")") {
+			// Try to extract the numeric value from tuple-like strings
+			// This handles cases where DuckDB returns floats as tuples
+			if strings.HasPrefix(valStr, "(") && strings.HasSuffix(valStr, ")") {
+				// Remove parentheses and try to parse as float
+				inner := strings.Trim(valStr, "()")
+				if innerFloat, err := strconv.ParseFloat(inner, 64); err == nil {
+					return fmt.Sprintf("%g", innerFloat)
+				}
+			}
+		}
+
+		// Handle single-element slices (might be how DuckDB returns single values)
+		if rv.Kind() == reflect.Slice && rv.Len() == 1 {
+			elem := rv.Index(0)
+			if elem.CanInterface() {
+				return formatValue(elem.Interface(), connectionType)
+			}
+		}
+
+		return valStr
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -176,65 +176,93 @@ func printWarningForOutput(output string, message string) {
 	}
 }
 
-// connectionTypeMap maps package paths to connection type names
-var connectionTypeMap = map[string]string{
-	"duckdb":     "duckdb",
-	"bigquery":   "bigquery",
-	"postgres":   "postgres",
-	"snowflake":  "snowflake",
-	"mysql":      "mysql",
-	"mssql":      "mssql",
-	"clickhouse": "clickhouse",
-	"athena":     "athena",
-	"databricks": "databricks",
-	"oracle":     "oracle",
-	"sqlite":     "sqlite",
-	"trino":      "trino",
-	"synapse":    "synapse",
-	"hana":       "hana",
-	"spanner":    "spanner",
+// Asset type to connection type mapping
+var assetTypeToConnectionMap = map[string]string{
+	"duckdb.sql":        "duckdb",
+	"duckdb.seed":       "duckdb",
+	"duckdb.source":     "duckdb",
+	"bq.sql":            "bigquery",
+	"bq.seed":           "bigquery",
+	"bq.source":         "bigquery",
+	"sf.sql":            "snowflake",
+	"sf.seed":           "snowflake",
+	"sf.source":         "snowflake",
+	"pg.sql":            "postgres",
+	"pg.seed":           "postgres",
+	"pg.source":         "postgres",
+	"ms.sql":            "mssql",
+	"ms.seed":           "mssql",
+	"ms.source":         "mssql",
+	"athena.sql":        "athena",
+	"athena.seed":       "athena",
+	"athena.source":     "athena",
+	"clickhouse.sql":    "clickhouse",
+	"clickhouse.seed":   "clickhouse",
+	"clickhouse.source": "clickhouse",
+	"databricks.sql":    "databricks",
+	"databricks.seed":   "databricks",
+	"databricks.source": "databricks",
+	"synapse.sql":       "synapse",
+	"synapse.seed":      "synapse",
+	"synapse.source":    "synapse",
+	"trino.sql":         "trino",
+	"oracle.sql":        "oracle",
+	"oracle.source":     "oracle",
+	"hana.sql":          "hana",
+	"hana.source":       "hana",
+	"spanner.sql":       "spanner",
+	"spanner.source":    "spanner",
 }
 
-// getConnectionType determines the connection type from the connection object
+var knownConnections = []string{
+	"duckdb", "bigquery", "postgres", "snowflake", "mysql", "mssql",
+	"clickhouse", "athena", "databricks", "oracle", "sqlite", "trino",
+	"synapse", "hana", "spanner", "redshift",
+}
+
+func getConnectionTypeFromAssetType(assetType string) string {
+	if assetType == "" {
+		return "unknown"
+	}
+
+	if connType, exists := assetTypeToConnectionMap[assetType]; exists {
+		return connType
+	}
+
+	return "unknown"
+}
+
 func getConnectionType(conn interface{}) string {
 	if conn == nil {
 		return "unknown"
 	}
 
-	// Use reflection to determine the connection type
 	connType := reflect.TypeOf(conn)
 	if connType == nil {
 		return "unknown"
 	}
 
-	// If it's a pointer, get the element type
 	if connType.Kind() == reflect.Ptr {
 		connType = connType.Elem()
 	}
 
-	// Get the package name to determine the connection type
 	pkgPath := connType.PkgPath()
 
-	// Check each known connection type
-	for pkgName, connTypeName := range connectionTypeMap {
-		if strings.Contains(pkgPath, pkgName) {
-			return connTypeName
+	for _, connName := range knownConnections {
+		if strings.Contains(pkgPath, connName) {
+			return connName
 		}
 	}
 
 	return "unknown"
 }
 
-// formatValue properly formats values based on the connection type
-// Handles platform-specific value formatting (e.g., DuckDB float tuples, etc.)
 func formatValue(val interface{}, connectionType string) string {
 	if val == nil {
 		return ""
 	}
 
-	// Only apply DuckDB-specific formatting for DuckDB connections
 	if connectionType != "duckdb" {
-		// For non-DuckDB connections, use standard formatting
 		switch v := val.(type) {
 		case float64:
 			return fmt.Sprintf("%g", v)
@@ -255,13 +283,10 @@ func formatValue(val interface{}, connectionType string) string {
 		}
 	}
 
-	// Handle different types that DuckDB might return
 	switch v := val.(type) {
 	case float64:
-		// Format float64 with appropriate precision
 		return fmt.Sprintf("%g", v)
 	case float32:
-		// Format float32 with appropriate precision
 		return fmt.Sprintf("%g", v)
 	case int64:
 		return fmt.Sprintf("%d", v)
@@ -274,27 +299,21 @@ func formatValue(val interface{}, connectionType string) string {
 	case bool:
 		return fmt.Sprintf("%t", v)
 	default:
-		// Try to handle DuckDB decimal types using reflection
-		// DuckDB might return a struct that implements certain methods
 		rv := reflect.ValueOf(val)
 		if rv.Kind() == reflect.Struct {
-			// Try to access fields by index (DuckDB structs might have fields in order: Width, Scale, Value)
 			if rv.NumField() >= 3 {
 				widthField := rv.Field(0)
 				scaleField := rv.Field(1)
 				valueField := rv.Field(2)
 
 				if widthField.IsValid() && scaleField.IsValid() && valueField.IsValid() {
-					// This might be a DuckDB decimal struct
 					if valueField.CanInterface() && scaleField.CanInterface() {
 						value := valueField.Interface()
 						scale := scaleField.Interface()
 
-						// Convert value to float64
 						var floatValue float64
 						switch v := value.(type) {
 						case *big.Int:
-							// Convert big.Int to float64
 							floatValue, _ = new(big.Float).SetInt(v).Float64()
 						case int64:
 							floatValue = float64(v)
@@ -307,11 +326,9 @@ func formatValue(val interface{}, connectionType string) string {
 						case float32:
 							floatValue = float64(v)
 						default:
-							// Fallback to string representation
 							return fmt.Sprintf("%v", val)
 						}
 
-						// Convert scale to int
 						var scaleInt int
 						switch s := scale.(type) {
 						case uint8:
@@ -323,11 +340,9 @@ func formatValue(val interface{}, connectionType string) string {
 						case int:
 							scaleInt = s
 						default:
-							// Fallback: assume scale of 1
 							scaleInt = 1
 						}
 
-						// Convert using the scale: divide by 10^scale
 						divisor := 1.0
 						for i := 0; i < scaleInt; i++ {
 							divisor *= 10
@@ -338,25 +353,17 @@ func formatValue(val interface{}, connectionType string) string {
 			}
 		}
 
-		// For other types, try to extract the actual value
 		valStr := fmt.Sprintf("%v", val)
 
-		// Check if it's a DuckDB tuple-like string (contains braces)
-		// DuckDB returns floats as {width scale value} format
-		// Examples: {2 1 15} for 1.5, {6 5 314159} for 3.14159
 		if strings.HasPrefix(valStr, "{") && strings.HasSuffix(valStr, "}") {
-			// Remove braces and split by spaces
 			inner := strings.Trim(valStr, "{}")
 			parts := strings.Fields(inner)
 			if len(parts) >= 3 {
-				// For DuckDB float tuples, the format is {width scale value}
-				// where the second part is the scale and the last part is the value
 				scaleStr := parts[1]
 				valueStr := parts[2]
 
 				if scale, err := strconv.Atoi(scaleStr); err == nil {
 					if value, err := strconv.ParseFloat(valueStr, 64); err == nil {
-						// Convert using the scale: divide by 10^scale
 						divisor := 1.0
 						for i := 0; i < scale; i++ {
 							divisor *= 10
@@ -367,12 +374,8 @@ func formatValue(val interface{}, connectionType string) string {
 			}
 		}
 
-		// Check if it's a tuple-like string (contains parentheses)
 		if strings.Contains(valStr, "(") && strings.Contains(valStr, ")") {
-			// Try to extract the numeric value from tuple-like strings
-			// This handles cases where DuckDB returns floats as tuples
 			if strings.HasPrefix(valStr, "(") && strings.HasSuffix(valStr, ")") {
-				// Remove parentheses and try to parse as float
 				inner := strings.Trim(valStr, "()")
 				if innerFloat, err := strconv.ParseFloat(inner, 64); err == nil {
 					return fmt.Sprintf("%g", innerFloat)
@@ -380,7 +383,6 @@ func formatValue(val interface{}, connectionType string) string {
 			}
 		}
 
-		// Handle single-element slices (might be how DuckDB returns single values)
 		if rv.Kind() == reflect.Slice && rv.Len() == 1 {
 			elem := rv.Index(0)
 			if elem.CanInterface() {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -176,7 +176,7 @@ func printWarningForOutput(output string, message string) {
 	}
 }
 
-// Asset type to connection type mapping
+// Asset type to connection type mapping.
 var assetTypeToConnectionMap = map[string]string{
 	"duckdb.sql":        "duckdb",
 	"duckdb.seed":       "duckdb",
@@ -214,6 +214,8 @@ var assetTypeToConnectionMap = map[string]string{
 	"spanner.source":    "spanner",
 }
 
+const unknownConnectionType = "unknown"
+
 var knownConnections = []string{
 	"duckdb", "bigquery", "postgres", "snowflake", "mysql", "mssql",
 	"clickhouse", "athena", "databricks", "oracle", "sqlite", "trino",
@@ -222,24 +224,24 @@ var knownConnections = []string{
 
 func getConnectionTypeFromAssetType(assetType string) string {
 	if assetType == "" {
-		return "unknown"
+		return unknownConnectionType
 	}
 
 	if connType, exists := assetTypeToConnectionMap[assetType]; exists {
 		return connType
 	}
 
-	return "unknown"
+	return unknownConnectionType
 }
 
 func getConnectionType(conn interface{}) string {
 	if conn == nil {
-		return "unknown"
+		return unknownConnectionType
 	}
 
 	connType := reflect.TypeOf(conn)
 	if connType == nil {
-		return "unknown"
+		return unknownConnectionType
 	}
 
 	if connType.Kind() == reflect.Ptr {
@@ -254,7 +256,7 @@ func getConnectionType(conn interface{}) string {
 		}
 	}
 
-	return "unknown"
+	return unknownConnectionType
 }
 
 func formatValue(val interface{}, connectionType string) string {
@@ -269,15 +271,15 @@ func formatValue(val interface{}, connectionType string) string {
 		case float32:
 			return fmt.Sprintf("%g", v)
 		case int64:
-			return fmt.Sprintf("%d", v)
+			return strconv.FormatInt(v, 10)
 		case int32:
-			return fmt.Sprintf("%d", v)
+			return strconv.FormatInt(int64(v), 10)
 		case int:
-			return fmt.Sprintf("%d", v)
+			return strconv.Itoa(v)
 		case string:
 			return v
 		case bool:
-			return fmt.Sprintf("%t", v)
+			return strconv.FormatBool(v)
 		default:
 			return fmt.Sprintf("%v", val)
 		}
@@ -289,15 +291,15 @@ func formatValue(val interface{}, connectionType string) string {
 	case float32:
 		return fmt.Sprintf("%g", v)
 	case int64:
-		return fmt.Sprintf("%d", v)
+		return strconv.FormatInt(v, 10)
 	case int32:
-		return fmt.Sprintf("%d", v)
+		return strconv.FormatInt(int64(v), 10)
 	case int:
-		return fmt.Sprintf("%d", v)
+		return strconv.Itoa(v)
 	case string:
 		return v
 	case bool:
-		return fmt.Sprintf("%t", v)
+		return strconv.FormatBool(v)
 	default:
 		rv := reflect.ValueOf(val)
 		if rv.Kind() == reflect.Struct {
@@ -344,7 +346,7 @@ func formatValue(val interface{}, connectionType string) string {
 						}
 
 						divisor := 1.0
-						for i := 0; i < scaleInt; i++ {
+						for range scaleInt {
 							divisor *= 10
 						}
 						return fmt.Sprintf("%g", floatValue/divisor)
@@ -365,7 +367,7 @@ func formatValue(val interface{}, connectionType string) string {
 				if scale, err := strconv.Atoi(scaleStr); err == nil {
 					if value, err := strconv.ParseFloat(valueStr, 64); err == nil {
 						divisor := 1.0
-						for i := 0; i < scale; i++ {
+						for range scale {
 							divisor *= 10
 						}
 						return fmt.Sprintf("%g", value/divisor)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -264,27 +264,32 @@ func formatValue(val interface{}, connectionType string) string {
 		return ""
 	}
 
-	if connectionType != "duckdb" {
-		switch v := val.(type) {
-		case float64:
-			return fmt.Sprintf("%g", v)
-		case float32:
-			return fmt.Sprintf("%g", v)
-		case int64:
-			return strconv.FormatInt(v, 10)
-		case int32:
-			return strconv.FormatInt(int64(v), 10)
-		case int:
-			return strconv.Itoa(v)
-		case string:
-			return v
-		case bool:
-			return strconv.FormatBool(v)
-		default:
-			return fmt.Sprintf("%v", val)
-		}
+	if connectionType == "duckdb" {
+		return formatValueForDuckDB(val)
 	}
 
+	switch v := val.(type) {
+	case float64:
+		return fmt.Sprintf("%g", v)
+	case float32:
+		return fmt.Sprintf("%g", v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int:
+		return strconv.Itoa(v)
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+
+func formatValueForDuckDB(val interface{}) string {
 	switch v := val.(type) {
 	case float64:
 		return fmt.Sprintf("%g", v)
@@ -388,7 +393,7 @@ func formatValue(val interface{}, connectionType string) string {
 		if rv.Kind() == reflect.Slice && rv.Len() == 1 {
 			elem := rv.Index(0)
 			if elem.CanInterface() {
-				return formatValue(elem.Interface(), connectionType)
+				return formatValue(elem.Interface(), "duckdb")
 			}
 		}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -288,7 +288,6 @@ func formatValue(val interface{}, connectionType string) string {
 	}
 }
 
-
 func formatValueForDuckDB(val interface{}) string {
 	switch v := val.(type) {
 	case float64:

--- a/integration-tests/.bruin.yml
+++ b/integration-tests/.bruin.yml
@@ -242,3 +242,9 @@ environments:
       duckdb:
         - name: "duckdb-scd2-by-time"
           path: "duckdb-files/scd2-by-time.db"
+  
+  env-float-test:
+    connections:
+      duckdb:
+        - name: "duckdb-float-test"
+          path: "duckdb-files/float-test.db"

--- a/integration-tests/expected_connections.json
+++ b/integration-tests/expected_connections.json
@@ -515,6 +515,17 @@
         ]
       },
       "schema_prefix": ""
+    },
+    "env-float-test": {
+      "connections": {
+        "duckdb": [
+          {
+            "name": "duckdb-float-test",
+            "path": "duckdb-files/float-test.db"
+          }
+        ]
+      },
+      "schema_prefix": ""
     }
   }
 }

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -1015,6 +1015,54 @@ func TestIndividualTasks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "query-float-direct-connection",
+			task: e2e.Task{
+				Name:    "query-float-direct-connection",
+				Command: binary,
+				Args:    []string{"query", "--connection", "duckdb-default", "--query", "SELECT 1.5 as float_value, 2.0 as another_float, 3.14159 as pi"},
+				Expected: e2e.Output{
+					ExitCode: 0,
+					Contains: []string{"1.5", "2", "3.14159"},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
+			name: "query-float-different-connection",
+			task: e2e.Task{
+				Name:    "query-float-different-connection",
+				Command: binary,
+				Args:    []string{"query", "--connection", "duckdb-variables", "--query", "SELECT 4.5 as custom_float, 5.0 as another_custom, 0.001 as small_float"},
+				Expected: e2e.Output{
+					ExitCode: 0,
+					Contains: []string{"4.5", "5", "0.001"},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
+			name: "query-float-complex-values",
+			task: e2e.Task{
+				Name:    "query-float-complex-values",
+				Command: binary,
+				Args:    []string{"query", "--connection", "duckdb-default", "--query", "SELECT 123.456 as complex_float, 0.0001 as very_small, 999.999 as large_decimal"},
+				Expected: e2e.Output{
+					ExitCode: 0,
+					Contains: []string{"123.456", "0.0001", "999.999"},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_initial.csv
+++ b/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_initial.csv
@@ -1,4 +1,4 @@
 ID,Name,Price,_is_current
-1,Cola,{3 2 399},true
-2,Tea,{3 2 499},true
-3,Coffee,{3 2 599},true
+1,Cola,3.99,true
+2,Tea,4.99,true
+3,Coffee,5.99,true

--- a/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_updated_01.csv
+++ b/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_updated_01.csv
@@ -1,6 +1,6 @@
 ID,Name,Price,_is_current
-1,Cola,{3 2 399},false
-1,Cola,{3 2 799},true
-2,Tea,{3 2 499},true
-3,Coffee,{3 2 599},false
-4,Fanta,{3 2 199},true
+1,Cola,3.99,false
+1,Cola,7.99,true
+2,Tea,4.99,true
+3,Coffee,5.99,false
+4,Fanta,1.99,true

--- a/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_updated_02.csv
+++ b/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_updated_02.csv
@@ -1,7 +1,7 @@
 ID,Name,Price,_is_current
-1,Cola,{3 2 399},false
-1,Cola,{3 2 799},false
-1,Cola,{3 2 99},true
-2,Tea,{3 2 499},false
-3,Coffee,{3 2 599},false
-4,Fanta,{3 2 199},false
+1,Cola,3.99,false
+1,Cola,7.99,false
+1,Cola,0.99,true
+2,Tea,4.99,false
+3,Coffee,5.99,false
+4,Fanta,1.99,false

--- a/integration-tests/test-pipelines/float-test-pipeline/assets/float_test_asset.sql
+++ b/integration-tests/test-pipelines/float-test-pipeline/assets/float_test_asset.sql
@@ -1,0 +1,8 @@
+-- Test asset for float value formatting
+SELECT 
+    1.5 as simple_float,
+    2.0 as another_float,
+    3.14159 as pi,
+    0.1 as tenth,
+    123.456 as complex_float,
+    0.001 as small_float

--- a/integration-tests/test-pipelines/float-test-pipeline/pipeline.yml
+++ b/integration-tests/test-pipelines/float-test-pipeline/pipeline.yml
@@ -1,0 +1,10 @@
+name: float-test-pipeline
+description: Test pipeline for float value formatting across different connection modes
+
+default_connections:
+  duckdb: "duckdb-float-test"
+
+assets:
+  - name: float_test_asset
+    type: duckdb.sql
+    path: assets/float_test_asset.sql


### PR DESCRIPTION
query command now converts the DuckDB tuple to a float value e.g. whereas before query would return `{3 2 299}` now it return `2.99`.

Added integration tests and adapted expectations of current integration tests.