### PR TITLE
Fix jinja rendering for asset metadata

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/bigquery" //nolint:unused
@@ -1197,13 +1196,7 @@ func AssetMetadata() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			// Create a proper Jinja renderer with full context including start_date, end_date, etc.
-			// Use yesterday as the default date range, similar to other commands
-			yesterday := time.Now().AddDate(0, 0, -1)
-			startDate := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)
-			endDate := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 23, 59, 59, 999999999, time.UTC)
-			
-			renderer := jinja.NewRendererWithStartEndDates(&startDate, &endDate, pp.Pipeline.Name, "asset-metadata-run", pp.Pipeline.Variables.Value())
+			renderer := jinja.NewRendererWithStartEndDates(&defaultStartDate, &defaultEndDate, pp.Pipeline.Name, "asset-metadata-run", pp.Pipeline.Variables.Value())
 			whole := &query.WholeFileExtractor{Fs: afero.NewOsFs(), Renderer: renderer}
 			extractor, err := whole.CloneForAsset(ctx, pp.Pipeline, pp.Asset)
 			if err != nil {


### PR DESCRIPTION
Replace the limited Jinja renderer with a full-context renderer for `bruin internal asset-metadata` to resolve "missing variable" errors.

The `bruin internal asset-metadata` command was using `query.DefaultJinjaRenderer`, which only provides a very limited set of variables. This caused SQL assets using common Jinja variables like `{{start_date}}` or `{{end_date}}` to fail with "missing variable" errors. By switching to `jinja.NewRendererWithStartEndDates`, the command now has access to a complete set of context variables, aligning its behavior with other commands that render Jinja templates.

---
[Slack Thread](https://bruintalk.slack.com/archives/C07SBCEK5NK/p1758894625859009?thread_ts=1758894625.859009&cid=C07SBCEK5NK)

<a href="https://cursor.com/background-agent?bcId=bc-ffb462fb-5ea6-4134-a359-0b5cbc48e69f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffb462fb-5ea6-4134-a359-0b5cbc48e69f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

