### PR TITLE
Feature: added start and end date to asset-metadata

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -1196,6 +1196,8 @@ func AssetMetadata() *cli.Command {
 				return cli.Exit("asset path is required", 1)
 			}
 
+			environment := c.String("environment")
+
 			fs := afero.NewOsFs()
 
 			pp, err := GetPipelineAndAsset(ctx, assetPath, fs, c.String("config-file"))
@@ -1204,7 +1206,16 @@ func AssetMetadata() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			manager, errs := connection.NewManagerFromConfig(pp.Config)
+			// Load config and switch environment if specified
+			cm := pp.Config
+			if environment != "" {
+				err = switchEnvironment(environment, false, cm, os.Stdin)
+				if err != nil {
+					return err
+				}
+			}
+
+			manager, errs := connection.NewManagerFromConfig(cm)
 			if len(errs) > 0 {
 				printErrorJSON(errs[0])
 				return cli.Exit("", 1)

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -1167,8 +1167,8 @@ func AssetMetadata() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "environment",
-				Aliases: []string{"env"},
-				Usage:   "Target environment name as defined in .bruin.yml",
+				Aliases: []string{"e", "env"},
+				Usage:   "the environment to use",
 			},
 			&cli.StringFlag{
 				Name:    "config-file",

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -9,9 +9,6 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
 func BenchmarkInternalParsePipeline(b *testing.B) {
@@ -193,65 +190,4 @@ func normalize(s string) string {
 		}
 	}
 	return strings.Join(out, "\n")
-}
-
-func TestAssetMetadataCommand(t *testing.T) {
-	t.Parallel()
-	cmd := AssetMetadata()
-
-	assert.Equal(t, "asset-metadata", cmd.Name)
-	assert.NotNil(t, cmd.Action)
-
-	flagNames := make(map[string]bool)
-	for _, flag := range cmd.Flags {
-		if f, ok := flag.(*cli.StringFlag); ok {
-			flagNames[f.Name] = true
-		}
-	}
-
-	expectedFlags := []string{"environment", "config-file", "start-date", "end-date"}
-	for _, expectedFlag := range expectedFlags {
-		assert.True(t, flagNames[expectedFlag], "Expected flag %s to be present", expectedFlag)
-	}
-
-	startDateFlag := findStringFlag(cmd.Flags, "start-date")
-	require.NotNil(t, startDateFlag, "start-date flag should exist")
-	assert.Contains(t, startDateFlag.Usage, "start date of the range")
-	assert.Contains(t, startDateFlag.Usage, "YYYY-MM-DD")
-	assert.NotNil(t, startDateFlag.Sources, "start-date flag should have sources")
-
-	endDateFlag := findStringFlag(cmd.Flags, "end-date")
-	require.NotNil(t, endDateFlag, "end-date flag should exist")
-	assert.Contains(t, endDateFlag.Usage, "end date of the range")
-	assert.Contains(t, endDateFlag.Usage, "YYYY-MM-DD")
-	assert.NotNil(t, endDateFlag.Sources, "end-date flag should have sources")
-}
-
-func TestAssetMetadataDefaultDates(t *testing.T) {
-	t.Parallel()
-
-	yesterday := time.Now().AddDate(0, 0, -1)
-	expectedStartDate := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)
-	expectedEndDate := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 23, 59, 59, 0, time.UTC)
-
-	assert.Equal(t, expectedStartDate, defaultStartDate, "Default start date should be beginning of yesterday")
-	assert.Equal(t, expectedEndDate, defaultEndDate, "Default end date should be end of yesterday")
-
-	cmd := AssetMetadata()
-	startDateFlag := findStringFlag(cmd.Flags, "start-date")
-	require.NotNil(t, startDateFlag)
-	assert.Equal(t, expectedStartDate.Format("2006-01-02 15:04:05.000000"), startDateFlag.Value)
-
-	endDateFlag := findStringFlag(cmd.Flags, "end-date")
-	require.NotNil(t, endDateFlag)
-	assert.Equal(t, expectedEndDate.Format("2006-01-02 15:04:05")+".999999", endDateFlag.Value)
-}
-
-func findStringFlag(flags []cli.Flag, name string) *cli.StringFlag {
-	for _, flag := range flags {
-		if stringFlag, ok := flag.(*cli.StringFlag); ok && stringFlag.Name == name {
-			return stringFlag
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Add flags environment, start-date and end-date to asset-metadata.

Tested manually.