### PR TITLE
Add bruin.yml connection info to tableau docs

### DIFF
--- a/docs/assets/tableau-refresh.md
+++ b/docs/assets/tableau-refresh.md
@@ -2,6 +2,50 @@
 
 Bruin supports integrating Tableau assets into your data pipelines. You can represent Tableau datasources, workbooks, worksheets, and dashboards as assets, and trigger refreshes for datasources and workbooks directly from your pipeline.
 
+## Connection
+
+In order to set up a Tableau connection, you need to add a configuration item to `connections` in the `.bruin.yml` file.
+
+Tableau supports two authentication methods:
+
+### Personal Access Token (Recommended)
+
+```yaml
+connections:
+  tableau:
+    - name: "connection_name"
+      host: "your-tableau-server.com"
+      site_id: "your-site-id"
+      personal_access_token_name: "your-token-name"
+      personal_access_token_secret: "your-token-secret"
+      api_version: "3.4" # optional, defaults to 3.4
+```
+
+### Username and Password
+
+```yaml
+connections:
+  tableau:
+    - name: "connection_name"
+      host: "your-tableau-server.com"
+      site_id: "your-site-id"
+      username: "your-username"
+      password: "your-password"
+      api_version: "3.4" # optional, defaults to 3.4
+```
+
+**Parameters:**
+- `name`: A unique name for this connection
+- `host`: Your Tableau Server hostname (without https://)
+- `site_id`: The site identifier (content URL) for your Tableau site
+- `personal_access_token_name`: Personal Access Token name (PAT authentication)
+- `personal_access_token_secret`: Personal Access Token secret (PAT authentication)
+- `username`: Your Tableau username (username/password authentication)
+- `password`: Your Tableau password (username/password authentication)
+- `api_version`: Tableau REST API version (optional, defaults to "3.4")
+
+> **Note:** Either Personal Access Token credentials (name and secret) or username/password credentials are required. Personal Access Token authentication is recommended for production environments.
+
 ## Supported Tableau Asset Types
 
 - `tableau.datasource` — Represents a Tableau data source (can be refreshed)


### PR DESCRIPTION
Add `bruin.yml` connection configuration details to the Tableau documentation.

---
[Slack Thread](https://bruintalk.slack.com/archives/D092PT1QB89/p1758902323564119?thread_ts=1758902323.564119&cid=D092PT1QB89)

<a href="https://cursor.com/background-agent?bcId=bc-e1465192-4a16-466c-867f-b3302b7ecd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1465192-4a16-466c-867f-b3302b7ecd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

