### PR TITLE
document enforce schema

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -71,6 +71,7 @@ parameters:
 | `sql_limit` | No | `--sql-limit` | Applies a `LIMIT` clause when extracting from the source. |
 | `sql_exclude_columns` | No | `--sql-exclude-columns` | List of columns to skip during extraction. |
 | `staging_bucket` | No | `--staging-bucket` | Overrides the staging bucket that Ingestr uses for intermediate files. |
+| `enforce_schema` | No | `--columns` | When set to `true`, enforces the column types defined in the asset's `columns` section. Ingestr will create or update the destination table with the specified schema. |
 
 ### Column metadata
 
@@ -121,3 +122,35 @@ parameters:
   source_table: <mysheetid>.<sheetname>
   destination: snowflake
 ```
+
+### Enforce schema with column types
+This example shows how to use `enforce_schema` to ensure the destination table has the correct column types. This is useful when the source system's type inference doesn't match your requirements.
+
+```yaml
+name: raw.users
+type: ingestr
+parameters:
+  source_connection: mongodb_prod
+  source_table: prod.users
+  destination: bigquery
+  incremental_strategy: merge
+  incremental_key: updated_at
+  enforce_schema: true
+
+columns:
+  - name: _id
+    type: string
+    primary_key: true
+  - name: name
+    type: string
+  - name: email
+    type: string
+  - name: age
+    type: integer
+  - name: created_at
+    type: timestamp
+  - name: updated_at
+    type: timestamp
+```
+
+When `enforce_schema: true` is set, Bruin passes the column type hints to Ingestr via the `--columns` flag, ensuring the destination table schema matches your definition.

--- a/docs/assets/python.md
+++ b/docs/assets/python.md
@@ -262,6 +262,49 @@ Bruin uses Apache Arrow under the hood to keep the returned data efficiently, an
 
 This flow ensures that the typing information gathered from the dataframe will be preserved when loading to the destination, and it supports incremental loads, deduplication, and all the other features of ingestr.
 
+### Enforcing column types
+
+By default, ingestr infers column types from the dataframe. If you want to enforce specific column types in the destination table, you can use the `enforce_schema` parameter along with column definitions:
+
+```bruin-python
+"""@bruin
+name: tier1.users_api
+image: python:3.11
+connection: bigquery
+
+materialization:
+  type: table
+  strategy: merge
+
+parameters:
+  enforce_schema: true
+
+columns:
+  - name: id
+    type: integer
+    primary_key: true
+  - name: name
+    type: string
+  - name: email
+    type: string
+  - name: created_at
+    type: timestamp
+@bruin"""
+
+import pandas as pd
+
+def materialize():
+    # Fetch data from API
+    return pd.DataFrame({
+        'id': [1, 2, 3],
+        'name': ['Alice', 'Bob', 'Charlie'],
+        'email': ['alice@example.com', 'bob@example.com', 'charlie@example.com'],
+        'created_at': pd.to_datetime(['2024-01-01', '2024-01-02', '2024-01-03'])
+    })
+```
+
+When `enforce_schema: true` is set, Bruin passes the column type hints to ingestr, ensuring the destination table schema matches your definition rather than relying on type inference.
+
 ## Column-level lineage
 
 Bruin supports column-level lineage for Python assets as well as SQL assets. In order to get column-level lineage, you need to annotate the columns that are exposed by the Bruin asset.

--- a/docs/assets/seed.md
+++ b/docs/assets/seed.md
@@ -10,15 +10,18 @@ parameters:
     path: seed.csv
 ```
 
-The `type` key in the configuration defines what platform to run the query against. 
+The `type` key in the configuration defines what platform to run the query against.
 
 You can see the "Data Platforms" on the left sidebar to see supported types.
 
 ## Parameters
 
-The `parameters` key in the configuration defines the parameters for the seed asset. The `path` parameter is the path to the CSV file that will be loaded into the data platform. The path can be:
-- **A relative file path**: relative to the asset definition file (e.g., `./seed.csv`)
-- **A URL**: an HTTP or HTTPS URL pointing to a publicly accessible CSV file (e.g., `https://example.com/data.csv`)
+The `parameters` key in the configuration defines the parameters for the seed asset.
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| `path` | Yes | - | Path to the CSV file to load. Can be a relative path (relative to the asset definition file) or a URL pointing to a publicly accessible CSV file. |
+| `enforce_schema` | No | `true` | When `true`, enforces column types defined in the `columns` section. Set to `false` to let ingestr infer types from the CSV. |
 
 ::: warning Column validation skipped for URLs
 When using a URL path, column validation is skipped during `bruin validate`. Column mismatches will be caught at runtime when `bruin run` fetches the data.
@@ -81,3 +84,46 @@ parameters:
 ```
 
 This will download the CSV from the URL and load it into the database at runtime.
+
+### Enforcing column types
+By default, seed assets enforce the column types defined in the `columns` section. This ensures your destination table has the correct schema.
+
+```yaml
+name: dashboard.contacts
+type: bigquery.seed
+
+parameters:
+    path: contacts.csv
+
+columns:
+  - name: id
+    type: integer
+    primary_key: true
+  - name: name
+    type: string
+  - name: email
+    type: string
+  - name: created_at
+    type: timestamp
+```
+
+When columns are defined, Bruin passes type hints to ingestr, ensuring the destination table uses the specified types rather than inferring them from the CSV content.
+
+### Disabling schema enforcement
+If you prefer to let ingestr infer column types from the CSV content, you can disable schema enforcement:
+
+```yaml
+name: dashboard.raw_data
+type: duckdb.seed
+
+parameters:
+    path: data.csv
+    enforce_schema: false
+
+columns:
+  - name: id
+    checks:
+      - name: not_null
+```
+
+With `enforce_schema: false`, the column types will be inferred from the CSV data. You can still define columns for quality checks and documentation without enforcing specific types.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for the enforce_schema parameter across asset types (ingestr, Python, seed).
  * Includes parameter tables, YAML and Python examples, and guidance for enabling/disabling enforcement.
  * Explains how column type hints are passed to ingestr and how to use quality-check-only column definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->