### PR TITLE
Stripe documentation table issue

### DIFF
--- a/docs/ingestion/stripe.md
+++ b/docs/ingestion/stripe.md
@@ -41,45 +41,46 @@ parameters:
 - `source_connection`: The name of the Stripe connection defined in .bruin.yml.
 - `source_table`: The name of the data table in Stripe you want to ingest. Available tables:
 
-Table    PK    Inc Key    Inc Strategy    Details
-account    id    created    merge    Contains information about a Stripe account, including balances, payouts, and account settings.
-apple_pay_domain    id    created    merge    Represents Apple Pay domains registered with Stripe for processing Apple Pay payments.
-application_fee    id    created    merge    Records fees collected by platforms on payments processed through connected accounts.
-balance_transaction    id    created    merge    Records transactions that affect the Stripe account balance, such as charges, refunds, and payouts.
-charge    id    created    merge    Returns a list of charges.
-checkout_session    id    created    merge    Contains data about Checkout sessions created for payment processing workflows.
-coupon    id    created    merge    Stores data about discount codes or coupons that can be applied to invoices, subscriptions, or other charges.
-credit_note    id    created    merge    Contains credit note information for refunds and adjustments.
-customer    id    created    merge    Holds information about customers, such as billing details, payment methods, and associated transactions.
-dispute    id    created    merge    Records payment disputes and chargebacks filed by customers or banks.
-event    id    created    merge    Logs all events in the Stripe account, including customer actions, account updates, and system-generated events.
-invoice    id    created    merge    Represents invoices sent to customers, detailing line items, amounts, and payment status.
-invoice_item    id    created    merge    Contains individual line items that can be added to invoices.
-invoice_line_item    id    created    merge    Represents line items within invoices.
-payment_intent    id    created    merge    Represents payment intents tracking the lifecycle of payments from creation to completion.
-payment_link    id    created    merge    Contains information about payment links created for collecting payments.
-payment_method    id    created    merge    Stores payment method information such as cards, bank accounts, and other payment instruments.
-payment_method_domain    id    created    merge    Represents domains verified for payment method collection.
-payout    id    created    merge    Records payouts made from Stripe accounts to bank accounts or debit cards.
-plan    id    created    merge    Contains subscription plan information including pricing and billing intervals.
-price    id    created    merge    Contains pricing information for products, including currency, amount, and billing intervals.
-product    id    created    merge    Represents products that can be sold or subscribed to, including metadata and pricing information.
-promotion_code    id    created    merge    Stores data about promotion codes that customers can use to apply coupons.
-quote    id    created    merge    Contains quote information for customers, including line items and pricing.
-refund    id    created    merge    Records refunds issued for charges, including partial and full refunds.
-review    id    created    merge    Contains payment review information for payments flagged by Stripe Radar.
-setup_attempt    id    created    merge    Records attempts to set up payment methods for future payments.
-setup_intent    id    created    merge    Represents setup intents for collecting payment method information.
-shipping_rate    id    created    merge    Contains shipping rate information for orders and invoices.
-subscription    id    created    merge    Represents a customer's subscription to a recurring service, detailing billing cycles, plans, and status.
-subscription_item    id    created    merge    Contains individual items within a subscription, including quantities and pricing.
-subscription_schedule    id    created    merge    Represents scheduled changes to subscriptions over time.
-tax_code    id    created    merge    Contains tax code information for products and services.
-tax_id    id    created    merge    Stores tax ID information for customers and accounts.
-tax_rate    id    created    merge    Contains tax rate information applied to invoices and subscriptions.
-top_up    id    created    merge    Records top-ups made to Stripe accounts.
-transfer    id    created    merge    Records transfers between Stripe accounts.
-webhook_endpoint    id    created    merge    Contains webhook endpoint configurations for receiving event notifications.
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| account | id | created | merge | Contains information about a Stripe account, including balances, payouts, and account settings. |
+| apple_pay_domain | id | created | merge | Represents Apple Pay domains registered with Stripe for processing Apple Pay payments. |
+| application_fee | id | created | merge | Records fees collected by platforms on payments processed through connected accounts. |
+| balance_transaction | id | created | merge | Records transactions that affect the Stripe account balance, such as charges, refunds, and payouts. |
+| charge | id | created | merge | Returns a list of charges. |
+| checkout_session | id | created | merge | Contains data about Checkout sessions created for payment processing workflows. |
+| coupon | id | created | merge | Stores data about discount codes or coupons that can be applied to invoices, subscriptions, or other charges. |
+| credit_note | id | created | merge | Contains credit note information for refunds and adjustments. |
+| customer | id | created | merge | Holds information about customers, such as billing details, payment methods, and associated transactions. |
+| dispute | id | created | merge | Records payment disputes and chargebacks filed by customers or banks. |
+| event | id | created | merge | Logs all events in the Stripe account, including customer actions, account updates, and system-generated events. |
+| invoice | id | created | merge | Represents invoices sent to customers, detailing line items, amounts, and payment status. |
+| invoice_item | id | created | merge | Contains individual line items that can be added to invoices. |
+| invoice_line_item | id | created | merge | Represents line items within invoices. |
+| payment_intent | id | created | merge | Represents payment intents tracking the lifecycle of payments from creation to completion. |
+| payment_link | id | created | merge | Contains information about payment links created for collecting payments. |
+| payment_method | id | created | merge | Stores payment method information such as cards, bank accounts, and other payment instruments. |
+| payment_method_domain | id | created | merge | Represents domains verified for payment method collection. |
+| payout | id | created | merge | Records payouts made from Stripe accounts to bank accounts or debit cards. |
+| plan | id | created | merge | Contains subscription plan information including pricing and billing intervals. |
+| price | id | created | merge | Contains pricing information for products, including currency, amount, and billing intervals. |
+| product | id | created | merge | Represents products that can be sold or subscribed to, including metadata and pricing information. |
+| promotion_code | id | created | merge | Stores data about promotion codes that customers can use to apply coupons. |
+| quote | id | created | merge | Contains quote information for customers, including line items and pricing. |
+| refund | id | created | merge | Records refunds issued for charges, including partial and full refunds. |
+| review | id | created | merge | Contains payment review information for payments flagged by Stripe Radar. |
+| setup_attempt | id | created | merge | Records attempts to set up payment methods for future payments. |
+| setup_intent | id | created | merge | Represents setup intents for collecting payment method information. |
+| shipping_rate | id | created | merge | Contains shipping rate information for orders and invoices. |
+| subscription | id | created | merge | Represents a customer's subscription to a recurring service, detailing billing cycles, plans, and status. |
+| subscription_item | id | created | merge | Contains individual items within a subscription, including quantities and pricing. |
+| subscription_schedule | id | created | merge | Represents scheduled changes to subscriptions over time. |
+| tax_code | id | created | merge | Contains tax code information for products and services. |
+| tax_id | id | created | merge | Stores tax ID information for customers and accounts. |
+| tax_rate | id | created | merge | Contains tax rate information applied to invoices and subscriptions. |
+| top_up | id | created | merge | Records top-ups made to Stripe accounts. |
+| transfer | id | created | merge | Records transfers between Stripe accounts. |
+| webhook_endpoint | id | created | merge | Contains webhook endpoint configurations for receiving event notifications. |
 
 
 ### Step 3: [Run](/commands/run) asset to ingest data


### PR DESCRIPTION
Refactor Stripe documentation table to use proper Markdown syntax for improved readability and consistency.

---
[Slack Thread](https://bruintalk.slack.com/archives/C07RG5NR0RX/p1768324129799179?thread_ts=1768324129.799179&cid=C07RG5NR0RX)

<a href="https://cursor.com/background-agent?bcId=bc-07c759c9-7fc0-418d-b852-f6e5d70a302b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07c759c9-7fc0-418d-b852-f6e5d70a302b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

