### PR TITLE
feat: move import database metadata to metadata field

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -396,7 +396,6 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 
 	totalTables := 0
 	mergedTableCount := 0
-	skippedTableCount := 0
 	var warnings []importWarning
 
 	for _, schemaObj := range summary.Schemas {
@@ -435,10 +434,12 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 				existingAssets[assetName] = createdAsset
 				totalTables++
 			case ingestrImport:
-				// ingestr assets carry no columns, so there is nothing to merge
-				// into an existing asset; skip it without re-persisting to avoid
-				// a misleading "Merged" count on re-runs.
-				skippedTableCount++
+				existingAsset := existingAssets[assetName]
+				mergeImportMetadata(existingAsset, createdAsset)
+				if err = existingAsset.Persist(fs, pipelineFound); err != nil {
+					return err
+				}
+				mergedTableCount++
 			default:
 				existingAsset := existingAssets[assetName]
 
@@ -473,10 +474,6 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 
 	fmt.Printf("Imported %d tables and Merged %d from data warehouse '%s'%s into pipeline '%s'\n",
 		totalTables, mergedTableCount, summary.Name, filterDesc, pipelinePath)
-
-	if skippedTableCount > 0 {
-		fmt.Printf("Skipped %d existing assets (already present in the pipeline)\n", skippedTableCount)
-	}
 
 	if len(warnings) > 0 {
 		fmt.Printf("\nWarnings encountered during import (%d tables affected):\n", len(warnings))
@@ -891,6 +888,25 @@ func mergeImportMetadata(dst, src *pipeline.Asset) {
 	if src.Owner != "" {
 		dst.Owner = src.Owner
 	}
+}
+
+// formatNumber formats a number with commas for readability.
+func formatNumber(n int64) string {
+	if n < 1000 {
+		return strconv.FormatInt(n, 10)
+	}
+
+	s := strconv.FormatInt(n, 10)
+	var result strings.Builder
+
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result.WriteRune(',')
+		}
+		result.WriteRune(c)
+	}
+
+	return result.String()
 }
 
 // formatBytes formats a byte count into a human-readable string.

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -452,21 +452,8 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 						existingAsset.Columns = append(existingAsset.Columns, c)
 					}
 				}
-				// Always refresh metadata so it stays current on re-import.
-				// We merge key-by-key to preserve any user-added custom metadata keys.
-				if createdAsset.Metadata != nil {
-					if existingAsset.Metadata == nil {
-						existingAsset.Metadata = make(pipeline.EmptyStringMap)
-					}
-					for k, v := range createdAsset.Metadata {
-						existingAsset.Metadata[k] = v
-					}
-				}
-
-				// Update owner if the database reports one
-				if createdAsset.Owner != "" {
-					existingAsset.Owner = createdAsset.Owner
-				}
+				// Refresh metadata and owner so they stay current on re-import
+				mergeImportMetadata(existingAsset, createdAsset)
 
 				err = existingAsset.Persist(fs, pipelineFound)
 				mergedTableCount++
@@ -879,6 +866,31 @@ func buildImportMetadata(table *ansisql.DBTable) (string, map[string]string, str
 	}
 
 	return table.Description, metadata, table.Owner
+}
+
+// importMetadataKeys are the keys written by buildImportMetadata.
+// These are cleared before re-merging so that absent metrics don't linger.
+var importMetadataKeys = []string{"extracted_at", "created_at", "last_modified", "row_count", "size"}
+
+// mergeImportMetadata refreshes the import-generated metadata on an existing asset.
+// It clears known import keys first (so absent metrics are removed), then copies
+// all keys from src. Any user-added custom keys on dst are preserved.
+func mergeImportMetadata(dst, src *pipeline.Asset) {
+	if src.Metadata != nil {
+		if dst.Metadata == nil {
+			dst.Metadata = make(pipeline.EmptyStringMap)
+		}
+		for _, k := range importMetadataKeys {
+			delete(dst.Metadata, k)
+		}
+		for k, v := range src.Metadata {
+			dst.Metadata[k] = v
+		}
+	}
+
+	if src.Owner != "" {
+		dst.Owner = src.Owner
+	}
 }
 
 // formatBytes formats a byte count into a human-readable string.

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -441,6 +441,8 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 				skippedTableCount++
 			default:
 				existingAsset := existingAssets[assetName]
+
+				// Merge new columns — only add columns that don't already exist
 				existingColumns := make(map[string]pipeline.Column, len(existingAsset.Columns))
 				for _, column := range existingAsset.Columns {
 					existingColumns[column.Name] = column
@@ -450,6 +452,22 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 						existingAsset.Columns = append(existingAsset.Columns, c)
 					}
 				}
+				// Always refresh metadata so it stays current on re-import.
+				// We merge key-by-key to preserve any user-added custom metadata keys.
+				if createdAsset.Metadata != nil {
+					if existingAsset.Metadata == nil {
+						existingAsset.Metadata = make(pipeline.EmptyStringMap)
+					}
+					for k, v := range createdAsset.Metadata {
+						existingAsset.Metadata[k] = v
+					}
+				}
+
+				// Update owner if the database reports one
+				if createdAsset.Owner != "" {
+					existingAsset.Owner = createdAsset.Owner
+				}
+
 				err = existingAsset.Persist(fs, pipelineFound)
 				mergedTableCount++
 				if err != nil {
@@ -744,8 +762,9 @@ func createAsset(ctx context.Context, assetsPath, schemaName, tableName string, 
 		actualAssetType = convertSourceTypeToQueryType(assetType)
 	}
 
-	// Build enhanced description with metadata
-	description := buildEnhancedDescription(table, schemaName, tableName)
+	// Extract structured metadata from the table — metadata goes to the Metadata field
+	// so it can be refreshed on re-import, while description holds only the DB comment.
+	description, metadata, owner := buildImportMetadata(table)
 
 	// Build asset name as <schema>.<table>
 	assetName := fmt.Sprintf("%s.%s", strings.ToLower(schemaName), strings.ToLower(tableName))
@@ -759,6 +778,8 @@ func createAsset(ctx context.Context, assetsPath, schemaName, tableName string, 
 			Content: content,
 		},
 		Description: description,
+		Metadata:    metadata,
+		Owner:       owner,
 	}
 
 	// Set materialization for views
@@ -811,6 +832,7 @@ func supportsIngestrSource(conn any) bool {
 func createIngestrAsset(assetsPath, schemaName, tableName, sourceConnection, destination string, table *ansisql.DBTable) *pipeline.Asset {
 	schemaFolder := filepath.Join(assetsPath, strings.ToLower(schemaName))
 	fileName := strings.ToLower(tableName) + ".asset.yml"
+	description, metadata, owner := buildImportMetadata(table)
 
 	return &pipeline.Asset{
 		Name: fmt.Sprintf("%s.%s", strings.ToLower(schemaName), strings.ToLower(tableName)),
@@ -819,7 +841,9 @@ func createIngestrAsset(assetsPath, schemaName, tableName, sourceConnection, des
 			Name: fileName,
 			Path: filepath.Join(schemaFolder, fileName),
 		},
-		Description: buildEnhancedDescription(table, schemaName, tableName),
+		Description: description,
+		Metadata:    metadata,
+		Owner:       owner,
 		Parameters: pipeline.ParameterMap{
 			"source_connection": sourceConnection,
 			"source_table":      fmt.Sprintf("%s.%s", schemaName, tableName),
@@ -828,76 +852,33 @@ func createIngestrAsset(assetsPath, schemaName, tableName, sourceConnection, des
 	}
 }
 
-// getTableTypeDescription returns a human-readable description for the table type.
-func getTableTypeDescription(tableType ansisql.DBTableType) string {
-	if tableType == ansisql.DBTableTypeView {
-		return "view"
-	}
-	return "table"
-}
+// buildImportMetadata extracts structured metadata from a database table for import.
+// Returns the DB description, a metadata map for the Metadata field, and the table owner.
+// This keeps operational data (timestamps, sizes) in metadata where it can be refreshed
+// on re-import, while the description holds only the actual database comment.
+func buildImportMetadata(table *ansisql.DBTable) (string, map[string]string, string) {
+	metadata := make(map[string]string)
 
-// buildEnhancedDescription creates a rich description for imported assets with metadata.
-func buildEnhancedDescription(table *ansisql.DBTable, schemaName, tableName string) string {
-	var parts []string
+	// Always record when this import was performed
+	metadata["extracted_at"] = time.Now().UTC().Format(time.RFC3339)
 
-	// Start with the original database description if available
-	if table.Description != "" {
-		parts = append(parts, table.Description)
-		parts = append(parts, "") // Empty line for separation
-	}
-
-	// Add import metadata section
-	parts = append(parts, "Imported "+getTableTypeDescription(table.Type)+": "+schemaName+"."+tableName)
-
-	// Add extraction timestamp (current time)
-	extractedAt := time.Now().UTC().Format(time.RFC3339)
-	parts = append(parts, "Extracted at: "+extractedAt)
-
-	// Add creation timestamp if available
 	if table.CreatedAt != nil {
-		parts = append(parts, "Created at: "+table.CreatedAt.UTC().Format(time.RFC3339))
+		metadata["created_at"] = table.CreatedAt.UTC().Format(time.RFC3339)
 	}
 
-	// Add last modification timestamp if available
 	if table.LastModified != nil {
-		parts = append(parts, "Last modified: "+table.LastModified.UTC().Format(time.RFC3339))
+		metadata["last_modified"] = table.LastModified.UTC().Format(time.RFC3339)
 	}
 
-	// Add row count if available
 	if table.RowCount != nil {
-		parts = append(parts, "Row count: "+formatNumber(*table.RowCount))
+		metadata["row_count"] = strconv.FormatInt(*table.RowCount, 10)
 	}
 
-	// Add size if available
 	if table.SizeBytes != nil {
-		parts = append(parts, "Size: "+formatBytes(*table.SizeBytes))
+		metadata["size"] = formatBytes(*table.SizeBytes)
 	}
 
-	// Add owner if available
-	if table.Owner != "" {
-		parts = append(parts, "Owner: "+table.Owner)
-	}
-
-	return strings.Join(parts, "\n")
-}
-
-// formatNumber formats a number with commas for readability.
-func formatNumber(n int64) string {
-	if n < 1000 {
-		return strconv.FormatInt(n, 10)
-	}
-
-	s := strconv.FormatInt(n, 10)
-	var result strings.Builder
-
-	for i, c := range s {
-		if i > 0 && (len(s)-i)%3 == 0 {
-			result.WriteRune(',')
-		}
-		result.WriteRune(c)
-	}
-
-	return result.String()
+	return table.Description, metadata, table.Owner
 }
 
 // formatBytes formats a byte count into a human-readable string.

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -115,7 +115,6 @@ type dbSummaryLoadedMsg struct {
 type importCompleteMsg struct {
 	importedCount int
 	mergedCount   int
-	skippedCount  int
 	warnings      []importWarning
 	err           error
 }
@@ -222,7 +221,6 @@ type importDatabaseModel struct {
 
 	importedCount  int
 	mergedCount    int
-	skippedCount   int
 	importWarnings []importWarning
 	importError    error
 	importDone     bool
@@ -275,7 +273,6 @@ func (m *importDatabaseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case importCompleteMsg:
 		m.importedCount = msg.importedCount
 		m.mergedCount = msg.mergedCount
-		m.skippedCount = msg.skippedCount
 		m.importWarnings = msg.warnings
 		m.importError = msg.err
 		m.importDone = true
@@ -604,10 +601,9 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 		assetType := determineAssetTypeFromConnection(connName, conn)
 
 		var (
-			totalTables       int
-			mergedTableCount  int
-			skippedTableCount int
-			warnings          []importWarning
+			totalTables      int
+			mergedTableCount int
+			warnings         []importWarning
 		)
 
 		for i, schema := range summary.Schemas {
@@ -644,10 +640,12 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 					existingAssets[assetName] = createdAsset
 					totalTables++
 				case ingestrImport:
-					// ingestr assets carry no columns, so there is nothing to
-					// merge into an existing asset; skip it without re-persisting
-					// to avoid a misleading "merged" count on re-runs.
-					skippedTableCount++
+					existingAsset := existingAssets[assetName]
+					mergeImportMetadata(existingAsset, createdAsset)
+					if pErr := existingAsset.Persist(fs, pipelineFound); pErr != nil {
+						return importCompleteMsg{err: pErr}
+					}
+					mergedTableCount++
 				default:
 					existingAsset := existingAssets[assetName]
 					existingColumns := make(map[string]pipeline.Column, len(existingAsset.Columns))
@@ -659,6 +657,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 							existingAsset.Columns = append(existingAsset.Columns, c)
 						}
 					}
+					mergeImportMetadata(existingAsset, createdAsset)
 					if pErr := existingAsset.Persist(fs, pipelineFound); pErr != nil {
 						return importCompleteMsg{err: pErr}
 					}
@@ -670,7 +669,6 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 		return importCompleteMsg{
 			importedCount: totalTables,
 			mergedCount:   mergedTableCount,
-			skippedCount:  skippedTableCount,
 			warnings:      warnings,
 		}
 	}
@@ -772,10 +770,6 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 		successStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(colorSuccess)).Bold(true)
 		fmt.Println(successStyle.Render(fmt.Sprintf("✓ Imported %d tables, merged %d from '%s' into '%s'",
 			fm.importedCount, fm.mergedCount, fm.selectedConnName, pipelinePath)))
-
-		if fm.skippedCount > 0 {
-			fmt.Println(dbtuiDimStyle.Render(fmt.Sprintf("  Skipped %d existing assets (already present in the pipeline)", fm.skippedCount)))
-		}
 
 		if len(fm.importWarnings) > 0 {
 			fmt.Printf("\nWarnings (%d):\n", len(fm.importWarnings))

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -76,14 +76,15 @@ func TestCreateAsset(t *testing.T) {
 	testAssetsPath := filepath.Join("test", "assets")
 
 	tests := []struct {
-		name              string
-		schemaName        string
-		tableName         string
-		assetType         pipeline.AssetType
-		fillColumns       bool
-		table             *ansisql.DBTable
-		want              *pipeline.Asset
-		descriptionPrefix string // Expected prefix of the description (since it now includes dynamic timestamp)
+		name            string
+		schemaName      string
+		tableName       string
+		assetType       pipeline.AssetType
+		fillColumns     bool
+		table           *ansisql.DBTable
+		want            *pipeline.Asset
+		wantDescription string
+		wantOwner       string
 	}{
 		{
 			name:        "successful asset creation without columns (fillColumns false)",
@@ -105,7 +106,6 @@ func TestCreateAsset(t *testing.T) {
 				},
 				Columns: nil,
 			},
-			descriptionPrefix: "Imported table: public.users",
 		},
 		{
 			name:        "successful asset creation with pre-fetched columns",
@@ -135,7 +135,6 @@ func TestCreateAsset(t *testing.T) {
 					{Name: "price", Type: "DECIMAL", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
 				},
 			},
-			descriptionPrefix: "Imported table: public.products",
 		},
 		{
 			name:        "fillColumns true but no pre-fetched columns and no conn returns empty",
@@ -157,7 +156,6 @@ func TestCreateAsset(t *testing.T) {
 				},
 				Columns: nil,
 			},
-			descriptionPrefix: "Imported table: public.orders",
 		},
 		{
 			name:        "view asset creation with view definition",
@@ -184,7 +182,6 @@ func TestCreateAsset(t *testing.T) {
 				},
 				Columns: nil,
 			},
-			descriptionPrefix: "Imported view: public.active_users",
 		},
 		{
 			name:        "view without view definition is not treated as view",
@@ -207,7 +204,6 @@ func TestCreateAsset(t *testing.T) {
 				},
 				Columns: nil,
 			},
-			descriptionPrefix: "Imported view: public.some_view",
 		},
 		{
 			name:        "bigquery view asset creation",
@@ -234,7 +230,31 @@ func TestCreateAsset(t *testing.T) {
 				},
 				Columns: nil,
 			},
-			descriptionPrefix: "Imported view: analytics.daily_metrics",
+		},
+		{
+			name:        "asset with database description and owner",
+			schemaName:  "public",
+			tableName:   "customers",
+			assetType:   pipeline.AssetTypePostgresSource,
+			fillColumns: false,
+			table: &ansisql.DBTable{
+				Name:        "customers",
+				Type:        ansisql.DBTableTypeTable,
+				Description: "Customer master data table",
+				Owner:       "data_team",
+				Columns:     nil,
+			},
+			want: &pipeline.Asset{
+				Name: "public.customers",
+				Type: pipeline.AssetTypePostgresSource,
+				ExecutableFile: pipeline.ExecutableFile{
+					Name: "customers.asset.yml",
+					Path: filepath.Join(testAssetsPath, "public", "customers.asset.yml"),
+				},
+				Columns: nil,
+			},
+			wantDescription: "Customer master data table",
+			wantOwner:       "data_team",
 		},
 	}
 
@@ -244,9 +264,6 @@ func TestCreateAsset(t *testing.T) {
 
 			ctx := t.Context()
 
-			// Pass nil for conn since we're testing the pre-fetched columns path
-			// When dbColumns is empty and conn is nil, it will try fillAssetColumnsFromDB
-			// which will fail, but for these tests we're just checking the pre-fetched path
 			got, warning := createAsset(ctx, testAssetsPath, tt.schemaName, tt.tableName, tt.assetType, nil, tt.fillColumns, tt.table)
 
 			// When dbColumns is empty and conn is nil, we get a warning about failing to fill columns
@@ -256,17 +273,109 @@ func TestCreateAsset(t *testing.T) {
 				assert.Equal(t, "", warning)
 			}
 
-			// Check the description contains the expected prefix and "Extracted at:" timestamp
-			assert.True(t, strings.Contains(got.Description, tt.descriptionPrefix),
-				"Expected description to contain %q, got %q", tt.descriptionPrefix, got.Description)
-			assert.True(t, strings.Contains(got.Description, "Extracted at:"),
-				"Expected description to contain 'Extracted at:', got %q", got.Description)
+			// Metadata should always contain extracted_at
+			assert.NotEmpty(t, got.Metadata["extracted_at"], "expected extracted_at in metadata")
 
-			// Compare all other fields except Description
-			tt.want.Description = got.Description // Copy description to make comparison work
+			// Description should only contain the actual DB comment, not synthetic import text
+			assert.Equal(t, tt.wantDescription, got.Description)
+
+			// Owner should come from the database table owner
+			assert.Equal(t, tt.wantOwner, got.Owner)
+
+			// Copy dynamic fields for full struct comparison
+			tt.want.Description = got.Description
+			tt.want.Metadata = got.Metadata
+			tt.want.Owner = got.Owner
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestBuildImportMetadata(t *testing.T) {
+	t.Parallel()
+
+	rowCount := int64(1234567)
+	sizeBytes := int64(268435456) // 256 MB
+
+	table := &ansisql.DBTable{
+		Description: "A test table",
+		Owner:       "analytics_team",
+		RowCount:    &rowCount,
+		SizeBytes:   &sizeBytes,
+	}
+
+	description, metadata, owner := buildImportMetadata(table)
+
+	assert.Equal(t, "A test table", description)
+	assert.Equal(t, "analytics_team", owner)
+	assert.NotEmpty(t, metadata["extracted_at"])
+	assert.Equal(t, "1234567", metadata["row_count"])
+	assert.Equal(t, "256.00 MB", metadata["size"])
+}
+
+func TestBuildImportMetadataOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	// Table with no optional fields set
+	table := &ansisql.DBTable{}
+
+	description, metadata, owner := buildImportMetadata(table)
+
+	assert.Empty(t, description)
+	assert.Empty(t, owner)
+	assert.NotEmpty(t, metadata["extracted_at"])
+	assert.Empty(t, metadata["row_count"])
+	assert.Empty(t, metadata["size"])
+	assert.Empty(t, metadata["created_at"])
+	assert.Empty(t, metadata["last_modified"])
+}
+
+func TestReimportUpdatesMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Simulate an existing asset with old metadata and a user-added custom key
+	existingAsset := &pipeline.Asset{
+		Name:  "public.users",
+		Owner: "old_owner",
+		Metadata: pipeline.EmptyStringMap{
+			"extracted_at":    "2024-01-01T00:00:00Z",
+			"row_count":       "100",
+			"custom_user_key": "should_be_preserved",
+		},
+	}
+
+	// Simulate a freshly created asset from re-import with updated metadata
+	createdAsset := &pipeline.Asset{
+		Name:  "public.users",
+		Owner: "new_owner",
+		Metadata: pipeline.EmptyStringMap{
+			"extracted_at": "2025-06-01T00:00:00Z",
+			"row_count":    "200",
+			"size":         "512.00 MB",
+		},
+	}
+
+	// Apply the same merge logic used in the re-import branch
+	if createdAsset.Metadata != nil {
+		if existingAsset.Metadata == nil {
+			existingAsset.Metadata = make(pipeline.EmptyStringMap)
+		}
+		for k, v := range createdAsset.Metadata {
+			existingAsset.Metadata[k] = v
+		}
+	}
+	if createdAsset.Owner != "" {
+		existingAsset.Owner = createdAsset.Owner
+	}
+
+	// Import-generated keys should be refreshed
+	assert.Equal(t, "new_owner", existingAsset.Owner)
+	assert.Equal(t, "200", existingAsset.Metadata["row_count"])
+	assert.Equal(t, "512.00 MB", existingAsset.Metadata["size"])
+	assert.Equal(t, "2025-06-01T00:00:00Z", existingAsset.Metadata["extracted_at"])
+
+	// User-added custom key should be preserved
+	assert.Equal(t, "should_be_preserved", existingAsset.Metadata["custom_user_key"])
 }
 
 func TestDetermineAssetTypeFromConnection(t *testing.T) {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -330,52 +330,71 @@ func TestBuildImportMetadataOptionalFields(t *testing.T) {
 	assert.Empty(t, metadata["last_modified"])
 }
 
-func TestReimportUpdatesMetadata(t *testing.T) {
+func TestMergeImportMetadata(t *testing.T) {
 	t.Parallel()
 
-	// Simulate an existing asset with old metadata and a user-added custom key
-	existingAsset := &pipeline.Asset{
-		Name:  "public.users",
-		Owner: "old_owner",
-		Metadata: pipeline.EmptyStringMap{
-			"extracted_at":    "2024-01-01T00:00:00Z",
-			"row_count":       "100",
-			"custom_user_key": "should_be_preserved",
-		},
-	}
+	t.Run("refreshes metadata and owner, preserves custom keys", func(t *testing.T) {
+		t.Parallel()
 
-	// Simulate a freshly created asset from re-import with updated metadata
-	createdAsset := &pipeline.Asset{
-		Name:  "public.users",
-		Owner: "new_owner",
-		Metadata: pipeline.EmptyStringMap{
-			"extracted_at": "2025-06-01T00:00:00Z",
-			"row_count":    "200",
-			"size":         "512.00 MB",
-		},
-	}
-
-	// Apply the same merge logic used in the re-import branch
-	if createdAsset.Metadata != nil {
-		if existingAsset.Metadata == nil {
-			existingAsset.Metadata = make(pipeline.EmptyStringMap)
+		existing := &pipeline.Asset{
+			Name:  "public.users",
+			Owner: "old_owner",
+			Metadata: pipeline.EmptyStringMap{
+				"extracted_at":    "2024-01-01T00:00:00Z",
+				"row_count":       "100",
+				"custom_user_key": "should_be_preserved",
+			},
 		}
-		for k, v := range createdAsset.Metadata {
-			existingAsset.Metadata[k] = v
+
+		created := &pipeline.Asset{
+			Name:  "public.users",
+			Owner: "new_owner",
+			Metadata: pipeline.EmptyStringMap{
+				"extracted_at": "2025-06-01T00:00:00Z",
+				"row_count":    "200",
+				"size":         "512.00 MB",
+			},
 		}
-	}
-	if createdAsset.Owner != "" {
-		existingAsset.Owner = createdAsset.Owner
-	}
 
-	// Import-generated keys should be refreshed
-	assert.Equal(t, "new_owner", existingAsset.Owner)
-	assert.Equal(t, "200", existingAsset.Metadata["row_count"])
-	assert.Equal(t, "512.00 MB", existingAsset.Metadata["size"])
-	assert.Equal(t, "2025-06-01T00:00:00Z", existingAsset.Metadata["extracted_at"])
+		mergeImportMetadata(existing, created)
 
-	// User-added custom key should be preserved
-	assert.Equal(t, "should_be_preserved", existingAsset.Metadata["custom_user_key"])
+		assert.Equal(t, "new_owner", existing.Owner)
+		assert.Equal(t, "200", existing.Metadata["row_count"])
+		assert.Equal(t, "512.00 MB", existing.Metadata["size"])
+		assert.Equal(t, "2025-06-01T00:00:00Z", existing.Metadata["extracted_at"])
+		assert.Equal(t, "should_be_preserved", existing.Metadata["custom_user_key"])
+	})
+
+	t.Run("clears stale import keys when DB stops reporting them", func(t *testing.T) {
+		t.Parallel()
+
+		existing := &pipeline.Asset{
+			Name: "public.users",
+			Metadata: pipeline.EmptyStringMap{
+				"extracted_at":    "2024-01-01T00:00:00Z",
+				"row_count":       "100",
+				"size":            "256.00 MB",
+				"created_at":      "2023-01-01T00:00:00Z",
+				"custom_user_key": "keep_me",
+			},
+		}
+
+		// Second import: DB no longer reports row_count, size, or created_at
+		created := &pipeline.Asset{
+			Name: "public.users",
+			Metadata: pipeline.EmptyStringMap{
+				"extracted_at": "2025-06-01T00:00:00Z",
+			},
+		}
+
+		mergeImportMetadata(existing, created)
+
+		assert.Equal(t, "2025-06-01T00:00:00Z", existing.Metadata["extracted_at"])
+		assert.Empty(t, existing.Metadata["row_count"], "stale row_count should be cleared")
+		assert.Empty(t, existing.Metadata["size"], "stale size should be cleared")
+		assert.Empty(t, existing.Metadata["created_at"], "stale created_at should be cleared")
+		assert.Equal(t, "keep_me", existing.Metadata["custom_user_key"])
+	})
 }
 
 func TestDetermineAssetTypeFromConnection(t *testing.T) {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1113,8 +1113,10 @@ func TestCreateIngestrAsset(t *testing.T) {
 	// path are lowercased while source_table preserves the original case
 	// for databases with case-sensitive identifiers.
 	table := &ansisql.DBTable{
-		Name: "Users",
-		Type: ansisql.DBTableTypeTable,
+		Name:        "Users",
+		Type:        ansisql.DBTableTypeTable,
+		Description: "Application users",
+		Owner:       "identity_team",
 	}
 
 	got := createIngestrAsset(testAssetsPath, "myDB", "Users", "localMongo", "duckdb", table)
@@ -1131,12 +1133,12 @@ func TestCreateIngestrAsset(t *testing.T) {
 			"source_table":      "myDB.Users",
 			"destination":       "duckdb",
 		},
+		Description: "Application users",
+		Owner:       "identity_team",
 	}
 
-	assert.Contains(t, got.Description, "Imported table: myDB.Users")
-	assert.Contains(t, got.Description, "Extracted at:")
-
-	want.Description = got.Description
+	assert.NotEmpty(t, got.Metadata["extracted_at"])
+	want.Metadata = got.Metadata
 	assert.Equal(t, want, got)
 }
 

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -27,6 +27,7 @@ The database import command streamlines the process of migrating existing databa
 - Connecting to your database using existing connection configurations
 - Scanning database schemas and tables
 - Creating asset definition files
+- Capturing table comments, ownership, and operational metadata
 - Optionally filling column metadata from the database schema
 - Organizing assets in the pipeline's `assets/` directory
 
@@ -87,6 +88,8 @@ For a source table named `public.Users`, it writes `assets/public/users.asset.ym
 ```yaml
 name: public.users
 type: ingestr
+metadata:
+  extracted_at: "2026-08-26T12:00:00Z"
 parameters:
   source_connection: postgres-source
   source_table: public.Users
@@ -95,7 +98,7 @@ parameters:
 
 The destination connection is resolved from the pipeline's default connection for the selected destination platform. Running the pipeline then transfers each source table directly to the identically named destination table. The source schema and table spelling is preserved in `source_table`, while the Bruin asset name and destination table name use the import command's existing lowercase convention.
 
-`--destination` is required and must be a supported ingestr destination. Passing it without `--ingestr` is rejected. Re-running an ingestr import skips assets that already exist instead of overwriting them. The older `--as-ingestr` spelling remains available as an alias for compatibility.
+`--destination` is required and must be a supported ingestr destination. Passing it without `--ingestr` is rejected. Re-running an ingestr import preserves the existing asset definition while refreshing its import-generated metadata and any owner reported by the database. The older `--as-ingestr` spelling remains available as an alias for compatibility.
 
 #### MongoDB
 
@@ -116,6 +119,8 @@ For a database `myDB` with a `Users` collection this writes `assets/mydb/users.a
 ```yaml
 name: mydb.users
 type: ingestr
+metadata:
+  extracted_at: "2026-08-26T12:00:00Z"
 parameters:
   source_connection: localMongo
   source_table: myDB.Users
@@ -191,7 +196,14 @@ Each imported table creates a YAML **source** asset file with the following stru
 
 ```yaml
 type: pg.source  # or sf.source, bq.source, ms.source, etc.
-description: "Imported table schema.table"
+description: Customer orders
+owner: analytics
+metadata:
+  extracted_at: "2026-08-26T12:00:00Z"
+  created_at: "2024-01-10T09:30:00Z"
+  last_modified: "2026-08-25T18:45:00Z"
+  row_count: "1234567"
+  size: 256.00 MB
 ```
 
 These are metadata-only source assets. SQL transformation assets live in `.sql` files, and `import database` does not generate SQL templates.
@@ -199,8 +211,12 @@ These are metadata-only source assets. SQL transformation assets live in `.sql` 
 The asset file includes:
 
 - **File Name**: `assets/<schema>/<table>.asset.yml` (lowercase)
-- **Description**: `"Imported table {schema}.{table}"`
+- **Description**: The database table comment, when available
+- **Owner**: The database table owner, when available
+- **Metadata**: The extraction timestamp and any creation time, last-modified time, row count, and size reported by the database
 - **Asset Type**: Automatically determined from connection type
+
+Re-importing refreshes the import-generated metadata and any owner reported by the database while preserving custom metadata keys and the existing description.
 
 > [!INFO]
 > **Asset Name** is derived from the file path, e.g. `assets/schema/table.asset.yml` -> `schema.table` (lowercase)
@@ -211,7 +227,12 @@ By default, the asset will include column metadata:
 
 ```yaml
 type: pg.source
-description: "Imported table schema.table"
+description: Customer orders
+owner: analytics
+metadata:
+  extracted_at: "2026-08-26T12:00:00Z"
+  row_count: "1234567"
+  size: 256.00 MB
 columns:
   - name: column_name
     type: column_type


### PR DESCRIPTION
## Summary
- Moves operational metadata (row count, size, and timestamps) from the asset `description` field to the structured `metadata` field in `bruin import database`
- Keeps the database table comment in `description` and writes the database owner to the dedicated `owner` field
- Refreshes import-generated metadata on re-import, removes stale generated keys, and preserves custom metadata
- Applies the same behavior to command-line, interactive TUI, and `--ingestr` imports
- Updates the database import documentation with the generated asset structure

## Test plan
- [x] `make format`
- [x] `make test`
- [x] GitHub CI Checks workflow
- [ ] Manual: run `bruin import database` and verify YAML output has a `metadata` block instead of operational data embedded in `description`
- [ ] Manual: re-run import on the same asset and verify generated metadata is refreshed while custom metadata remains
