### PR TITLE
Remove MySQL catalog mentions from DuckDB x DuckLake docs

### DIFF
--- a/docs/getting-started/lakehouse.md
+++ b/docs/getting-started/lakehouse.md
@@ -24,8 +24,8 @@ For more guidance, see DuckLake's [choosing a catalog database](https://ducklake
 | DuckDB| <span class="lh-check" aria-label="supported"></span> |
 | SQLite | <span class="lh-check" aria-label="supported"></span> |
 | Postgres| <span class="lh-check" aria-label="supported"></span> |
-| MySQL    | Planned |
 
+MySQL catalogs are currently not supported for DuckLake in Bruin due to limitations in the DuckDB MySQL connector and incomplete MySQL support in the DuckLake DuckDB extension.
 
 
 #### Iceberg

--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -180,8 +180,8 @@ connections:
 | DuckDB | <span class="lh-check" aria-label="supported"></span> |
 | SQLite | <span class="lh-check" aria-label="supported"></span> |
 | Postgres | <span class="lh-check" aria-label="supported"></span> |
-| MySQL    | Planned |
 
+MySQL catalogs are currently not supported for DuckLake in Bruin due to limitations in the DuckDB MySQL connector and incomplete MySQL support in the DuckLake DuckDB extension.
 
 
 #### Iceberg


### PR DESCRIPTION
## Summary
- Removes MySQL-as-catalog mentions for DuckLake from docs and clarifies current support status.
- Added a brief note in both pages that MySQL catalogs are currently unsupported for DuckLake in Bruin due to DuckDB/DuckLake extension limitations.