### PR TITLE
claude/session-011CUZVAbhtfGohHw6Pd7oez

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/postgres"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/sqlparser"
 	"github.com/pkg/errors"
@@ -92,6 +93,12 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment string, manager conf
 		return fillStatusFailed, fmt.Errorf("connection for asset '%s' does not support schema introspection", pp.Asset.Name)
 	}
 	tableName := pp.Asset.Name
+
+	// For PostgreSQL, quote the table name to handle case-sensitive names
+	if _, ok := conn.(*postgres.Client); ok {
+		tableName = postgres.QuoteIdentifier(tableName)
+	}
+
 	queryStr := fmt.Sprintf("SELECT * FROM %s WHERE 1=0 LIMIT 0", tableName)
 	if _, ok := conn.(*mssql.DB); ok {
 		queryStr = "SELECT TOP 0 * FROM " + tableName


### PR DESCRIPTION
This fix addresses an issue where the fill-from-db command would fail when working with PostgreSQL tables that have mixed-case names (e.g., schema.MyTable). PostgreSQL requires such identifiers to be properly quoted to preserve case sensitivity.

Changes:
- Exported QuoteIdentifier function in postgres package to handle proper quoting of schema and table names
- Updated fillColumnsFromDB in cmd/patch.go to use QuoteIdentifier for PostgreSQL connections
- Updated fillAssetColumnsFromDB in cmd/import.go to use QuoteIdentifier for PostgreSQL connections
- Table references are now properly quoted as "schema"."table_name"

The QuoteIdentifier function splits the identifier on "." and quotes each part separately, ensuring case-sensitive names are preserved when querying PostgreSQL databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)