### PR TITLE
Add JSON output format to data-diff command

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -1129,6 +1129,11 @@ func buildColumnStatistics(t1Col, t2Col *diff.Column, tolerance float64) JSONCol
 	stats1 := t1Col.Stats
 	stats2 := t2Col.Stats
 
+	// Check if statistics types are compatible
+	if stats1.Type() != stats2.Type() {
+		return stats
+	}
+
 	switch stats1.Type() {
 	case "numerical":
 		numStats1 := stats1.(*diff.NumericalStatistics)


### PR DESCRIPTION
# PR Overview 
* Added a new `--output` flag to support `plain` (default) and `json` output formats.
* Improved error handling to return structured JSON errors when `--output=json` is used.
* Implemented JSON output for schema comparison results, including detailed statistics and differences.
* Structured JSON output to include a summary, schema differences, and generated ALTER statements.

