### PR TITLE
Remove airport_fee from trips_summary.sql

### DIFF
--- a/templates/nyc-taxi/assets/staging/trips_summary.sql
+++ b/templates/nyc-taxi/assets/staging/trips_summary.sql
@@ -140,7 +140,6 @@ normalized_trips AS ( -- Normalize column names from raw data (cast, coalesce, r
     improvement_surcharge,
     total_amount,
     congestion_surcharge,
-    airport_fee,
     taxi_type,
     extracted_at,
   FROM raw.trips_raw


### PR DESCRIPTION
Removed since we are not using the column anywhere in staging output, green taxi-trip dataset does not have an airport_fee column, and since duckdb is throwing a SQL error.