### PR TITLE
Docs: clarify Python materialization requires explicit `connection`

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -73,7 +73,8 @@ The type of the asset determines how execution will happen. Must be one of the t
 
 ## `connection`
 
-The connection name used to run this asset. If omitted, Bruin uses the pipeline-level `default_connections` value for the asset platform.
+The connection name used to run this asset. If omitted, Bruin uses the pipeline-level `default_connections` value for the asset platform in most cases.
+For Python assets with `materialization.type: table`, `connection` must be set explicitly on the asset.
 
 ```yaml
 connection: bigquery-default

--- a/docs/assets/python.md
+++ b/docs/assets/python.md
@@ -305,9 +305,10 @@ You can override the value of variables at runtime using `--var` [flag](/assets/
 
 Bruin runs regular Python scripts by default; however, quite often teams need to load data into a destination from their Python scripts. Bruin supports materializing the data returned by a Python script into a data warehouse.
 
-The requirements to get this working is:
+The requirements to get this working are:
 
 - define a `materialization` config in the asset definition
+- define a `connection` in the asset definition (required for Python assets with `materialization.type: table`)
 - have a function called `materialize` in your Python script that returns a pandas/polars dataframe or a list of dicts.
 
 > [!WARNING]


### PR DESCRIPTION
### Summary
- Clarify in Python asset docs that `connection` is required for Python assets with `materialization.type: table`.
- Clarify in definition schema docs that `default_connections` fallback does not apply to that Python materialization case.