### PR TITLE
Query log sql formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bruin",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,6 +8,7 @@
         "esbuild": "^0.27.1",
         "highlight.js": "^11.10.0",
         "markdown-it": "^14.1.0",
+        "sql-formatter": "^15.7.0",
         "vite": "^6.4.1"
       },
       "devDependencies": {
@@ -2652,6 +2653,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
+    },
     "node_modules/dompurify": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
@@ -3173,6 +3180,12 @@
         "ufo": "^1.6.1"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3190,6 +3203,34 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/non-layered-tidy-tree-layout": {
       "version": "2.0.2",
@@ -3346,6 +3387,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
@@ -3372,6 +3432,15 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -3506,6 +3575,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.7.0.tgz",
+      "integrity": "sha512-o2yiy7fYXK1HvzA8P6wwj8QSuwG3e/XcpWht/jIxkQX99c0SVPw0OXdLSV9fHASPiYB09HLA0uq8hokGydi/QA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
     "node_modules/stringify-entities": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "esbuild": "^0.27.1",
     "highlight.js": "^11.10.0",
     "markdown-it": "^14.1.0",
+    "sql-formatter": "^15.7.0",
     "vite": "^6.4.1"
   },
   "overrides": {

--- a/scripts/format-sql.js
+++ b/scripts/format-sql.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * SQL Formatter Script
+ * 
+ * This script reads SQL from stdin and outputs formatted SQL to stdout.
+ * Used by the Bruin CLI to format SQL queries in query logs.
+ * 
+ * Usage:
+ *   echo "SELECT * FROM users WHERE id = 1" | node scripts/format-sql.js
+ *   echo "SELECT * FROM users WHERE id = 1" | node scripts/format-sql.js --dialect=bigquery
+ * 
+ * Options:
+ *   --dialect=<dialect>  SQL dialect (bigquery, snowflake, postgres, mysql, etc.)
+ */
+
+const { format } = require('sql-formatter');
+
+// Read SQL from stdin
+let sql = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', (chunk) => {
+    sql += chunk;
+});
+
+process.stdin.on('end', () => {
+    try {
+        // Parse command line arguments for dialect
+        const args = process.argv.slice(2);
+        let dialect = 'sql';  // default dialect
+        
+        for (const arg of args) {
+            if (arg.startsWith('--dialect=')) {
+                dialect = arg.split('=')[1];
+            }
+        }
+        
+        // Map common dialect names to sql-formatter supported dialects
+        const dialectMap = {
+            'bigquery': 'bigquery',
+            'bq': 'bigquery',
+            'snowflake': 'snowflake',
+            'sf': 'snowflake',
+            'postgres': 'postgresql',
+            'postgresql': 'postgresql',
+            'pg': 'postgresql',
+            'mysql': 'mysql',
+            'redshift': 'redshift',
+            'spark': 'spark',
+            'trino': 'trino',
+            'sql': 'sql',
+            'duckdb': 'sql',
+            'clickhouse': 'sql',
+            'athena': 'trino',
+            'mssql': 'transactsql',
+            'tsql': 'transactsql',
+            'transactsql': 'transactsql',
+            'synapse': 'transactsql',
+            'databricks': 'spark',
+        };
+        
+        const mappedDialect = dialectMap[dialect.toLowerCase()] || 'sql';
+        
+        const formatted = format(sql, {
+            language: mappedDialect,
+            tabWidth: 2,
+            useTabs: false,
+            keywordCase: 'upper',
+            linesBetweenQueries: 2,
+        });
+        
+        process.stdout.write(formatted);
+        process.exit(0);
+    } catch (error) {
+        // If formatting fails, output the original SQL
+        process.stderr.write(`Warning: SQL formatting failed: ${error.message}\n`);
+        process.stdout.write(sql);
+        process.exit(0);  // Still exit 0 to not break the flow
+    }
+});
+
+process.stdin.on('error', (error) => {
+    process.stderr.write(`Error reading stdin: ${error.message}\n`);
+    process.exit(1);
+});


### PR DESCRIPTION
Add SQL formatting to query logs to improve readability in the CLI and VS Code extension.

Currently, SQL queries in query logs are saved as single long lines, making them difficult to parse and understand. This PR introduces a `formatted_query` field to the query log, providing a properly indented and line-broken version of the SQL query. This significantly enhances the user experience when reviewing query history, particularly for tools like the VS Code extension that consume these logs. The formatting is performed using the `sql-formatter` JavaScript library via an inline Node.js execution, with a graceful fallback to the original query if Node.js is unavailable.

---
[Slack Thread](https://bruintalk.slack.com/archives/C09404160R1/p1769029079447179?thread_ts=1769029079.447179&cid=C09404160R1)

<a href="https://cursor.com/background-agent?bcId=bc-67fa8519-5931-46f3-863c-c1e15b4f30df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67fa8519-5931-46f3-863c-c1e15b4f30df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

