### PR TITLE
Athena no-op source asset

### DIFF
--- a/docs/platforms/athena.md
+++ b/docs/platforms/athena.md
@@ -196,3 +196,73 @@ type: athena.sensor.query
 parameters:
     query: select exists(select 1 from upstream_table where inserted_at > "{{ end_timestamp }}"
 ```
+
+### `athena.source`
+
+Defines Athena source assets for documenting existing tables and views in your Athena database. These assets are no-op (they don't execute), but are useful for:
+
+- Documenting existing Athena tables and views
+- Adding column descriptions and metadata
+- Establishing lineage relationships
+- Query preview functionality in the VSCode extension
+
+#### Example: Document an existing Athena table
+
+```yaml
+name: analytics.website_events
+type: athena.source
+description: "Raw website event data collected from tracking pixels"
+connection: athena-default
+
+tags:
+  - analytics
+  - raw-data
+  - events
+domains:
+  - web-analytics
+
+meta:
+  business_owner: "Analytics Team"
+  data_steward: "analytics@company.com"
+  refresh_frequency: "real-time"
+
+depends:
+  - analytics.users
+  - analytics.sessions
+
+columns:
+  - name: event_id
+    type: "string"
+    description: "Unique identifier for each event"
+
+  - name: user_id
+    type: "string"
+    description: "Identifier of the user who triggered the event"
+
+  - name: event_type
+    type: "string"
+    description: "Type of event (page_view, click, form_submit, etc.)"
+
+  - name: event_timestamp
+    type: "timestamp"
+    description: "Timestamp when the event occurred"
+
+  - name: page_url
+    type: "string"
+    description: "URL of the page where the event occurred"
+```
+
+## Ingesting Data from Athena
+
+While the `athena.sql` and `athena.source` asset types are useful for documentation and lineage, you can use [Ingestr assets](../assets/ingestr.md) to move data from Athena to other data warehouse platforms.
+
+### Example: Ingest Athena table to BigQuery
+
+```yaml
+name: raw.website_events
+type: ingestr
+parameters:
+  source_connection: athena-default
+  source_table: analytics.website_events
+  destination: bigquery
+```


### PR DESCRIPTION
Add documentation for the `athena.source` asset type to document existing Athena tables/views as a no-op source asset.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1771578985645109?thread_ts=1771578985.645109&cid=C094932THFW)

<p><a href="https://cursor.com/agents?id=bc-db3b3fac-6c18-56d4-9e73-df7e6f24393e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db3b3fac-6c18-56d4-9e73-df7e6f24393e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

