### PR TITLE
Mcp installation bruin path

### DIFF
--- a/docs/getting-started/bruin-mcp.md
+++ b/docs/getting-started/bruin-mcp.md
@@ -12,6 +12,17 @@ Bruin MCP allows you to extend your AI agents to analyze, understand, and build 
 Please make sure you have [Bruin CLI installed](/getting-started/introduction/installation.md).
 :::
 
+:::warning Windows Users
+On Windows, you may need to use the full path to the `bruin` executable instead of just `bruin` in the configuration files below.
+
+To find the path, run the following command in your terminal:
+```bash
+which bruin
+```
+
+Then use the output path (e.g., `C:\Users\YourName\.bruin\bin\bruin.exe`) in place of `bruin` in the `command` field of your MCP configuration.
+:::
+
 ### Claude Code
 
 To use Bruin MCP in Claude Code, run the following command in your terminal:


### PR DESCRIPTION
Update MCP installation instructions to guide Windows users on specifying the full `bruin` executable path in `mcp.json`.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1771875204116119?thread_ts=1771875204.116119&cid=C094932THFW)

<p><a href="https://cursor.com/agents/bc-5e218f29-afc1-5e34-9266-7fe910829576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e218f29-afc1-5e34-9266-7fe910829576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

