### PR TITLE
implemented table sensor and query sensor for mysql

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1559,13 +1559,26 @@ func SetupExecutors(
 		mainExecutors[pipeline.AssetTypeS3KeySensor][scheduler.TaskInstanceTypeMain] = s3KeySensor
 	}
 
-	if s.WillRunTaskOfType(pipeline.AssetTypeMySQLQuery) || estimateCustomCheckType == pipeline.AssetTypeMySQLQuery {
+	if s.WillRunTaskOfType(pipeline.AssetTypeMySQLQuery) ||
+		estimateCustomCheckType == pipeline.AssetTypeMySQLQuery ||
+		s.WillRunTaskOfType(pipeline.AssetTypeMySQLQuerySensor) ||
+		s.WillRunTaskOfType(pipeline.AssetTypeMySQLTableSensor) {
 		mysqlOperator := mysql.NewBasicOperator(conn, wholeFileExtractor, mysql.NewMaterializer(fullRefresh), parser)
 		mysqlCheckRunner := mysql.NewColumnCheckOperator(conn)
+		mysqlQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+		mysqlTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeMySQLQuery][scheduler.TaskInstanceTypeMain] = mysqlOperator
 		mainExecutors[pipeline.AssetTypeMySQLQuery][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
 		mainExecutors[pipeline.AssetTypeMySQLQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
+		mainExecutors[pipeline.AssetTypeMySQLQuerySensor][scheduler.TaskInstanceTypeMain] = mysqlQuerySensor
+		mainExecutors[pipeline.AssetTypeMySQLQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
+		mainExecutors[pipeline.AssetTypeMySQLQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
+		mainExecutors[pipeline.AssetTypeMySQLTableSensor][scheduler.TaskInstanceTypeMain] = mysqlTableSensor
+		mainExecutors[pipeline.AssetTypeMySQLTableSensor][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
+		mainExecutors[pipeline.AssetTypeMySQLTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 	}
 
 	return mainExecutors, nil

--- a/pkg/executor/defaults.go
+++ b/pkg/executor/defaults.go
@@ -122,6 +122,18 @@ var DefaultExecutorsV2 = map[pipeline.AssetType]Config{
 		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
 		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},
 	},
+	pipeline.AssetTypeMySQLQuerySensor: {
+		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
+		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},
+		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
+		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},
+	},
+	pipeline.AssetTypeMySQLTableSensor: {
+		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
+		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},
+		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
+		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},
+	},
 	pipeline.AssetTypeClickHouse: {
 		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
 		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1088,6 +1088,7 @@ var TableSensorAllowedAssetTypes = map[pipeline.AssetType]bool{
 	pipeline.AssetTypeMsSQLTableSensor:      true,
 	pipeline.AssetTypePostgresTableSensor:   true,
 	pipeline.AssetTypeSynapseTableSensor:    true,
+	pipeline.AssetTypeMySQLTableSensor:      true,
 }
 
 var platformNames = map[pipeline.AssetType]string{
@@ -1100,6 +1101,7 @@ var platformNames = map[pipeline.AssetType]string{
 	pipeline.AssetTypeMsSQLTableSensor:      "MS SQL",
 	pipeline.AssetTypeClickHouseTableSensor: "ClickHouse",
 	pipeline.AssetTypeSynapseTableSensor:    "Synapse",
+	pipeline.AssetTypeMySQLTableSensor:      "MySQL",
 }
 
 func ValidateTableSensorTableParameter(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -1177,6 +1179,11 @@ var tableNameValidationRules = map[string]TableNameValidationRule{
 		FormatDesc:    "`table` or `schema.table`",
 	},
 	"Synapse": {
+		MinComponents: 1,
+		MaxComponents: 2,
+		FormatDesc:    "`table` or `schema.table`",
+	},
+	"MySQL": {
 		MinComponents: 1,
 		MaxComponents: 2,
 		FormatDesc:    "`table` or `schema.table`",

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3550,6 +3550,65 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 
+		// MySQL tests
+		{
+			name: "MySQL - no table parameter",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeMySQLTableSensor,
+			},
+			want:    []string{"MySQL table sensor requires a `table` parameter"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "MySQL - empty table component",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeMySQLTableSensor,
+				Parameters: map[string]string{
+					"table": "analytics.",
+				},
+			},
+			want:    []string{"MySQL table sensor `table` parameter contains empty components, 'analytics.' given"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "MySQL - invalid format (too many components)",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeMySQLTableSensor,
+				Parameters: map[string]string{
+					"table": "analytics.sales.daily",
+				},
+			},
+			want:    []string{"MySQL table sensor `table` parameter must be in format `table` or `schema.table`, 'analytics.sales.daily' given"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "MySQL - valid table format",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeMySQLTableSensor,
+				Parameters: map[string]string{
+					"table": "orders",
+				},
+			},
+			want:    []string{},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "MySQL - valid schema.table format",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeMySQLTableSensor,
+				Parameters: map[string]string{
+					"table": "analytics.orders",
+				},
+			},
+			want:    []string{},
+			wantErr: assert.NoError,
+		},
+
 		// Synapse tests
 		{
 			name: "Synapse - no table parameter",

--- a/pkg/mysql/db.go
+++ b/pkg/mysql/db.go
@@ -242,6 +242,31 @@ ORDER BY table_schema, table_name;
 	return summary, nil
 }
 
+func (c *Client) BuildTableExistsQuery(tableName string) (string, error) {
+	tableComponents := strings.Split(tableName, ".")
+	for _, component := range tableComponents {
+		if component == "" {
+			return "", fmt.Errorf("table name must be in format schema.table or table, '%s' given", tableName)
+		}
+	}
+
+	switch len(tableComponents) {
+	case 1:
+		return strings.TrimSpace(fmt.Sprintf(
+			"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '%s'",
+			tableComponents[0],
+		)), nil
+	case 2:
+		return strings.TrimSpace(fmt.Sprintf(
+			"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'",
+			tableComponents[0],
+			tableComponents[1],
+		)), nil
+	default:
+		return "", fmt.Errorf("table name must be in format schema.table or table, '%s' given", tableName)
+	}
+}
+
 func (c *Client) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error {
 	if asset == nil {
 		return errors.New("asset cannot be nil")

--- a/pkg/mysql/operator.go
+++ b/pkg/mysql/operator.go
@@ -23,6 +23,7 @@ type MySQLClient interface {
 	RunQueryWithoutResult(ctx context.Context, query *query.Query) error
 	Select(ctx context.Context, query *query.Query) ([][]interface{}, error)
 	SelectWithSchema(ctx context.Context, queryObj *query.Query) (*query.QueryResult, error)
+	BuildTableExistsQuery(tableName string) (string, error)
 	Ping(ctx context.Context) error
 	GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error)
 	CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -56,6 +56,8 @@ const (
 	AssetTypePostgresQuery          = AssetType("pg.sql")
 	AssetTypePostgresSeed           = AssetType("pg.seed")
 	AssetTypeMySQLQuery             = AssetType("my.sql")
+	AssetTypeMySQLQuerySensor       = AssetType("my.sensor.query")
+	AssetTypeMySQLTableSensor       = AssetType("my.sensor.table")
 	AssetTypePostgresQuerySensor    = AssetType("pg.sensor.query")
 	AssetTypePostgresTableSensor    = AssetType("pg.sensor.table")
 	AssetTypeRedshiftQuery          = AssetType("rs.sql")
@@ -591,6 +593,8 @@ var AssetTypeConnectionMapping = map[AssetType]string{
 	AssetTypePostgresTableSensor:   "postgres",
 	AssetTypePostgresSource:        "postgres",
 	AssetTypeMySQLQuery:            "mysql",
+	AssetTypeMySQLQuerySensor:      "mysql",
+	AssetTypeMySQLTableSensor:      "mysql",
 	AssetTypeRedshiftQuery:         "redshift",
 	AssetTypeRedshiftSeed:          "redshift",
 	AssetTypeRedshiftQuerySensor:   "redshift",


### PR DESCRIPTION
This pull request adds support for MySQL table and query sensors throughout the codebase. It introduces new asset types for MySQL sensors, implements validation and executor setup for these types, and includes comprehensive tests for table name validation and query building. The changes ensure MySQL sensors are handled consistently with other platforms.

**MySQL Sensor Support**

* Added new asset types: `AssetTypeMySQLQuerySensor` and `AssetTypeMySQLTableSensor` in `pipeline.go`, and mapped them to the MySQL connection type. [[1]](diffhunk://#diff-e12d12a4cfe02aa5eca86c201e08ca1ac7631b7614a7ba97a121f898c6d11e9aR59-R60) [[2]](diffhunk://#diff-e12d12a4cfe02aa5eca86c201e08ca1ac7631b7614a7ba97a121f898c6d11e9aR596-R597)
* Updated executor setup in `cmd/run.go` to initialize and register main, column check, and custom check executors for the new MySQL sensor asset types.
* Added default executor configurations for the new MySQL sensor asset types in `defaults.go`.

**Linting and Validation**

* Enabled MySQL table sensors in the set of allowed table sensor asset types and platform names in `rules.go`, and defined table name validation rules for MySQL. [[1]](diffhunk://#diff-d009400542ddc6f2e0ded7a6221273704f0062bdafbeb68e011a58680be2a501R1091) [[2]](diffhunk://#diff-d009400542ddc6f2e0ded7a6221273704f0062bdafbeb68e011a58680be2a501R1104) [[3]](diffhunk://#diff-d009400542ddc6f2e0ded7a6221273704f0062bdafbeb68e011a58680be2a501R1186-R1190)
* Added comprehensive unit tests for MySQL table sensor parameter validation, covering missing, empty, invalid, and valid table name formats in `rules_test.go`.

**MySQL Table Existence Query**

* Implemented `BuildTableExistsQuery` in `db.go` to generate a query that checks if a table exists in MySQL, supporting both `table` and `schema.table` formats with error handling for invalid formats.
* Added interface method for `BuildTableExistsQuery` in `MySQLClient` and corresponding unit tests for query generation and validation in `db_test.go`. [[1]](diffhunk://#diff-f69ec6efb68e82cb31d5929f9d629bc986eebbdd571340441bf5a93c0efc266eR26) [[2]](diffhunk://#diff-b9e674398aa06b5d7f7366f6dca6c8a81970f6c2d9f58e78521650563a15696dR232-R289)