### PR TITLE
Add SQL query logging to all database operators in verbose mode

### DIFF
--- a/pkg/clickhouse/operator.go
+++ b/pkg/clickhouse/operator.go
@@ -2,10 +2,8 @@ package clickhouse
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -13,8 +11,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) ([]string, error)
@@ -87,16 +83,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	for _, queryString := range materializedQueries {
 		p := &query.Query{Query: queryString}
 
-		// Print SQL query in verbose mode
-		if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-			if w, ok := writer.(io.Writer); ok {
-				queryPreview := strings.TrimSpace(p.Query)
-				if len(queryPreview) > CharacterLimit {
-					queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-				}
-				fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-			}
-		}
+		ansisql.LogQueryIfVerbose(ctx, writer, p.Query)
 
 		err = conn.RunQueryWithoutResult(ctx, p)
 		if err != nil {

--- a/pkg/databricks/operator.go
+++ b/pkg/databricks/operator.go
@@ -2,9 +2,6 @@ package databricks
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -14,8 +11,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) ([]string, error)
@@ -95,16 +90,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	for _, queryString := range materializedQueries {
 		p := &query.Query{Query: queryString}
 
-		// Print SQL query in verbose mode
-		if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-			if w, ok := writer.(io.Writer); ok {
-				queryPreview := strings.TrimSpace(p.Query)
-				if len(queryPreview) > CharacterLimit {
-					queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-				}
-				fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-			}
-		}
+		ansisql.LogQueryIfVerbose(ctx, writer, p.Query)
 
 		err = conn.RunQueryWithoutResult(ctx, p)
 		if err != nil {

--- a/pkg/duckdb/operator.go
+++ b/pkg/duckdb/operator.go
@@ -2,9 +2,6 @@ package duck
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -14,8 +11,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) (string, error)
@@ -106,16 +101,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	// Print SQL query in verbose mode
-	if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-		if w, ok := writer.(io.Writer); ok {
-			queryPreview := strings.TrimSpace(q.Query)
-			if len(queryPreview) > CharacterLimit {
-				queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-			}
-			fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-		}
-	}
+	ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
 
 	return conn.RunQueryWithoutResult(ctx, q)
 }

--- a/pkg/postgres/operator.go
+++ b/pkg/postgres/operator.go
@@ -2,9 +2,7 @@ package postgres
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -16,8 +14,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/sqlparser"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) (string, error)
@@ -124,16 +120,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	if o.devEnv == nil {
-		// Print SQL query in verbose mode
-		if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-			if w, ok := writer.(io.Writer); ok {
-				queryPreview := strings.TrimSpace(q.Query)
-				if len(queryPreview) > CharacterLimit {
-					queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-				}
-				fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-			}
-		}
+		ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
 		return conn.RunQueryWithoutResult(ctx, q)
 	}
 
@@ -142,16 +129,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return err
 	}
 
-	// Print SQL query in verbose mode
-	if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-		if w, ok := writer.(io.Writer); ok {
-			queryPreview := strings.TrimSpace(q.Query)
-			if len(queryPreview) > CharacterLimit {
-				queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-			}
-			fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-		}
-	}
+	ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
 
 	err = conn.RunQueryWithoutResult(ctx, q)
 	if err != nil {

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -2,9 +2,7 @@ package snowflake
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -16,8 +14,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) (string, error)
@@ -120,16 +116,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	// Print SQL query in verbose mode
-	if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-		if w, ok := writer.(io.Writer); ok {
-			queryPreview := strings.TrimSpace(q.Query)
-			if len(queryPreview) > CharacterLimit {
-				queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-			}
-			fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-		}
-	}
+	ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
 
 	return conn.RunQueryWithoutResult(ctx, q)
 }

--- a/pkg/synapse/operator.go
+++ b/pkg/synapse/operator.go
@@ -2,9 +2,6 @@ package synapse
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -15,8 +12,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) ([]string, error)
@@ -85,16 +80,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	for _, queryString := range materializedQueries {
 		p := &query.Query{Query: queryString}
 
-		// Print SQL query in verbose mode
-		if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-			if w, ok := writer.(io.Writer); ok {
-				queryPreview := strings.TrimSpace(p.Query)
-				if len(queryPreview) > CharacterLimit {
-					queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-				}
-				fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-			}
-		}
+		ansisql.LogQueryIfVerbose(ctx, writer, p.Query)
 
 		err = conn.RunQueryWithoutResult(ctx, p)
 		if err != nil {

--- a/pkg/trino/operator.go
+++ b/pkg/trino/operator.go
@@ -2,10 +2,8 @@ package trino
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -13,8 +11,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-const CharacterLimit = 10000
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) (string, error)
@@ -86,16 +82,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 
 	// Execute each query separately
 	for _, queryObj := range materializedQueries {
-		// Print SQL query in verbose mode
-		if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
-			if w, ok := writer.(io.Writer); ok {
-				queryPreview := strings.TrimSpace(queryObj.Query)
-				if len(queryPreview) > CharacterLimit {
-					queryPreview = queryPreview[:CharacterLimit] + "\n... (truncated)"
-				}
-				fmt.Fprintf(w, "Executing SQL query:\n%s\n\n", queryPreview)
-			}
-		}
+		ansisql.LogQueryIfVerbose(ctx, writer, queryObj.Query)
 
 		err = conn.RunQueryWithoutResult(ctx, queryObj)
 		if err != nil {


### PR DESCRIPTION
This commit adds query logging functionality to all SQL operator implementations to match the existing behavior in the BigQuery operator. When running in verbose/ debug mode, operators will now log the SQL query they are executing before execution.

Changes:
- Added query logging to Snowflake operator
- Added query logging to PostgreSQL operator (both devEnv paths)
- Added query logging to Athena operator (multi-query support)
- Added query logging to MSSQL operator
- Added query logging to Synapse operator (multi-query support)
- Added query logging to Databricks operator (multi-query support)
- Added query logging to ClickHouse operator (multi-query support)
- Added query logging to DuckDB operator
- Added query logging to Trino operator (multi-query support)

All operators now:
- Check for executor.KeyVerbose context flag to enable logging
- Use executor.KeyPrinter context value to get the output writer
- Truncate queries longer than 10,000 characters
- Format output as "Executing SQL query:\n{query}\n\n"

This provides consistent debugging experience across all database platforms and helps users understand what queries are being executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)