### PR TITLE
remove the uv warning

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -155,7 +155,7 @@ func (u *UvPythonRunner) runWithNoMaterialization(ctx context.Context, execCtx *
 	}
 
 	// Fall back to requirements.txt or no dependencies (existing behavior)
-	flags := []string{"run", "--no-config", "--no-sync", "--python", pythonVersion}
+	flags := []string{"run", "--no-config", "--no-project", "--python", pythonVersion}
 	if execCtx.requirementsTxt != "" {
 		flags = append(flags, "--with-requirements", execCtx.requirementsTxt)
 	}
@@ -289,7 +289,7 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 	} else {
 		// Fall back to requirements.txt or no dependencies
 		runRepo = execCtx.repo
-		flags = []string{"run", "--no-config", "--no-sync", "--python", pythonVersion}
+		flags = []string{"run", "--no-config", "--no-project", "--python", pythonVersion}
 		if execCtx.requirementsTxt != "" {
 			flags = append(flags, "--with-requirements", execCtx.requirementsTxt)
 		}

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -42,7 +42,7 @@ func Test_uvPythonRunner_Run(t *testing.T) {
 				cmd := new(mockCmd)
 				cmd.On("Run", mock.Anything, repo, &CommandInstance{
 					Name: "~/.bruin/uv",
-					Args: []string{"run", "--no-config", "--no-sync", "--python", "3.11", "--module", module},
+					Args: []string{"run", "--no-config", "--no-project", "--python", "3.11", "--module", module},
 				}).Return(assert.AnError)
 
 				inst := new(mockUvInstaller)
@@ -69,7 +69,7 @@ func Test_uvPythonRunner_Run(t *testing.T) {
 				cmd := new(mockCmd)
 				cmd.On("Run", mock.Anything, repo, &CommandInstance{
 					Name: "~/.bruin/uv",
-					Args: []string{"run", "--no-config", "--no-sync", "--python", "3.11", "--with-requirements", "/path/to/requirements.txt", "--module", module},
+					Args: []string{"run", "--no-config", "--no-project", "--python", "3.11", "--with-requirements", "/path/to/requirements.txt", "--module", module},
 				}).Return(assert.AnError)
 
 				inst := new(mockUvInstaller)
@@ -96,7 +96,7 @@ func Test_uvPythonRunner_Run(t *testing.T) {
 				cmd := new(mockCmd)
 				cmd.On("Run", mock.Anything, repo, &CommandInstance{
 					Name: "~/.bruin/uv",
-					Args: []string{"run", "--no-config", "--no-sync", "--python", "3.13", "--with-requirements", "/path/to/requirements.txt", "--module", module},
+					Args: []string{"run", "--no-config", "--no-project", "--python", "3.13", "--with-requirements", "/path/to/requirements.txt", "--module", module},
 				}).Return(assert.AnError)
 
 				inst := new(mockUvInstaller)


### PR DESCRIPTION
This PR removes the annoying `warning: `--no-sync` has no effect when used outside of a project` warning from Python asset logs.