### PR TITLE
Reconciler API pooling

### DIFF
--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -1244,7 +1244,8 @@ func (d *Client) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, e
 	mu := sync.Mutex{}
 	var errs []error
 
-	workers := max(runtime.NumCPU(), 8)
+	// Use a smaller pool size to reduce API call frequency
+	workers := min(runtime.NumCPU(), 4)
 
 	p := pool.New().WithMaxGoroutines(workers)
 
@@ -1325,7 +1326,8 @@ func (d *Client) GetDatabaseSummaryForSchemas(ctx context.Context, schemas []str
 	mu := sync.Mutex{}
 	var errs []error
 
-	workers := max(runtime.NumCPU(), 8)
+	// Use a smaller pool size to reduce API call frequency
+	workers := min(runtime.NumCPU(), 4)
 	p := pool.New().WithMaxGoroutines(workers)
 
 	// Only iterate over requested schemas (datasets)


### PR DESCRIPTION
Replaced `errgroup.Group` with `conc.Pool` and reduced BigQuery pool sizes to decrease Kubernetes API call frequency and improve concurrency control.

The change to `conc.Pool` with explicit goroutine limits (2 for pipe consumption, 4 for BigQuery) provides more granular control over concurrency, directly addressing the issue of hitting the Kubernetes API too frequently. Additionally, the error handling order for command execution and pipe consumption was standardized across `claudecode`, `python`, and `r` runners to ensure pipes are fully read before the command exits, preventing potential deadlocks.

---
Linear Issue: [BRU-3433](https://linear.app/bruin/issue/BRU-3433/reconciler-drop-the-frequency-of-the-api)

<a href="https://cursor.com/background-agent?bcId=bc-5e2eac8f-3397-4f0b-ba0d-eae81e52f6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e2eac8f-3397-4f0b-ba0d-eae81e52f6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

