### PR TITLE
perf: cache compiled regexp patterns in policy selector matching

### DIFF
--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -30,10 +30,10 @@ var (
 
 var validRulePattern = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
 
-// patternCache stores compiled regexp patterns to avoid recompilation
+// patternCache stores compiled regexp patterns to avoid recompilation.
 var patternCache sync.Map
 
-// getCompiledPattern returns a compiled regexp pattern from cache or compiles and caches it
+// getCompiledPattern returns a compiled regexp pattern from cache or compiles and caches it.
 func getCompiledPattern(pattern string) (*regexp.Regexp, error) {
 	if cached, ok := patternCache.Load(pattern); ok {
 		return cached.(*regexp.Regexp), nil


### PR DESCRIPTION
## Summary

This PR optimizes the `doesSelectorMatch` function in `pkg/lint/policy.go` by implementing a `sync.Map`-based cache for compiled regexp patterns. This eliminates redundant regexp compilation during policy validation, which significantly improves performance.

## Problem

During pipeline validation, the same regex patterns are compiled repeatedly:
- `.*/policies-builtin/.*` appears 50+ times per validation run
- `.*/policies-custom/.*` appears 20+ times
- `pipeline:policy-selector` appears 15+ times
- And many more patterns...

When testing pipelines in integration tests using the default `policy.yml`, these are the number of calls to `doesSelectorMatch` (which end up calling`regexp.MatchString` many times):

| Pipeline | Assets | `doesSelectorMatch` Calls | Pattern Repetition |
|----------|--------|---------------------------|-------------------|
| `policies-builtin` | 2 | ~40 calls | Same patterns repeated 20x each |
| `happy-path` | 6 | ~120 calls | Same patterns repeated 20x each |
| `parse-lineage-pipeline` | 4 | ~80 calls | Same patterns repeated 20x each |

## Solution

Added a thread-safe pattern cache using `sync.Map`:

```go
// patternCache stores compiled regexp patterns to avoid recompilation
var patternCache sync.Map

// getCompiledPattern returns a compiled regexp pattern from cache or compiles and caches it
func getCompiledPattern(pattern string) (*regexp.Regexp, error) {
    if cached, ok := patternCache.Load(pattern); ok {
        return cached.(*regexp.Regexp), nil
    }

    compiled, err := regexp.Compile(pattern)
    if err != nil {
        return nil, err
    }

    patternCache.Store(pattern, compiled)
    return compiled, nil
}
```

Modified `doesSelectorMatch` to use the cached patterns instead of `regexp.MatchString()`.

## Performance Impact

Benchmark results on Apple M4 Pro show dramatic improvements:

### Execution Time
- **91.50% faster** overall (3.388µ → 288.0n)
- Individual selectors: 70-97% faster
- Concurrent validation: **96.50% faster** (74.965µ → 2.628µ)

### Memory Usage  
- **99.26% less memory** allocation (9.597Ki → 72.86B)
- Individual selectors: 99.24-99.37% reduction
- Concurrent validation: **98.20% reduction** (179.976Ki → 3.247Ki)

### Allocations
- **96.47% fewer allocations** (84.02 → 2.964)
- Individual selectors: 95-98% reduction
- Concurrent validation: **94.66% reduction** (1293 → 69)

## Testing

- Used this for benchmarks: 
[policy_bench_test.txt](https://github.com/user-attachments/files/22866368/policy_bench_test.txt)
- Benchmarks before: 
[before.txt](https://github.com/user-attachments/files/22866371/before.txt).
- Benchmarks after this change: 
[after.txt](https://github.com/user-attachments/files/22866373/after.txt)
- Benchstat output:
 
```
% benchstat before.txt after.txt 
goos: darwin
goarch: arm64
pkg: github.com/bruin-data/bruin/pkg/lint
cpu: Apple M4 Pro
                                                                        │  before.txt   │             after.txt              │
                                                                        │    sec/op     │   sec/op     vs base               │
IntegrationTestPolicySelectors/builtin-policies-selector-14                2656.5n ± 1%   769.6n ± 1%  -71.03% (p=0.002 n=6)
IntegrationTestPolicySelectors/builtin-policies-alternative-selector-14    2694.5n ± 1%   769.2n ± 1%  -71.45% (p=0.002 n=6)
IntegrationTestPolicySelectors/custom-policy-selector-14                   2694.5n ± 5%   790.9n ± 1%  -70.65% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-asset-selector-14                    1492.0n ± 1%   230.7n ± 2%  -84.54% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-pipeline-selector-14                1970.50n ± 2%   79.39n ± 2%  -95.97% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-by-tag-selector-14                  1936.50n ± 1%   78.59n ± 1%  -95.94% (p=0.002 n=6)
IntegrationTestPolicySelectors/fail-case-selectors-14                     2430.50n ± 1%   80.12n ± 1%  -96.70% (p=0.002 n=6)
IntegrationTestPolicySelectors/validate-single-asset-selector-14          2937.00n ± 1%   96.15n ± 1%  -96.73% (p=0.002 n=6)
IntegrationTestPolicyConcurrent-14                                         74.965µ ± 3%   2.628µ ± 4%  -96.50% (p=0.002 n=6)
geomean                                                                     3.388µ        288.0n       -91.50%

                                                                        │   before.txt   │              after.txt              │
                                                                        │      B/op      │     B/op      vs base               │
IntegrationTestPolicySelectors/builtin-policies-selector-14                 7633.00 ± 0%     48.00 ± 0%  -99.37% (p=0.002 n=6)
IntegrationTestPolicySelectors/builtin-policies-alternative-selector-14     7630.00 ± 0%     48.00 ± 0%  -99.37% (p=0.002 n=6)
IntegrationTestPolicySelectors/custom-policy-selector-14                    7633.00 ± 0%     48.00 ± 0%  -99.37% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-asset-selector-14                     4357.50 ± 0%     32.00 ± 0%  -99.27% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-pipeline-selector-14                  6236.00 ± 0%     40.00 ± 0%  -99.36% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-by-tag-selector-14                    6236.00 ± 0%     40.00 ± 0%  -99.36% (p=0.002 n=6)
IntegrationTestPolicySelectors/fail-case-selectors-14                       7333.00 ± 0%     48.00 ± 0%  -99.35% (p=0.002 n=6)
IntegrationTestPolicySelectors/validate-single-asset-selector-14            8398.00 ± 0%     64.00 ± 0%  -99.24% (p=0.002 n=6)
IntegrationTestPolicyConcurrent-14                                        179.976Ki ± 1%   3.247Ki ± 1%  -98.20% (p=0.002 n=6)
geomean                                                                     9.597Ki          72.86       -99.26%

                                                                        │  before.txt  │             after.txt             │
                                                                        │  allocs/op   │ allocs/op   vs base               │
IntegrationTestPolicySelectors/builtin-policies-selector-14                47.000 ± 0%   2.000 ± 0%  -95.74% (p=0.002 n=6)
IntegrationTestPolicySelectors/builtin-policies-alternative-selector-14    47.000 ± 0%   2.000 ± 0%  -95.74% (p=0.002 n=6)
IntegrationTestPolicySelectors/custom-policy-selector-14                   47.000 ± 0%   2.000 ± 0%  -95.74% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-asset-selector-14                    40.000 ± 0%   2.000 ± 0%  -95.00% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-pipeline-selector-14                 68.000 ± 0%   2.000 ± 0%  -97.06% (p=0.002 n=6)
IntegrationTestPolicySelectors/select-by-tag-selector-14                   68.000 ± 0%   2.000 ± 0%  -97.06% (p=0.002 n=6)
IntegrationTestPolicySelectors/fail-case-selectors-14                      84.000 ± 0%   2.000 ± 0%  -97.62% (p=0.002 n=6)
IntegrationTestPolicySelectors/validate-single-asset-selector-14          100.000 ± 0%   2.000 ± 0%  -98.00% (p=0.002 n=6)
IntegrationTestPolicyConcurrent-14                                        1293.00 ± 0%   69.00 ± 0%  -94.66% (p=0.002 n=6)
geomean                                                                     84.02        2.964       -96.47%
```

## Files Changed

- `pkg/lint/policy.go`: Added pattern caching implementation

## Related

- Following up changes similar to #1199 