### PR TITLE
Validate asset before type check to prevent nil pointer errors

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -1508,6 +1508,11 @@ func LockAssetDependencies() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
+			if asset == nil {
+				printErrorJSON(errors2.New("file is not a valid asset"))
+				return cli.Exit("", 1)
+			}
+
 			// Check if asset is a Python asset
 			if asset.Type != pipeline.AssetTypePython && !strings.HasSuffix(asset.ExecutableFile.Path, ".py") {
 				printErrorJSON(errors2.New("asset is not a Python asset"))


### PR DESCRIPTION
# PR Overview 
This PR improves error handling in `LockAssetDependencies` by validating the asset before checking its type.

Previously, attempting to lock dependencies for an invalid asset (example: on requirements.txt) resulted in a nil pointer error, leading to a confusing failure. With this change, the asset is validated upfront and a clear, user-friendly error message is returned instead.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid asset files. The system now displays a clear error message when an asset file cannot be processed, preventing potential crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->