### PR TITLE
Improve QuickStart docs: new `init` flow + bug fixes

### DIFF
--- a/docs/getting-started/introduction/quickstart.md
+++ b/docs/getting-started/introduction/quickstart.md
@@ -14,7 +14,7 @@ Bruin includes a handy command called `init`, you can simply run that command to
       
 ```bash
 bruin init default my-pipeline  
-cd my-pipeline
+cd bruin/my-pipeline
 ```
 
 This command will:


### PR DESCRIPTION
## Summary 
This PR improves QuickStart docs page by fixing the mistakes present and enhancing its body.
- added `cd bruin/my-pipeline` in instructions after `bruin init default my-pipeline` to reduce initial confusions
- fix sql asset bugs
- fix `[!code ++]` annotations in **Data Quality Checks** section
- Align guide's language with the updated `bruin init default` command. #1456
- Add useful links and details

found an issue with `bruin run --only checks assets/player_stats.sql` #1457 

### Justifications
- add `cd bruin/my-pipeline`: When following the QuickStart guide running commands such as `bruin run <smth>` right after `bruin init default my-pipeline` results in an error since it can't find the directory. Adding `cd my-pipeline` reduces confusion. (instead of adding `my-pipline/...` to all the other commands)
- add `value: 1` to sql asseet checks: check out #1457 PR description for details.
- `[!code ++]` annotations

| Before | After |
|--------|-------|
| <img width="528" height="652" alt="before" src="https://github.com/user-attachments/assets/ce24e23b-8d01-4666-9bb0-7ea61042c5c0" />|<img width="528" height="652" alt="after" src="https://github.com/user-attachments/assets/fb524355-c119-4193-ae51-6a2375bad1cd" />|

## How to test

Build the docs using:
```bash
npm install
npm run docs:dev
# then, open the docs
```
- the built docs should reflect the above mentioned change
