### PR TITLE
 Reject invalid template args ('.' and '..') in bruin init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -258,6 +258,11 @@ func Init() *cli.Command {
 				}
 			}
 
+			if templateName == "." || templateName == ".." {
+				errorPrinter.Printf("Template name cannot be '%s'\n", templateName)
+				return cli.Exit("", 1)
+			}
+
 			_, err = templates.Templates.ReadDir(templateName)
 			if err != nil {
 				errorPrinter.Printf("Template '%s' not found\n", templateName)


### PR DESCRIPTION
bruin init now explicitly rejects . and .. as template arguments and returns the error:

```bash
Template name cannot be '.'
# or
Template name cannot be '..'
```

This prevents unintended behavior when users use `bruin init` like this from habit:
```
bruin init .
```

- fixes linear issue: https://linear.app/bruin/issue/BRU-3928