### PR TITLE
Clickhouse port secure optional

### DIFF
--- a/integration-tests/expectations/expected_bruin.yaml
+++ b/integration-tests/expectations/expected_bruin.yaml
@@ -9,5 +9,3 @@ environments:
                   host: 127.0.0.1
                   port: 19000
                   database: default
-                  http_port: 0
-                  secure: null

--- a/integration-tests/expectations/expected_bruin_chess.yaml
+++ b/integration-tests/expectations/expected_bruin_chess.yaml
@@ -12,8 +12,6 @@ environments:
                   host: 127.0.0.1
                   port: 19000
                   database: default
-                  http_port: 0
-                  secure: null
             chess:
                 - name: chess-default
                   players:

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -373,9 +373,7 @@
         "password",
         "host",
         "port",
-        "database",
-        "http_port",
-        "secure"
+        "database"
       ]
     },
     "ClickupConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -532,8 +532,8 @@ type ClickHouseConnection struct {
 	Host     string `yaml:"host"     json:"host" mapstructure:"host"`
 	Port     int    `yaml:"port"     json:"port" mapstructure:"port"`
 	Database string `yaml:"database" json:"database" mapstructure:"database"`
-	HTTPPort int    `yaml:"http_port" json:"http_port" mapstructure:"http_port"`
-	Secure   *int   `yaml:"secure" json:"secure" mapstructure:"secure"`
+	HTTPPort int    `yaml:"http_port,omitempty" json:"http_port,omitempty" mapstructure:"http_port"`
+	Secure   *int   `yaml:"secure,omitempty" json:"secure,omitempty" mapstructure:"secure"`
 }
 
 func (c ClickHouseConnection) GetName() string {


### PR DESCRIPTION
Make `http_port` and `secure` fields optional for ClickHouse connections.

This change ensures that the generated JSON schema correctly marks these fields as optional, preventing them from being enforced as required by tools consuming the schema.

---
[Slack Thread](https://bruintalk.slack.com/archives/C07MPCZ2Y3Y/p1771856590993809?thread_ts=1771856590.993809&cid=C07MPCZ2Y3Y)

<p><a href="https://cursor.com/agents?id=bc-2b248d28-361c-5615-bc28-94847c22bcec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b248d28-361c-5615-bc28-94847c22bcec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

