### PR TITLE
docs: surface pipeline variable schema guidance across assets

### DIFF
--- a/docs/assets/templating/macros.md
+++ b/docs/assets/templating/macros.md
@@ -396,10 +396,16 @@ name: sales_pipeline
 variables:
   regions:
     type: array
-    default: ['US', 'EU', 'APAC']
+    minItems: 1
+    items:
+      type: string
+      enum: ['US', 'EU', 'APAC']
+    default: ['US', 'EU']
   min_revenue:
     type: integer
-    default: 1000
+    minimum: 1000
+    maximum: 100000
+    default: 5000
 ```
 
 `macros/filters.sql`
@@ -425,6 +431,9 @@ AND region = '{{ region }}'
 {% endfor %}
 ```
 :::
+
+> [!TIP]
+> The pipeline snippet above showcases array enums and numeric bounds. For additional JSON Schema keywords you can mix into macros-driven workflows—including nested objects and nullable values—refer to the [pipeline variables keyword reference](/getting-started/pipeline-variables#supported-json-schema-keywords).
 
 ### Dynamic Column Generation
 

--- a/docs/assets/templating/templating.md
+++ b/docs/assets/templating/templating.md
@@ -22,12 +22,12 @@ variables:
 ```
 
 `asset.sql`
-```sql 
+```sql
 SELECT
     conversion_date,
     cohort_id,
     {% for day_n in var.days %}
-    SUM(IFF(days_since_install < {{ day_n }}, revenue, 0)) 
+    SUM(IFF(days_since_install < {{ day_n }}, revenue, 0))
     AS revenue_{{ day_n }}_days
     {% if not loop.last %},{% endif %}
     {% endfor %}
@@ -35,6 +35,9 @@ FROM user_cohorts
 GROUP BY 1,2
 ```
 :::
+
+> [!TIP]
+> Need enumerations, numeric bounds, or nested structures for your variables? Consult the [JSON Schema keyword reference](/getting-started/pipeline-variables#supported-json-schema-keywords) for the full list of `type` values and examples of arrays-of-objects and object-of-arrays patterns you can reuse in templated SQL.
 
 This will render into the following SQL query:
 

--- a/docs/getting-started/pipeline.md
+++ b/docs/getting-started/pipeline.md
@@ -62,9 +62,42 @@ default:
 
 
 variables:
-  run_mode:
+  target_segment:
     type: string
-    default: "incremental"
+    enum: ["self_serve", "enterprise", "partner"]
+    default: "enterprise"
+  forecast_horizon_days:
+    type: integer
+    minimum: 7
+    maximum: 90
+    default: 30
+  experiment_cohorts:
+    type: array
+    items:
+      type: object
+      required: [name, weight, channels]
+      properties:
+        name:
+          type: string
+        weight:
+          type: number
+        channels:
+          type: array
+          items:
+            type: string
+    default:
+      - name: enterprise_baseline
+        weight: 0.6
+        channels: ["email", "customer_success"]
+  channel_overrides:
+    type: object
+    properties:
+      email:
+        type: array
+        items:
+          type: string
+    default:
+      email: ["enterprise_newsletter"]
 
 ```
 
@@ -330,7 +363,7 @@ Secrets item:
 ### Variables
 
 Define pipeline-scoped parameters with safe defaults so you can change behavior without editing code.
-Great for toggling modes (e.g., full vs incremental) or passing environment-specific values.
+Great for steering business logic (e.g., targeting a customer segment) or tuning data science parameters (e.g., forecast horizons).
 
 See also: [Variables](/getting-started/pipeline-variables).
 
@@ -338,18 +371,51 @@ Example:
 
 ```yaml
 variables:
-  run_mode:
+  target_segment:
     type: string
-    default: "incremental"
+    enum: ["self_serve", "enterprise", "partner"]
+    default: "enterprise"
+  forecast_horizon_days:
+    type: integer
+    minimum: 7
+    maximum: 90
+    default: 30
+  experiment_cohorts:
+    type: array
+    items:
+      type: object
+      required: [name, weight, channels]
+      properties:
+        name:
+          type: string
+        weight:
+          type: number
+        channels:
+          type: array
+          items:
+            type: string
+    default:
+      - name: enterprise_baseline
+        weight: 0.6
+        channels: ["email", "customer_success"]
+  channel_overrides:
+    type: object
+    properties:
+      email:
+        type: array
+        items:
+          type: string
+    default:
+      email: ["enterprise_newsletter"]
 ```
 
 - **Type:** `Object (map[string]variable-schema)`
 
 Variable schema fields (subset):
 
-| Field   | Type   | Required | Notes                                                                   |
-|---------|--------|----------|-------------------------------------------------------------------------|
-| type    | String | no       | JSON Schema type: string, integer, number, boolean, object, array       |
-| default | any    | yes      | REQUIRED. Must be present; used as the variable value unless overridden |
+| Field   | Type   | Required | Notes                                                                                   |
+|---------|--------|----------|-----------------------------------------------------------------------------------------|
+| type    | String | no       | JSON Schema type: string, integer, number, boolean, object, array, null. See [variables type reference](/getting-started/pipeline-variables#supported-json-schema-keywords) for details and examples. |
+| default | any    | yes      | REQUIRED. Must be present; used as the variable value unless overridden                 |
+| enum    | Array  | no       | Restrict values to a fixed list (e.g. `enum: ["self_serve", "enterprise", "partner"]`). See [variables documentation](/getting-started/pipeline-variables#supported-json-schema-keywords) for more JSON Schema keywords you can use. |
 
->


### PR DESCRIPTION
## Summary
- link Python asset guidance to the JSON Schema keyword reference and refresh the example with business and experimentation variables
- add tips in the templating and macro docs that point to the supported type list for more complex variable structures
- update the macro walkthrough to demonstrate enum-constrained arrays and bounded numeric parameters

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_6909e84f1c98832b8467d1e87bba8880