### PR TITLE
Fix: snowflake private key

### DIFF
--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -27,8 +27,47 @@ Where account is the identifier that you can copy here:
 
 ### Key-based Authentication
 
-Snowflake currently supports both password-based authentication as well as key-based authentication. In order to set up key-based authentication, follow the following steps.
+Snowflake currently supports both password-based authentication as well as key-based authentication.
 
+You can configure the private key in two ways:
+
+#### Option 1: Private Key File Path
+
+```yaml
+    connections:
+      snowflake:
+        - name: "connection_name"
+          username: "sfuser"
+          account: "AAAAAAA-AA00000"
+          database: "dev"
+          schema: "schema_name" # optional
+          warehouse: "warehouse_name" # optional
+          role: "data_analyst" # optional
+          region: "eu-west1" # optional
+          private_key_path: "path/to/private_key" # optional
+```
+
+#### Option 2: Private Key Content (Direct)
+
+```yaml
+    connections:
+      snowflake:
+        - name: "connection_name"
+          username: "sfuser"
+          account: "AAAAAAA-AA00000"
+          database: "dev"
+          schema: "schema_name" # optional
+          warehouse: "warehouse_name" # optional
+          role: "data_analyst" # optional
+          region: "eu-west1" # optional
+          private_key: |
+            -----BEGIN PRIVATE KEY-----
+            OEKLvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEIAoIBAQC0Xc2pIYcLxdve
+            E+J5c5f...
+            -----END PRIVATE KEY-----
+```
+
+In order to set up key-based authentication, follow the following steps.
 
 #### Step 1: Generate a key-pair
 

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -274,18 +274,31 @@ type SnowflakeConnection struct {
 }
 
 func (c SnowflakeConnection) MarshalJSON() ([]byte, error) {
+
+	if c.PrivateKey != "" && c.PrivateKeyPath != "" {
+		fmt.Printf("Warning: Both private_key and private_key_path are set for Snowflake connection '%s'. Using private_key content and ignoring private_key_path.\n", c.Name)
+	}
+
+	if c.PrivateKey == "" && c.PrivateKeyPath != "" {
+		contents, err := os.ReadFile(c.PrivateKeyPath)
+		if err != nil {
+			return []byte{}, err
+		}
+
+		c.PrivateKey = string(contents)
+	}
+
 	return json.Marshal(map[string]string{
-		"name":             c.Name,
-		"account":          c.Account,
-		"username":         c.Username,
-		"password":         c.Password,
-		"region":           c.Region,
-		"role":             c.Role,
-		"database":         c.Database,
-		"schema":           c.Schema,
-		"warehouse":        c.Warehouse,
-		"private_key_path": c.PrivateKeyPath,
-		"private_key":      c.PrivateKey,
+		"name":        c.Name,
+		"account":     c.Account,
+		"username":    c.Username,
+		"password":    c.Password,
+		"region":      c.Region,
+		"role":        c.Role,
+		"database":    c.Database,
+		"schema":      c.Schema,
+		"warehouse":   c.Warehouse,
+		"private_key": c.PrivateKey,
 	})
 }
 

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -274,7 +274,6 @@ type SnowflakeConnection struct {
 }
 
 func (c SnowflakeConnection) MarshalJSON() ([]byte, error) {
-
 	if c.PrivateKey != "" && c.PrivateKeyPath != "" {
 		fmt.Printf("Warning: Both private_key and private_key_path are set for Snowflake connection '%s'. Using private_key content and ignoring private_key_path.\n", c.Name)
 	}


### PR DESCRIPTION
Fixed Private Key Injection:

1. Modified `SnowflakeConnection.MarshalJSON()` to read private key content from files automatically. Python assets now receive the actual private key content, not just file paths
2.  Removed `private_key_path` from JSON output sent to Python assets
3. Added Warning for Configuration Conflicts. Shows warning when both `private_key` and `private_key_path` are specified.
Explains which value is being used (direct content takes priority).
4. Updated Documentation