### PR TITLE
Zoomcamp readme error

### DIFF
--- a/templates/zoomcamp/README.md
+++ b/templates/zoomcamp/README.md
@@ -157,7 +157,7 @@ Let's start by initializing a simple project to learn the basics before diving i
 **Initialize the default template:**
 ```bash
 bruin init default my-first-pipeline
-cd my-first-pipeline
+cd bruin
 ```
 
 **Explore the generated structure:**


### PR DESCRIPTION
This should be cd bruin which matches with the folder you show in the video and documentation. cd my-first-pipeline cause error message as you need to go inside bruin folder first.