### PR TITLE
User and team tests

### DIFF
--- a/integration-tests/e2e-tests/README.md
+++ b/integration-tests/e2e-tests/README.md
@@ -1,0 +1,79 @@
+# E2E Tests for User & Team Management
+
+This directory contains Playwright-based end-to-end tests for the User & Team Management features.
+
+## Pages Tested
+
+- `/user/api-tokens` - API Tokens management
+- `/teams/{team}` - Team Settings
+- `/user/profile` - Profile Settings
+
+## Test Scenarios
+
+| Test | Description |
+|------|-------------|
+| `test_api_tokens_page_loads` | Verify API tokens page loads with token list and create button |
+| `test_create_api_token` | Create a new API token and verify it's displayed |
+| `test_delete_api_token` | Delete an API token and verify removal |
+| `test_team_settings_loads` | Verify team settings page loads with members list and tabs |
+| `test_profile_settings_loads` | Verify profile page loads with all sections (profile, password, 2FA) |
+| `test_update_profile_information` | Update profile info and verify success message |
+
+## Required UI Element IDs
+
+The following IDs should be present in the frontend:
+
+- `#api-tokens-table` - Table/list of API tokens
+- `#create-token-button` - Button to create a new token
+- `#token-display-once` - Element displaying the newly created token (shown once)
+- `#team-settings-tabs` - Tabs for team settings
+- `#team-members-list` - List of team members
+- `#profile-form` - Profile settings form
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+playwright install chromium
+```
+
+2. Configure environment variables:
+
+```bash
+export BASE_URL="http://localhost:3000"  # Application URL
+export TEST_USER_EMAIL="test@example.com"  # Test user email
+export TEST_USER_PASSWORD="testpassword"  # Test user password
+export TEST_TEAM_NAME="test-team"  # Team name for team tests
+export HEADLESS="true"  # Set to "false" to see browser
+```
+
+## Running Tests
+
+Run all tests:
+
+```bash
+pytest test_user_team_management.py -v
+```
+
+Run specific test class:
+
+```bash
+pytest test_user_team_management.py::TestAPITokens -v
+pytest test_user_team_management.py::TestTeamSettings -v
+pytest test_user_team_management.py::TestProfileSettings -v
+```
+
+Run a specific test:
+
+```bash
+pytest test_user_team_management.py::TestAPITokens::test_api_tokens_page_loads -v
+```
+
+## Test Output
+
+Tests will produce detailed output including:
+- Pass/fail status for each test
+- Screenshots on failure (if configured)
+- Trace files for debugging (if enabled)

--- a/integration-tests/e2e-tests/conftest.py
+++ b/integration-tests/e2e-tests/conftest.py
@@ -1,0 +1,102 @@
+"""
+Pytest configuration and fixtures for User & Team Management e2e tests.
+
+This module provides Playwright fixtures for browser-based testing.
+"""
+
+import os
+
+import pytest
+from playwright.sync_api import Page, sync_playwright
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Get the base URL for the application under test.
+    
+    Returns the BASE_URL environment variable or defaults to localhost.
+    """
+    return os.environ.get("BASE_URL", "http://localhost:3000")
+
+
+@pytest.fixture(scope="session")
+def browser_context_args():
+    """Configure browser context options."""
+    return {
+        "viewport": {"width": 1280, "height": 720},
+        "ignore_https_errors": True,
+    }
+
+
+@pytest.fixture(scope="session")
+def playwright_instance():
+    """Create a Playwright instance for the test session."""
+    with sync_playwright() as playwright:
+        yield playwright
+
+
+@pytest.fixture(scope="session")
+def browser(playwright_instance):
+    """Launch a browser instance for the test session."""
+    browser = playwright_instance.chromium.launch(
+        headless=os.environ.get("HEADLESS", "true").lower() == "true"
+    )
+    yield browser
+    browser.close()
+
+
+@pytest.fixture
+def context(browser, browser_context_args):
+    """Create a new browser context for each test."""
+    context = browser.new_context(**browser_context_args)
+    yield context
+    context.close()
+
+
+@pytest.fixture
+def page(context) -> Page:
+    """Create a new page for each test."""
+    page = context.new_page()
+    yield page
+    page.close()
+
+
+@pytest.fixture
+def authenticated_page(page: Page, base_url: str) -> Page:
+    """Provide an authenticated page for tests requiring login.
+    
+    This fixture handles authentication before returning the page.
+    Configure authentication via environment variables:
+    - TEST_USER_EMAIL: User email for login
+    - TEST_USER_PASSWORD: User password for login
+    """
+    email = os.environ.get("TEST_USER_EMAIL", "test@example.com")
+    password = os.environ.get("TEST_USER_PASSWORD", "testpassword")
+    
+    # Navigate to login page and authenticate
+    page.goto(f"{base_url}/login")
+    
+    # Fill in login credentials
+    page.fill('input[name="email"], input[type="email"], #email', email)
+    page.fill('input[name="password"], input[type="password"], #password', password)
+    
+    # Submit the login form
+    page.click('button[type="submit"], #login-button, button:has-text("Sign in")')
+    
+    # Wait for navigation to complete
+    page.wait_for_load_state("networkidle")
+    
+    return page
+
+
+@pytest.fixture
+def test_team_name() -> str:
+    """Provide a test team name for team-related tests."""
+    return os.environ.get("TEST_TEAM_NAME", "test-team")
+
+
+@pytest.fixture
+def test_token_name() -> str:
+    """Provide a unique token name for API token tests."""
+    import uuid
+    return f"test-token-{uuid.uuid4().hex[:8]}"

--- a/integration-tests/e2e-tests/requirements.txt
+++ b/integration-tests/e2e-tests/requirements.txt
@@ -1,0 +1,4 @@
+# E2E Testing Dependencies for User & Team Management Tests
+pytest>=8.0.0
+playwright>=1.40.0
+pytest-playwright>=0.4.4

--- a/integration-tests/e2e-tests/test_user_team_management.py
+++ b/integration-tests/e2e-tests/test_user_team_management.py
@@ -1,0 +1,298 @@
+"""
+User & Team Management E2E Tests.
+
+This module contains Playwright-based tests for:
+- API Tokens page (/user/api-tokens)
+- Team Settings (/teams/{team})
+- Profile Settings (/user/profile)
+
+Test IDs expected in the UI:
+- #api-tokens-table
+- #create-token-button
+- #token-display-once
+- #team-settings-tabs
+- #team-members-list
+- #profile-form
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+class TestAPITokens:
+    """Tests for the API Tokens page (/user/api-tokens)."""
+
+    def test_api_tokens_page_loads(
+        self, authenticated_page: Page, base_url: str
+    ) -> None:
+        """Test that the API tokens page loads correctly.
+        
+        Verifies:
+        - Token list/table appears (#api-tokens-table)
+        - Create token button exists (#create-token-button)
+        """
+        page = authenticated_page
+        
+        # Navigate to API tokens page
+        page.goto(f"{base_url}/user/api-tokens")
+        page.wait_for_load_state("networkidle")
+        
+        # Verify token list/table appears
+        tokens_table = page.locator("#api-tokens-table")
+        expect(tokens_table).to_be_visible()
+        
+        # Verify create token button exists
+        create_button = page.locator("#create-token-button")
+        expect(create_button).to_be_visible()
+
+    def test_create_api_token(
+        self, authenticated_page: Page, base_url: str, test_token_name: str
+    ) -> None:
+        """Test creating a new API token.
+        
+        Verifies:
+        - Click create token button
+        - Fill token name and permissions
+        - Token is created and displayed once (#token-display-once)
+        """
+        page = authenticated_page
+        
+        # Navigate to API tokens page
+        page.goto(f"{base_url}/user/api-tokens")
+        page.wait_for_load_state("networkidle")
+        
+        # Click create token button
+        create_button = page.locator("#create-token-button")
+        create_button.click()
+        
+        # Wait for the create token form/modal to appear
+        page.wait_for_selector('input[name="token-name"], #token-name-input')
+        
+        # Fill in token name
+        page.fill('input[name="token-name"], #token-name-input', test_token_name)
+        
+        # Select permissions if available (check a read permission checkbox)
+        read_permission = page.locator('input[type="checkbox"][name*="read"], #permission-read')
+        if read_permission.count() > 0:
+            read_permission.first.check()
+        
+        # Submit the form to create the token
+        page.click('button[type="submit"], #create-token-submit, button:has-text("Create")')
+        
+        # Wait for token creation to complete
+        page.wait_for_load_state("networkidle")
+        
+        # Verify the token is displayed once (for copying)
+        token_display = page.locator("#token-display-once")
+        expect(token_display).to_be_visible()
+        
+        # Verify the token value is not empty
+        token_value = token_display.text_content()
+        assert token_value and len(token_value.strip()) > 0, "Token should be displayed"
+
+    def test_delete_api_token(
+        self, authenticated_page: Page, base_url: str
+    ) -> None:
+        """Test deleting an API token.
+        
+        Verifies:
+        - Click delete on a token
+        - Confirm deletion
+        - Token is removed from list
+        """
+        page = authenticated_page
+        
+        # Navigate to API tokens page
+        page.goto(f"{base_url}/user/api-tokens")
+        page.wait_for_load_state("networkidle")
+        
+        # Get the tokens table
+        tokens_table = page.locator("#api-tokens-table")
+        expect(tokens_table).to_be_visible()
+        
+        # Find delete buttons for tokens
+        delete_buttons = page.locator(
+            '#api-tokens-table button[data-action="delete"], '
+            '#api-tokens-table .delete-token-button, '
+            '#api-tokens-table button:has-text("Delete")'
+        )
+        
+        # Check if there are any tokens to delete
+        if delete_buttons.count() == 0:
+            pytest.skip("No tokens available to delete")
+        
+        # Get the initial count of tokens
+        initial_token_count = delete_buttons.count()
+        
+        # Get the first token's identifier for verification
+        first_token_row = page.locator("#api-tokens-table tbody tr, #api-tokens-table [data-token-row]").first
+        token_identifier = first_token_row.get_attribute("data-token-id") or first_token_row.text_content()
+        
+        # Click delete on the first token
+        delete_buttons.first.click()
+        
+        # Handle confirmation dialog/modal
+        confirm_button = page.locator(
+            'button:has-text("Confirm"), '
+            'button:has-text("Yes"), '
+            '#confirm-delete-button, '
+            '[data-action="confirm-delete"]'
+        )
+        
+        # Wait for and click confirm button if present
+        if confirm_button.count() > 0:
+            confirm_button.first.click()
+        
+        # Wait for the deletion to complete
+        page.wait_for_load_state("networkidle")
+        
+        # Verify the token count has decreased
+        delete_buttons_after = page.locator(
+            '#api-tokens-table button[data-action="delete"], '
+            '#api-tokens-table .delete-token-button, '
+            '#api-tokens-table button:has-text("Delete")'
+        )
+        
+        # Token should be removed from the list
+        assert delete_buttons_after.count() < initial_token_count, \
+            "Token count should decrease after deletion"
+
+
+class TestTeamSettings:
+    """Tests for the Team Settings page (/teams/{team})."""
+
+    def test_team_settings_loads(
+        self, authenticated_page: Page, base_url: str, test_team_name: str
+    ) -> None:
+        """Test that the team settings page loads correctly.
+        
+        Verifies:
+        - Team members list appears (#team-members-list)
+        - Settings tabs appear (#team-settings-tabs)
+        """
+        page = authenticated_page
+        
+        # Navigate to team settings page
+        page.goto(f"{base_url}/teams/{test_team_name}")
+        page.wait_for_load_state("networkidle")
+        
+        # Verify team members list appears
+        members_list = page.locator("#team-members-list")
+        expect(members_list).to_be_visible()
+        
+        # Verify settings tabs appear
+        settings_tabs = page.locator("#team-settings-tabs")
+        expect(settings_tabs).to_be_visible()
+
+
+class TestProfileSettings:
+    """Tests for the Profile Settings page (/user/profile)."""
+
+    def test_profile_settings_loads(
+        self, authenticated_page: Page, base_url: str
+    ) -> None:
+        """Test that the profile settings page loads correctly.
+        
+        Verifies:
+        - Profile form displays (#profile-form)
+        - Profile section exists
+        - Password section exists
+        - 2FA section exists
+        """
+        page = authenticated_page
+        
+        # Navigate to profile settings page
+        page.goto(f"{base_url}/user/profile")
+        page.wait_for_load_state("networkidle")
+        
+        # Verify profile form displays
+        profile_form = page.locator("#profile-form")
+        expect(profile_form).to_be_visible()
+        
+        # Verify profile section exists (name/email fields)
+        profile_section = page.locator(
+            '#profile-section, '
+            '[data-section="profile"], '
+            'section:has-text("Profile")'
+        )
+        expect(profile_section.first).to_be_visible()
+        
+        # Verify password section exists
+        password_section = page.locator(
+            '#password-section, '
+            '[data-section="password"], '
+            'section:has-text("Password")'
+        )
+        expect(password_section.first).to_be_visible()
+        
+        # Verify 2FA section exists
+        twofa_section = page.locator(
+            '#twofa-section, '
+            '#2fa-section, '
+            '[data-section="2fa"], '
+            'section:has-text("Two-Factor"), '
+            'section:has-text("2FA")'
+        )
+        expect(twofa_section.first).to_be_visible()
+
+    def test_update_profile_information(
+        self, authenticated_page: Page, base_url: str
+    ) -> None:
+        """Test updating profile information.
+        
+        Verifies:
+        - Update name/email fields
+        - Save changes
+        - Success message appears
+        """
+        page = authenticated_page
+        
+        # Navigate to profile settings page
+        page.goto(f"{base_url}/user/profile")
+        page.wait_for_load_state("networkidle")
+        
+        # Verify profile form is visible
+        profile_form = page.locator("#profile-form")
+        expect(profile_form).to_be_visible()
+        
+        # Get the name input field
+        name_input = page.locator(
+            '#profile-form input[name="name"], '
+            '#profile-form input[name="full_name"], '
+            '#profile-form input[name="displayName"], '
+            '#profile-form #name-input'
+        )
+        
+        # Update the name field with a test value
+        if name_input.count() > 0:
+            # Get current value to restore later or use for verification
+            current_name = name_input.first.input_value()
+            test_name = f"{current_name} Updated" if current_name else "Test User Updated"
+            
+            # Clear and fill with new value
+            name_input.first.fill(test_name)
+        
+        # Find and click the save/submit button
+        save_button = page.locator(
+            '#profile-form button[type="submit"], '
+            '#save-profile-button, '
+            'button:has-text("Save"), '
+            'button:has-text("Update Profile")'
+        )
+        expect(save_button.first).to_be_visible()
+        save_button.first.click()
+        
+        # Wait for the save operation to complete
+        page.wait_for_load_state("networkidle")
+        
+        # Verify success message appears
+        success_message = page.locator(
+            '.success-message, '
+            '[data-testid="success-message"], '
+            '.alert-success, '
+            '.toast-success, '
+            '[role="alert"]:has-text("success"), '
+            ':has-text("Profile updated"), '
+            ':has-text("Changes saved")'
+        )
+        expect(success_message.first).to_be_visible()


### PR DESCRIPTION
Add Playwright E2E tests for User & Team Management pages to address BRU-2832.

These tests require the following IDs to be present in the frontend:
- `#api-tokens-table`
- `#create-token-button`
- `#token-display-once`
- `#team-settings-tabs`
- `#team-members-list`
- `#profile-form`

---
Linear Issue: [BRU-2832](https://linear.app/bruin/issue/BRU-2832/user-and-team-management-tests)

<a href="https://cursor.com/background-agent?bcId=bc-6ed71418-da4a-419b-bafc-bc6dff156e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ed71418-da4a-419b-bafc-bc6dff156e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

