### PR TITLE
perf: pre-compile regexp in removeComments() for

### DIFF
--- a/pkg/pipeline/materializer.go
+++ b/pkg/pipeline/materializer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var commentRegex = regexp.MustCompile(`/\* *@bruin[\s\w\S]*@bruin *\*/`)
+
 type (
 	MaterializerFunc        func(task *Asset, query string) (string, error)
 	AssetMaterializationMap map[MaterializationType]map[MaterializationStrategy]MaterializerFunc
@@ -44,10 +46,7 @@ func (m *Materializer) Render(asset *Asset, query string) (string, error) {
 }
 
 func removeComments(query string) string {
-	bytes := []byte(query)
-	re := regexp.MustCompile(`/\* *@bruin[\s\w\S]*@bruin *\*/`)
-	newBytes := re.ReplaceAll(bytes, []byte(""))
-	return string(newBytes)
+	return commentRegex.ReplaceAllString(query, "")
 }
 
 func (m *Materializer) IsFullRefresh() bool {


### PR DESCRIPTION
## Summary

This PR optimizes the `removeComments()` function in the Materializer by pre-compiling the Bruin comment regexp, eliminating the expensive recompilation overhead that occurred on every function call.

## Problem

The `removeComments()` function was recompiling the regexp pattern `/\* *@bruin[\s\w\S]*@bruin *\*/` on every invocation. This function is called extensively during pipeline execution:

- Every asset execution across all database platforms (BigQuery, Snowflake, PostgreSQL, etc.)
- During linting operations for query validation
- During rendering operations for template processing
- In concurrent scenarios with multiple workers

For large pipelines with hundreds or thousands of assets, this created a significant performance bottleneck.

## Solution

- **Pre-compile regexp**: Move regexp compilation to package-level variable `commentRegex`
- **Simplify implementation**: Use `ReplaceAllString()` instead of `ReplaceAll()` with byte conversion
- **Remove overhead**: Eliminate unnecessary string-to-bytes conversion

## Performance Impact

Benchmark results show dramatic improvements across all scenarios:

### Overall Performance (geomean)
- **71.57% faster execution** (5.669µs → 1.612µs)
- **96.04% reduction in memory allocation** (6.761Ki → 274.4B)
- **92.86% fewer allocations** (42 → 3 allocs/op)

### Key Scenarios
- **Simple queries with comments**: 73.69% faster, 97.81% less memory
- **Complex queries with comments**: 35.13% faster, 90.50% less memory
- **Concurrent access**: 63.49% faster, 90.37% less memory
- **Large YAML configs**: 14.60% faster, 86.36% less memory
- **No-match scenarios**: 94.22% faster, 89.76% less memory

## Changes

```go
// Before
func removeComments(query string) string {
    bytes := []byte(query)
    re := regexp.MustCompile(`/\* *@bruin[\s\w\S]*@bruin *\*/`)  // ❌ Recompiled every call
    newBytes := re.ReplaceAll(bytes, []byte(""))
    return string(newBytes)
}

// After
var commentRegex = regexp.MustCompile(`/\* *@bruin[\s\w\S]*@bruin *\*/`)  // ✅ Pre-compiled

func removeComments(query string) string {
    return commentRegex.ReplaceAllString(query, "")  // ✅ Simplified
}
```

## Testing

- ✅ All existing tests pass
- ✅ Benchmark suite attached as a file but not as part of the PR as well as benchmark output files and `benchstat` results: 
[materializer_bench_test.txt](https://github.com/user-attachments/files/22865311/materializer_bench_test.txt)

- ✅ Performance regression testing with `benchstat`
- ✅ Concurrent access testing
- ✅ Memory allocation analysis

## Impact
[benchmark_after.txt](https://github.com/user-attachments/files/22865300/benchmark_after.txt)
[benchmark_before.txt](https://github.com/user-attachments/files/22865301/benchmark_before.txt)
[benchstat_results.txt](https://github.com/user-attachments/files/22865302/benchstat_results.txt)


This optimization will have the most significant impact on:
- **Large pipelines** with hundreds/thousands of assets
- **Concurrent execution** scenarios
- **Frequent linting** operations
- **Memory-constrained environments**

The improvement scales linearly with pipeline size, making it particularly valuable for enterprise-scale data pipelines.

## Benchmarks

Run benchmarks with:
```bash
go test -bench=BenchmarkRemoveComments -benchmem -count=10 ./pkg/pipeline
```

Compare results with:
```bash
benchstat before.txt after.txt
```

Output:

```
goos: darwin
goarch: arm64
pkg: github.com/bruin-data/bruin/pkg/pipeline
cpu: Apple M4 Pro
                                              │   before.txt   │             after.txt              │
                                              │     sec/op     │   sec/op     vs base               │
RemoveComments/simple_query_no_comments-14      1917.50n ± 11%   52.57n ± 1%  -97.26% (p=0.002 n=6)
RemoveComments/simple_query_with_comments-14     2620.0n ±  4%   689.4n ± 0%  -73.69% (p=0.002 n=6)
RemoveComments/complex_query_no_comments-14      2068.0n ±  2%   112.7n ± 1%  -94.55% (p=0.002 n=6)
RemoveComments/complex_query_with_comments-14     5.949µ ±  4%   3.859µ ± 0%  -35.13% (p=0.002 n=6)
RemoveComments/large_yaml_config-14               17.12µ ±  2%   14.62µ ± 0%  -14.60% (p=0.002 n=6)
RemoveComments/multiple_comment_blocks-14         3.364µ ±  1%   1.421µ ± 0%  -57.75% (p=0.002 n=6)
RemoveCommentsConcurrent-14                      1233.0n ±  1%   450.2n ± 2%  -63.49% (p=0.002 n=6)
RemoveCommentsMemory-14                           5.891µ ±  2%   3.857µ ± 0%  -34.52% (p=0.002 n=6)
RemoveCommentsLargeInput-14                       200.9µ ±  1%   177.2µ ± 5%  -11.78% (p=0.002 n=6)
RemoveCommentsNoMatch-14                         2019.0n ±  1%   116.7n ± 1%  -94.22% (p=0.002 n=6)
RemoveCommentsManyMatches-14                      18.55µ ±  3%   16.23µ ± 1%  -12.51% (p=0.002 n=6)
geomean                                           5.669µ         1.612µ       -71.57%

                                              │  before.txt  │              after.txt              │
                                              │     B/op     │     B/op      vs base               │
RemoveComments/simple_query_no_comments-14      5053.00 ± 0%     80.00 ± 0%  -98.42% (p=0.002 n=6)
RemoveComments/simple_query_with_comments-14     5123.0 ± 0%     112.0 ± 0%  -97.81% (p=0.002 n=6)
RemoveComments/complex_query_no_comments-14      5830.5 ± 0%     596.0 ± 0%  -89.78% (p=0.002 n=6)
RemoveComments/complex_query_with_comments-14    6239.5 ± 0%     593.0 ± 0%  -90.50% (p=0.002 n=6)
RemoveComments/large_yaml_config-14             9.314Ki ± 0%   1.271Ki ± 0%  -86.36% (p=0.002 n=6)
RemoveComments/multiple_comment_blocks-14       5301.00 ± 0%     80.00 ± 0%  -98.49% (p=0.002 n=6)
RemoveCommentsConcurrent-14                      6307.0 ± 0%     607.5 ± 0%  -90.37% (p=0.002 n=6)
RemoveCommentsMemory-14                          6242.0 ± 0%     593.0 ± 0%  -90.50% (p=0.002 n=6)
RemoveCommentsLargeInput-14                     17294.5 ± 0%     113.0 ± 1%  -99.35% (p=0.002 n=6)
RemoveCommentsNoMatch-14                         5832.0 ± 0%     597.0 ± 0%  -89.76% (p=0.002 n=6)
RemoveCommentsManyMatches-14                    9261.50 ± 1%     83.00 ± 0%  -99.10% (p=0.002 n=6)
geomean                                         6.761Ki          274.4       -96.04%

                                              │ before.txt  │             after.txt             │
                                              │  allocs/op  │ allocs/op   vs base               │
RemoveComments/simple_query_no_comments-14      42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveComments/simple_query_with_comments-14    42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveComments/complex_query_no_comments-14     42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveComments/complex_query_with_comments-14   42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveComments/large_yaml_config-14             42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveComments/multiple_comment_blocks-14       42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveCommentsConcurrent-14                     42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveCommentsMemory-14                         42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveCommentsLargeInput-14                     42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveCommentsNoMatch-14                        42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
RemoveCommentsManyMatches-14                    42.000 ± 0%   3.000 ± 0%  -92.86% (p=0.002 n=6)
geomean                                          42.00        3.000       -92.86%
```

## Related

- Addresses performance bottleneck identified in regexp usage analysis
- Part of ongoing performance optimization efforts
- No breaking changes to public API