### PR TITLE
Improve adc error handling

### DIFF
--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -96,7 +96,6 @@ func NewDB(c *Config) (*Client, error) {
 			}
 		}
 	}
-	// If ADC is enabled, we don't add any credential options - let Google SDK find them automatically
 
 	client, err := bigquery.NewClient(
 		context.Background(),
@@ -158,7 +157,6 @@ func (d *Client) NewDataTransferClient(ctx context.Context) (*datatransfer.Clien
 			}
 		}
 	}
-	// If ADC is enabled, we don't add any credential options - let Google SDK find them automatically
 
 	client, err := datatransfer.NewClient(ctx, options...)
 	if err != nil {


### PR DESCRIPTION
This pull request improves authentication error handling for Google Cloud BigQuery and Data Transfer clients by proactively checking for Application Default Credentials (ADC) availability during client initialization. The previous approach relied on post-failure error inspection, but now the code checks for credentials up front and provides clearer error messages. Additionally, credential error detection logic has been removed in favor of this more robust approach.
