### PR TITLE
Mcp windows git bash

### DIFF
--- a/docs/getting-started/bruin-mcp.md
+++ b/docs/getting-started/bruin-mcp.md
@@ -15,10 +15,12 @@ Please make sure you have [Bruin CLI installed](/getting-started/introduction/in
 :::warning Windows Users
 On Windows, you may need to use the full path to the `bruin` executable instead of just `bruin` in the configuration files below.
 
-To find the path, run the following command in your terminal:
+To find the path, open **Git Bash** (not PowerShell or Command Prompt) and run the following command:
 ```bash
 which bruin
 ```
+
+> **Note:** The `which` command is a Unix/Bash command and will not work in PowerShell or Command Prompt. Make sure you're using Git Bash, which is included with [Git for Windows](https://git-scm.com/download/win).
 
 Then use the output path (e.g., `C:\Users\YourName\.bruin\bin\bruin.exe`) in place of `bruin` in the `command` field of your MCP configuration.
 :::


### PR DESCRIPTION
Clarify MCP installation instructions for Windows users to explicitly state that `which bruin` must be run in Git Bash.

This prevents confusion as `which` is a Unix/Bash command and will not work in PowerShell or Command Prompt.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1771875204116119?thread_ts=1771875204.116119&cid=C094932THFW)

<p><a href="https://cursor.com/agents/bc-26649045-d1f3-503f-a741-5a59a74f51d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26649045-d1f3-503f-a741-5a59a74f51d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

