### PR TITLE
docs: update `type` description to link to canonical enum source

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -58,7 +58,7 @@ We use `uri` (Universal Resource Identifier) as another way to identify assets. 
 - **Type:** `String`
 
 ## `type`
-The type of the asset, determines how the execution will happen. Must be one of the types [here](https://github.com/bruin-data/bruin/blob/main/pkg/executor/defaults.go).
+The type of the asset, determines how the execution will happen. Must be one of the types [here](https://github.com/bruin-data/bruin/blob/main/pkg/pipeline/pipeline.go#L33).
 - **Type:** `String` 
 
 ## `owner`


### PR DESCRIPTION
## **Motivation**

While learning about basic Bruin concepts, I noticed that the existing link pointed to an outdated documentation artifact

After a quick investigation, I found that the [pipeline.go](https://github.com/bruin-data/bruin/blob/main/pkg/pipeline/pipeline.go#L33) file provides a richer and more accurate source of truth for available `type` values.

This change improves developer onboarding by directly linking to the live enum definition, ensuring the documentation stays synchronized with the codebase.

### **Before**

The section referenced an outdated documentation link that no longer exists (private repository possibly).

### **After**

```md
## `type`
The type of the asset, determines how the execution will happen. Must be one of the types [here](https://github.com/bruin-data/bruin/blob/main/pkg/pipeline/pipeline.go#L33).
- **Type:** `String`
```

