### PR TITLE
feat(oracle): add Oracle dialect with materialization strategies

### DIFF
--- a/pkg/oracle/checks.go
+++ b/pkg/oracle/checks.go
@@ -44,6 +44,13 @@ func (c *AcceptedValuesCheck) Check(ctx context.Context, ti *scheduler.ColumnChe
 	res := strings.Join(val, "','")
 	res = fmt.Sprintf("'%s'", res)
 
+	if err := validateIdentifier(ti.GetAsset().Name, "table name"); err != nil {
+		return err
+	}
+	if err := validateIdentifier(ti.Column.Name, "column name"); err != nil {
+		return err
+	}
+
 	qq := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE CAST(%s as VARCHAR2(4000)) NOT IN (%s)", ti.GetAsset().Name, ti.Column.Name, res)
 
 	return ansisql.NewCountableQueryCheck(c.conn, 0, &query.Query{Query: qq}, "accepted_values", func(count int64) error {
@@ -62,6 +69,13 @@ func (c *PatternCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInsta
 
 	// Escape single quotes to prevent SQL injection / syntax errors
 	escapedPattern := strings.ReplaceAll(*ti.Check.Value.String, "'", "''")
+
+	if err := validateIdentifier(ti.GetAsset().Name, "table name"); err != nil {
+		return err
+	}
+	if err := validateIdentifier(ti.Column.Name, "column name"); err != nil {
+		return err
+	}
 
 	// Oracle uses REGEXP_LIKE for regex matching, so NOT REGEXP_LIKE finds lines that do not match the pattern.
 	qq := fmt.Sprintf(

--- a/pkg/oracle/checks.go
+++ b/pkg/oracle/checks.go
@@ -1,0 +1,77 @@
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/scheduler"
+)
+
+type AcceptedValuesCheck struct {
+	conn config.ConnectionGetter
+}
+
+func (c *AcceptedValuesCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
+	if ti.Check.Value.StringArray == nil && ti.Check.Value.IntArray == nil {
+		return fmt.Errorf("unexpected value for accepted_values check, the values must to be an array, instead %T", ti.Check.Value)
+	}
+
+	if ti.Check.Value.StringArray != nil && len(*ti.Check.Value.StringArray) == 0 {
+		return fmt.Errorf("no values provided for accepted_values check")
+	}
+
+	if ti.Check.Value.IntArray != nil && len(*ti.Check.Value.IntArray) == 0 {
+		return fmt.Errorf("no values provided for accepted_values check")
+	}
+
+	var val []string
+	if ti.Check.Value.StringArray != nil {
+		for _, v := range *ti.Check.Value.StringArray {
+			// Escape single quotes to prevent SQL injection / syntax errors
+			val = append(val, strings.ReplaceAll(v, "'", "''"))
+		}
+	} else {
+		for _, v := range *ti.Check.Value.IntArray {
+			val = append(val, strconv.Itoa(v))
+		}
+	}
+
+	res := strings.Join(val, "','")
+	res = fmt.Sprintf("'%s'", res)
+
+	qq := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE CAST(%s as VARCHAR2(4000)) NOT IN (%s)", ti.GetAsset().Name, ti.Column.Name, res)
+
+	return ansisql.NewCountableQueryCheck(c.conn, 0, &query.Query{Query: qq}, "accepted_values", func(count int64) error {
+		return fmt.Errorf("column '%s' has %d rows that are not in the accepted values", ti.Column.Name, count)
+	}).Check(ctx, ti)
+}
+
+type PatternCheck struct {
+	conn config.ConnectionGetter
+}
+
+func (c *PatternCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
+	if ti.Check.Value.String == nil {
+		return fmt.Errorf("unexpected value %s for pattern check, the value must be a string", ti.Check.Value.ToString())
+	}
+
+	// Escape single quotes to prevent SQL injection / syntax errors
+	escapedPattern := strings.ReplaceAll(*ti.Check.Value.String, "'", "''")
+
+	// Oracle uses REGEXP_LIKE for regex matching, so NOT REGEXP_LIKE finds lines that do not match the pattern.
+	qq := fmt.Sprintf(
+		"SELECT count(*) FROM %s WHERE NOT REGEXP_LIKE(%s, '%s')",
+		ti.GetAsset().Name,
+		ti.Column.Name,
+		escapedPattern,
+	)
+
+	return ansisql.NewCountableQueryCheck(c.conn, 0, &query.Query{Query: qq}, "pattern", func(count int64) error {
+		return fmt.Errorf("column %s has %d values that don't satisfy the pattern %s", ti.Column.Name, count, *ti.Check.Value.String)
+	}).Check(ctx, ti)
+}

--- a/pkg/oracle/checks_test.go
+++ b/pkg/oracle/checks_test.go
@@ -1,0 +1,178 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAcceptedValuesCheck_Check(t *testing.T) {
+	t.Parallel()
+
+	runTestsForCountZeroCheck(
+		t,
+		func(q *mockQuerierWithResult) ansisql.CheckRunner {
+			conn := new(mockConnectionFetcher)
+			conn.On("GetConnection", "oracle-default").Return(q, nil)
+			return &AcceptedValuesCheck{conn: conn}
+		},
+		"SELECT COUNT(*) FROM dataset.test_asset WHERE CAST(test_column as VARCHAR2(4000)) NOT IN ('test','test2')",
+		"column 'test_column' has 5 rows that are not in the accepted values",
+		&pipeline.ColumnCheck{
+			Name: "accepted_values",
+			Value: pipeline.ColumnCheckValue{
+				StringArray: &[]string{"test", "test2"},
+			},
+		},
+	)
+
+	runTestsForCountZeroCheck(
+		t,
+		func(q *mockQuerierWithResult) ansisql.CheckRunner {
+			conn := new(mockConnectionFetcher)
+			conn.On("GetConnection", "oracle-default").Return(q, nil)
+			return &AcceptedValuesCheck{conn: conn}
+		},
+		"SELECT COUNT(*) FROM dataset.test_asset WHERE CAST(test_column as VARCHAR2(4000)) NOT IN ('1','2')",
+		"column 'test_column' has 5 rows that are not in the accepted values",
+		&pipeline.ColumnCheck{
+			Name: "accepted_values",
+			Value: pipeline.ColumnCheckValue{
+				IntArray: &[]int{1, 2},
+			},
+		},
+	)
+
+	runTestsForCountZeroCheck(
+		t,
+		func(q *mockQuerierWithResult) ansisql.CheckRunner {
+			conn := new(mockConnectionFetcher)
+			conn.On("GetConnection", "oracle-default").Return(q, nil)
+			return &AcceptedValuesCheck{conn: conn}
+		},
+		"SELECT COUNT(*) FROM dataset.test_asset WHERE CAST(test_column as VARCHAR2(4000)) NOT IN ('it''s','they''re')",
+		"column 'test_column' has 5 rows that are not in the accepted values",
+		&pipeline.ColumnCheck{
+			Name: "accepted_values",
+			Value: pipeline.ColumnCheckValue{
+				StringArray: &[]string{"it's", "they're"},
+			},
+		},
+	)
+}
+
+func runTestsForCountZeroCheck(t *testing.T, instanceBuilder func(q *mockQuerierWithResult) ansisql.CheckRunner, expectedQueryString string, expectedErrorMessage string, checkInstance *pipeline.ColumnCheck) {
+	expectedQuery := &query.Query{Query: expectedQueryString}
+	setupFunc := func(val [][]interface{}, err error) func(n *mockQuerierWithResult) {
+		return func(q *mockQuerierWithResult) {
+			q.On("Select", mock.Anything, expectedQuery).
+				Return(val, err).
+				Once()
+		}
+	}
+
+	checkError := func(message string) assert.ErrorAssertionFunc {
+		return func(t assert.TestingT, err error, i ...interface{}) bool {
+			return assert.EqualError(t, err, message)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(n *mockQuerierWithResult)
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "failed to run query",
+			setup:   setupFunc(nil, assert.AnError),
+			wantErr: assert.Error,
+		},
+		{
+			name:    "multiple results are returned",
+			setup:   setupFunc([][]interface{}{{1}, {2}}, nil),
+			wantErr: assert.Error,
+		},
+		{
+			name:    "null values found",
+			setup:   setupFunc([][]interface{}{{5}}, nil),
+			wantErr: checkError(expectedErrorMessage),
+		},
+		{
+			name:    "null values found with int64 results",
+			setup:   setupFunc([][]interface{}{{int64(5)}}, nil),
+			wantErr: checkError(expectedErrorMessage),
+		},
+		{
+			name:    "no null values found, test passed",
+			setup:   setupFunc([][]interface{}{{0}}, nil),
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "no null values found, result is a string, test passed",
+			setup:   setupFunc([][]interface{}{{"0"}}, nil),
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := new(mockQuerierWithResult)
+			tt.setup(q)
+
+			n := instanceBuilder(q)
+
+			testInstance := &scheduler.ColumnCheckInstance{
+				AssetInstance: &scheduler.AssetInstance{
+					Asset: &pipeline.Asset{
+						Name: "dataset.test_asset",
+						Type: pipeline.AssetTypeOracleQuery,
+					},
+					Pipeline: &pipeline.Pipeline{
+						Name: "test",
+					},
+				},
+				Column: &pipeline.Column{
+					Name: "test_column",
+					Checks: []pipeline.ColumnCheck{
+						{
+							Name: "not_null",
+						},
+					},
+				},
+				Check: checkInstance,
+			}
+
+			tt.wantErr(t, n.Check(t.Context(), testInstance))
+			defer q.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPatternCheck_Check(t *testing.T) {
+	t.Parallel()
+
+	pattern := "(a|b)"
+
+	runTestsForCountZeroCheck(
+		t,
+		func(q *mockQuerierWithResult) ansisql.CheckRunner {
+			conn := new(mockConnectionFetcher)
+			conn.On("GetConnection", "oracle-default").Return(q, nil)
+			return &PatternCheck{conn: conn}
+		},
+		"SELECT count(*) FROM dataset.test_asset WHERE NOT REGEXP_LIKE(test_column, '(a|b)')",
+		"column test_column has 5 values that don't satisfy the pattern (a|b)",
+		&pipeline.ColumnCheck{
+			Name: "pattern",
+			Value: pipeline.ColumnCheckValue{
+				String: &pattern,
+			},
+		},
+	)
+}

--- a/pkg/oracle/materialization.go
+++ b/pkg/oracle/materialization.go
@@ -97,6 +97,9 @@ func buildSCD2ByTimeFullRefresh(asset *pipeline.Asset, query string) (string, er
 	if asset.Materialization.IncrementalKey == "" {
 		return "", errors.New("incremental_key is required for SCD2_by_time strategy")
 	}
+	if err := validateIdentifier(asset.Materialization.IncrementalKey, "incremental_key column"); err != nil {
+		return "", err
+	}
 
 	primaryKeys := asset.ColumnNamesWithPrimaryKey()
 	if len(primaryKeys) == 0 {
@@ -232,6 +235,11 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 
 	mergeColumns := ansisql.GetColumnsWithMergeLogic(asset)
 	columnNames := asset.ColumnNames()
+	for _, name := range columnNames {
+		if err := validateIdentifier(name, "column name"); err != nil {
+			return "", err
+		}
+	}
 	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
 
 	onQuery := strings.Join(buildPKConditions(primaryKeys, "target", "source"), " AND ")
@@ -297,6 +305,9 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 
 	if asset.Materialization.IncrementalKey == "" {
 		return "", errors.New("incremental_key is required for SCD2_by_time strategy")
+	}
+	if err := validateIdentifier(asset.Materialization.IncrementalKey, "incremental_key column"); err != nil {
+		return "", err
 	}
 
 	var (

--- a/pkg/oracle/materialization.go
+++ b/pkg/oracle/materialization.go
@@ -1,0 +1,414 @@
+package oracle
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+)
+
+// validIdentifierRe matches Oracle unquoted identifiers.
+// Allows schema-qualified names like "MY_SCHEMA.MY_TABLE".
+var validIdentifierRe = regexp.MustCompile(`^[A-Za-z_#$][A-Za-z0-9_#$.]*$`)
+
+// validateIdentifier rejects names that could cause SQL injection when
+// interpolated outside of EXECUTE IMMEDIATE string literals.
+func validateIdentifier(name, kind string) error {
+	if !validIdentifierRe.MatchString(name) {
+		return fmt.Errorf("invalid Oracle %s: %q contains unsupported characters", kind, name)
+	}
+	return nil
+}
+
+func NewMaterializer(fullRefresh bool) *pipeline.Materializer {
+	return &pipeline.Materializer{
+		MaterializationMap: matMap,
+		FullRefresh:        fullRefresh,
+	}
+}
+
+var matMap = pipeline.AssetMaterializationMap{
+	pipeline.MaterializationTypeView: {
+		pipeline.MaterializationStrategyNone:           viewMaterializer,
+		pipeline.MaterializationStrategyCreateReplace:  viewMaterializer,
+		pipeline.MaterializationStrategyAppend:         errorMaterializer,
+		pipeline.MaterializationStrategyDeleteInsert:   errorMaterializer,
+		pipeline.MaterializationStrategyTruncateInsert: errorMaterializer,
+		pipeline.MaterializationStrategyMerge:          errorMaterializer,
+	},
+	pipeline.MaterializationTypeTable: {
+		pipeline.MaterializationStrategyNone:           buildCreateReplaceQuery,
+		pipeline.MaterializationStrategyCreateReplace:  buildCreateReplaceQuery,
+		pipeline.MaterializationStrategyAppend:         buildAppendQuery,
+		pipeline.MaterializationStrategyDeleteInsert:   buildIncrementalQuery,
+		pipeline.MaterializationStrategyTruncateInsert: buildTruncateInsertQuery,
+		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
+		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
+		pipeline.MaterializationStrategySCD2ByTime:     buildSCD2ByTimeQuery,
+	},
+}
+
+// escapeOracleString doubles single quotes for use inside PL/SQL string literals (EXECUTE IMMEDIATE).
+func escapeOracleString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+func errorMaterializer(asset *pipeline.Asset, query string) (string, error) {
+	return "", fmt.Errorf("materialization strategy %s is not supported for materialization type %s", asset.Materialization.Strategy, asset.Materialization.Type)
+}
+
+func viewMaterializer(asset *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(asset.Name, "view name"); err != nil {
+		return "", err
+	}
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+	return fmt.Sprintf("CREATE OR REPLACE VIEW %s AS\n%s", asset.Name, query), nil
+}
+
+func buildCreateReplaceQuery(task *pipeline.Asset, query string) (string, error) {
+	if task.Materialization.Strategy == pipeline.MaterializationStrategySCD2ByTime {
+		return buildSCD2ByTimeFullRefresh(task, query)
+	}
+
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+	// Oracle (pre-23c) lacks CREATE OR REPLACE TABLE, so we use a PL/SQL block
+	// that drops (with exception handling for non-existent tables) then creates.
+	// DDL requires EXECUTE IMMEDIATE inside PL/SQL; single quotes in the query
+	// and identifiers are escaped for the string literal context.
+	escapedQuery := escapeOracleString(query)
+	escapedName := escapeOracleString(task.Name)
+	return fmt.Sprintf(`BEGIN
+   BEGIN
+      EXECUTE IMMEDIATE 'DROP TABLE %s PURGE';
+   EXCEPTION
+      WHEN OTHERS THEN
+         IF SQLCODE != -942 THEN
+            RAISE;
+         END IF;
+   END;
+   EXECUTE IMMEDIATE 'CREATE TABLE %s AS %s';
+END;`, escapedName, escapedName, escapedQuery), nil
+}
+
+func buildSCD2ByTimeFullRefresh(asset *pipeline.Asset, query string) (string, error) {
+	if asset.Materialization.IncrementalKey == "" {
+		return "", errors.New("incremental_key is required for SCD2_by_time strategy")
+	}
+
+	primaryKeys := asset.ColumnNamesWithPrimaryKey()
+	if len(primaryKeys) == 0 {
+		return "", errors.New("materialization strategy 'SCD2_by_time' requires the `primary_key` field to be set on at least one column")
+	}
+
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+
+	createAsQuery := fmt.Sprintf(`SELECT
+  src.*,
+  CAST(src.%s AS TIMESTAMP) AS bruin_valid_from,
+  TO_TIMESTAMP('9999-12-31 23:59:59', 'YYYY-MM-DD HH24:MI:SS') AS bruin_valid_until,
+  1 AS bruin_is_current
+FROM (
+%s
+) src`, asset.Materialization.IncrementalKey, query)
+
+	escapedQuery := escapeOracleString(createAsQuery)
+	escapedName := escapeOracleString(asset.Name)
+
+	return fmt.Sprintf(`BEGIN
+   BEGIN
+      EXECUTE IMMEDIATE 'DROP TABLE %s PURGE';
+   EXCEPTION
+      WHEN OTHERS THEN
+         IF SQLCODE != -942 THEN
+            RAISE;
+         END IF;
+   END;
+   EXECUTE IMMEDIATE 'CREATE TABLE %s AS %s';
+END;`, escapedName, escapedName, escapedQuery), nil
+}
+
+func buildAppendQuery(asset *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(asset.Name, "table name"); err != nil {
+		return "", err
+	}
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+	return fmt.Sprintf("INSERT INTO %s %s", asset.Name, query), nil
+}
+
+// buildTruncateInsertQuery wraps TRUNCATE + INSERT in a PL/SQL block.
+// TRUNCATE is DDL in Oracle, so it must be executed via EXECUTE IMMEDIATE.
+func buildTruncateInsertQuery(task *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(task.Name, "table name"); err != nil {
+		return "", err
+	}
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+	escapedName := escapeOracleString(task.Name)
+	return fmt.Sprintf(`BEGIN
+   EXECUTE IMMEDIATE 'TRUNCATE TABLE %s';
+   INSERT INTO %s
+%s
+;
+END;`, escapedName, task.Name, query), nil
+}
+
+func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(asset.Name, "table name"); err != nil {
+		return "", err
+	}
+	if asset.Materialization.IncrementalKey == "" {
+		return "", errors.New("incremental_key is required for time_interval strategy")
+	}
+	if err := validateIdentifier(asset.Materialization.IncrementalKey, "incremental_key column"); err != nil {
+		return "", err
+	}
+	if asset.Materialization.TimeGranularity == "" {
+		return "", errors.New("time_granularity is required for time_interval strategy")
+	}
+	if !(asset.Materialization.TimeGranularity == pipeline.MaterializationTimeGranularityTimestamp ||
+		asset.Materialization.TimeGranularity == pipeline.MaterializationTimeGranularityDate) {
+		return "", errors.New("time_granularity must be either 'date' or 'timestamp'")
+	}
+
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+
+	startVar := "{{start_timestamp}}"
+	endVar := "{{end_timestamp}}"
+	if asset.Materialization.TimeGranularity == pipeline.MaterializationTimeGranularityDate {
+		startVar = "{{start_date}}"
+		endVar = "{{end_date}}"
+	}
+
+	return fmt.Sprintf(`BEGIN
+   DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s';
+   INSERT INTO %s
+%s
+;
+END;`, asset.Name, asset.Materialization.IncrementalKey, startVar, endVar, asset.Name, query), nil
+}
+
+func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(task.Name, "table name"); err != nil {
+		return "", err
+	}
+	mat := task.Materialization
+	if mat.IncrementalKey == "" {
+		return "", fmt.Errorf("materialization strategy %s requires the `incremental_key` field to be set", mat.Strategy)
+	}
+	if err := validateIdentifier(mat.IncrementalKey, "incremental_key column"); err != nil {
+		return "", err
+	}
+
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+
+	// Wrap DELETE + INSERT in a single PL/SQL block so both DML statements
+	// execute atomically through the Go driver in one ExecContext call.
+	// Uses EXISTS instead of IN (SELECT DISTINCT ...) to let Oracle's optimizer
+	// choose the best semi-join strategy without forcing a full DISTINCT sort.
+	return fmt.Sprintf(`BEGIN
+   DELETE FROM %s t WHERE EXISTS (
+      SELECT 1 FROM (%s) s WHERE s.%s = t.%s
+   );
+   INSERT INTO %s
+%s
+;
+END;`, task.Name, query, mat.IncrementalKey, mat.IncrementalKey, task.Name, query), nil
+}
+
+func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(asset.Name, "table name"); err != nil {
+		return "", err
+	}
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	primaryKeys := asset.ColumnNamesWithPrimaryKey()
+	if len(primaryKeys) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `primary_key` field to be set on at least one column", asset.Materialization.Strategy)
+	}
+
+	mergeColumns := ansisql.GetColumnsWithMergeLogic(asset)
+	columnNames := asset.ColumnNames()
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+
+	onQuery := strings.Join(buildPKConditions(primaryKeys, "target", "source"), " AND ")
+
+	insertCols := strings.Join(columnNames, ", ")
+
+	whenMatchedThenQuery := ""
+	if len(mergeColumns) > 0 {
+		matchedUpdateStatements := make([]string, 0, len(mergeColumns))
+		for _, col := range mergeColumns {
+			if col.MergeSQL != "" {
+				matchedUpdateStatements = append(matchedUpdateStatements, fmt.Sprintf("target.%s = %s", col.Name, col.MergeSQL))
+			} else {
+				matchedUpdateStatements = append(matchedUpdateStatements, fmt.Sprintf("target.%s = source.%s", col.Name, col.Name))
+			}
+		}
+		whenMatchedThenQuery = "WHEN MATCHED THEN UPDATE SET " + strings.Join(matchedUpdateStatements, ", ")
+	}
+
+	mergeLines := []string{
+		fmt.Sprintf("MERGE INTO %s target", asset.Name),
+		fmt.Sprintf("USING (\n%s\n) source ON (%s)", query, onQuery),
+	}
+	if whenMatchedThenQuery != "" {
+		mergeLines = append(mergeLines, whenMatchedThenQuery)
+	}
+	mergeLines = append(mergeLines, fmt.Sprintf("WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)", insertCols, getSourcePrefix(columnNames)))
+
+	return strings.Join(mergeLines, "\n") + ";", nil
+}
+
+func getSourcePrefix(columns []string) string {
+	res := make([]string, len(columns))
+	for i, c := range columns {
+		res[i] = "source." + c
+	}
+	return strings.Join(res, ", ")
+}
+
+// buildPKConditions generates NULL-safe equality comparisons for primary key columns.
+// Standard equality (a = b) evaluates to UNKNOWN when either side is NULL, which
+// would cause a MERGE to treat the row as NOT MATCHED and insert duplicates.
+func buildPKConditions(primaryKeys []string, leftAlias, rightAlias string) []string {
+	conditions := make([]string, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		conditions[i] = fmt.Sprintf(
+			"(%[1]s.%[3]s = %[2]s.%[3]s OR (%[1]s.%[3]s IS NULL AND %[2]s.%[3]s IS NULL))",
+			leftAlias, rightAlias, pk,
+		)
+	}
+	return conditions
+}
+
+func buildPKJoin(leftAlias, rightAlias string, primaryKeys []string) string {
+	return strings.Join(buildPKConditions(primaryKeys, leftAlias, rightAlias), " AND ")
+}
+
+func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
+	if err := validateIdentifier(asset.Name, "table name"); err != nil {
+		return "", err
+	}
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+
+	if asset.Materialization.IncrementalKey == "" {
+		return "", errors.New("incremental_key is required for SCD2_by_time strategy")
+	}
+
+	var (
+		primaryKeys         = make([]string, 0, 4)
+		joinConds           = make([]string, 0, 5)
+		insertCols          = make([]string, 0, 12)
+		insertValues        = make([]string, 0, 12)
+		incrementalKeyFound bool
+	)
+	for _, col := range asset.Columns {
+		switch col.Name {
+		case "bruin_valid_from", "bruin_valid_until", "bruin_is_current":
+			return "", fmt.Errorf("column name %s is reserved for SCD-2 and cannot be used", col.Name)
+		}
+		if col.Name == asset.Materialization.IncrementalKey {
+			incrementalKeyFound = true
+			lcType := strings.ToLower(col.Type)
+			if strings.Contains(lcType, "time zone") {
+				return "", errors.New("TIMESTAMP WITH TIME ZONE is not supported for SCD2_by_time incremental_key; use TIMESTAMP or DATE instead")
+			}
+			if !strings.Contains(lcType, "timestamp") && !strings.Contains(lcType, "date") {
+				return "", errors.New("incremental_key must be TIMESTAMP or DATE in SCD2_by_time strategy")
+			}
+		}
+		insertCols = append(insertCols, col.Name)
+		insertValues = append(insertValues, "source."+col.Name)
+
+		if col.PrimaryKey {
+			primaryKeys = append(primaryKeys, col.Name)
+		}
+	}
+
+	if !incrementalKeyFound {
+		return "", fmt.Errorf("incremental_key '%s' not found in column definitions", asset.Materialization.IncrementalKey)
+	}
+
+	if len(primaryKeys) == 0 {
+		return "", fmt.Errorf(
+			"materialization strategy %s requires the primary_key field to be set on at least one column",
+			asset.Materialization.Strategy,
+		)
+	}
+
+	insertCols = append(insertCols, "bruin_valid_from", "bruin_valid_until", "bruin_is_current")
+	insertValues = append(insertValues,
+		"CAST(source."+asset.Materialization.IncrementalKey+" AS TIMESTAMP)",
+		"TO_TIMESTAMP('9999-12-31 23:59:59', 'YYYY-MM-DD HH24:MI:SS')",
+		"1",
+	)
+
+	for _, pk := range primaryKeys {
+		joinConds = append(joinConds, fmt.Sprintf(
+			"(target.%[1]s = source.%[1]s OR (target.%[1]s IS NULL AND source.%[1]s IS NULL))", pk,
+		))
+	}
+	joinConds = append(joinConds, "source.bruin_is_current_src = 1")
+	onCondition := strings.Join(joinConds, " AND ")
+	tbl := asset.Name
+	pkJoinUpdateStr := strings.Join(buildPKConditions(primaryKeys, "target", "source"), " AND ")
+
+	// Wrap the entire SCD2 logic in a PL/SQL block so both UPDATE and MERGE
+	// execute atomically through the Go driver.
+	// The EXISTS guard on the UPDATE prevents an empty source batch from
+	// marking all existing current rows as expired.
+	queryStr := fmt.Sprintf(`BEGIN
+UPDATE %s target
+SET bruin_valid_until = LOCALTIMESTAMP, bruin_is_current = 0
+WHERE target.bruin_is_current = 1
+  AND NOT EXISTS (
+    SELECT 1 FROM (%s) source
+    WHERE %s
+  )
+  AND EXISTS (SELECT 1 FROM (%s) source_exists);
+
+MERGE INTO (SELECT * FROM %s WHERE bruin_is_current = 1) target
+USING (
+  WITH s1 AS (
+    %s
+  )
+  SELECT s1.*, 1 AS bruin_is_current_src
+  FROM s1
+  UNION ALL
+  SELECT s1.*, 0 AS bruin_is_current_src
+  FROM s1
+  JOIN %s t1 ON (%s)
+  WHERE t1.bruin_valid_from < CAST(s1.%s AS TIMESTAMP) AND t1.bruin_is_current = 1
+) source
+ON (%s)
+WHEN MATCHED THEN
+  UPDATE SET
+    target.bruin_valid_until = CAST(source.%s AS TIMESTAMP),
+    target.bruin_is_current  = 0
+  WHERE target.bruin_valid_from < CAST(source.%s AS TIMESTAMP)
+WHEN NOT MATCHED THEN
+  INSERT (%s)
+  VALUES (%s);
+END;`,
+		tbl,
+		query,
+		pkJoinUpdateStr,
+		query,
+		tbl,
+		query,
+		tbl,
+		buildPKJoin("t1", "s1", primaryKeys),
+		asset.Materialization.IncrementalKey,
+		onCondition,
+		asset.Materialization.IncrementalKey,
+		asset.Materialization.IncrementalKey,
+		strings.Join(insertCols, ", "),
+		strings.Join(insertValues, ", "),
+	)
+
+	return strings.TrimSpace(queryStr), nil
+}

--- a/pkg/oracle/materialization_test.go
+++ b/pkg/oracle/materialization_test.go
@@ -1,0 +1,540 @@
+package oracle
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaterializer_Render(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		task        *pipeline.Asset
+		query       string
+		want        string
+		wantErr     bool
+		fullRefresh bool
+	}{
+		{
+			name:  "no materialization, return raw query",
+			task:  &pipeline.Asset{},
+			query: "SELECT 1",
+			want:  "SELECT 1",
+		},
+		{
+			name: "materialize to a view",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type: pipeline.MaterializationTypeView,
+				},
+			},
+			query: "SELECT 1",
+			want:  "CREATE OR REPLACE VIEW my.asset AS\nSELECT 1",
+		},
+		{
+			name: "materialize to a table, default to create+replace",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type: pipeline.MaterializationTypeTable,
+				},
+			},
+			query: "SELECT 1",
+			want: `BEGIN
+   BEGIN
+      EXECUTE IMMEDIATE 'DROP TABLE my.asset PURGE';
+   EXCEPTION
+      WHEN OTHERS THEN
+         IF SQLCODE != -942 THEN
+            RAISE;
+         END IF;
+   END;
+   EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT 1';
+END;`,
+		},
+		{
+			name: "create+replace with single-quoted query content",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type: pipeline.MaterializationTypeTable,
+				},
+			},
+			query: "SELECT 'hello' FROM dual",
+			want: `BEGIN
+   BEGIN
+      EXECUTE IMMEDIATE 'DROP TABLE my.asset PURGE';
+   EXCEPTION
+      WHEN OTHERS THEN
+         IF SQLCODE != -942 THEN
+            RAISE;
+         END IF;
+   END;
+   EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT ''hello'' FROM dual';
+END;`,
+		},
+		{
+			name: "materialize to a table with append",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyAppend,
+				},
+			},
+			query: "SELECT 1",
+			want:  "INSERT INTO my.asset SELECT 1",
+		},
+		{
+			name: "incremental strategies require the incremental_key to be set",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDeleteInsert,
+				},
+			},
+			query:   "SELECT 1",
+			wantErr: true,
+		},
+		{
+			name: "delete+insert builds a proper PL/SQL block",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
+					IncrementalKey: "dt",
+				},
+			},
+			query: "SELECT 1 as dt",
+			want: `BEGIN
+   DELETE FROM my.asset t WHERE EXISTS (
+      SELECT 1 FROM (SELECT 1 as dt) s WHERE s.dt = t.dt
+   );
+   INSERT INTO my.asset
+SELECT 1 as dt
+;
+END;`,
+		},
+		{
+			name: "merge without columns",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{},
+			},
+			query:   "SELECT 1 as id",
+			wantErr: true,
+		},
+		{
+			name: "merge without primary keys",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int"},
+				},
+			},
+			query:   "SELECT 1 as id",
+			wantErr: true,
+		},
+		{
+			name: "merge with primary keys",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "name", Type: "varchar", PrimaryKey: false, UpdateOnMerge: true},
+				},
+			},
+			query: "SELECT 1 as id, 'abc' as name",
+			want:  "MERGE INTO my.asset target\nUSING (\nSELECT 1 as id, 'abc' as name\n) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))\nWHEN MATCHED THEN UPDATE SET target.name = source.name\nWHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);",
+		},
+		{
+			name: "merge with custom MergeSQL expression",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "name", Type: "varchar", UpdateOnMerge: true, MergeSQL: "COALESCE(source.name, target.name)"},
+				},
+			},
+			query: "SELECT 1 as id, 'abc' as name",
+			want:  "MERGE INTO my.asset target\nUSING (\nSELECT 1 as id, 'abc' as name\n) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))\nWHEN MATCHED THEN UPDATE SET target.name = COALESCE(source.name, target.name)\nWHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);",
+		},
+		{
+			name: "merge insert-only, no UpdateOnMerge columns",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "name", Type: "varchar"},
+				},
+			},
+			query: "SELECT 1 as id, 'abc' as name",
+			want:  "MERGE INTO my.asset target\nUSING (\nSELECT 1 as id, 'abc' as name\n) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))\nWHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);",
+		},
+		{
+			name: "semicolon trimming and schema-qualified table name",
+			task: &pipeline.Asset{
+				Name: "my_schema.my_table",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyAppend,
+				},
+			},
+			query: "SELECT 1 FROM dual ;  ",
+			want:  "INSERT INTO my_schema.my_table SELECT 1 FROM dual",
+		},
+		{
+			name: "invalid identifier is rejected",
+			task: &pipeline.Asset{
+				Name: "my;table--drop",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyAppend,
+				},
+			},
+			query:   "SELECT 1",
+			wantErr: true,
+		},
+		{
+			name: "view with append strategy is rejected",
+			task: &pipeline.Asset{
+				Name: "my.view",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeView,
+					Strategy: pipeline.MaterializationStrategyAppend,
+				},
+			},
+			query:   "SELECT 1",
+			wantErr: true,
+		},
+		{
+			name: "truncate+insert builds PL/SQL block",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyTruncateInsert,
+				},
+			},
+			query: "SELECT 1",
+			want: `BEGIN
+   EXECUTE IMMEDIATE 'TRUNCATE TABLE my.asset';
+   INSERT INTO my.asset
+SELECT 1
+;
+END;`,
+		},
+		{
+			name: "time_interval with timestamp granularity",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        pipeline.MaterializationStrategyTimeInterval,
+					IncrementalKey:  "ts",
+					TimeGranularity: pipeline.MaterializationTimeGranularityTimestamp,
+				},
+			},
+			query: "SELECT 1 as ts",
+			want: `BEGIN
+   DELETE FROM my.asset WHERE ts BETWEEN '{{start_timestamp}}' AND '{{end_timestamp}}';
+   INSERT INTO my.asset
+SELECT 1 as ts
+;
+END;`,
+		},
+		{
+			name: "time_interval with date granularity",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        pipeline.MaterializationStrategyTimeInterval,
+					IncrementalKey:  "dt",
+					TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+				},
+			},
+			query: "SELECT 1 as dt",
+			want: `BEGIN
+   DELETE FROM my.asset WHERE dt BETWEEN '{{start_date}}' AND '{{end_date}}';
+   INSERT INTO my.asset
+SELECT 1 as dt
+;
+END;`,
+		},
+		{
+			name: "time_interval missing incremental_key",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        pipeline.MaterializationStrategyTimeInterval,
+					TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+				},
+			},
+			query:   "SELECT 1",
+			wantErr: true,
+		},
+		{
+			name: "time_interval missing time_granularity",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategyTimeInterval,
+					IncrementalKey: "ts",
+				},
+			},
+			query:   "SELECT 1",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := NewMaterializer(tt.fullRefresh)
+			render, err := m.Render(tt.task, tt.query)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if !assert.Equal(t, tt.want, render) {
+					t.Logf("\nWant:\n%s\nGot:\n%s", tt.want, render)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSCD2QueryByTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		asset       *pipeline.Asset
+		query       string
+		want        string
+		wantErr     bool
+		fullRefresh bool
+	}{
+		{
+			name: "scd2_no_primary_key",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "ts",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "INTEGER"},
+					{Name: "event_name", Type: "VARCHAR"},
+					{Name: "ts", Type: "TIMESTAMP"},
+				},
+			},
+			query:       "SELECT id, event_name, ts from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+		{
+			name: "scd2_no_incremental_key",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategySCD2ByTime,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "event_name", Type: "VARCHAR"},
+				},
+			},
+			query:       "SELECT id, event_name from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+		{
+			name: "scd2_table_exists_with_incremental_key",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "ts",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "event_name", Type: "VARCHAR"},
+					{Name: "ts", Type: "DATE"},
+				},
+			},
+			query: "SELECT id, event_name, ts from source_table",
+			want: `BEGIN
+UPDATE my.asset target
+SET bruin_valid_until = LOCALTIMESTAMP, bruin_is_current = 0
+WHERE target.bruin_is_current = 1
+  AND NOT EXISTS (
+    SELECT 1 FROM (SELECT id, event_name, ts from source_table) source
+    WHERE (target.id = source.id OR (target.id IS NULL AND source.id IS NULL))
+  )
+  AND EXISTS (SELECT 1 FROM (SELECT id, event_name, ts from source_table) source_exists);
+
+MERGE INTO (SELECT * FROM my.asset WHERE bruin_is_current = 1) target
+USING (
+  WITH s1 AS (
+    SELECT id, event_name, ts from source_table
+  )
+  SELECT s1.*, 1 AS bruin_is_current_src
+  FROM s1
+  UNION ALL
+  SELECT s1.*, 0 AS bruin_is_current_src
+  FROM s1
+  JOIN my.asset t1 ON ((t1.id = s1.id OR (t1.id IS NULL AND s1.id IS NULL)))
+  WHERE t1.bruin_valid_from < CAST(s1.ts AS TIMESTAMP) AND t1.bruin_is_current = 1
+) source
+ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)) AND source.bruin_is_current_src = 1)
+WHEN MATCHED THEN
+  UPDATE SET
+    target.bruin_valid_until = CAST(source.ts AS TIMESTAMP),
+    target.bruin_is_current  = 0
+  WHERE target.bruin_valid_from < CAST(source.ts AS TIMESTAMP)
+WHEN NOT MATCHED THEN
+  INSERT (id, event_name, ts, bruin_valid_from, bruin_valid_until, bruin_is_current)
+  VALUES (source.id, source.event_name, source.ts, CAST(source.ts AS TIMESTAMP), TO_TIMESTAMP('9999-12-31 23:59:59', 'YYYY-MM-DD HH24:MI:SS'), 1);
+END;`,
+		},
+		{
+			name: "scd2_reserved_columns",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "ts",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "bruin_valid_from", Type: "TIMESTAMP"},
+					{Name: "ts", Type: "TIMESTAMP"},
+				},
+			},
+			query:       "SELECT id, _valid_from, ts from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+		{
+			name: "scd2_invalid_incremental_key_type",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "ts",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "ts", Type: "VARCHAR"},
+				},
+			},
+			query:       "SELECT id, ts from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+		{
+			name: "scd2_incremental_key_not_in_columns",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "missing_col",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "ts", Type: "TIMESTAMP"},
+				},
+			},
+			query:       "SELECT id, ts from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+		{
+			name: "scd2_timestamp_with_timezone_rejected",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "ts",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "ts", Type: "TIMESTAMP WITH TIME ZONE"},
+				},
+			},
+			query:       "SELECT id, ts from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+		{
+			name: "scd2_timestamp_with_local_timezone_rejected",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByTime,
+					IncrementalKey: "ts",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true, Type: "INTEGER"},
+					{Name: "ts", Type: "TIMESTAMP WITH LOCAL TIME ZONE"},
+				},
+			},
+			query:       "SELECT id, ts from source_table",
+			wantErr:     true,
+			fullRefresh: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewMaterializer(tt.fullRefresh)
+			render, err := m.Render(tt.asset, tt.query)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, strings.TrimSpace(tt.want), render)
+			}
+		})
+	}
+}

--- a/pkg/oracle/operator.go
+++ b/pkg/oracle/operator.go
@@ -1,0 +1,150 @@
+package oracle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/devenv"
+	"github.com/bruin-data/bruin/pkg/executor"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/scheduler"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+)
+
+type materializer interface {
+	Render(task *pipeline.Asset, query string) (string, error)
+	LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error
+}
+
+// OracleClient is the interface for executing queries against Oracle.
+// Note: table and column names are used as-is (unquoted uppercase identifiers).
+// If your Oracle objects were created with quoted lowercase names, you must
+// ensure asset names match the exact case used during creation.
+type OracleClient interface {
+	RunQueryWithoutResult(ctx context.Context, query *query.Query) error
+}
+
+type devEnv interface {
+	Modify(ctx context.Context, p *pipeline.Pipeline, a *pipeline.Asset, q *query.Query) (*query.Query, error)
+	RegisterAssetForSchemaCache(ctx context.Context, p *pipeline.Pipeline, a *pipeline.Asset, q *query.Query) error
+}
+
+type BasicOperator struct {
+	connection   config.ConnectionGetter
+	extractor    query.QueryExtractor
+	materializer materializer
+	devEnv       devEnv
+}
+
+func NewBasicOperator(conn config.ConnectionGetter, extractor query.QueryExtractor, materializer materializer, parser *sqlparser.SQLParser) *BasicOperator {
+	return &BasicOperator{
+		connection:   conn,
+		extractor:    extractor,
+		materializer: materializer,
+		devEnv: &devenv.DevEnvQueryModifier{
+			Dialect: "oracle",
+			Conn:    conn,
+			Parser:  parser,
+		},
+	}
+}
+
+func (o BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error {
+	return o.RunTask(ctx, ti.GetPipeline(), ti.GetAsset())
+}
+
+func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) error {
+	extractor, err := o.extractor.CloneForAsset(ctx, p, asset)
+	if err != nil {
+		return fmt.Errorf("failed to clone extractor for asset %s: %w", asset.Name, err)
+	}
+
+	queries, err := extractor.ExtractQueriesFromString(asset.ExecutableFile.Content)
+	if err != nil {
+		return fmt.Errorf("cannot extract queries from the task file: %w", err)
+	}
+
+	if len(queries) == 0 {
+		return nil
+	}
+
+	if len(queries) > 1 && asset.Materialization.Type != pipeline.MaterializationTypeNone {
+		return errors.New("Oracle operator can only handle a single query when materialization is enabled")
+	}
+
+	q := queries[0]
+	materialized, err := o.materializer.Render(asset, q.String())
+	if err != nil {
+		return err
+	}
+
+	writer := ctx.Value(executor.KeyPrinter)
+	if err := o.materializer.LogIfFullRefreshAndDDL(writer, asset); err != nil {
+		return err
+	}
+
+	q.Query = materialized
+
+	if asset.Materialization.Strategy == pipeline.MaterializationStrategyTimeInterval {
+		renderedQueries, err := extractor.ExtractQueriesFromString(materialized)
+		if err != nil {
+			return fmt.Errorf("cannot re-extract rendered query for time_interval strategy: %w", err)
+		}
+		if len(renderedQueries) == 0 {
+			return errors.New("rendered queries unexpectedly empty")
+		}
+		q.Query = renderedQueries[0].Query
+	}
+
+	connName, err := p.GetConnectionNameForAsset(asset)
+	if err != nil {
+		return err
+	}
+
+	conn, ok := o.connection.GetConnection(connName).(OracleClient)
+	if !ok {
+		return fmt.Errorf("'%s' either does not exist or is not an Oracle connection", connName)
+	}
+
+	// We don't have CreateSchemaIfNotExist required in the interface implemented natively yet on Oracle.
+
+	if o.devEnv == nil {
+		ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
+		return conn.RunQueryWithoutResult(ctx, q)
+	}
+
+	q, err = o.devEnv.Modify(ctx, p, asset, q)
+	if err != nil {
+		return err
+	}
+
+	ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
+
+	if err := conn.RunQueryWithoutResult(ctx, q); err != nil {
+		return err
+	}
+
+	if err := o.devEnv.RegisterAssetForSchemaCache(ctx, p, asset, q); err != nil {
+		return fmt.Errorf("cannot register asset for schema cache: %w", err)
+	}
+
+	return nil
+}
+
+func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnCheckOperator {
+	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
+		"not_null":        ansisql.NewNotNullCheck(manager),
+		"unique":          ansisql.NewUniqueCheck(manager),
+		"positive":        ansisql.NewPositiveCheck(manager),
+		"non_negative":    ansisql.NewNonNegativeCheck(manager),
+		"negative":        ansisql.NewNegativeCheck(manager),
+		"min":             ansisql.NewMinCheck(manager),
+		"max":             ansisql.NewMaxCheck(manager),
+		"accepted_values": &AcceptedValuesCheck{conn: manager},
+		"pattern":         &PatternCheck{conn: manager},
+	})
+}


### PR DESCRIPTION
## Summary

Adds full materialization support for the Oracle dialect, including all major strategies and Oracle-specific PL/SQL handling.

## Materialization Strategies

| Strategy | Implementation |
|---|---|
| `create+replace` | PL/SQL block: `DROP TABLE PURGE` + `CREATE TABLE AS` via `EXECUTE IMMEDIATE` | | `append` | Standard `INSERT INTO` |
| `delete+insert` | `EXISTS`-based DELETE + INSERT in PL/SQL block | | `truncate+insert` | `EXECUTE IMMEDIATE 'TRUNCATE TABLE ...'` + INSERT (TRUNCATE is DDL in Oracle) | | `merge` | Standard `MERGE INTO` with NULL-safe PK comparisons | | `time_interval` | DELETE by date/timestamp range + INSERT | | `SCD2_by_time` | UPDATE to expire + MERGE with inline view pattern (workaround for ORA-38104) | | [view](cci:1://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/mssql/materialization.go:41:0-43:1) | `CREATE OR REPLACE VIEW` |

## Key Design Decisions

- **`LOCALTIMESTAMP` over `CURRENT_TIMESTAMP`**: Oracle's `CURRENT_TIMESTAMP` returns `TIMESTAMP WITH TIME ZONE` (Typ=188), but SCD2 columns use plain `TIMESTAMP` (Typ=187). `LOCALTIMESTAMP` matches the column type exactly.
- **`EXISTS` over `IN (SELECT DISTINCT ...)`**: Lets Oracle's optimizer choose the best semi-join strategy without forcing a full DISTINCT sort.
- **NULL-safe PK comparisons**: [(a.pk = b.pk OR (a.pk IS NULL AND b.pk IS NULL))](cci:1://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/materialization.go:287:0-289:1) prevents phantom duplicate inserts when primary keys contain NULL values.
- **`DROP TABLE PURGE`**: Avoids Oracle recyclebin pollution on table replacement.
- **Identifier validation**: Regex-based validation rejects names with SQL-injection-prone characters before interpolation into raw SQL.
- **View error guards**: Unsupported strategies (append, merge, etc.) explicitly error when materialization type is [view](cci:1://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/mssql/materialization.go:41:0-43:1).
- **PL/SQL blocks for DDL**: Oracle cannot execute DDL directly inside PL/SQL, so `EXECUTE IMMEDIATE` is used for DROP, CREATE, and TRUNCATE statements.

## Files Changed

- [pkg/oracle/materialization.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/materialization.go:0:0-0:0) — All materialization strategy implementations
- [pkg/oracle/materialization_test.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/materialization_test.go:0:0-0:0) — 28 test cases covering all strategies
- [pkg/oracle/operator.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/operator.go:0:0-0:0) — Oracle task operator
- [pkg/oracle/operator_test.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/operator_test.go:0:0-0:0) — Operator tests
- [pkg/oracle/checks.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/checks.go:0:0-0:0) — Oracle check implementations
- [pkg/oracle/checks_test.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/checks_test.go:0:0-0:0) — Check tests
- [pkg/oracle/db.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/db.go:0:0-0:0) — Connection handling improvements
- [pkg/oracle/db_test.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/pkg/oracle/db_test.go:0:0-0:0) — Connection tests
- [cmd/run.go](cci:7://file:///Users/maliackgoz/Documents/GitHub/bruin/cmd/run.go:0:0-0:0) — Register Oracle dialect

## Testing

- All unit tests pass with `go test -race` (81.9% coverage)
- Integration tested against Oracle Free 26ai Docker container
- Verified all 6 strategies end-to-end: SCD2, create+replace, delete+insert, append, merge (composite PK), truncate+insert
- `gofmt`, `gci`, `go vet` all clean