### PR TITLE
Add bronze-to-silver Snowflake template

### DIFF
--- a/templates/bronze-silver-snowflake/.bruin.yml
+++ b/templates/bronze-silver-snowflake/.bruin.yml
@@ -1,0 +1,15 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      snowflake:
+        - name: "snowflake-default"
+          account: "<your-account-identifier>"
+          username: "<your-username>"
+          password: "<your-password>"
+          database: "<your-database>"
+          schema: "BRONZE"
+          warehouse: "COMPUTE_WH"
+          role: "ANALYST"

--- a/templates/bronze-silver-snowflake/README.md
+++ b/templates/bronze-silver-snowflake/README.md
@@ -1,0 +1,56 @@
+# Bruin - Bronze to Silver Snowflake Template
+
+This template bootstrap demonstrates a full bronze-to-silver workflow on Snowflake using the public [Frankfurter FX API](https://www.frankfurter.app/). Bruin ingests raw exchange rates with `ingestr` into a Snowflake bronze schema and then produces a curated silver snapshot that summarises recent performance metrics.
+
+## Prerequisites
+
+- A Snowflake account with permission to create tables in your target database/schema.
+- A warehouse that can execute the silver transformation query.
+- Authenticated `bruin` CLI with `ingestr` dependencies installed (via `make deps`).
+
+### Configure `.bruin.yml`
+
+Update the generated `.bruin.yml` with your credentials. The template ships with placeholders that you can replace:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      snowflake:
+        - name: "snowflake-default"
+          account: "ABCD1234-XY00000"
+          username: "BRUIN_DEV"
+          password: "<replace-with-password-or-remove-for-key-auth>"
+          database: "BRUIN_DEMO"
+          schema: "BRONZE"
+          warehouse: "COMPUTE_WH"
+          role: "ANALYST"
+```
+
+If you use key-based authentication, replace the `password` with the `private_key_path` or inline `private_key` fields. See [`docs/platforms/snowflake.md`](../../docs/platforms/snowflake.md) for full configuration options.
+
+## Assets
+
+- **`bronze_raw_data.asset.yml`**: Uses `ingestr` to copy the Frankfurter `/rates` endpoint into Snowflake. Column-level checks confirm base currency coverage, ensure exchange rates remain positive, and track ingestion timestamps.
+- **`silver_aggregated.sql`**: Snowflake SQL transformation (`sf.sql`) that surfaces the most recent rate alongside 7-day and 30-day deltas with rolling averages and bounds for each currency code. It includes column checks for critical metrics and a custom check enforcing non-null rolling averages.
+
+## Running the Pipeline
+
+1. Initialise the template (choose your target directory):
+   ```bash
+   bruin init bronze-silver-snowflake my-fx-pipeline
+   ```
+2. Replace the Snowflake placeholders in `.bruin.yml` with working credentials and grant your role rights to the target schema.
+3. Validate the project structure and asset definitions:
+   ```bash
+   bruin validate my-fx-pipeline
+   ```
+4. Execute the bronze and silver layers:
+   ```bash
+   bruin run my-fx-pipeline/pipeline.yml --environment default
+   ```
+
+The run will ingest raw FX observations into `bronze.frankfurter_rates` and then populate `silver.currency_rate_snapshot` with current rate intelligence that can feed downstream gold data products.

--- a/templates/bronze-silver-snowflake/assets/bronze_raw_data.asset.yml
+++ b/templates/bronze-silver-snowflake/assets/bronze_raw_data.asset.yml
@@ -1,0 +1,46 @@
+name: bronze.frankfurter_rates
+type: ingestr
+
+description: Ingests daily foreign exchange rates from the Frankfurter API into Snowflake without transformation to form the bronze layer.
+columns:
+  - name: base_currency
+    type: varchar
+    description: "Three letter code representing the base currency returned by the Frankfurter API."
+    checks:
+      - name: not_null
+  - name: currency_code
+    type: varchar
+    description: "Quoted currency code fetched from the Frankfurter API response payload."
+    checks:
+      - name: not_null
+  - name: rate
+    type: float
+    description: "Exchange rate published by the European Central Bank for the associated currency pair."
+    checks:
+      - name: not_null
+      - name: positive
+  - name: date
+    type: timestamp
+    description: "Timestamp associated with the exchange rate reading."
+    checks:
+      - name: not_null
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: rates
+  destination: snowflake
+  destination_table: frankfurter_rates
+  loader_file_format: jsonl
+
+custom_checks:
+  - name: ensure single base currency
+    value: 1
+    query: |
+      SELECT COUNT(DISTINCT base_currency) AS distinct_base_currencies
+      FROM bronze.frankfurter_rates
+  - name: ensure positive rates
+    value: 0
+    query: |
+      SELECT COUNT(*) AS non_positive_rates
+      FROM bronze.frankfurter_rates
+      WHERE rate <= 0

--- a/templates/bronze-silver-snowflake/assets/silver_aggregated.sql
+++ b/templates/bronze-silver-snowflake/assets/silver_aggregated.sql
@@ -1,0 +1,131 @@
+/* @bruin
+
+name: silver.currency_rate_snapshot
+type: sf.sql
+materialization:
+  type: table
+
+description: |
+  Aggregates the bronze Frankfurter exchange rate feed in Snowflake to provide a latest-rate snapshot
+  with rolling thirty day statistics and point-in-time deltas.
+
+depends:
+  - bronze.frankfurter_rates
+
+columns:
+  - name: currency_code
+    type: varchar
+    description: "Quoted currency code for the FX pair."
+    checks:
+        - name: not_null
+  - name: base_currency
+    type: varchar
+    description: "Shared base currency from the bronze layer."
+    checks:
+        - name: not_null
+  - name: latest_rate_date
+    type: date
+    description: "Calendar date of the most recent available exchange rate."
+    checks:
+        - name: not_null
+  - name: latest_rate
+    type: float
+    description: "Most recent exchange rate value for the currency pair."
+    checks:
+        - name: not_null
+        - name: positive
+  - name: rate_change_7d
+    type: float
+    description: "Difference between the latest rate and the rate seven days prior."
+  - name: rate_change_30d
+    type: float
+    description: "Difference between the latest rate and the rate thirty days prior."
+  - name: avg_rate_30d
+    type: float
+    description: "Average exchange rate over the past thirty days."
+    checks:
+        - name: positive
+  - name: min_rate_30d
+    type: float
+    description: "Minimum exchange rate recorded in the thirty day window."
+    checks:
+        - name: positive
+  - name: max_rate_30d
+    type: float
+    description: "Maximum exchange rate recorded in the thirty day window."
+    checks:
+        - name: positive
+
+custom_checks:
+  - name: ensure avg rate populated
+    value: 0
+    query: |
+      SELECT COUNT(*) AS avg_rate_missing
+      FROM silver.currency_rate_snapshot
+      WHERE avg_rate_30d IS NULL
+
+@bruin*/
+
+WITH base_data AS (
+    SELECT
+        currency_code,
+        base_currency,
+        CAST(date AS DATE) AS rate_date,
+        rate
+    FROM bronze.frankfurter_rates
+),
+lagged AS (
+    SELECT
+        currency_code,
+        base_currency,
+        rate_date,
+        rate,
+        LAG(rate, 7) OVER (PARTITION BY currency_code ORDER BY rate_date) AS rate_lag_7d,
+        LAG(rate, 30) OVER (PARTITION BY currency_code ORDER BY rate_date) AS rate_lag_30d,
+        ROW_NUMBER() OVER (PARTITION BY currency_code ORDER BY rate_date DESC) AS row_num
+    FROM base_data
+),
+latest AS (
+    SELECT
+        currency_code,
+        base_currency,
+        rate_date,
+        rate,
+        rate_lag_7d,
+        rate_lag_30d
+    FROM lagged
+    WHERE row_num = 1
+),
+recent_window AS (
+    SELECT
+        currency_code,
+        base_currency,
+        rate
+    FROM base_data
+    WHERE rate_date >= DATEADD(day, -30, CURRENT_DATE())
+),
+aggregated AS (
+    SELECT
+        currency_code,
+        base_currency,
+        AVG(rate) AS avg_rate_30d,
+        MIN(rate) AS min_rate_30d,
+        MAX(rate) AS max_rate_30d
+    FROM recent_window
+    GROUP BY 1, 2
+)
+SELECT
+    l.currency_code,
+    l.base_currency,
+    l.rate_date AS latest_rate_date,
+    l.rate AS latest_rate,
+    l.rate - COALESCE(l.rate_lag_7d, l.rate) AS rate_change_7d,
+    l.rate - COALESCE(l.rate_lag_30d, l.rate) AS rate_change_30d,
+    a.avg_rate_30d,
+    a.min_rate_30d,
+    a.max_rate_30d
+FROM latest l
+JOIN aggregated a
+  ON a.currency_code = l.currency_code
+ AND a.base_currency = l.base_currency
+ORDER BY l.currency_code;

--- a/templates/bronze-silver-snowflake/pipeline.yml
+++ b/templates/bronze-silver-snowflake/pipeline.yml
@@ -1,0 +1,2 @@
+name: bronze-silver-snowflake
+description: Bronze-to-silver Snowflake pipeline seeded from Frankfurter exchange rates.


### PR DESCRIPTION
## Summary
- add a `bronze-silver-snowflake` template that ingests Frankfurter rates into Snowflake and promotes them to a curated silver snapshot
- document Snowflake setup, template usage, and configuration placeholders to align with existing template guidance
- include column-level and custom quality checks on both assets to meet the acceptance criteria for data validation

## Testing
- not run (template only)

Closes #1221
