### PR TITLE
fix: render macros in used-tables validation

### DIFF
--- a/pkg/sqlparser/parser.go
+++ b/pkg/sqlparser/parser.go
@@ -425,7 +425,18 @@ func (s *SQLParser) GetMissingDependenciesForAsset(asset *pipeline.Asset, pipeli
 		return []string{}, nil //nolint:nilerr
 	}
 
-	renderedQ, err := renderer.Render(asset.ExecutableFile.Content)
+	queryToRender := asset.ExecutableFile.Content
+	if len(pipeline.Macros) > 0 {
+		var macroContent strings.Builder
+		for _, macro := range pipeline.Macros {
+			macroContent.WriteString(string(macro))
+			macroContent.WriteString("\n")
+		}
+
+		queryToRender = macroContent.String() + "\n" + queryToRender
+	}
+
+	renderedQ, err := renderer.Render(queryToRender)
 	if err != nil {
 		return []string{}, errors.New("failed to render the query before parsing the SQL")
 	}

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -1023,6 +1023,31 @@ func TestGetMissingDependenciesForAsset(t *testing.T) {
 			expectedDeps:  []string{},
 			expectedError: false,
 		},
+		{
+			name: "asset query renders with pipeline macros",
+			asset: &pipeline.Asset{
+				Name: "macro_example",
+				Type: pipeline.AssetTypeDuckDBQuery,
+				Upstreams: []pipeline.Upstream{
+					{Type: "asset", Value: "example"},
+				},
+				ExecutableFile: pipeline.ExecutableFile{
+					Content: "{{ count_by('example', 'country') }}",
+				},
+			},
+			pipeline: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{Name: "example"},
+				},
+				Macros: []pipeline.Macro{
+					`{% macro count_by(table, column) -%}
+SELECT {{ column }}, COUNT(*) AS count FROM {{ table }} GROUP BY {{ column }}
+{%- endmacro %}`,
+				},
+			},
+			expectedDeps:  []string{},
+			expectedError: false,
+		},
 	}
 
 	parser, err := NewSQLParser(true)


### PR DESCRIPTION
Render pipeline macros before parsing used tables. Add regression test for macro-based DuckDB asset validation.