### PR TITLE
fix: remove t.Parallel from ensureIngestrInstalled tests that share g…

### DIFF
--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -176,7 +176,7 @@ func Test_buildIngestrPackageKey(t *testing.T) {
 	}
 }
 
-func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) {
+func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) { //nolint:paralleltest
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()
 
@@ -214,7 +214,7 @@ func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) {
 	assert.Equal(t, int32(1), installCount.Load(), "ingestr should only be installed once for the same package combination")
 }
 
-func Test_ensureIngestrInstalled_InstallsForDifferentPackages(t *testing.T) {
+func Test_ensureIngestrInstalled_InstallsForDifferentPackages(t *testing.T) { //nolint:paralleltest
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()
 
@@ -251,7 +251,7 @@ func Test_ensureIngestrInstalled_InstallsForDifferentPackages(t *testing.T) {
 	assert.Equal(t, int32(3), installCount.Load(), "ingestr should be installed once for each unique package combination")
 }
 
-func Test_ensureIngestrInstalled_ConcurrentCalls(t *testing.T) {
+func Test_ensureIngestrInstalled_ConcurrentCalls(t *testing.T) { //nolint:paralleltest
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()
 


### PR DESCRIPTION
These three tests share a global cache and reset it at the start. When they run in parallel, one test's reset can wipe the cache while another test is still using it, causing flaky failures.