### PR TITLE
Query single connection inference

### DIFF
--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -69,10 +69,12 @@ func TestValidateFlags(t *testing.T) {
 			errorMsg:    "direct query mode requires both --connection and --query flags",
 		},
 		{
-			name:        "missing connection in direct mode",
+			name:        "query only mode (connection inferred from config)",
 			query:       "SELECT * FROM table",
-			expectError: true,
-			errorMsg:    "must use either:\n1. Direct query mode (--connection and --query), or\n2. Asset mode (--asset with optional --environment), or\n3. Auto-detect mode (--asset to detect the connection and --query to run arbitrary queries)",
+			limit:       10,
+			expectError: false,
+			// Connection will be inferred from config if there's exactly one
+			limitedQuery: "SELECT * FROM (\nSELECT * FROM table\n) as t LIMIT 10",
 		},
 		{
 			name:        "mixing direct query and asset modes",

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -178,7 +178,7 @@ type importWarning struct {
 func runImport(ctx context.Context, pipelinePath, connectionName, schema string, schemas []string, fillColumns bool, environment, configFile string) error {
 	fs := afero.NewOsFs()
 
-	conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
+	_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
 	if err != nil {
 		return errors2.Wrap(err, "failed to get database connection")
 	}
@@ -1060,7 +1060,7 @@ func runScheduledQueriesImport(ctx context.Context, pipelinePath, connectionName
 	fs := afero.NewOsFs()
 
 	// Get BigQuery connection
-	conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
+	_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
 	if err != nil {
 		return errors2.Wrap(err, "failed to get BigQuery connection")
 	}

--- a/cmd/import_tableau.go
+++ b/cmd/import_tableau.go
@@ -21,7 +21,7 @@ func runTableauImport(ctx context.Context, pipelinePath, connectionName, environ
 	fmt.Printf("🔧 Getting Tableau connection '%s'...\n", connectionName)
 
 	// Get Tableau connection
-	conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
+	_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
 	if err != nil {
 		return errors2.Wrapf(err, "failed to get Tableau connection '%s' from environment '%s'", connectionName, environment)
 	}

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -225,7 +225,7 @@ func DBSummary() *cli.Command {
 			output := c.String("output")
 
 			// Get connection from config
-			conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
+			_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
 			if err != nil {
 				return handleError(output, errors2.Wrap(err, "failed to get database connection"))
 			}
@@ -801,7 +801,7 @@ func FetchDatabases() *cli.Command {
 			output := c.String("output")
 
 			// Get connection from config
-			conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
+			_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
 			if err != nil {
 				return handleError(output, errors2.Wrap(err, "failed to get database connection"))
 			}
@@ -916,7 +916,7 @@ func FetchTables() *cli.Command {
 			environment := c.String("environment")
 			output := c.String("output")
 
-			conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
+			_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
 			if err != nil {
 				return handleError(output, errors2.Wrap(err, "failed to get database connection"))
 			}
@@ -1116,7 +1116,7 @@ func FetchColumns() *cli.Command {
 			output := c.String("output")
 
 			// Get connection from config
-			conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
+			_, conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, c.String("config-file"))
 			if err != nil {
 				return handleError(output, errors2.Wrap(err, "failed to get database connection"))
 			}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -142,6 +142,22 @@ func (c *Connections) ConnectionsSummaryList() map[string]string {
 	return c.typeNameMap
 }
 
+// GetSingleConnectionName returns the connection name if there's exactly one connection configured.
+// Returns the connection name and true if exactly one connection exists, otherwise returns empty string and false.
+func (c *Connections) GetSingleConnectionName() (string, bool) {
+	if c.typeNameMap == nil {
+		c.buildConnectionKeyMap()
+	}
+
+	if len(c.typeNameMap) == 1 {
+		for name := range c.typeNameMap {
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
 func GetConnectionsSchema() (string, error) {
 	schema := jsonschema.Reflect(&Connections{})
 	jsonStringSchema, err := json.Marshal(schema)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -2102,6 +2102,88 @@ func TestConnections_MergeFrom(t *testing.T) {
 	}
 }
 
+func TestConnections_GetSingleConnectionName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		connections     *Connections
+		expectedName    string
+		expectedSuccess bool
+	}{
+		{
+			name:            "no connections returns false",
+			connections:     &Connections{},
+			expectedName:    "",
+			expectedSuccess: false,
+		},
+		{
+			name: "single postgres connection returns name",
+			connections: &Connections{
+				Postgres: []PostgresConnection{
+					{Name: "my-postgres"},
+				},
+			},
+			expectedName:    "my-postgres",
+			expectedSuccess: true,
+		},
+		{
+			name: "single bigquery connection returns name",
+			connections: &Connections{
+				GoogleCloudPlatform: []GoogleCloudPlatformConnection{
+					{Name: "my-bigquery"},
+				},
+			},
+			expectedName:    "my-bigquery",
+			expectedSuccess: true,
+		},
+		{
+			name: "single duckdb connection returns name",
+			connections: &Connections{
+				DuckDB: []DuckDBConnection{
+					{Name: "my-duckdb"},
+				},
+			},
+			expectedName:    "my-duckdb",
+			expectedSuccess: true,
+		},
+		{
+			name: "multiple connections of same type returns false",
+			connections: &Connections{
+				Postgres: []PostgresConnection{
+					{Name: "postgres1"},
+					{Name: "postgres2"},
+				},
+			},
+			expectedName:    "",
+			expectedSuccess: false,
+		},
+		{
+			name: "multiple connections of different types returns false",
+			connections: &Connections{
+				Postgres: []PostgresConnection{
+					{Name: "my-postgres"},
+				},
+				Snowflake: []SnowflakeConnection{
+					{Name: "my-snowflake"},
+				},
+			},
+			expectedName:    "",
+			expectedSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, ok := tt.connections.GetSingleConnectionName()
+			assert.Equal(t, tt.expectedSuccess, ok)
+			assert.Equal(t, tt.expectedName, name)
+		})
+	}
+}
+
 func TestLoadFromFileOrEnv_EnvironmentVariable(t *testing.T) {
 	// Test data from environ.yml
 	envConfigContent := `default_environment: dev


### PR DESCRIPTION
Allow `bruin query` to infer the connection when only one is configured in `.bruin.yml`.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1769030359217879?thread_ts=1769030359.217879&cid=C094932THFW)

<a href="https://cursor.com/background-agent?bcId=bc-42c1bd85-93d5-40db-aeb2-12ede4f55b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42c1bd85-93d5-40db-aeb2-12ede4f55b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

