### PR TITLE
Add full refresh flag to context

### DIFF
--- a/docs/assets/templating/templating.md
+++ b/docs/assets/templating/templating.md
@@ -66,6 +66,7 @@ Bruin injects various variables by default:
 | `end_timestamp` | The end timestamp in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) format | "2023-12-02T15:30:00.000000Z07:00" |
 | `pipeline` | The name of the currently executing pipeline | `my_pipeline` |
 | `run_id` | The unique identifier for the current [pipeline run](../../getting-started/concepts.md#pipeline-run) | `run_1234567890` |
+| `is_full_refresh` | Boolean indicating whether the full refresh flag is set | `True` or `False` |
 
 You can use these variables in your SQL queries by referencing them with the `{{ }}` syntax:
 ```sql

--- a/docs/getting-started/pipeline-variables.md
+++ b/docs/getting-started/pipeline-variables.md
@@ -116,6 +116,7 @@ Bruin injects several variables automatically:
 | `end_timestamp` | The end timestamp in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) format | "2023-12-02T15:30:00.000000Z07:00" |
 | `pipeline` | The name of the currently executing pipeline | `my_pipeline` |
 | `run_id` | The unique identifier for the current pipeline run | `run_1234567890` |
+| `is_full_refresh` | Boolean indicating whether the full refresh flag is set | `True` or `False` |
 
 In Python assets these built-ins are exposed as environment variables (e.g. `BRUIN_START_DATE`). User-defined variables are available as the JSON string `BRUIN_VARS`.
 


### PR DESCRIPTION
Add `is_full_refresh` boolean Jinja variable to indicate if a full refresh is requested.

This variable allows users to write conditional logic in their templates that depends on whether the `--full-refresh` flag was provided during `bruin run` or `bruin render` commands. It defaults to `false` if the flag is not explicitly set.

---
[Slack Thread](https://bruintalk.slack.com/archives/C07RG5NR0RX/p1759507006652659?thread_ts=1759507006.652659&cid=C07RG5NR0RX)

<a href="https://cursor.com/background-agent?bcId=bc-2e37df30-39cf-493d-9937-05bf423a7ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e37df30-39cf-493d-9937-05bf423a7ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

