### PR TITLE
Fix missing ODBC runtime in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     binutils \
     python3-dev \
+    unixodbc \
+    libodbc2 \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Adds `unixodbc` and `libodbc2` to the Docker image so `pyodbc` can load `libodbc.so.2` in CI/container runs. 
Fixes #1405.

## Smoke Test
```bash
docker build -t bruin:odbc-fix .
docker run --rm --entrypoint bash bruin:odbc-fix -lc '/home/bruin/.bruin/uv run --python 3.11 --with pyodbc==5.1.0 python -c "import pyodbc; print(\"pyodbc ok\")"'
```

<img width="1114" height="246" alt="Screenshot 2026-02-17 at 12 24 44" src="https://github.com/user-attachments/assets/c7cfb1a3-22ab-478e-a7ce-36c32e68eb3b" />

