### PR TITLE
Ingestr.exe file lock

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	ingestrInstallMutex     sync.Mutex
+	ingestrInstallMutex      sync.Mutex
 	ingestrInstalledPackages = make(map[string]bool)
 )
 

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockUvInstaller struct {
@@ -169,13 +170,15 @@ func Test_buildIngestrPackageKey(t *testing.T) {
 			t.Parallel()
 
 			u := &UvPythonRunner{}
-			key := u.buildIngestrPackageKey(context.Background(), tt.extraPackages)
+			key := u.buildIngestrPackageKey(t.Context(), tt.extraPackages)
 			assert.Equal(t, tt.expected, key)
 		})
 	}
 }
 
 func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) {
+	t.Parallel()
+
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()
 
@@ -198,22 +201,24 @@ func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) {
 		binaryFullPath: "~/.bruin/uv",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	extraPackages := []string{"pyodbc"}
 
 	err := u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), installCount.Load(), "ingestr should only be installed once for the same package combination")
 }
 
 func Test_ensureIngestrInstalled_InstallsForDifferentPackages(t *testing.T) {
+	t.Parallel()
+
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()
 
@@ -236,21 +241,23 @@ func Test_ensureIngestrInstalled_InstallsForDifferentPackages(t *testing.T) {
 		binaryFullPath: "~/.bruin/uv",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := u.ensureIngestrInstalled(ctx, []string{"pyodbc"}, repo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = u.ensureIngestrInstalled(ctx, []string{"duckdb"}, repo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = u.ensureIngestrInstalled(ctx, []string{"pyodbc", "duckdb"}, repo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, int32(3), installCount.Load(), "ingestr should be installed once for each unique package combination")
 }
 
 func Test_ensureIngestrInstalled_ConcurrentCalls(t *testing.T) {
+	t.Parallel()
+
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()
 
@@ -273,7 +280,7 @@ func Test_ensureIngestrInstalled_ConcurrentCalls(t *testing.T) {
 		binaryFullPath: "~/.bruin/uv",
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	extraPackages := []string{"pyodbc"}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Add synchronization for `ingestr` installation to fix Windows file lock issues when multiple workers run concurrently.

The `uv tool install ingestr` command was called per-task without synchronization, leading to race conditions and file lock conflicts on `ingestr.exe` on Windows when multiple workers attempted to install/update `ingestr` simultaneously.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1771844876224339?thread_ts=1771844876.224339&cid=C094932THFW)

<p><a href="https://cursor.com/agents?id=bc-a64c1584-27df-58cd-af3c-972bfb36c62c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a64c1584-27df-58cd-af3c-972bfb36c62c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

