### PR TITLE
Stop removing asset names during format command

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -965,7 +965,6 @@ func (a *Asset) PrefixUpstreams(prefix string) {
 func (a *Asset) removeRedundanciesBeforePersisting() {
 	a.clearDuplicateUpstreams()
 	a.removeExtraSpacesAtLineEndingsInTextContent()
-	a.removeNameIfItCanBeInferredFromPath()
 
 	// python assets don't require a type anymore
 	if a.Type == AssetTypePython && strings.HasSuffix(a.ExecutableFile.Path, ".py") {
@@ -1031,17 +1030,6 @@ func (a *Asset) removeExtraSpacesAtLineEndingsInTextContent() {
 	for i := range a.CustomChecks {
 		a.CustomChecks[i].Description = ClearSpacesAtLineEndings(a.CustomChecks[i].Description)
 		a.CustomChecks[i].Query = ClearSpacesAtLineEndings(a.CustomChecks[i].Query)
-	}
-}
-
-func (a *Asset) removeNameIfItCanBeInferredFromPath() {
-	potentialName, err := a.GetNameIfItWasSetFromItsPath(nil)
-	if err != nil {
-		return
-	}
-
-	if potentialName == a.Name {
-		a.Name = ""
 	}
 }
 


### PR DESCRIPTION
# PR Overview 
This PR removes removeNameIfItCanBeInferredFromPath from the format logic, so running the format command no longer deletes asset names. This behavior was confusing for users.