### PR TITLE
remove `exportloopref` from `.golangci.yml`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,6 @@ linters:
     - depguard
     - tagalign
     - gocyclo
-    - exportloopref
     - godox
     - nonamedreturns
     - maintidx


### PR DESCRIPTION
## Summary 
Removes the deprecated `exportloopref` entry from `.golangci.yml` to get rid of the `golangci-lint` warning during `make format`. 
No functional code changes.

This Warning:
<img width="893" height="150" alt="Screenshot 2026-01-06 at 10 59 56" src="https://github.com/user-attachments/assets/0be04014-0032-413a-87da-e2d8c1220ca9" />