### PR TITLE
Add lint rule to flag metadata columns missing from SQL query

### DIFF
--- a/docs/getting-started/policies.md
+++ b/docs/getting-started/policies.md
@@ -256,6 +256,16 @@ Bruin provides a set of built-in lint rules that are ready to use without requir
       <td><code>pipeline</code></td>
       <td>Pipeline must push it's metadata</td>
     </tr>
+    <tr>
+      <td><code>query-matches-columns</code></td>
+      <td><code>asset</code></td>
+      <td>Columns found in the query must exist in asset metadata.</td>
+    </tr>
+    <tr>
+      <td><code>columns-matches-query</code></td>
+      <td><code>asset</code></td>
+      <td>Columns found in asset metadata must exist in the query.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/pkg/lint/policy.go
+++ b/pkg/lint/policy.go
@@ -206,10 +206,15 @@ func (spec *PolicySpecification) getValidators(name string, sqlParser sqlParser)
 	def, found := spec.compiledRules[name]
 	if !found {
 		validators, found := builtinRules[name]
-		if found && name == "query-matches-columns" && sqlParser != nil {
+		if found && sqlParser != nil {
 			// Special case: replace the noop validator with the actual implementation
 			if realParser, ok := sqlParser.(*sqlparser.SQLParser); ok {
-				validators.Asset = QueryColumnsMatchColumnsPolicy(realParser)
+				switch name {
+				case "query-matches-columns":
+					validators.Asset = QueryColumnsMatchColumnsPolicy(realParser)
+				case "columns-matches-query":
+					validators.Asset = QueryHasAllMetadataColumnsPolicy(realParser)
+				}
 			}
 		}
 		return validators, found

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -451,6 +451,9 @@ var builtinRules = map[string]validators{
 	"query-matches-columns": {
 		Asset: noopAssetValidator,
 	},
+	"columns-matches-query": {
+		Asset: noopAssetValidator,
+	},
 }
 
 func QueryColumnsMatchColumnsPolicy(parser *sqlparser.SQLParser) func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -509,6 +512,71 @@ func QueryColumnsMatchColumnsPolicy(parser *sqlparser.SQLParser) func(ctx contex
 			issues = append(issues, &Issue{
 				Task:        asset,
 				Description: "Columns found in query but missing from columns metadata: " + strings.Join(missingColumns, ", "),
+				Context:     missingColumns,
+			})
+		}
+
+		return issues, nil
+	}
+}
+
+func QueryHasAllMetadataColumnsPolicy(parser *sqlparser.SQLParser) func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	return func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+		issues := make([]*Issue, 0)
+
+		if parser == nil {
+			return issues, nil
+		}
+
+		if !asset.IsSQLAsset() {
+			return issues, nil
+		}
+
+		dialect, err := sqlparser.AssetTypeToDialect(asset.Type)
+		if err != nil { //nolint:nilerr
+			return issues, nil
+		}
+
+		var renderer jinja.RendererInterface
+		renderer = jinja.NewRendererWithYesterday("your-pipeline-name", "your-run-id")
+		renderer, err = renderer.CloneForAsset(ctx, p, asset)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create renderer for asset %s", asset.Name)
+		}
+
+		renderedQuery, err := renderer.Render(asset.ExecutableFile.Content)
+		if err != nil { //nolint:nilerr
+			return issues, nil
+		}
+		// Build schema from upstream assets using lineage extractor
+		lineageExtractor := lineage.NewLineageExtractor(parser)
+		schema := lineageExtractor.TableSchemaForUpstreams(p, asset)
+
+		lineage, err := parser.ColumnLineage(renderedQuery, dialect, schema)
+		if err != nil { //nolint:nilerr
+			return issues, nil
+		}
+
+		if len(lineage.Columns) == 0 {
+			return issues, nil
+		}
+
+		queryColumns := make(map[string]bool)
+		for _, col := range lineage.Columns {
+			queryColumns[col.Name] = true
+		}
+
+		missingColumns := make([]string, 0)
+		for _, metadataCol := range asset.Columns {
+			if !queryColumns[metadataCol.Name] {
+				missingColumns = append(missingColumns, metadataCol.Name)
+			}
+		}
+
+		if len(missingColumns) > 0 {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "Columns found in columns metadata but missing from query: " + strings.Join(missingColumns, ", "),
 				Context:     missingColumns,
 			})
 		}

--- a/pkg/lint/policy_builtins_test.go
+++ b/pkg/lint/policy_builtins_test.go
@@ -290,3 +290,264 @@ func TestQueryColumnsMatchColumnsPolicy_JinjaIntegration(t *testing.T) { //nolin
 		assert.Empty(t, issues, "This test alone cannot distinguish between working and broken cloneForAsset")
 	})
 }
+
+
+
+func TestQueryHasAllMetadataColumnsPolicy(t *testing.T) { //nolint:paralleltest
+	// Set up context with required values for cloneForAsset
+	ctx := context.WithValue(context.Background(), pipeline.RunConfigStartDate, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)) //nolint:usetesting
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-123")
+	ctx = context.WithValue(ctx, pipeline.RunConfigApplyIntervalModifiers, false)
+
+	t.Run("returns no issues when parser is nil", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(nil)
+
+		asset := &pipeline.Asset{
+			Name: "test.table",
+			Type: "bq.sql",
+		}
+		pipeline := &pipeline.Pipeline{}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+
+	t.Run("returns no issues for non-SQL assets", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "test.table",
+			Type: "python",
+		}
+		pipeline := &pipeline.Pipeline{}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+
+	t.Run("returns no issues when asset type dialect conversion fails", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "test.table",
+			Type: "invalid.sql",
+			ExecutableFile: pipeline.ExecutableFile{
+				Content: "SELECT 1",
+			},
+		}
+		pipeline := &pipeline.Pipeline{}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+    
+	t.Run("integration test - real parser with simple jinja", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "test.users",
+			Type: "bq.sql",
+			ExecutableFile: pipeline.ExecutableFile{
+				Content: "SELECT id, {{ var.email_col }} as email FROM users WHERE active = {{ var.is_active }}",
+			},
+			Columns: []pipeline.Column{
+				{Name: "id"},
+				{Name: "email"},
+				// Extra phone metadata to trigger issue
+				{Name: "phone"},
+			},
+		}
+		pipeline := &pipeline.Pipeline{
+			Name: "test-pipeline",
+			Variables: pipeline.Variables{
+				"email_col": map[string]any{
+					"type":    "string",
+					"default": "user_email",
+				},
+				"is_active": map[string]any{
+					"type":    "boolean",
+					"default": true,
+				},
+			},
+		}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		// MUST find the extra phone metadata - if cloneForAsset is disabled, this will fail
+		require.Len(t, issues, 1, "Should detect extra phone metadata after Jinja variable resolution")
+		assert.Contains(t, issues[0].Description, "phone")
+	})
+
+	t.Run("integration test - this variable resolution MUST work", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "analytics.users",
+			Type: "bq.sql",
+			ExecutableFile: pipeline.ExecutableFile{
+				Content: "SELECT id, name FROM {{ this }}",
+			},
+			Columns: []pipeline.Column{
+				{Name: "id"},
+				{Name: "name"},
+				// Extra extra_metadata to force detection
+				{Name: "extra_metadata"},
+			},
+		}
+		pipeline := &pipeline.Pipeline{
+			Name: "test-pipeline",
+		}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		// This MUST find the missing extra_metadata metadata if {{ this }} is properly resolved
+		require.Len(t, issues, 1, "Should detect extra extra_metadata column after {{ this }} resolution to 'analytics.users'")
+		assert.Contains(t, issues[0].Description, "extra_metadata")
+	})
+}
+
+
+func TestQueryHasAllMetadataColumnsPolicy_JinjaIntegration(t *testing.T) { //nolint:paralleltest
+	// Set up context with required values for cloneForAsset
+	ctx := context.WithValue(context.Background(), pipeline.RunConfigStartDate, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)) //nolint:usetesting
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-123")
+	ctx = context.WithValue(ctx, pipeline.RunConfigApplyIntervalModifiers, false)
+
+	t.Run("complex jinja template with variables and this resolution MUST work", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "analytics.user_metrics",
+			Type: "bq.sql",
+			ExecutableFile: pipeline.ExecutableFile{
+				Content: "SELECT {{ var.id_col }}, {{ var.email_col }} FROM {{ var.source_table }} WHERE created_at >= '{{ var.cutoff_date }}' AND {{ var.id_col }} NOT IN (SELECT {{ var.id_col }} FROM {{ this }})",
+			},
+			Columns: []pipeline.Column{
+				{Name: "user_id"},
+				{Name: "email"},
+				// Intentionally extra 'score' metadata to test detection
+				{Name: "score"},
+			},
+		}
+		pipeline := &pipeline.Pipeline{
+			Name: "analytics-pipeline",
+			Variables: pipeline.Variables{
+				"id_col": map[string]any{
+					"type":    "string",
+					"default": "user_id",
+				},
+				"email_col": map[string]any{
+					"type":    "string",
+					"default": "email",
+				},
+				"source_table": map[string]any{
+					"type":    "string",
+					"default": "raw.users",
+				},
+				"cutoff_date": map[string]any{
+					"type":    "string",
+					"default": "2023-01-01",
+				},
+			},
+		}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		// MUST detect extra score metadata after all Jinja variables are resolved
+		require.Len(t, issues, 1, "Should detect extra score metadata after complex Jinja variable resolution")
+		assert.Contains(t, issues[0].Description, "score")
+	})
+
+	t.Run("jinja template with boolean and numeric variables MUST work", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "analytics.active_users",
+			Type: "bq.sql",
+			ExecutableFile: pipeline.ExecutableFile{
+				Content: "SELECT id, name FROM users WHERE active = {{ var.is_active }} AND score >= {{ var.min_score }}",
+			},
+			Columns: []pipeline.Column{
+				{Name: "id"},
+				{Name: "name"},
+				// Intentionally extra 'score' metadata to test detection
+				{Name: "score"},
+			},
+		}
+		pipeline := &pipeline.Pipeline{
+			Name: "scoring-pipeline",
+			Variables: pipeline.Variables{
+				"is_active": map[string]any{
+					"type":    "boolean",
+					"default": true,
+				},
+				"min_score": map[string]any{
+					"type":    "integer",
+					"default": 85,
+				},
+			},
+		}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		// MUST detect extra score metadata after boolean/numeric variable resolution
+		require.Len(t, issues, 1, "Should detect extra score metadata after boolean/numeric variable resolution")
+		assert.Contains(t, issues[0].Description, "score")
+	})
+
+	t.Run("test that FAILS without cloneForAsset - undefined jinja variables", func(t *testing.T) { //nolint:paralleltest
+		validator := lint.QueryHasAllMetadataColumnsPolicy(sharedSQLParser)
+
+		asset := &pipeline.Asset{
+			Name: "test.table",
+			Type: "bq.sql",
+			ExecutableFile: pipeline.ExecutableFile{
+				// This template uses undefined variables that only cloneForAsset would provide
+				Content: "SELECT id, name FROM {{ this }} WHERE status = '{{ var.user_status }}'",
+			},
+			Columns: []pipeline.Column{
+				{Name: "id"},
+				{Name: "name"},
+			},
+		}
+		pipeline := &pipeline.Pipeline{
+			Name: "test-pipeline",
+			Variables: pipeline.Variables{
+				"user_status": map[string]any{
+					"type":    "string",
+					"default": "active",
+				},
+			},
+		}
+
+		issues, err := validator(ctx, pipeline, asset)
+
+		require.NoError(t, err)
+		// Without cloneForAsset, the template "SELECT id, name FROM {{ this }}" will fail to render
+		// because 'this' and 'var' are undefined, so the function returns no issues
+		// With cloneForAsset, it should render to "SELECT id, name FROM test.table WHERE status = 'active'"
+		// and correctly find all columns match, so no issues
+
+		// If cloneForAsset is working, we expect no issues (all columns match)
+		// If cloneForAsset is disabled, we also get no issues (due to graceful Jinja failure handling)
+		// So we need a more sophisticated test...
+		assert.Empty(t, issues, "This test alone cannot distinguish between working and broken cloneForAsset")
+	})
+}
+
+
+
+
+


### PR DESCRIPTION
Added a new lint check that compares asset column metadata to rendered SQL queries and reports columns defined in metadata but missing from the query. Includes tests.