### PR TITLE
Binary size regression

### DIFF
--- a/docs/embed.go
+++ b/docs/embed.go
@@ -2,5 +2,9 @@ package docs
 
 import "embed"
 
-//go:embed all:getting-started all:commands all:quality all:secrets all:deployment all:cicd all:cloud all:vscode-extension all:ingestion all:platforms all:assets *.md
+// Only embed markdown files - media files (png, gif, jpg, mp4) are not needed
+// and were causing ~34MB of unnecessary binary bloat.
+// Patterns cover: root level, 1 deep, 2 deep, and 3 deep directories.
+//
+//go:embed *.md */*.md */*/*.md */*/*/*.md
 var DocsFS embed.FS


### PR DESCRIPTION
Refactor `docs/embed.go` to only embed markdown files, reducing binary size by ~34MB.

The `all:` prefix in `docs/embed.go` was embedding all files, including ~34MB of unused media files (PNG, GIF, JPG, MP4), causing a significant binary size regression between v0.11.411 and v0.11.412. The MCP server only utilizes `.md` files, so this change explicitly targets only markdown files for embedding.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1768488845542219?thread_ts=1768488845.542219&cid=C094932THFW)

<a href="https://cursor.com/background-agent?bcId=bc-b3917473-6276-4f16-8c06-01d6e5c0fa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3917473-6276-4f16-8c06-01d6e5c0fa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized documentation embedding by restricting to Markdown files only and excluding media assets, resulting in a leaner package footprint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->