### PR TITLE
Add Python cache ignores to `.gitignore` during bruin run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -859,7 +859,7 @@ func Run(isDebug *bool) *cli.Command {
 					return cli.Exit("", 1)
 				}
 			}
-			
+
 			err = ensurePythonCacheGitignore(afero.NewOsFs(), repoRoot.Path)
 			if err != nil {
 				errorPrinter.Printf("Failed to add Python cache patterns to .gitignore: %v\n", err)


### PR DESCRIPTION
## Summary
Add python cache patterns to the project .gitignore during `bruin run` alongside existing log ignore updates.

### Justification
Running Python assets generates bytecode caches. This keeps new projects and their diffs are cleaner.

> [!NOTE]
> Minimal Downside.
> This hides Python bytecode if a project **intentionally** wants to commit it for packaging or deployment; they would need an explicit negate rule.
> I could not find any other downsides

| Before | Now |
|--------|-------|
|<img width="428" height="224" alt="Screenshot 2026-01-05 at 14 37 54" src="https://github.com/user-attachments/assets/94a7aad6-3f74-4794-af5a-c25df7b44521" />|<img width="428" height="224" alt="Screenshot 2026-01-05 at 14 37 50" src="https://github.com/user-attachments/assets/ab7e4341-088c-4c3b-bed3-ae7d8532aa4e" />|


## How to Test
```
path/to/bruin init default my-pipeline
path/to/bruin run ./bruin/my-pipeline
```
- generated `.gitignore` should have python should contain `__pycache__/` and `*.py[cod]` in addition to other file/directories. (only after `run`)
