### PR TITLE
default_connections name change in first-tutorial.md

### DIFF
--- a/docs/getting-started/tutorials/first-tutorial.md
+++ b/docs/getting-started/tutorials/first-tutorial.md
@@ -71,8 +71,8 @@ Just like in Step 3, the pipeline.yml file also comes pre-configured for our tas
 ```yaml
 name: chess_duckdb
 default_connections:
-    duckdb: "duckdb_default"  
-    chess: "chess_connection"
+    duckdb: "duckdb-default"
+    chess: "chess-default"
 ```
 > [!INFO]
 > **What is a Pipeline?**  


### PR DESCRIPTION
in first-tutorial.md for pipeline.yml example names are changed from duckdb: "**duckdb_default**" and chess: "**chess_connection**" to duckdb: "**duckdb-default**"  and chess: "**chess-default**"