### PR TITLE
Add Doppler as secrets backend option

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -564,7 +564,7 @@ func Run(isDebug *bool) *cli.Command {
 			&cli.StringFlag{
 				Name:    "secrets-backend",
 				Sources: cli.EnvVars("BRUIN_SECRETS_BACKEND"),
-				Usage:   "the source of secrets if different from .bruin.yml. Possible values: 'vault'",
+				Usage:   "the source of secrets if different from .bruin.yml. Possible values: 'vault', 'doppler'",
 			},
 			&cli.BoolFlag{
 				Name:  "no-validation",
@@ -795,12 +795,18 @@ func Run(isDebug *bool) *cli.Command {
 			var errs []error
 
 			secretsBackend := c.String("secrets-backend")
-			if secretsBackend == "vault" {
+			switch secretsBackend {
+			case "vault":
 				connectionManager, err = secrets.NewVaultClientFromEnv(logger) //nolint:contextcheck
 				if err != nil {
 					errs = append(errs, errors.Wrap(err, "failed to initialize vault client"))
 				}
-			} else {
+			case "doppler":
+				connectionManager, err = secrets.NewDopplerClientFromEnv(logger)
+				if err != nil {
+					errs = append(errs, errors.Wrap(err, "failed to initialize doppler client"))
+				}
+			default:
 				connectionManager, errs = connection.NewManagerFromConfigWithContext(ctx, cm)
 			}
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -49,6 +49,7 @@ table td:first-child {
 | `--exp-use-winget-for-uv` | bool | `false` | Use PowerShell to manage and install `uv` on Windows. Has no effect on non-Windows systems. |
 | `--debug-ingestr-src` | str | - | Use ingestr from the given path instead of the builtin version. |
 | `--config-file` | str | - | The path to the `.bruin.yml` file. |
+| `--secrets-backend` | str | - | The source of secrets if different from .bruin.yml. Possible values: `vault`, `doppler`. Can also be set via `BRUIN_SECRETS_BACKEND` environment variable. |
 | `--no-validation` | bool | `false` | Skip validation for this run. |
 | `--no-timestamp` | bool | `false` | Skip logging timestamps for this run. |
 | `--no-color` | bool | `false` | Plain log output for this run. |
@@ -195,6 +196,42 @@ metadata_push:
 ```
 
 When pushing the metadata, Bruin will detect the right connection to use, same way as it happens with running the asset.
+
+## Using Alternative Secrets Backends
+
+By default, Bruin reads connection credentials from the `.bruin.yml` file. However, you can use alternative secrets management solutions like HashiCorp Vault or Doppler.
+
+### Using Doppler
+
+To use Doppler as your secrets backend:
+
+```bash
+bruin run --secrets-backend doppler
+```
+
+Or set via environment variable:
+```bash
+export BRUIN_SECRETS_BACKEND=doppler
+bruin run
+```
+
+For more details on configuring Doppler, see the [Doppler secrets documentation](/secrets/doppler).
+
+### Using Vault
+
+To use HashiCorp Vault as your secrets backend:
+
+```bash
+bruin run --secrets-backend vault
+```
+
+Or set via environment variable:
+```bash
+export BRUIN_SECRETS_BACKEND=vault
+bruin run
+```
+
+For more details on configuring Vault, see the [Vault secrets documentation](/secrets/vault).
 
 
 

--- a/docs/secrets/doppler.md
+++ b/docs/secrets/doppler.md
@@ -1,0 +1,162 @@
+# Using Doppler as a Secrets Backend
+
+Bruin supports using [Doppler](https://www.doppler.com/) as a secrets backend for managing connection credentials. This is controlled via the `--secrets-backend` flag on the `run` command.
+
+## Enabling Doppler
+
+To use Doppler as your secrets backend, pass the flag:
+
+```bash
+bruin run --secrets-backend doppler
+```
+
+You can also set the backend via environment variable:
+
+```bash
+export BRUIN_SECRETS_BACKEND=doppler
+bruin run
+```
+
+## Configuring Doppler Connection
+
+Bruin connects to Doppler using environment variables. The following are required:
+
+- `BRUIN_DOPPLER_TOKEN`: Your Doppler service token (create one in your Doppler project settings)
+- `BRUIN_DOPPLER_PROJECT`: The Doppler project name
+- `BRUIN_DOPPLER_CONFIG`: The Doppler config name (e.g., `dev`, `prod`, `staging`)
+
+### Example Setup
+
+```bash
+export BRUIN_DOPPLER_TOKEN=dp.st.your-token-here
+export BRUIN_DOPPLER_PROJECT=my-data-project
+export BRUIN_DOPPLER_CONFIG=dev
+
+bruin run --secrets-backend doppler
+```
+
+## Storing Secrets in Doppler
+
+Bruin expects connection credentials to be stored in Doppler as JSON strings. Each secret should be named after the connection name and contain the connection details in a specific format.
+
+### Secret Format
+
+The secret value must be a JSON string with two required fields:
+
+- `type`: The connection type (must match a valid Bruin connection type)
+- `details`: An object containing the connection-specific configuration
+
+### Example: PostgreSQL Connection
+
+In Doppler, create a secret named `my-postgres` with this value:
+
+```json
+{
+  "type": "postgres",
+  "details": {
+    "host": "localhost",
+    "port": 5432,
+    "username": "myuser",
+    "password": "mypassword",
+    "database": "mydatabase",
+    "schema": "public"
+  }
+}
+```
+
+### Example: Snowflake Connection
+
+In Doppler, create a secret named `my-snowflake` with this value:
+
+```json
+{
+  "type": "snowflake",
+  "details": {
+    "account": "my-account",
+    "username": "myuser",
+    "password": "mypassword",
+    "warehouse": "my-warehouse",
+    "database": "my-database",
+    "schema": "my-schema"
+  }
+}
+```
+
+### Example: Google BigQuery Connection
+
+In Doppler, create a secret named `my-bigquery` with this value:
+
+```json
+{
+  "type": "google_cloud_platform",
+  "details": {
+    "project_id": "my-gcp-project",
+    "service_account_file": "/path/to/service-account.json"
+  }
+}
+```
+
+## Supported Connection Types
+
+The `type` field must be one of the valid Bruin connection types. Common types include:
+
+- `postgres` - PostgreSQL database
+- `mysql` - MySQL database
+- `snowflake` - Snowflake data warehouse
+- `google_cloud_platform` - Google BigQuery
+- `redshift` - AWS Redshift
+- `databricks` - Databricks
+- `generic` - Generic key-value secrets
+
+For a complete list of supported connection types and their configuration schemas, see the [connections documentation](../getting-started/introduction/quickstart.md#bruin-yml).
+
+## How It Works
+
+When you run Bruin with `--secrets-backend doppler`:
+
+1. Bruin connects to Doppler using your credentials
+2. For each connection referenced in your pipeline, Bruin fetches the corresponding secret from Doppler
+3. The secret is parsed and validated according to the connection type
+4. The connection is established using the fetched credentials
+5. Results are cached in memory for the duration of the run
+
+## Troubleshooting
+
+### Environment Variables Not Set
+
+If you see an error like:
+```
+failed to initialize doppler client: BRUIN_DOPPLER_TOKEN env variable not set
+```
+
+Make sure all three required environment variables are set:
+```bash
+echo $BRUIN_DOPPLER_TOKEN
+echo $BRUIN_DOPPLER_PROJECT
+echo $BRUIN_DOPPLER_CONFIG
+```
+
+### Secret Not Found
+
+If you see an error like:
+```
+secret 'my-connection' not found in Doppler
+```
+
+Verify that:
+1. The secret exists in Doppler with the exact name used in your pipeline
+2. The secret is in the correct project and config
+3. Your Doppler token has access to read the secret
+
+### Invalid Secret Format
+
+If you see an error like:
+```
+failed to parse secret as JSON
+```
+
+Verify that:
+1. The secret value in Doppler is valid JSON
+2. The JSON includes both `type` and `details` fields
+3. The `type` value matches a supported connection type
+4. The `details` object contains all required fields for that connection type

--- a/docs/secrets/overview.md
+++ b/docs/secrets/overview.md
@@ -4,5 +4,6 @@ Bruin CLI normally retrieves secrets to instantiate connections to different pla
 
 At the moment, Bruin supports the following:
  * [Hashicorp Vault](./vault)
+ * [Doppler](./doppler)
  * [.bruin.yml](./bruinyml)
 

--- a/pkg/secrets/doppler.go
+++ b/pkg/secrets/doppler.go
@@ -1,0 +1,231 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/connection"
+	"github.com/bruin-data/bruin/pkg/logger"
+	"github.com/pkg/errors"
+)
+
+const dopplerAPIBaseURL = "https://api.doppler.com/v3"
+
+type dopplerHTTPClient interface {
+	GetSecret(ctx context.Context, secretName string) (map[string]any, error)
+}
+
+type httpDopplerClient struct {
+	token   string
+	project string
+	config  string
+	client  *http.Client
+}
+
+func (h *httpDopplerClient) GetSecret(ctx context.Context, secretName string) (map[string]any, error) {
+	url := fmt.Sprintf("%s/configs/config/secrets/download?project=%s&config=%s&format=json", dopplerAPIBaseURL, h.project, h.config)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request")
+	}
+
+	req.Header.Set("Authorization", "Bearer "+h.token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch secrets from Doppler")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, errors.Errorf("doppler API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var allSecrets map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&allSecrets); err != nil {
+		return nil, errors.Wrap(err, "failed to decode Doppler response")
+	}
+
+	secretValue, ok := allSecrets[secretName]
+	if !ok {
+		return nil, errors.Errorf("secret '%s' not found in Doppler", secretName)
+	}
+
+	secretStr, ok := secretValue.(string)
+	if !ok {
+		return nil, errors.Errorf("secret '%s' is not a string", secretName)
+	}
+
+	var secretData map[string]any
+	if err := json.Unmarshal([]byte(secretStr), &secretData); err != nil {
+		return nil, errors.Wrap(err, "failed to parse secret as JSON")
+	}
+
+	return secretData, nil
+}
+
+// DopplerClient manages secrets from Doppler.
+type DopplerClient struct {
+	client                  dopplerHTTPClient
+	logger                  logger.Logger
+	cacheConnections        map[string]any
+	cacheConnectionsDetails map[string]any
+}
+
+// NewDopplerClientFromEnv creates a new Doppler client from environment variables.
+func NewDopplerClientFromEnv(logger logger.Logger) (*DopplerClient, error) {
+	token := os.Getenv("BRUIN_DOPPLER_TOKEN")
+	if token == "" {
+		return nil, errors.New("BRUIN_DOPPLER_TOKEN env variable not set")
+	}
+	project := os.Getenv("BRUIN_DOPPLER_PROJECT")
+	if project == "" {
+		return nil, errors.New("BRUIN_DOPPLER_PROJECT env variable not set")
+	}
+	config := os.Getenv("BRUIN_DOPPLER_CONFIG")
+	if config == "" {
+		return nil, errors.New("BRUIN_DOPPLER_CONFIG env variable not set")
+	}
+
+	return NewDopplerClient(logger, token, project, config)
+}
+
+// NewDopplerClient creates a new Doppler secrets client.
+func NewDopplerClient(logger logger.Logger, token, project, config string) (*DopplerClient, error) {
+	if token == "" {
+		return nil, errors.New("empty doppler token provided")
+	}
+	if project == "" {
+		return nil, errors.New("empty doppler project provided")
+	}
+	if config == "" {
+		return nil, errors.New("empty doppler config provided")
+	}
+
+	httpClient := &httpDopplerClient{
+		token:   token,
+		project: project,
+		config:  config,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+
+	return &DopplerClient{
+		client:                  httpClient,
+		logger:                  logger,
+		cacheConnections:        make(map[string]any),
+		cacheConnectionsDetails: make(map[string]any),
+	}, nil
+}
+
+// GetConnection retrieves a connection by name from Doppler.
+func (c *DopplerClient) GetConnection(name string) any {
+	if conn, ok := c.cacheConnections[name]; ok {
+		return conn
+	}
+
+	manager, err := c.getDopplerManager(name)
+	if err != nil {
+		return nil
+	}
+
+	conn := manager.GetConnection(name)
+	c.cacheConnections[name] = conn
+
+	return conn
+}
+
+// GetConnectionDetails retrieves connection details by name from Doppler.
+func (c *DopplerClient) GetConnectionDetails(name string) any {
+	if deets, ok := c.cacheConnectionsDetails[name]; ok {
+		return deets
+	}
+
+	manager, err := c.getDopplerManager(name)
+	if err != nil {
+		return nil
+	}
+
+	deets := manager.GetConnectionDetails(name)
+	c.cacheConnectionsDetails[name] = deets
+
+	return deets
+}
+
+func (c *DopplerClient) getDopplerManager(name string) (config.ConnectionAndDetailsGetter, error) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelFunc()
+
+	secretData, err := c.client.GetSecret(ctx, name)
+	if err != nil {
+		c.logger.Error("failed to read secret from Doppler", "error", err)
+		return nil, err
+	}
+
+	detailsRaw, okDetails := secretData["details"]
+	secretType, okType := secretData["type"].(string)
+	if !okDetails && !okType {
+		c.logger.Error("failed to read secret from Doppler", "error", "no details or type found")
+		return nil, errors.New("no details or type found")
+	}
+
+	details, ok := detailsRaw.(map[string]any)
+	if !ok {
+		c.logger.Error("failed to read secret from Doppler", "error", "details is not a map", "details:", detailsRaw)
+		return nil, errors.New("details is not a map")
+	}
+
+	details["name"] = name
+
+	// This is a hacky way to use the already existing logic in connections manager that processes connections config to create the right
+	// platform/db client
+	connectionsMap := map[string][]map[string]any{
+		secretType: {
+			details,
+		},
+	}
+
+	serialized, err := json.Marshal(connectionsMap)
+	if err != nil {
+		c.logger.Error("failed to marshal connections map", "error", err)
+		return nil, err
+	}
+
+	var connections config.Connections
+
+	if err := json.Unmarshal(serialized, &connections); err != nil {
+		c.logger.Error("failed to unmarshal connections map", "error", err)
+		return nil, err
+	}
+
+	environment := config.Environment{
+		Connections: &connections,
+	}
+
+	cfg := config.Config{
+		Environments: map[string]config.Environment{
+			"default": environment,
+		},
+		SelectedEnvironmentName: "default",
+		SelectedEnvironment:     &environment,
+		DefaultEnvironmentName:  "default",
+	}
+
+	manager, errs := connection.NewManagerFromConfig(&cfg)
+	if len(errs) > 0 {
+		c.logger.Error("failed to create manager from config", "error", errs)
+		return nil, errors.Wrap(errs[0], "failed to create manager from config")
+	}
+
+	return manager, nil
+}

--- a/pkg/secrets/doppler_test.go
+++ b/pkg/secrets/doppler_test.go
@@ -1,0 +1,198 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDopplerClient(t *testing.T) {
+	t.Parallel()
+	log := &mockLogger{}
+
+	t.Run("returns error if token is empty", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewDopplerClient(log, "", "project", "config")
+		require.Error(t, err)
+		require.Nil(t, client)
+		require.Contains(t, err.Error(), "empty doppler token")
+	})
+
+	t.Run("returns error if project is empty", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewDopplerClient(log, "token", "", "config")
+		require.Error(t, err)
+		require.Nil(t, client)
+		require.Contains(t, err.Error(), "empty doppler project")
+	})
+
+	t.Run("returns error if config is empty", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewDopplerClient(log, "token", "project", "")
+		require.Error(t, err)
+		require.Nil(t, client)
+		require.Contains(t, err.Error(), "empty doppler config")
+	})
+
+	t.Run("creates client successfully with valid parameters", func(t *testing.T) {
+		t.Parallel()
+		client, err := NewDopplerClient(log, "token", "project", "config")
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+}
+
+// mockDopplerHTTPClient implements the dopplerHTTPClient interface for testing.
+type mockDopplerHTTPClient struct {
+	response map[string]any
+	err      error
+}
+
+func (m *mockDopplerHTTPClient) GetSecret(ctx context.Context, secretName string) (map[string]any, error) {
+	return m.response, m.err
+}
+
+func TestDopplerClient_GetConnection_ReturnsConnection(t *testing.T) {
+	t.Parallel()
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: map[string]any{
+				"details": map[string]any{
+					"username": "testuser",
+					"password": "testpass",
+					"host":     "testhost",
+					"port":     float64(5432),
+					"database": "testdb",
+					"schema":   "testschema",
+				},
+				"type": "postgres",
+			},
+			err: nil,
+		},
+		logger:           &mockLogger{},
+		cacheConnections: make(map[string]any),
+	}
+
+	conn := c.GetConnection("test-connection")
+	require.NotNil(t, conn)
+}
+
+func TestDopplerClient_GetConnection_ReturnsGenericConnection(t *testing.T) {
+	t.Parallel()
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: map[string]any{
+				"details": map[string]any{
+					"value": "somevalue",
+				},
+				"type": "generic",
+			},
+			err: nil,
+		},
+		logger:           &mockLogger{},
+		cacheConnections: make(map[string]any),
+	}
+
+	conn := c.GetConnection("test-connection")
+	require.NotNil(t, conn)
+	require.Equal(t, "somevalue", conn.(*config.GenericConnection).Value)
+}
+
+func TestDopplerClient_GetConnection_HandlesError(t *testing.T) {
+	t.Parallel()
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: nil,
+			err:      errors.New("doppler API error"),
+		},
+		logger:           &mockLogger{},
+		cacheConnections: make(map[string]any),
+	}
+
+	conn := c.GetConnection("test-connection")
+	require.Nil(t, conn)
+}
+
+func TestDopplerClient_GetConnectionDetails_ReturnsDetails(t *testing.T) {
+	t.Parallel()
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: map[string]any{
+				"details": map[string]any{
+					"value": "somevalue",
+				},
+				"type": "generic",
+			},
+			err: nil,
+		},
+		logger:                  &mockLogger{},
+		cacheConnectionsDetails: make(map[string]any),
+	}
+
+	deets := c.GetConnectionDetails("test-connection")
+	require.NotNil(t, deets)
+	gc, ok := deets.(*config.GenericConnection)
+	require.True(t, ok)
+	require.Equal(t, "test-connection", gc.Name)
+	require.Equal(t, "somevalue", gc.Value)
+}
+
+func TestDopplerClient_GetConnectionDetails_FromCache(t *testing.T) {
+	t.Parallel()
+	cachedConnection := config.GenericConnection{
+		Name:  "test-connection",
+		Value: "cached-value",
+	}
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: nil,
+			err:      errors.New("should not be called"),
+		},
+		logger:                  &mockLogger{},
+		cacheConnectionsDetails: map[string]any{"test-connection": &cachedConnection},
+	}
+
+	deets := c.GetConnectionDetails("test-connection")
+	require.NotNil(t, deets)
+	gc, ok := deets.(*config.GenericConnection)
+	require.True(t, ok)
+	require.Equal(t, "cached-value", gc.Value)
+}
+
+func TestDopplerClient_GetSecret_MissingDetailsAndType(t *testing.T) {
+	t.Parallel()
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: map[string]any{
+				"some_field": "value",
+			},
+			err: nil,
+		},
+		logger:                  &mockLogger{},
+		cacheConnectionsDetails: make(map[string]any),
+	}
+
+	deets := c.GetConnectionDetails("test-connection")
+	require.Nil(t, deets)
+}
+
+func TestDopplerClient_GetSecret_DetailsNotAMap(t *testing.T) {
+	t.Parallel()
+	c := &DopplerClient{
+		client: &mockDopplerHTTPClient{
+			response: map[string]any{
+				"details": "not-a-map",
+				"type":    "generic",
+			},
+			err: nil,
+		},
+		logger:                  &mockLogger{},
+		cacheConnectionsDetails: make(map[string]any),
+	}
+
+	deets := c.GetConnectionDetails("test-connection")
+	require.Nil(t, deets)
+}


### PR DESCRIPTION
Added Doppler as a third way to retrieve connection secrets alongside Vault and .bruin.yml.

Implementation:
- Created DopplerClient in pkg/secrets/doppler.go
  - Fetches secrets from Doppler API v3
  - Environment variables: BRUIN_DOPPLER_TOKEN, BRUIN_DOPPLER_PROJECT, BRUIN_DOPPLER_CONFIG
  - Implements ConnectionAndDetailsGetter interface
  - Caches connections to minimize API calls

- Added comprehensive tests in pkg/secrets/doppler_test.go
  - Tests for validation, connection retrieval, caching, and error handling
  - All tests passing

- Updated cmd/run.go
  - Added 'doppler' to --secrets-backend flag possible values
  - Added switch case for doppler backend selection
  - Follows same pattern as Vault implementation

- Documentation
  - Created docs/secrets/doppler.md with setup and usage guide
  - Updated docs/secrets/overview.md to list Doppler
  - Added --secrets-backend flag docs to docs/commands/run.md
  - Added usage examples for both Doppler and Vault

Usage:
  bruin run --secrets-backend doppler
  OR
  export BRUIN_SECRETS_BACKEND=doppler && bruin run

Generated with [Claude Code](https://claude.com/claude-code)