### PR TITLE
minimal-logs update 

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -887,8 +887,10 @@ func Run(isDebug *bool) *cli.Command {
 			}
 
 			sendTelemetry(s, c)
-			infoPrinter.Printf("\nInterval: %s - %s\n", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339))
-			infoPrinter.Printf("\n%s\n\n", executionStartLog)
+			if !c.Bool("minimal-logs") {
+				infoPrinter.Printf("\nInterval: %s - %s\n", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339))
+				infoPrinter.Printf("\n%s\n\n", executionStartLog)
+			}
 			if runConfig.SensorMode != "" {
 				if !(runConfig.SensorMode == "skip" || runConfig.SensorMode == "once" || runConfig.SensorMode == "wait") {
 					errorPrinter.Printf("invalid value for '--mode' flag: '%s', valid options are --skip ,--once, --wait", runConfig.SensorMode)
@@ -922,6 +924,7 @@ func Run(isDebug *bool) *cli.Command {
 				DoNotLogTimestamp: c.Bool("no-timestamp"),
 				DoNotLogTaskName:  preview.RunningForAnAsset,
 				NoColor:           c.Bool("no-color"),
+				MinimalLogs:       c.Bool("minimal-logs"),
 			}
 
 			ex, err := executor.NewConcurrent(logger, mainExecutors, c.Int("workers"), formatOpts)
@@ -968,8 +971,13 @@ func Run(isDebug *bool) *cli.Command {
 				if singleCheckID != "" {
 					printSingleCheckError(errorsInTaskResults[0])
 				} else {
-					printExecutionSummary(results, s, duration, len(results))
-					printErrorsInResults(errorsInTaskResults, s)
+					if c.Bool("minimal-logs") {
+						summaryPrinter.Printf("\n\nFailed %d tasks in %s\n", len(errorsInTaskResults), duration.Truncate(time.Millisecond).String())
+						printErrorsMinimal(errorsInTaskResults)
+					} else {
+						printExecutionSummary(results, s, duration, len(results))
+						printErrorsInResults(errorsInTaskResults, s)
+					}
 				}
 				return cli.Exit("", 1)
 			}
@@ -983,7 +991,7 @@ func Run(isDebug *bool) *cli.Command {
 			// Print execution summary (unless minimal-logs is enabled)
 			minimalLogs := c.Bool("minimal-logs")
 			if minimalLogs {
-				successPrinter.Printf("\n\nExecuted %d tasks in %s\n", len(results), duration.Truncate(time.Millisecond).String())
+				summaryPrinter.Printf("\n\nExecuted %d tasks in %s\n", len(results), duration.Truncate(time.Millisecond).String())
 			} else {
 				printExecutionSummary(results, s, duration, len(results))
 			}
@@ -1177,6 +1185,13 @@ func printErrorsInResults(errorsInTaskResults []*scheduler.TaskExecutionResult, 
 	}
 	fmt.Println()
 	fmt.Println(tree.String())
+}
+
+func printErrorsMinimal(errorsInTaskResults []*scheduler.TaskExecutionResult) {
+	for _, result := range errorsInTaskResults {
+		assetName := result.Instance.GetAsset().Name
+		fmt.Printf("\n  %s: %s\n", assetName, result.Error)
+	}
 }
 
 func printSingleCheckError(result *scheduler.TaskExecutionResult) {

--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -44,6 +44,7 @@ type FormattingOptions struct {
 	DoNotLogTimestamp bool
 	DoNotLogTaskName  bool
 	NoColor           bool
+	MinimalLogs       bool
 }
 
 type Concurrent struct {
@@ -107,10 +108,12 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 		if !w.formatOpts.NoColor {
 			runningPrinter = color.New(color.Faint)
 		}
-		if w.formatOpts.DoNotLogTimestamp {
-			fmt.Printf("%s\n", runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
-		} else {
-			fmt.Printf("%s %s\n", timestampStr, runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
+		if !w.formatOpts.MinimalLogs {
+			if w.formatOpts.DoNotLogTimestamp {
+				fmt.Printf("%s\n", runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
+			} else {
+				fmt.Printf("%s %s\n", timestampStr, runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
+			}
 		}
 		w.printLock.Unlock()
 
@@ -146,11 +149,13 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 			res = "Failed"
 		}
 
-		if w.formatOpts.DoNotLogTimestamp {
-			fmt.Printf("%s\n", printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
-		} else {
-			timestampStr = whitePrinter("[%s]", time.Now().Format(timeFormat))
-			fmt.Printf("%s %s\n", timestampStr, printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+		if !w.formatOpts.MinimalLogs {
+			if w.formatOpts.DoNotLogTimestamp {
+				fmt.Printf("%s\n", printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+			} else {
+				timestampStr = whitePrinter("[%s]", time.Now().Format(timeFormat))
+				fmt.Printf("%s %s\n", timestampStr, printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+			}
 		}
 		w.printLock.Unlock()
 		results <- &scheduler.TaskExecutionResult{


### PR DESCRIPTION
<img width="949" height="501" alt="image" src="https://github.com/user-attachments/assets/e9212a47-f409-4e40-b8b0-590e100c2466" />  Before (asset run failed)

<img width="902" height="257" alt="image" src="https://github.com/user-attachments/assets/ff85c714-101c-4deb-b87f-a960e035cb24" /> after (asset run failed)

<img width="866" height="598" alt="image" src="https://github.com/user-attachments/assets/7bd4f704-cc19-400a-97f4-93bb4911b07e" /> before (asset run success)

<img width="761" height="226" alt="image" src="https://github.com/user-attachments/assets/966a9bb4-8b37-4931-8d04-b7293dde6e0e" /> after (asset run success)


<img width="772" height="231" alt="image" src="https://github.com/user-attachments/assets/6e62c28a-2ca0-4aac-8078-b2f0ba5db830" /> before (single check sucess)


<img width="767" height="140" alt="image" src="https://github.com/user-attachments/assets/9f2cbc93-69c7-4495-8745-ae5618077dc3" /> after (single check success)


<img width="784" height="232" alt="image" src="https://github.com/user-attachments/assets/d9575230-339c-460a-b924-14d7c9eb20bb" /> before (single check failed)


<img width="696" height="132" alt="image" src="https://github.com/user-attachments/assets/266796f0-da17-409f-bf13-bd5fbe2adc83" /> after (single check failed)




