### PR TITLE
Fix BigQuery Decimal Rendering in `bruin query`

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -810,6 +810,9 @@ func formatQueryCellForDisplay(cell interface{}) interface{} {
 func formatQueryCellForJSON(cell interface{}) interface{} {
 	switch v := cell.(type) {
 	case *big.Rat:
+		if v == nil {
+			return nil
+		}
 		return json.Number(formatBigRatAsDecimal(v))
 	case big.Rat:
 		vcopy := v

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -281,15 +281,40 @@ func TestFormatQueryRowsForJSON(t *testing.T) {
 	assert.Same(t, repeatingRat, input[1][1])
 }
 
-func TestFormatQueryRowsForJSON_MarshalAsNumbers(t *testing.T) {
+func TestFormatQueryRowsForJSON_Marshal(t *testing.T) {
 	t.Parallel()
 
 	rat, ok := new(big.Rat).SetString("32097247/500000")
 	require.True(t, ok)
 
-	rows := formatQueryRowsForJSON([][]interface{}{{rat}})
+	var nilRat *big.Rat
 
-	payload, err := json.Marshal(rows)
-	require.NoError(t, err)
-	assert.Equal(t, `[[64.194494]]`, string(payload))
+	tests := []struct {
+		name     string
+		cell     interface{}
+		expected string
+	}{
+		{
+			name:     "big rat marshals as number",
+			cell:     rat,
+			expected: `[[64.194494]]`,
+		},
+		{
+			name:     "nil big rat marshals as null",
+			cell:     nilRat,
+			expected: `[[null]]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rows := formatQueryRowsForJSON([][]interface{}{{tt.cell}})
+
+			payload, err := json.Marshal(rows)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(payload))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Fix `bruin query` output where BigQuery `NUMERIC/BIGNUMERIC` values (`*big.Rat` type )were shown as fractions like `32097247/500000`.
- Keep JSON numerics as numeric literals (using `json.Number`), not strings.
- Apply consistently across plain table output, JSON output, CSV output/export, and saved query logs.


## Context
- The runtime column comes back as BigQuery `NUMERIC`, and then Go represents them as `*big.Rat`
- default formatting (`fmt.Sprintf("%v", val)` / JSON marshal) formats `*big.Rat` as numerator/denom, so we see fractions like 32097247/500000 instead 

## Manual Tests
### Create Table
```sql
CREATE OR REPLACE TABLE `general.numerics_test` AS
SELECT
    1 AS id,
    CAST('32097247' AS NUMERIC) / CAST('500000' AS NUMERIC) AS num_exact,
    CAST('-111' AS NUMERIC) / CAST('100' AS NUMERIC) AS num_negative,
    CAST('12500' AS NUMERIC) / CAST('1000' AS NUMERIC) AS num_trim_test,
    CAST('1' AS BIGNUMERIC) / CAST('3' AS BIGNUMERIC) AS bignum_repeating;
```
### Now
<img width="1044" height="271" alt="Screenshot 2026-02-09 at 23 30 01" src="https://github.com/user-attachments/assets/515b0ad6-97cf-41da-b208-ed3956f8e5c3" />

### Before
<img width="1117" height="109" alt="Screenshot 2026-02-09 at 23 39 29 copy" src="https://github.com/user-attachments/assets/d312e0df-7d56-460f-89b3-f7f69ca0078c" />

### Bigquery Console Output
<img width="944" height="300" alt="Screenshot 2026-02-10 at 00 11 02" src="https://github.com/user-attachments/assets/4ae7a955-24ad-4306-aef3-6562b5a55073" />

### CSV file output
```csv
id,num_exact,num_negative,num_trim_test,bignum_repeating
1,64.194494,-1.11,12.5,0.33333333333333333333333333333333333333
```

### JSON file output
```json
{
	"columns": [
		{
			"name": "id",
			"type": "INTEGER"
		},
		{
			"name": "num_exact",
			"type": "NUMERIC"
		},
		{
			"name": "num_negative",
			"type": "NUMERIC"
		},
		{
			"name": "num_trim_test",
			"type": "NUMERIC"
		},
		{
			"name": "bignum_repeating",
			"type": "BIGNUMERIC"
		}
	],
	"rows": [
		[
			1,
			64.194494,
			-1.11,
			12.5,
			0.33333333333333333333333333333333333333
		]
	],
	"connectionName": "bigquery-default",
	"query": "SELECT * FROM general.numerics_test;"
}

```