### PR TITLE
fix: skip validation silently when connection is not found

### DIFF
--- a/pkg/lint/query.go
+++ b/pkg/lint/query.go
@@ -249,24 +249,15 @@ func (q *QueryValidatorRule) validateTask(ctx context.Context, p *pipeline.Pipel
 
 			assetConnectionName, err := p.GetConnectionNameForAsset(task)
 			if err != nil {
-				mu.Lock()
-				issues = append(issues, &Issue{
-					Task:        task,
-					Description: fmt.Sprintf("Cannot get connection for task '%s': %v", task.Name, err),
-				})
-				mu.Unlock()
+				q.Logger.Debugf("failed to get connection name for asset '%s'", task.Name)
+				return
 			}
+
 			q.Logger.Debugw("The connection will be used for asset", "asset", task.Name, "connection", assetConnectionName)
 
 			validator := q.Connections.GetConnection(assetConnectionName)
 			if validator == nil {
-				mu.Lock()
-				issues = append(issues, &Issue{
-					Task:        task,
-					Description: fmt.Sprintf("Cannot get connection for task '%s': %v", task.Name, err),
-				})
-				mu.Unlock()
-
+				q.Logger.Debugf("failed to get connection instance for asset '%s'", task.Name)
 				return
 			}
 			valll, ok := validator.(queryValidator)


### PR DESCRIPTION
### Summary

Fixes an issue where the BigQuery (and other) query validators would report error messages for assets that don't have a matching connection configured.

### Problem

When running validate on a pipeline, the `validateTask` function was reporting errors like:
Cannot get connection for task 'my_dataset.test_table': <nil> (bigquery-validator)

This happened because:
1. The validator runs for ALL assets of a given type (e.g., all `bq.sql` assets) if at least one connection of that type exists in `.bruin.yml`
2. When an asset references a connection that doesn't exist, `validateTask` was creating an error issue instead of silently skipping

### Solution

Updated `validateTask` to match the behavior of `ValidateAsset`:
- If connection name cannot be resolved → skip silently (debug log only)
- If connection instance is not found → skip silently (debug log only)
- Only report errors for actual query validation failures

This is consistent with the principle that validation should only run when the required connection is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during asset validation to enhance system stability and prevent concurrent processing issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->