### PR TITLE
fix(dataproc): skip excluded directories in zip packaging

### DIFF
--- a/pkg/dataproc_serverless/package.go
+++ b/pkg/dataproc_serverless/package.go
@@ -18,10 +18,10 @@ var bruinExcludes = []string{
 }
 
 var dirExcludes = []*regexp.Regexp{
-	regexp.MustCompile(`[/\\].venv[/\\]`),
-	regexp.MustCompile(`[/\\]venv[/\\]`),
-	regexp.MustCompile(`^logs/.*$`),
-	regexp.MustCompile(`^\.git/.*$`),
+	regexp.MustCompile(`(^|[/\\])\.venv([/\\]|$)`),
+	regexp.MustCompile(`(^|[/\\])venv([/\\]|$)`),
+	regexp.MustCompile(`^logs([/\\]|$)`),
+	regexp.MustCompile(`^\.git([/\\]|$)`),
 }
 
 func exclude(path string) bool {
@@ -46,6 +46,9 @@ func packageContextWithPrefix(zw *zip.Writer, context fs.FS) error {
 			return err
 		}
 		if exclude(name) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
 			return nil
 		}
 		if d.IsDir() {


### PR DESCRIPTION
Return fs.SkipDir when an excluded directory is encountered during
fs.WalkDir to prevent traversing into .venv, venv, logs, and .git
directories. Also fix regex patterns to match root-level directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
