### PR TITLE
test: follow testifylint suggestions in test files

### DIFF
--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -499,8 +499,7 @@ func TestListConnectionsCommand_ReturnsEmptyEnvironments(t *testing.T) {
 
 			// Verify that when listing all environments, empty environments are included
 			if tt.environment == "" {
-				assert.Equal(t, len(tt.expectedEnvs), len(cm.Environments),
-					"Should have all expected environments including empty ones")
+				assert.Len(t, cm.Environments, len(tt.expectedEnvs), "Should have all expected environments including empty ones")
 
 				// Count empty environments
 				emptyEnvCount := 0

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -737,7 +737,7 @@ func TestDB_UpdateTableMetadataIfNotExists(t *testing.T) {
 						}
 
 						// ensure we didn't drop any columns that we didn't have documented
-						assert.Equal(t, len(tt.tableResponse.Schema.Fields), len(table.Schema.Fields))
+						assert.Len(t, table.Schema.Fields, len(tt.tableResponse.Schema.Fields))
 
 						// ensure the primary keys are set correctly
 						primaryKeys := tt.asset.ColumnNamesWithPrimaryKey()

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -282,13 +282,13 @@ func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 				assert.EqualExportedValues(t, *asset, *gotAsset)
 
 				gotAssetUpstreams := gotAsset.GetUpstream()
-				assert.Equal(t, len(asset.GetUpstream()), len(gotAssetUpstreams))
+				assert.Len(t, gotAssetUpstreams, len(asset.GetUpstream()))
 				for upstreamIdx, u := range asset.GetUpstream() {
 					assert.EqualExportedValues(t, *u, *gotAssetUpstreams[upstreamIdx])
 				}
 
 				gotAssetDownstreams := gotAsset.GetDownstream()
-				assert.Equal(t, len(asset.GetDownstream()), len(gotAssetDownstreams))
+				assert.Len(t, gotAssetDownstreams, len(asset.GetDownstream()))
 				for idx, d := range asset.GetDownstream() {
 					assert.EqualExportedValues(t, *d, *gotAssetDownstreams[idx])
 				}

--- a/pkg/tableau/client_test.go
+++ b/pkg/tableau/client_test.go
@@ -138,7 +138,7 @@ func TestFindDatasourceIDByName(t *testing.T) {
 
 	id, err = FindDatasourceIDByName(context.Background(), "gamma", datasources)
 	require.NoError(t, err)
-	require.Equal(t, "", id)
+	require.Empty(t, id)
 
 	// nil datasources
 	_, err = FindDatasourceIDByName(context.Background(), "alpha", nil)
@@ -147,12 +147,12 @@ func TestFindDatasourceIDByName(t *testing.T) {
 	// empty slice
 	id, err = FindDatasourceIDByName(context.Background(), "alpha", []DataSourceInfo{})
 	require.NoError(t, err)
-	require.Equal(t, "", id)
+	require.Empty(t, id)
 
 	// empty name
 	id, err = FindDatasourceIDByName(context.Background(), "", datasources)
 	require.NoError(t, err)
-	require.Equal(t, "", id)
+	require.Empty(t, id)
 
 	// name with spaces
 	datasourcesWithSpaces := []DataSourceInfo{
@@ -189,7 +189,7 @@ func TestFindWorkbookIDByName(t *testing.T) {
 
 	id, err = FindWorkbookIDByName(context.Background(), "notfound", workbooks)
 	require.NoError(t, err)
-	require.Equal(t, "", id)
+	require.Empty(t, id)
 
 	// nil workbooks
 	_, err = FindWorkbookIDByName(context.Background(), "superstore", nil)
@@ -198,12 +198,12 @@ func TestFindWorkbookIDByName(t *testing.T) {
 	// empty slice
 	id, err = FindWorkbookIDByName(context.Background(), "superstore", []WorkbookInfo{})
 	require.NoError(t, err)
-	require.Equal(t, "", id)
+	require.Empty(t, id)
 
 	// empty name
 	id, err = FindWorkbookIDByName(context.Background(), "", workbooks)
 	require.NoError(t, err)
-	require.Equal(t, "", id)
+	require.Empty(t, id)
 
 	// name with spaces
 	workbooksWithSpaces := []WorkbookInfo{


### PR DESCRIPTION
- Use assert.Len() instead of assert.Equal() for length comparisons
- Use require.Empty() instead of require.Equal() for empty string checks
- Apply to connections, bigquery, pipeline, and tableau test files