### PR TITLE
mysql inits db only on query execution

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -646,14 +646,14 @@ func (m *Manager) AddMongoAtlasConnectionFromConfig(connection *config.MongoAtla
 	return nil
 }
 
-func (m *Manager) AddMySQLConnectionFromConfig(ctx context.Context, connection *config.MySQLConnection) error {
+func (m *Manager) AddMySQLConnectionFromConfig(connection *config.MySQLConnection) error {
 	m.mutex.Lock()
 	if m.Mysql == nil {
 		m.Mysql = make(map[string]*mysql.Client)
 	}
 	m.mutex.Unlock()
 
-	client, err := mysql.NewClientWithContext(ctx, &mysql.Config{
+	client, err := mysql.NewClient(&mysql.Config{
 		Username: connection.Username,
 		Password: connection.Password,
 		Host:     connection.Host,
@@ -2481,9 +2481,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Couchbase, connectionManager.AddCouchbaseConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Cursor, connectionManager.AddCursorConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.MongoAtlas, connectionManager.AddMongoAtlasConnectionFromConfig, &wg, &errList, &mu)
-	processConnections(cm.SelectedEnvironment.Connections.MySQL, func(conn *config.MySQLConnection) error {
-		return connectionManager.AddMySQLConnectionFromConfig(ctx, conn)
-	}, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.MySQL, connectionManager.AddMySQLConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Notion, connectionManager.AddNotionConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Allium, connectionManager.AddAlliumConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.HANA, connectionManager.AddHANAConnectionFromConfig, &wg, &errList, &mu)


### PR DESCRIPTION
This pull request refactors the MySQL client initialization logic to use lazy connection establishment. Before this change MySQL would try and establish connection to database on running any pipeline (even without any mysql assets - initialisation as redshift and pg) however this would block indefinitely when the connection was to a paused docker container.

Now connection is only attempted on running query (like with snowflake) 