### PR TITLE
Add bronze-to-silver Postgres template

### DIFF
--- a/docs/getting-started/templates-docs/bronze-silver-postgres-README.md
+++ b/docs/getting-started/templates-docs/bronze-silver-postgres-README.md
@@ -1,0 +1,67 @@
+# Bronze-to-Silver PostgreSQL Template
+
+The Bronze-to-Silver PostgreSQL template showcases how to pair a credential-free source with a relational
+destination by orchestrating an end-to-end Bruin pipeline. The flow ingests raw Frankfurter FX rates into a bronze
+table via `ingestr`, then curates a silver summary table with Postgres SQL transformations and built-in quality
+checks.
+
+## When to use this template
+
+Choose this template when you want to:
+
+- Stand up a lightweight demonstration of Bruin’s ELT workflow using managed PostgreSQL.
+- Combine ingestion, transformation, and validation in a single reproducible project.
+- Explore how Bruin enforces data contracts with column-level checks and freshness guarantees.
+
+## Pipeline overview
+
+```
+bronze-silver-postgres/
+├── .bruin.yml
+├── pipeline.yml
+└── assets/
+    ├── bronze_raw_data.asset.yml
+    └── silver_aggregated.sql
+```
+
+- **Bronze Layer (`bronze_raw_data.asset.yml`)**
+  - Uses `ingestr` to pull daily FX rates from the Frankfurter API into PostgreSQL.
+  - Adds column integrity checks, deduplication verification, and freshness monitoring.
+- **Silver Layer (`silver_aggregated.sql`)**
+  - Materializes an analytic summary table with rolling averages, latest rate snapshots, and observation counts.
+  - Ensures downstream quality with mandatory positive rate checks and recency validation.
+
+## Required connections
+
+Edit `.bruin.yml` to supply your PostgreSQL details (Frankfurter is credential-free):
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      postgres:
+        - name: "postgres-default"
+          host: "localhost"
+          port: 5432
+          database: "bruin"
+          username: "postgres"
+          password: "postgres"
+          ssl_mode: "disable"
+```
+
+Feel free to parameterize the credentials with environment variables or secrets before running in production.
+
+## Try it out
+
+```bash
+bruin init bronze-silver-postgres fx-demo
+cd fx-demo
+bruin validate
+bruin run
+```
+
+Running the template will populate `public.bronze_exchange_rates` and build `public.silver_exchange_rate_summary`.
+Both stages surface quality results so you can immediately confirm the data meets expectations.

--- a/templates/bronze-silver-postgres/.bruin.yml
+++ b/templates/bronze-silver-postgres/.bruin.yml
@@ -1,0 +1,14 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      postgres:
+        - name: "postgres-default"
+          host: "localhost"
+          port: 5432
+          database: "bruin"
+          username: "postgres"
+          password: "postgres"
+          ssl_mode: "disable"

--- a/templates/bronze-silver-postgres/README.md
+++ b/templates/bronze-silver-postgres/README.md
@@ -1,0 +1,58 @@
+# Bruin - Bronze to Silver Postgres Template
+
+This template demonstrates a complete bronze-to-silver ingestion workflow using PostgreSQL for storage.
+It combines the Frankfurter FX API as a credential-free source with a PostgreSQL destination to present a
+canonical ELT pattern: raw collection via `ingestr` followed by curated transformations in SQL.
+
+## Included assets
+
+- `assets/bronze_raw_data.asset.yml`  
+  Uses `ingestr` to copy foreign exchange rates from the Frankfurter API into PostgreSQL. The asset tracks
+  data quality via column-level checks, deduplication assurance, and freshness validation.
+
+- `assets/silver_aggregated.sql`  
+  Builds a summarized silver table in PostgreSQL with recent exchange rate insights, rolling averages,
+  and observation counts ready for analytics or downstream modeling.
+
+## Setup
+
+The template includes a `.bruin.yml` file seeded with placeholder connection values:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      postgres:
+        - name: "postgres-default"
+          host: "localhost"
+          port: 5432
+          database: "bruin"
+          username: "postgres"
+          password: "postgres"
+          ssl_mode: "disable"
+```
+
+Update the PostgreSQL connection with the credentials for your target instance. The Frankfurter source does not
+require authentication.
+
+Ensure the target database allows table creation in the `public` schema or adjust the asset definitions to match
+your own schema naming conventions.
+
+## Running the pipeline
+
+Initialize a new project from this template and execute the full bronze-to-silver flow:
+
+```bash
+bruin init bronze-silver-postgres my-fx-pipeline
+cd my-fx-pipeline
+bruin run
+```
+
+The run will:
+1. Ingest the latest Frankfurter exchange rates into `public.bronze_exchange_rates`.
+2. Build `public.silver_exchange_rate_summary`, providing recent averages and data freshness checks.
+
+Both assets include built-in quality checks so `bruin validate` and `bruin run` report actionable status.

--- a/templates/bronze-silver-postgres/assets/bronze_raw_data.asset.yml
+++ b/templates/bronze-silver-postgres/assets/bronze_raw_data.asset.yml
@@ -1,0 +1,52 @@
+name: public.bronze_exchange_rates
+type: ingestr
+
+description: >
+  Ingests daily FX rates from the Frankfurter API into PostgreSQL without transformations.
+  The dataset makes the raw bronze layer available for downstream silver modeling.
+
+columns:
+  - name: date
+    type: date
+    description: "Exchange rate date reported by the Frankfurter API."
+    checks:
+      - name: not_null
+  - name: base_currency
+    type: varchar
+    description: "Currency that the quote currency is priced against."
+    checks:
+      - name: not_null
+  - name: currency_code
+    type: varchar
+    description: "Quote currency code returned by Frankfurter."
+    checks:
+      - name: not_null
+  - name: rate
+    type: numeric
+    description: "Reported daily conversion rate between the base and quote currency."
+    checks:
+      - name: not_null
+      - name: positive
+
+custom_checks:
+  - name: unique currency per day
+    value: 0
+    query: |
+      SELECT COUNT(*)
+      FROM (
+        SELECT date, currency_code, base_currency
+        FROM public.bronze_exchange_rates
+        GROUP BY 1, 2, 3
+        HAVING COUNT(*) > 1
+      ) duplicates
+  - name: data freshness (3 day max lag)
+    value: 0
+    query: |
+      SELECT CASE WHEN MAX(CAST(date AS DATE)) < CURRENT_DATE - INTERVAL '3 days' THEN 1 ELSE 0 END AS stale_flag
+      FROM public.bronze_exchange_rates
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: exchange_rates
+  destination: postgres
+  destination_table: bronze_exchange_rates

--- a/templates/bronze-silver-postgres/assets/silver_aggregated.sql
+++ b/templates/bronze-silver-postgres/assets/silver_aggregated.sql
@@ -1,0 +1,116 @@
+/* @bruin
+
+name: public.silver_exchange_rate_summary
+type: pg.sql
+
+materialization:
+  type: table
+
+description: >
+  Aggregates the bronze Frankfurter exchange rate feed into a silver summary table with
+  fresh rates, rolling averages, and observation counts for downstream analytics.
+
+depends:
+  - public.bronze_exchange_rates
+
+columns:
+  - name: currency_code
+    type: varchar
+    description: "Quoted currency code."
+    checks:
+      - name: not_null
+  - name: base_currency
+    type: varchar
+    description: "Base currency that the quote is relative to."
+    checks:
+      - name: not_null
+  - name: latest_date
+    type: date
+    description: "Most recent exchange rate date captured in the bronze layer."
+    checks:
+      - name: not_null
+  - name: latest_rate
+    type: numeric
+    description: "Latest available exchange rate between the currency pair."
+    checks:
+      - name: not_null
+      - name: positive
+  - name: avg_rate_7d
+    type: numeric
+    description: "Seven day rolling average of the conversion rate."
+    checks:
+      - name: positive
+  - name: avg_rate_30d
+    type: numeric
+    description: "Thirty day rolling average of the conversion rate."
+    checks:
+      - name: positive
+  - name: observations_7d
+    type: integer
+    description: "Number of daily observations in the last seven days."
+    checks:
+      - name: non_negative
+  - name: observations_30d
+    type: integer
+    description: "Number of daily observations in the last thirty days."
+    checks:
+      - name: positive
+
+custom_checks:
+  - name: silver table populated
+    value: 0
+    query: |
+      SELECT CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END
+      FROM public.silver_exchange_rate_summary
+  - name: fresh latest date (<= 3 day lag)
+    value: 0
+    query: |
+      SELECT COUNT(*)
+      FROM public.silver_exchange_rate_summary
+      WHERE latest_date < CURRENT_DATE - INTERVAL '3 days'
+
+@bruin */
+
+WITH bronze_data AS (
+  SELECT
+    CAST(date AS DATE) AS rate_date,
+    base_currency,
+    currency_code,
+    CAST(rate AS NUMERIC) AS rate
+  FROM public.bronze_exchange_rates
+),
+recent AS (
+  SELECT
+    currency_code,
+    base_currency,
+    AVG(rate) FILTER (WHERE rate_date >= CURRENT_DATE - INTERVAL '7 days') AS avg_rate_7d,
+    AVG(rate) FILTER (WHERE rate_date >= CURRENT_DATE - INTERVAL '30 days') AS avg_rate_30d,
+    COUNT(*) FILTER (WHERE rate_date >= CURRENT_DATE - INTERVAL '7 days') AS observations_7d,
+    COUNT(*) FILTER (WHERE rate_date >= CURRENT_DATE - INTERVAL '30 days') AS observations_30d
+  FROM bronze_data
+  WHERE rate_date >= CURRENT_DATE - INTERVAL '30 days'
+  GROUP BY currency_code, base_currency
+),
+latest AS (
+  SELECT DISTINCT ON (currency_code, base_currency)
+    currency_code,
+    base_currency,
+    rate_date AS latest_date,
+    rate AS latest_rate
+  FROM bronze_data
+  ORDER BY currency_code, base_currency, rate_date DESC
+)
+SELECT
+  r.currency_code,
+  r.base_currency,
+  l.latest_date,
+  l.latest_rate,
+  COALESCE(r.avg_rate_7d, r.avg_rate_30d) AS avg_rate_7d,
+  r.avg_rate_30d,
+  r.observations_7d,
+  r.observations_30d
+FROM recent r
+JOIN latest l
+  ON r.currency_code = l.currency_code
+ AND r.base_currency = l.base_currency
+ORDER BY r.currency_code, r.base_currency;

--- a/templates/bronze-silver-postgres/pipeline.yml
+++ b/templates/bronze-silver-postgres/pipeline.yml
@@ -1,0 +1,6 @@
+name: bronze-silver-postgres
+schedule: daily
+start_date: "2024-01-01"
+
+default_connections:
+  postgres: "postgres-default"


### PR DESCRIPTION
## Summary
- add a bronze layer ingestr asset that loads Frankfurter FX data into PostgreSQL with column checks and freshness guards
- build a silver SQL asset that rolls up recent exchange-rate metrics for easy analytics consumption
- document how to initialize and use the new template, including the embedded .bruin.yml sample and docs page

## Design Decisions
- chose the Frankfurter source because it requires no credentials, making the template runnable out of the box
- stored both bronze and silver tables in the public schema to avoid extra schema management requirements for new users
- applied Bruin’s quality check conventions (column checks plus aggregate custom checks) so the pipeline mirrors existing templates

## Tests
- Not run: make test (GNU Make and Go toolchain are not available in this Windows sandbox)

## Alignment with Repo Patterns
- follows the existing template layout (.bruin.yml, pipeline.yml, ssets/, README.md) and documentation style in docs/getting-started/templates-docs
- keeps asset naming and quality checks consistent with other ingest + SQL pipelines in the repository

Closes #1222