### PR TITLE
Ensure ADC flag always present in GCP connection JSON

### DIFF
--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -78,12 +78,15 @@ func (c GoogleCloudPlatformConnection) MarshalJSON() ([]byte, error) {
 		c.ServiceAccountJSON = string(contents)
 	}
 
-	return json.Marshal(map[string]string{
-		"name":                 c.Name,
-		"service_account_json": c.ServiceAccountJSON,
-		"service_account_file": c.ServiceAccountFile,
-		"project_id":           c.ProjectID,
-	})
+	marshalable := map[string]interface{}{
+		"name":                                c.Name,
+		"service_account_json":                c.ServiceAccountJSON,
+		"service_account_file":                c.ServiceAccountFile,
+		"project_id":                          c.ProjectID,
+		"use_application_default_credentials": c.UseApplicationDefaultCredentials,
+	}
+
+	return json.Marshal(marshalable)
 }
 
 type AthenaConnection struct { //nolint:recvcheck

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoogleCloudPlatformConnectionMarshalJSONAlwaysIncludesUseADC(t *testing.T) {
+	t.Parallel()
+
+	conn := GoogleCloudPlatformConnection{
+		Name:      "conn1",
+		ProjectID: "my-project",
+		Location:  "us",
+		// UseApplicationDefaultCredentials intentionally left as zero value to ensure it marshals as false.
+	}
+
+	raw, err := conn.MarshalJSON()
+	require.NoError(t, err)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	adcValue, exists := payload["use_application_default_credentials"]
+	require.True(t, exists, "use_application_default_credentials should always be present in marshaled JSON")
+	assert.False(t, adcValue.(bool))
+}


### PR DESCRIPTION
## Summary
- always include the use_application_default_credentials flag in marshaled GCP connection JSON even when false
- add a regression test to ensure the ADC flag is always present

## Testing
- go test ./pkg/config

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a470ccf98832bae47e0f69c59e251)