### PR TITLE
Fix: docker build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -109,6 +109,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            BRANCH_NAME=${{ github.ref_name }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,6 +33,7 @@ concurrency:
 
 
 env:
+  DOCKER_BUILDKIT: 1
   REGISTRY: ghcr.io
   IMAGE_NAME: bruin-data/bruin
 
@@ -99,6 +100,18 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Go Build Cache for Docker
+        uses: actions/cache@v4
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('go.sum') }}
+
+      - name: Inject go-build-cache
+        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
+        with:
+          cache-source: go-build-cache
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,17 +101,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Go Build Cache for Docker
-        uses: actions/cache@v4
-        with:
-          path: go-build-cache
-          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('go.sum') }}
-
-      - name: Inject go-build-cache
-        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
-        with:
-          cache-source: go-build-cache
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -120,8 +109,8 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache:latest
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache:latest,mode=max
           build-args: |
             VERSION=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             BRANCH_NAME=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -110,8 +110,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VERSION=${{ github.ref_name }}
-            BRANCH_NAME=${{ github.ref_name }}
+            VERSION=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            BRANCH_NAME=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,17 +193,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Go Build Cache for Docker
-        uses: actions/cache@v4
-        with:
-          path: go-build-cache
-          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('go.sum') }}
-
-      - name: Inject go-build-cache
-        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
-        with:
-          cache-source: go-build-cache
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -212,8 +201,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache:latest
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache:latest,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
             BRANCH_NAME=${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            BRANCH_NAME=${{ github.ref_name }}
 
   install-windows:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
 
 env:
+  DOCKER_BUILDKIT: 1
   REGISTRY: ghcr.io
   IMAGE_NAME: bruin-data/bruin
 
@@ -191,6 +192,18 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Go Build Cache for Docker
+        uses: actions/cache@v4
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('go.sum') }}
+
+      - name: Inject go-build-cache
+        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
+        with:
+          cache-source: go-build-cache
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            VERSION=${{ github.ref_name }}
 
   install-windows:
     runs-on: windows-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN go mod download
 COPY . .
 
 # Build the application with version information from build args
-RUN CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.Version=${VERSION} -X main.BranchName=${BRANCH_NAME}" -o "bin/bruin" .
+RUN CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${BRANCH_NAME}" -o "bin/bruin" .
 
 # Final stage
 FROM debian:12.8-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM golang:1.23-bullseye AS builder
 
+# Build argument for version information
+ARG VERSION=dev
+ARG BRANCH_NAME=unknown
+
 # Install build dependencies including C++ standard library for DuckDB
 RUN apt-get update && apt-get install -y git gcc g++ libc6-dev
 
@@ -15,8 +19,8 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the application (using same command as Makefile but without tools dependency)
-RUN CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.Version=dev-$(shell git describe --tags --abbrev=0)" -o "bin/bruin" .
+# Build the application with version information from build args
+RUN CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.Version=${VERSION} -X main.BranchName=${BRANCH_NAME}" -o "bin/bruin" .
 
 # Final stage
 FROM debian:12.8-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,35 @@
+FROM golang:1.23-bullseye AS builder
+
+# Install build dependencies including C++ standard library for DuckDB
+RUN apt-get update && apt-get install -y git gcc g++ libc6-dev
+
+# Set working directory
+WORKDIR /src
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application (using same command as Makefile but without tools dependency)
+RUN CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.Version=dev-$(shell git describe --tags --abbrev=0)" -o "bin/bruin" .
+
+# Final stage
 FROM debian:12.8-slim
 
 RUN apt-get update && apt-get install -y curl git
 
-RUN  adduser --disabled-password --gecos '' bruin
+RUN adduser --disabled-password --gecos '' bruin
+
+# Copy the built binary from builder stage
+COPY --from=builder /src/bin/bruin /usr/local/bin/bruin
 
 USER bruin
 
-ARG VERSION=latest
-
-RUN curl -LsSf https://getbruin.com/install/cli | sh -s -- -d ${VERSION}
-
-ENV PATH="/home/bruin/.local/bin:${PATH}"
-
-RUN cd /tmp && bruin init bootstrap --in-place && bruin run bootstrap
-
-RUN rm -rf bootstrap
+ENV PATH="/usr/local/bin:${PATH}"
 
 CMD ["bruin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 # Copy source code
 COPY . .
 
-# Build the application with version information from build args (no cache for app code)
-RUN CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${BRANCH_NAME}" -o "bin/bruin" .
+# Build the application with version information from build args (with build cache for incremental builds)
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=1 go build -v -tags="no_duckdb_arrow" -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${BRANCH_NAME}" -o "bin/bruin" .
 
 # Final stage
 FROM debian:12.8-slim


### PR DESCRIPTION
This pull request updates the Docker build and release workflows and refactors the `Dockerfile` to improve build performance, caching, and image reproducibility. The main changes include switching to multi-stage builds, optimizing Docker layer caching, and passing version information from CI to the build. These updates make the build process more robust and efficient for both CI and local development.

**Dockerfile refactor and build improvements:**

* Refactored `Dockerfile` to use a multi-stage build: compiles the Go application with build arguments for `VERSION` and `BRANCH_NAME`, installs necessary dependencies, and copies the built binary to the final image. Adds a healthcheck for the application.

**CI workflow enhancements:**

* Updated `.github/workflows/build-test.yml` and `.github/workflows/release.yml` to set `DOCKER_BUILDKIT=1` for improved Docker build performance. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R36) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R12)
* Changed Docker cache strategy in both workflows to use registry-based caching (`type=registry`) instead of GitHub Actions cache (`type=gha`), improving cache effectiveness across builds. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L110-R116) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L202-R208)
* Passed `VERSION` and `BRANCH_NAME` as build arguments from CI to Docker builds, ensuring images are tagged with the correct version and branch information. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L110-R116) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L202-R208)
* Minor workflow cleanup: added blank lines for readability after Docker Buildx setup steps. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R103) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R195)