### PR TITLE
Revert to setup-go action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-# TODO: Replace with actions/setup-go once issue is resolved https://github.com/actions/setup-go/pull/515
       - name: Setup Go 
-        uses: antontroshin/setup-go@windows-go-mod-cache
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: "go.sum"
+          cache: true
       - name: Install R (Ubuntu)
         if: startsWith(matrix.platform, 'depot-ubuntu')
         run: |
@@ -150,12 +149,11 @@ jobs:
           msystem: UCRT64
           update: true
           install: git mingw-w64-ucrt-x86_64-gcc
-# TODO: Replace with actions/setup-go once issue is resolved https://github.com/actions/setup-go/pull/515
       - name: Setup Go 
-        uses: antontroshin/setup-go@windows-go-mod-cache
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: "go.sum"
+          cache: true
       - name: Release
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
Revert to using `actions/setup-go@v4` in the release workflow to improve caching and reduce execution time.

The previous custom `antontroshin/setup-go@windows-go-mod-cache` action was causing the "Post Setup Go" step to take an excessive amount of time (e.g., 15m 53s). Switching back to the official `actions/setup-go@v4` with `cache: true` is expected to provide more predictable caching behavior and significantly reduce the workflow's execution time.

---
[Slack Thread](https://bruintalk.slack.com/archives/C07SBCEK5NK/p1763390215641289?thread_ts=1763390215.641289&cid=C07SBCEK5NK)

<a href="https://cursor.com/background-agent?bcId=bc-a365303c-49a3-4e2f-8f00-e570e8f90744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a365303c-49a3-4e2f-8f00-e570e8f90744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

