### PR TITLE
message change in error printf for endDate check

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1072,7 +1072,7 @@ func ParseDate(startDateStr, endDateStr string, logger logger.Logger) (time.Time
 	logger.Debug("given end date: ", endDate)
 	if err != nil {
 		errorPrinter.Printf("Please give a valid end date: bruin run --end-date <end date>)\n")
-		errorPrinter.Printf("A valid start date can be in the YYYY-MM-DD or YYYY-MM-DD HH:MM:SS formats. \n")
+		errorPrinter.Printf("A valid end date can be in the YYYY-MM-DD or YYYY-MM-DD HH:MM:SS formats. \n")
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02"))
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02 15:04:05"))
 		return time.Time{}, time.Time{}, err


### PR DESCRIPTION
Printf changed to "A valid **end** date can be in the YYYY-MM-DD or YYYY-MM-DD HH:MM:SS formats." for endDate error check.