### PR TITLE
Fix BigQuery DECLARE statements with hooks

### DIFF
--- a/pkg/pipeline/hooks.go
+++ b/pkg/pipeline/hooks.go
@@ -12,10 +12,20 @@ func WrapHooks(query string, hooks Hooks) string {
 		return query
 	}
 
-	parts := make([]string, 0, len(preParts)+1+len(postParts))
+	// Extract DECLARE statements from the beginning of the query
+	// BigQuery requires DECLARE to come before any other statements
+	declares, remainingQuery := extractDeclareStatements(query)
+
+	parts := make([]string, 0, len(declares)+len(preParts)+1+len(postParts))
+
+	// Add DECLARE statements first
+	parts = append(parts, declares...)
+
+	// Add pre-hooks after DECLARE
 	parts = append(parts, preParts...)
 
-	if main := formatStatement(query); main != "" {
+	// Add the main query (without DECLARE statements)
+	if main := formatStatement(remainingQuery); main != "" {
 		parts = append(parts, main)
 	}
 
@@ -56,6 +66,54 @@ func formatStatement(query string) string {
 		return trimmed
 	}
 	return trimmed + ";"
+}
+
+// extractDeclareStatements separates DECLARE statements from the beginning of a query.
+// BigQuery requires DECLARE statements to appear before any other statements in a script.
+// Returns a slice of formatted DECLARE statements and the remaining query.
+func extractDeclareStatements(query string) ([]string, string) {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return nil, ""
+	}
+
+	// Split by semicolons to get individual statements
+	statements := splitStatements(trimmed)
+	var declares []string
+	firstNonDeclare := 0
+
+	// Collect all DECLARE statements from the beginning
+	for i, stmt := range statements {
+		stmtTrimmed := strings.TrimSpace(stmt)
+		if stmtTrimmed == "" {
+			continue
+		}
+
+		// Check if this statement starts with DECLARE (case-insensitive)
+		upperStmt := strings.ToUpper(stmtTrimmed)
+		if strings.HasPrefix(upperStmt, "DECLARE ") || upperStmt == "DECLARE" {
+			declares = append(declares, formatStatement(stmt))
+			firstNonDeclare = i + 1
+		} else {
+			// Stop at the first non-DECLARE statement
+			break
+		}
+	}
+
+	// If no DECLARE statements found, return the original query as-is
+	if len(declares) == 0 {
+		return nil, trimmed
+	}
+
+	// Rejoin the remaining statements
+	remaining := strings.Join(statements[firstNonDeclare:], ";")
+	return declares, strings.TrimSpace(remaining)
+}
+
+// splitStatements splits a query into individual statements by semicolons.
+// This is a simple split that doesn't handle strings or comments containing semicolons.
+func splitStatements(query string) []string {
+	return strings.Split(query, ";")
 }
 
 // ResolveHookTemplatesToNew renders hook query templates with the provided renderer and returns a new hooks value.

--- a/pkg/pipeline/hooks.go
+++ b/pkg/pipeline/hooks.go
@@ -68,52 +68,157 @@ func formatStatement(query string) string {
 	return trimmed + ";"
 }
 
-// extractDeclareStatements separates DECLARE statements from the beginning of a query.
-// BigQuery requires DECLARE statements to appear before any other statements in a script.
-// Returns a slice of formatted DECLARE statements and the remaining query.
+// extractDeclareStatements separates DECLARE statements from the beginning of a
+// query. BigQuery requires DECLARE statements to appear before any other
+// statements in a script, so when hooks are present the leading DECLAREs must
+// be lifted above the pre-hooks.
+//
+// The scan is SQL-aware: semicolons inside string literals (single, double,
+// backtick, and BigQuery triple-quoted), line comments (--) and block
+// comments (/* */) are not treated as statement terminators.
 func extractDeclareStatements(query string) ([]string, string) {
-	trimmed := strings.TrimSpace(query)
-	if trimmed == "" {
+	if strings.TrimSpace(query) == "" {
 		return nil, ""
 	}
 
-	// Split by semicolons to get individual statements
-	statements := splitStatements(trimmed)
 	var declares []string
-	firstNonDeclare := 0
-
-	// Collect all DECLARE statements from the beginning
-	for i, stmt := range statements {
-		stmtTrimmed := strings.TrimSpace(stmt)
-		if stmtTrimmed == "" {
-			continue
-		}
-
-		// Check if this statement starts with DECLARE (case-insensitive)
-		upperStmt := strings.ToUpper(stmtTrimmed)
-		if strings.HasPrefix(upperStmt, "DECLARE ") || upperStmt == "DECLARE" {
-			declares = append(declares, formatStatement(stmt))
-			firstNonDeclare = i + 1
-		} else {
-			// Stop at the first non-DECLARE statement
-			break
+	n := len(query)
+	i := 0
+	stmtStart := 0
+	for i < n {
+		switch c := query[i]; {
+		case c == '-' && i+1 < n && query[i+1] == '-':
+			for i < n && query[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < n && query[i+1] == '*':
+			i += 2
+			for i+1 < n && !(query[i] == '*' && query[i+1] == '/') {
+				i++
+			}
+			if i+1 < n {
+				i += 2
+			} else {
+				i = n
+			}
+		case c == '\'' || c == '"':
+			i = skipStringLiteral(query, i)
+		case c == '`':
+			i++
+			for i < n && query[i] != '`' {
+				i++
+			}
+			if i < n {
+				i++
+			}
+		case c == ';':
+			stmt := query[stmtStart:i]
+			if startsWithDeclare(stmt) {
+				declares = append(declares, formatStatement(stmt))
+				i++
+				stmtStart = i
+				continue
+			}
+			if strings.TrimSpace(stmt) == "" {
+				i++
+				stmtStart = i
+				continue
+			}
+			return declares, strings.TrimSpace(query[stmtStart:])
+		default:
+			i++
 		}
 	}
 
-	// If no DECLARE statements found, return the original query as-is
+	trailing := query[stmtStart:]
+	if strings.TrimSpace(trailing) == "" {
+		if len(declares) == 0 {
+			return nil, strings.TrimSpace(query)
+		}
+		return declares, ""
+	}
+	if startsWithDeclare(trailing) {
+		declares = append(declares, formatStatement(trailing))
+		return declares, ""
+	}
 	if len(declares) == 0 {
-		return nil, trimmed
+		return nil, strings.TrimSpace(query)
 	}
-
-	// Rejoin the remaining statements
-	remaining := strings.Join(statements[firstNonDeclare:], ";")
-	return declares, strings.TrimSpace(remaining)
+	return declares, strings.TrimSpace(trailing)
 }
 
-// splitStatements splits a query into individual statements by semicolons.
-// This is a simple split that doesn't handle strings or comments containing semicolons.
-func splitStatements(query string) []string {
-	return strings.Split(query, ";")
+// skipStringLiteral advances past a string literal beginning at query[i].
+// Handles BigQuery triple-quoted strings (”'...”' / """...""") in addition
+// to standard single/double-quoted strings with backslash escapes.
+func skipStringLiteral(query string, i int) int {
+	n := len(query)
+	quote := query[i]
+	if i+2 < n && query[i+1] == quote && query[i+2] == quote {
+		i += 3
+		for i+2 < n && !(query[i] == quote && query[i+1] == quote && query[i+2] == quote) {
+			i++
+		}
+		if i+2 < n {
+			return i + 3
+		}
+		return n
+	}
+	i++
+	for i < n {
+		if query[i] == '\\' && i+1 < n {
+			i += 2
+			continue
+		}
+		if query[i] == quote {
+			return i + 1
+		}
+		i++
+	}
+	return n
+}
+
+// startsWithDeclare reports whether stmt's first significant token is the
+// DECLARE keyword (case-insensitive). Leading whitespace and SQL comments are
+// skipped before the keyword check.
+func startsWithDeclare(stmt string) bool {
+	n := len(stmt)
+	i := 0
+	for i < n {
+		c := stmt[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == '-' && i+1 < n && stmt[i+1] == '-':
+			for i < n && stmt[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < n && stmt[i+1] == '*':
+			i += 2
+			for i+1 < n && !(stmt[i] == '*' && stmt[i+1] == '/') {
+				i++
+			}
+			if i+1 < n {
+				i += 2
+			} else {
+				return false
+			}
+		default:
+			rest := stmt[i:]
+			const kw = "DECLARE"
+			if len(rest) < len(kw) {
+				return false
+			}
+			if !strings.EqualFold(rest[:len(kw)], kw) {
+				return false
+			}
+			if len(rest) == len(kw) {
+				return true
+			}
+			next := rest[len(kw)]
+			return next == ' ' || next == '\t' || next == '\n' || next == '\r'
+		}
+	}
+	return false
 }
 
 // ResolveHookTemplatesToNew renders hook query templates with the provided renderer and returns a new hooks value.

--- a/pkg/pipeline/hooks.go
+++ b/pkg/pipeline/hooks.go
@@ -93,7 +93,7 @@ func extractDeclareStatements(query string) ([]string, string) {
 			}
 		case c == '/' && i+1 < n && query[i+1] == '*':
 			i += 2
-			for i+1 < n && !(query[i] == '*' && query[i+1] == '/') {
+			for i+1 < n && (query[i] != '*' || query[i+1] != '/') {
 				i++
 			}
 			if i+1 < n {
@@ -155,7 +155,7 @@ func skipStringLiteral(query string, i int) int {
 	quote := query[i]
 	if i+2 < n && query[i+1] == quote && query[i+2] == quote {
 		i += 3
-		for i+2 < n && !(query[i] == quote && query[i+1] == quote && query[i+2] == quote) {
+		for i+2 < n && (query[i] != quote || query[i+1] != quote || query[i+2] != quote) {
 			i++
 		}
 		if i+2 < n {
@@ -194,7 +194,7 @@ func startsWithDeclare(stmt string) bool {
 			}
 		case c == '/' && i+1 < n && stmt[i+1] == '*':
 			i += 2
-			for i+1 < n && !(stmt[i] == '*' && stmt[i+1] == '/') {
+			for i+1 < n && (stmt[i] != '*' || stmt[i+1] != '/') {
 				i++
 			}
 			if i+1 < n {

--- a/pkg/pipeline/hooks_test.go
+++ b/pkg/pipeline/hooks_test.go
@@ -66,6 +66,50 @@ func TestWrapHooks_TrimsAndSkipsEmpty(t *testing.T) {
 			},
 			want: "select 1;\nselect 2;\nselect 3;",
 		},
+		{
+			name:  "DECLARE statement with hooks",
+			query: "DECLARE var1 INT64;\nSELECT var1;",
+			hooks: Hooks{
+				Pre:  []Hook{{Query: "CREATE TEMP TABLE tmp AS SELECT 1"}},
+				Post: []Hook{{Query: "DROP TABLE tmp"}},
+			},
+			want: "DECLARE var1 INT64;\nCREATE TEMP TABLE tmp AS SELECT 1;\nSELECT var1;\nDROP TABLE tmp;",
+		},
+		{
+			name:  "multiple DECLARE statements with hooks",
+			query: "DECLARE var1 INT64; DECLARE var2 STRING; SELECT var1, var2;",
+			hooks: Hooks{
+				Pre:  []Hook{{Query: "SELECT 1"}},
+				Post: []Hook{{Query: "SELECT 2"}},
+			},
+			want: "DECLARE var1 INT64;\nDECLARE var2 STRING;\nSELECT 1;\nSELECT var1, var2;\nSELECT 2;",
+		},
+		{
+			name:  "DECLARE with array type",
+			query: "DECLARE distinct_keys array<date>;\nBEGIN TRANSACTION;\nSELECT 1;",
+			hooks: Hooks{
+				Pre:  []Hook{{Query: "CREATE SCHEMA IF NOT EXISTS test"}},
+				Post: []Hook{{Query: "COMMIT"}},
+			},
+			want: "DECLARE distinct_keys array<date>;\nCREATE SCHEMA IF NOT EXISTS test;\nBEGIN TRANSACTION;\nSELECT 1;\nCOMMIT;",
+		},
+		{
+			name:  "DECLARE case insensitive",
+			query: "declare var1 INT64;\nselect var1;",
+			hooks: Hooks{
+				Pre: []Hook{{Query: "SELECT 1"}},
+			},
+			want: "declare var1 INT64;\nSELECT 1;\nselect var1;",
+		},
+		{
+			name:  "no DECLARE statements preserves original behavior",
+			query: "SELECT 1; INSERT INTO table VALUES (2);",
+			hooks: Hooks{
+				Pre:  []Hook{{Query: "CREATE TABLE table (id INT)"}},
+				Post: []Hook{{Query: "DROP TABLE table"}},
+			},
+			want: "CREATE TABLE table (id INT);\nSELECT 1; INSERT INTO table VALUES (2);\nDROP TABLE table;",
+		},
 	}
 
 	for _, tt := range tests {
@@ -201,4 +245,73 @@ func TestAssetFormatContent_HookQueries_NoSemicolonInjection(t *testing.T) {
 	assert.Equal(t, "SELECT 1; -- comment", asset.Hooks.Pre[0].Query)
 	assert.Equal(t, "SELECT 2", asset.Hooks.Pre[1].Query)
 	assert.Equal(t, "SELECT 3;", asset.Hooks.Post[0].Query)
+}
+
+func TestExtractDeclareStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		query              string
+		wantDeclares       []string
+		wantRemainingQuery string
+	}{
+		{
+			name:               "no DECLARE statements",
+			query:              "SELECT 1; INSERT INTO table VALUES (2);",
+			wantDeclares:       nil,
+			wantRemainingQuery: "SELECT 1; INSERT INTO table VALUES (2);",
+		},
+		{
+			name:               "single DECLARE statement",
+			query:              "DECLARE var1 INT64; SELECT var1;",
+			wantDeclares:       []string{"DECLARE var1 INT64;"},
+			wantRemainingQuery: "SELECT var1;",
+		},
+		{
+			name:               "multiple DECLARE statements",
+			query:              "DECLARE var1 INT64; DECLARE var2 STRING; SELECT var1, var2;",
+			wantDeclares:       []string{"DECLARE var1 INT64;", "DECLARE var2 STRING;"},
+			wantRemainingQuery: "SELECT var1, var2;",
+		},
+		{
+			name:               "DECLARE with array type",
+			query:              "DECLARE distinct_keys array<date>;\nBEGIN TRANSACTION;\nSELECT 1;",
+			wantDeclares:       []string{"DECLARE distinct_keys array<date>;"},
+			wantRemainingQuery: "BEGIN TRANSACTION;\nSELECT 1;",
+		},
+		{
+			name:               "case insensitive DECLARE",
+			query:              "declare var1 INT64; DeClaRe var2 STRING; SELECT 1;",
+			wantDeclares:       []string{"declare var1 INT64;", "DeClaRe var2 STRING;"},
+			wantRemainingQuery: "SELECT 1;",
+		},
+		{
+			name:               "DECLARE in middle of query should stop at first non-DECLARE",
+			query:              "DECLARE var1 INT64; SELECT 1; DECLARE var2 STRING;",
+			wantDeclares:       []string{"DECLARE var1 INT64;"},
+			wantRemainingQuery: "SELECT 1; DECLARE var2 STRING;",
+		},
+		{
+			name:               "empty query",
+			query:              "",
+			wantDeclares:       nil,
+			wantRemainingQuery: "",
+		},
+		{
+			name:               "whitespace only",
+			query:              "   \n  \t  ",
+			wantDeclares:       nil,
+			wantRemainingQuery: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			declares, remaining := extractDeclareStatements(tt.query)
+			assert.Equal(t, tt.wantDeclares, declares)
+			assert.Equal(t, tt.wantRemainingQuery, remaining)
+		})
+	}
 }

--- a/pkg/pipeline/hooks_test.go
+++ b/pkg/pipeline/hooks_test.go
@@ -361,6 +361,12 @@ func TestExtractDeclareStatements(t *testing.T) {
 			wantDeclares:       []string{"DECLARE x INT64;"},
 			wantRemainingQuery: "",
 		},
+		{
+			name:               "double semicolons between DECLARE and main query",
+			query:              "DECLARE var1 INT64; ; SELECT 1;",
+			wantDeclares:       []string{"DECLARE var1 INT64;"},
+			wantRemainingQuery: "SELECT 1;",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/pipeline/hooks_test.go
+++ b/pkg/pipeline/hooks_test.go
@@ -110,6 +110,15 @@ func TestWrapHooks_TrimsAndSkipsEmpty(t *testing.T) {
 			},
 			want: "CREATE TABLE table (id INT);\nSELECT 1; INSERT INTO table VALUES (2);\nDROP TABLE table;",
 		},
+		{
+			name:  "DECLARE with semicolon inside string literal",
+			query: "DECLARE msg STRING DEFAULT 'a;b;c';\nSELECT msg;",
+			hooks: Hooks{
+				Pre:  []Hook{{Query: "CREATE SCHEMA IF NOT EXISTS test"}},
+				Post: []Hook{{Query: "DROP SCHEMA test"}},
+			},
+			want: "DECLARE msg STRING DEFAULT 'a;b;c';\nCREATE SCHEMA IF NOT EXISTS test;\nSELECT msg;\nDROP SCHEMA test;",
+		},
 	}
 
 	for _, tt := range tests {
@@ -302,6 +311,54 @@ func TestExtractDeclareStatements(t *testing.T) {
 			name:               "whitespace only",
 			query:              "   \n  \t  ",
 			wantDeclares:       nil,
+			wantRemainingQuery: "",
+		},
+		{
+			name:               "semicolon inside string literal is not a separator",
+			query:              "DECLARE msg STRING DEFAULT 'a;b;c'; SELECT msg;",
+			wantDeclares:       []string{"DECLARE msg STRING DEFAULT 'a;b;c';"},
+			wantRemainingQuery: "SELECT msg;",
+		},
+		{
+			name:               "semicolon inside double-quoted literal is not a separator",
+			query:              `DECLARE msg STRING DEFAULT "a;b"; SELECT msg;`,
+			wantDeclares:       []string{`DECLARE msg STRING DEFAULT "a;b";`},
+			wantRemainingQuery: "SELECT msg;",
+		},
+		{
+			name:               "semicolon inside triple-quoted literal is not a separator",
+			query:              "DECLARE msg STRING DEFAULT '''a;b;c'''; SELECT msg;",
+			wantDeclares:       []string{"DECLARE msg STRING DEFAULT '''a;b;c''';"},
+			wantRemainingQuery: "SELECT msg;",
+		},
+		{
+			name:               "semicolon inside line comment is not a separator",
+			query:              "DECLARE x INT64; -- end; of; line\nSELECT x;",
+			wantDeclares:       []string{"DECLARE x INT64;"},
+			wantRemainingQuery: "-- end; of; line\nSELECT x;",
+		},
+		{
+			name:               "semicolon inside block comment is not a separator",
+			query:              "DECLARE x INT64 DEFAULT 1 /* uses; semicolons; */; SELECT x;",
+			wantDeclares:       []string{"DECLARE x INT64 DEFAULT 1 /* uses; semicolons; */;"},
+			wantRemainingQuery: "SELECT x;",
+		},
+		{
+			name:               "DECLARE preceded by line comment is still recognized",
+			query:              "-- partition pruning\nDECLARE start_dt DATE;\nSELECT * FROM t WHERE dt >= start_dt;",
+			wantDeclares:       []string{"-- partition pruning\nDECLARE start_dt DATE;"},
+			wantRemainingQuery: "SELECT * FROM t WHERE dt >= start_dt;",
+		},
+		{
+			name:               "escaped quote inside string literal",
+			query:              `DECLARE msg STRING DEFAULT 'a\';b'; SELECT 1;`,
+			wantDeclares:       []string{`DECLARE msg STRING DEFAULT 'a\';b';`},
+			wantRemainingQuery: "SELECT 1;",
+		},
+		{
+			name:               "DECLARE without trailing semicolon",
+			query:              "DECLARE x INT64",
+			wantDeclares:       []string{"DECLARE x INT64;"},
 			wantRemainingQuery: "",
 		},
 	}


### PR DESCRIPTION
BigQuery requires DECLARE statements to appear at the very beginning of a script, before any other SQL statements. Previously, when assets used both hooks and DECLARE statements, pre-hooks would be inserted before DECLARE, causing BigQuery to reject the query with: "Syntax error: Expected end of input but got keyword DECLARE"

This is critical for partition pruning optimization where DECLARE statements define date ranges that BigQuery uses to skip scanning unnecessary partitions.

Changes:
- Modified WrapHooks() to extract DECLARE statements from the beginning of queries and place them before all hooks
- Added extractDeclareStatements() helper to identify and separate DECLARE statements (case-insensitive)
- Added comprehensive test coverage for DECLARE + hooks scenarios

The fix ensures proper query order:
1. DECLARE statements (must be first per BigQuery requirement)
2. Pre-hooks
3. Main query body
4. Post-hooks

Fixes issue where users had to choose between using DECLARE for partition pruning OR using hooks for schema setup/logging. Now both features can be used together.

🤖 Generated with Claude Code (https://claude.com/claude-code)