### PR TITLE
Mcp VS Code instructions

### DIFF
--- a/docs/cloud/mcp-setup.md
+++ b/docs/cloud/mcp-setup.md
@@ -1,6 +1,6 @@
 # Cloud MCP
 
-This guide shows how to connect **Cursor**, **Claude Code** and **Codex** to the **Bruin Cloud MCP** so your AI assistant can securely call Bruin Cloud tools (for example: listing pipelines, inspecting runs, or triggering actions) directly from chat.
+This guide shows how to connect **Cursor**, **VS Code**, **Claude Code** and **Codex** to the **Bruin Cloud MCP** so your AI assistant can securely call Bruin Cloud tools (for example: listing pipelines, inspecting runs, or triggering actions) directly from chat.
 
 ## Setup
 
@@ -36,6 +36,26 @@ Edit the **`.cursor/mcp.json`** file and add your token.
 ```
 
 Restart Cursor (or reload the window) so it picks up the MCP config.
+
+## VS Code
+
+Create a `.vscode/mcp.json` file in your project folder with the following configuration:
+
+```json
+{
+  "servers": {
+    "bruin_cloud": {
+      "type": "http",
+      "url": "https://cloud.getbruin.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+Restart VS Code (or reload the window) so it picks up the MCP config.
 
 ## Claude Code
 
@@ -97,5 +117,6 @@ Once the Bruin Cloud MCP server is connected, you can ask in natural language, f
 - **401 Unauthorized:** Missing or invalid Bearer token. Check that the token is correct and not expired.
 - **403 Forbidden / “Insufficient token permissions”:** Token does not have the `mcp:token` ability. Create a new token with MCP permission.
 - **Cursor, tools not showing:** Ensure `.cursor/mcp.json` is valid JSON and restart Cursor.
+- **VS Code, tools not showing:** Ensure `.vscode/mcp.json` is valid JSON and restart VS Code.
 - **Claude Code, server not found:** Run `claude mcp list` to confirm the server is configured; use `claude mcp get bruin_cloud` to check its URL and headers.
 - **Codex CLI, tools not available:** Ensure `~/.codex/config.toml` is valid toml and restart Codex CLI.

--- a/docs/getting-started/bruin-mcp.md
+++ b/docs/getting-started/bruin-mcp.md
@@ -35,6 +35,23 @@ To use Bruin MCP in Cursor IDE, go to Cursor Settings > MCP & Integrations > Add
 }
 ```
 
+### VS Code
+
+To use Bruin MCP in VS Code, create a `.vscode/mcp.json` file in your project folder with the following configuration:
+
+```json
+{
+  "servers": {
+    "bruin": {
+      "command": "bruin",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+After creating the file, restart VS Code or reload the window. You can verify the MCP server is connected by checking the MCP servers list in VS Code.
+
 ### Codex CLI
 
 To use Bruin MCP in Codex CLI, add the following configuration to your `~/.codex/config.toml` file:
@@ -98,7 +115,7 @@ Using the Bruin MCP server, you can build new data models while ensuring that th
 
 ## And more
 
-Once MCP setup is complete, you can ask questions in Cursor IDE or Claude Code like:
+Once MCP setup is complete, you can ask questions in Cursor IDE, VS Code, or Claude Code like:
 
 - "How do I create a BigQuery asset in Bruin?"
 - "How is a pipeline.yml file configured in Bruin?"


### PR DESCRIPTION
Add VS Code setup instructions to the local and cloud MCP documentation.

This update addresses the missing VS Code configuration, noting its use of the `"servers"` key in `.vscode/mcp.json` compared to Cursor's `"mcpServers"`.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1771524891911129?thread_ts=1771524891.911129&cid=C094932THFW)

<p><a href="https://cursor.com/background-agent?bcId=bc-cbb77f0b-8f90-5f5c-9386-c107bda4fb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbb77f0b-8f90-5f5c-9386-c107bda4fb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

