### PR TITLE
Brew documentation removal

### DIFF
--- a/docs/assets/r.md
+++ b/docs/assets/r.md
@@ -314,7 +314,7 @@ print(summary(forecast_result))
 
 R assets require R to be installed on your system. Install R using one of these methods:
 
-- **macOS**: `brew install r`
+- **macOS**: Download from [CRAN](https://cran.r-project.org/bin/macosx/)
 - **Ubuntu/Debian**: `sudo apt-get install r-base`
 - **Windows**: Download from [CRAN](https://cran.r-project.org/bin/windows/base/)
 - **Other platforms**: See [CRAN installation guides](https://cran.r-project.org/)

--- a/docs/commands/ai-enhance.md
+++ b/docs/commands/ai-enhance.md
@@ -16,12 +16,6 @@ Claude Code is the default and recommended AI provider. Install it using one of 
 curl -fsSL https://claude.ai/install.sh | bash
 ```
 
-**Homebrew (macOS):**
-
-```bash
-brew install --cask claude-code
-```
-
 **Windows PowerShell:**
 
 ```powershell
@@ -33,9 +27,6 @@ After installation, authenticate by running `claude` and following the prompts. 
 ```bash
 claude doctor
 ```
-
-> [!TIP]
-> Native installations (curl/PowerShell) auto-update automatically. Homebrew installations require manual updates via `brew upgrade claude-code`.
 
 ### Alternative Providers
 

--- a/docs/getting-started/introduction/installation.md
+++ b/docs/getting-started/introduction/installation.md
@@ -38,8 +38,6 @@ Or you can also use `wget` to install Bruin:
 wget -qO- https://getbruin.com/install/cli | sh
 ```
 
-> [!NOTE]
-> The Homebrew installation method is **deprecated**. If you previously installed Bruin using `brew`, uninstall it first before running the `curl` command.
 > [!IMPORTANT]
 > If you are on Windows, make sure to run the command in the [Git Bash](https://git-scm.com/downloads/win) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) terminal.
 


### PR DESCRIPTION
Remove all brew/Homebrew documentation from the docs as it is deprecated or no longer relevant.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1772032555708899?thread_ts=1772032555.708899&cid=C094932THFW)

<p><a href="https://cursor.com/agents/bc-958d18b5-f14e-5c43-bdf6-125af43561ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-958d18b5-f14e-5c43-bdf6-125af43561ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

