### PR TITLE
added complex types to duckdb

### DIFF
--- a/integration-tests/.bruin.yml
+++ b/integration-tests/.bruin.yml
@@ -263,7 +263,13 @@ environments:
       duckdb:
         - name: "duckdb-decimal"
           path: "duckdb-files/duckdb-decimal.db"
-        
+
+  env-duckdb-show-query:
+    connections:
+      duckdb:
+        - name: "duckdb-show-query"
+          path: "duckdb-files/show-query-test.db"
+
   env-validate-asset-time-interval:
     connections:
       duckdb:

--- a/integration-tests/expectations/expected_connections.json
+++ b/integration-tests/expectations/expected_connections.json
@@ -186,6 +186,17 @@
       },
       "schema_prefix": ""
     },
+    "env-duckdb-show-query": {
+      "connections": {
+        "duckdb": [
+          {
+            "name": "duckdb-show-query",
+            "path": "duckdb-files/show-query-test.db"
+          }
+        ]
+      },
+      "schema_prefix": ""
+    },
     "env-ingestr": {
       "connections": {
         "duckdb": [
@@ -223,6 +234,17 @@
           {
             "name": "duckdb-push-metadata",
             "path": "duckdb-files/push-metadata.db"
+          }
+        ]
+      },
+      "schema_prefix": ""
+    },
+    "env-python-pyproject-materialization": {
+      "connections": {
+        "duckdb": [
+          {
+            "name": "duckdb-python-pyproject-materialization",
+            "path": "duckdb-files/python-pyproject-materialization.db"
           }
         ]
       },
@@ -408,17 +430,6 @@
           {
             "name": "duckdb-run-python-materialization",
             "path": "duckdb-files/run-python-materialization.db"
-          }
-        ]
-      },
-      "schema_prefix": ""
-    },
-    "env-python-pyproject-materialization": {
-      "connections": {
-        "duckdb": [
-          {
-            "name": "duckdb-python-pyproject-materialization",
-            "path": "duckdb-files/python-pyproject-materialization.db"
           }
         ]
       },

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -3208,9 +3208,9 @@ func TestWorkflowTasks(t *testing.T) {
 				Name: "duckdb_query_show_list_columns",
 				Steps: []e2e.Task{
 					{
-						Name:    "duckdb-show-01: create table so SHOW returns rows with LIST-typed metadata",
+						Name:    "duckdb-show-01: run pipeline so SHOW returns rows with LIST-typed metadata",
 						Command: binary,
-						Args:    []string{"query", "--env", "env-duckdb-show-query", "--connection", "duckdb-show-query", "--query", "CREATE TABLE bruin_show_int_test (id INT);"},
+						Args:    []string{"run", "--env", "env-duckdb-show-query", "--full-refresh", filepath.Join(currentFolder, "test-pipelines/duckdb-query-show-pipeline")},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -3202,6 +3202,46 @@ func TestWorkflowTasks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "duckdb_query_show_list_columns",
+			workflow: e2e.Workflow{
+				Name: "duckdb_query_show_list_columns",
+				Steps: []e2e.Task{
+					{
+						Name:    "duckdb-show-01: create table so SHOW returns rows with LIST-typed metadata",
+						Command: binary,
+						Args:    []string{"query", "--env", "env-duckdb-show-query", "--connection", "duckdb-show-query", "--query", "CREATE TABLE bruin_show_int_test (id INT);"},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					{
+						Name:    "duckdb-show-02: SHOW succeeds via bruin query (Arrow LIST columns)",
+						Command: binary,
+						Args:    []string{"query", "--env", "env-duckdb-show-query", "--connection", "duckdb-show-query", "--query", "SHOW;", "--output", "json"},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							Contains: []string{
+								`"name":"column_names"`,
+								`"name":"column_types"`,
+								`"type":"VARCHAR"`,
+								"bruin_show_int_test",
+								"[id]",
+							},
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByContains,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/integration-tests/test-pipelines/duckdb-query-show-pipeline/assets/bruin_show_int_test.sql
+++ b/integration-tests/test-pipelines/duckdb-query-show-pipeline/assets/bruin_show_int_test.sql
@@ -1,0 +1,10 @@
+/* @bruin
+name: bruin_show_int_test
+type: duckdb.sql
+
+materialization:
+  type: table
+
+@bruin */
+
+SELECT 1 AS id;

--- a/integration-tests/test-pipelines/duckdb-query-show-pipeline/pipeline.yml
+++ b/integration-tests/test-pipelines/duckdb-query-show-pipeline/pipeline.yml
@@ -1,0 +1,4 @@
+name: duckdb_query_show
+
+default_connections:
+  duckdb: duckdb-show-query

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -336,6 +336,9 @@ func (c *Client) SelectWithSchema(ctx context.Context, queryObject *query.Query)
 					return nil, fallbackErr
 				}
 				result.Rows = rowsFallback
+				for i := range result.ColumnTypes {
+					result.ColumnTypes[i] = "VARCHAR"
+				}
 				return result, nil
 			}
 			return nil, err
@@ -413,6 +416,10 @@ func (c *Client) selectWithCastedColumns(ctx context.Context, queryText string, 
 			values[i] = c.convertValueWithType(val, columnTypes[i])
 		}
 		result = append(result, values)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return result, nil

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -248,6 +248,11 @@ func (c *Client) Select(ctx context.Context, query *query.Query) ([][]interface{
 
 		// Scan the result into the column pointers...
 		if err := rows.Scan(columnPointers...); err != nil {
+			if isUnsupportedComplexTypeScanError(err) {
+				// Release the first result set before issuing the fallback query on the same connection.
+				_ = rows.Close()
+				return c.selectWithCastedColumns(ctx, query.String(), cols)
+			}
 			return nil, err
 		}
 
@@ -323,6 +328,16 @@ func (c *Client) SelectWithSchema(ctx context.Context, queryObject *query.Query)
 
 		// Scan the result into the column pointers...
 		if err := rows.Scan(columnPointers...); err != nil {
+			if isUnsupportedComplexTypeScanError(err) {
+				// Release the first result set before issuing the fallback query on the same connection.
+				_ = rows.Close()
+				rowsFallback, fallbackErr := c.selectWithCastedColumns(ctx, queryObject.String(), cols)
+				if fallbackErr != nil {
+					return nil, fallbackErr
+				}
+				result.Rows = rowsFallback
+				return result, nil
+			}
 			return nil, err
 		}
 
@@ -332,6 +347,72 @@ func (c *Client) SelectWithSchema(ctx context.Context, queryObject *query.Query)
 		}
 
 		result.Rows = append(result.Rows, columns)
+	}
+
+	return result, nil
+}
+
+func isUnsupportedComplexTypeScanError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not yet implemented populating from columns of type list<") ||
+		strings.Contains(msg, "not yet implemented populating from columns of type struct<") ||
+		strings.Contains(msg, "not yet implemented populating from columns of type map<")
+}
+
+func buildCastedColumnsQuery(queryText string, columns []string) string {
+	trimmedQuery := strings.TrimSpace(queryText)
+	trimmedQuery = strings.TrimSuffix(trimmedQuery, ";")
+
+	if len(columns) == 0 {
+		return trimmedQuery
+	}
+
+	projections := make([]string, len(columns))
+	for i, col := range columns {
+		quoted := quoteIdentifier(col)
+		projections[i] = fmt.Sprintf("CAST(%s AS VARCHAR) AS %s", quoted, quoted)
+	}
+
+	return fmt.Sprintf("SELECT %s FROM (%s) AS __bruin_complex_type_query", strings.Join(projections, ", "), trimmedQuery)
+}
+
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+func (c *Client) selectWithCastedColumns(ctx context.Context, queryText string, columns []string) ([][]interface{}, error) {
+	castedQuery := buildCastedColumnsQuery(queryText, columns)
+	rows, err := c.connection.QueryContext(ctx, castedQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	columnTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([][]interface{}, 0)
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		pointers := make([]interface{}, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+
+		if err := rows.Scan(pointers...); err != nil {
+			return nil, err
+		}
+
+		for i, val := range values {
+			values[i] = c.convertValueWithType(val, columnTypes[i])
+		}
+		result = append(result, values)
 	}
 
 	return result, nil

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/diff"
@@ -360,10 +361,28 @@ func isUnsupportedComplexTypeScanError(err error) bool {
 		return false
 	}
 
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "not yet implemented populating from columns of type list<") ||
-		strings.Contains(msg, "not yet implemented populating from columns of type struct<") ||
-		strings.Contains(msg, "not yet implemented populating from columns of type map<")
+	var adbcErr *adbc.Error
+	if errors.As(err, &adbcErr) {
+		if adbcErr.Code != adbc.StatusNotImplemented {
+			return false
+		}
+		return isComplexTypePopulationMessage(adbcErr.Msg)
+	}
+
+	// Keep a fallback for non-ADBC errors so tests/mocks and future wrappers
+	// that lose typed metadata can still trigger the casted-query path.
+	return isComplexTypePopulationMessage(err.Error())
+}
+
+func isComplexTypePopulationMessage(msg string) bool {
+	normalized := strings.ToLower(msg)
+	if !strings.Contains(normalized, "populating from columns of type") {
+		return false
+	}
+
+	return strings.Contains(normalized, "list<") ||
+		strings.Contains(normalized, "struct<") ||
+		strings.Contains(normalized, "map<")
 }
 
 func buildCastedColumnsQuery(queryText string, columns []string) string {

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -320,6 +320,81 @@ func TestDB_SelectWithSchema_ListColumnScanErrorFallsBackToCastedQuery(t *testin
 	assert.Contains(t, conn.queries[1], `CAST("result" AS VARCHAR) AS "result"`)
 }
 
+func TestDB_Select_ListColumnScanErrorFallsBackToCastedQuery(t *testing.T) {
+	t.Parallel()
+
+	conn := &listScanErrorThenCastConnection{}
+	db := Client{
+		connection: conn,
+		config:     Config{Path: "some/path.db"},
+	}
+
+	rows, err := db.Select(t.Context(), &query.Query{Query: "SHOW;"})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{{"main"}}, rows)
+	require.Len(t, conn.queries, 2)
+	require.Equal(t, "SHOW;", conn.queries[0])
+	assert.Contains(t, conn.queries[1], `CAST("result" AS VARCHAR) AS "result"`)
+}
+
+func TestEphemeralConnection_QueryContext_SHOW_UsesBufferedFallbackForListColumns(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := t.Context()
+	path := filepath.Join(t.TempDir(), "ephemeral-show-proof.db")
+
+	client, err := NewClient(Config{Path: path})
+	require.NoError(t, err)
+	err = client.RunQueryWithoutResult(ctx, &query.Query{Query: "CREATE TABLE t1 (id INT);"})
+	require.NoError(t, err)
+
+	ephemeral, err := NewEphemeralConnection(Config{Path: path})
+	require.NoError(t, err)
+
+	rows, err := ephemeral.QueryContext(ctx, "SHOW;")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	require.NoError(t, err)
+	require.NotEmpty(t, columns)
+
+	columnTypes, err := rows.ColumnTypes()
+	require.NoError(t, err)
+	require.NotEmpty(t, columnTypes)
+
+	foundTable := false
+	foundListMetadata := false
+	for rows.Next() {
+		scanned := make([]interface{}, len(columns))
+		ptrs := make([]interface{}, len(columns))
+		for i := range scanned {
+			ptrs[i] = &scanned[i]
+		}
+		require.NoError(t, rows.Scan(ptrs...))
+
+		for _, v := range scanned {
+			strVal, ok := v.(string)
+			if !ok {
+				continue
+			}
+			if strVal == "t1" {
+				foundTable = true
+			}
+			if strVal == "[id]" {
+				foundListMetadata = true
+			}
+		}
+	}
+
+	require.NoError(t, rows.Err())
+	assert.True(t, foundTable, "expected SHOW output to include created table")
+	assert.True(t, foundListMetadata, "expected SHOW output to include list metadata serialized as string")
+}
+
 func TestIsUnsupportedComplexTypeScanError_MatchesDriverMessage(t *testing.T) {
 	t.Parallel()
 	e := errors.New("Not Implemented: not yet implemented populating from columns of type list<l: utf8, nullable>")

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -6,12 +6,14 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/jmoiron/sqlx"
@@ -397,8 +399,39 @@ func TestEphemeralConnection_QueryContext_SHOW_UsesBufferedFallbackForListColumn
 
 func TestIsUnsupportedComplexTypeScanError_MatchesDriverMessage(t *testing.T) {
 	t.Parallel()
-	e := errors.New("Not Implemented: not yet implemented populating from columns of type list<l: utf8, nullable>")
-	assert.True(t, isUnsupportedComplexTypeScanError(e))
+
+	t.Run("typed adbc error", func(t *testing.T) {
+		t.Parallel()
+		e := &adbc.Error{
+			Code: adbc.StatusNotImplemented,
+			Msg:  "not yet implemented populating from columns of type list<l: utf8, nullable>",
+		}
+		assert.True(t, isUnsupportedComplexTypeScanError(e))
+	})
+
+	t.Run("wrapped typed adbc error", func(t *testing.T) {
+		t.Parallel()
+		e := fmt.Errorf("wrapped: %w", &adbc.Error{
+			Code: adbc.StatusNotImplemented,
+			Msg:  "not yet implemented populating from columns of type struct<a: utf8>",
+		})
+		assert.True(t, isUnsupportedComplexTypeScanError(e))
+	})
+
+	t.Run("fallback string matching", func(t *testing.T) {
+		t.Parallel()
+		e := errors.New("Not Implemented: not yet implemented populating from columns of type map<k: utf8, v: int64>")
+		assert.True(t, isUnsupportedComplexTypeScanError(e))
+	})
+
+	t.Run("typed error with different status", func(t *testing.T) {
+		t.Parallel()
+		e := &adbc.Error{
+			Code: adbc.StatusInvalidArgument,
+			Msg:  "not yet implemented populating from columns of type list<l: utf8, nullable>",
+		}
+		assert.False(t, isUnsupportedComplexTypeScanError(e))
+	})
 }
 
 func TestClient_SelectWithSchema_SHOW_AfterCreateTable(t *testing.T) {

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package duck
 
 import (
@@ -5,6 +6,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +18,97 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type scanFailingRows struct {
+	nextCalled bool
+}
+
+func (r *scanFailingRows) Close() error {
+	return nil
+}
+
+func (r *scanFailingRows) Columns() ([]string, error) {
+	return []string{"result"}, nil
+}
+
+func (r *scanFailingRows) ColumnTypes() ([]*sql.ColumnType, error) {
+	return []*sql.ColumnType{{}}, nil
+}
+
+func (r *scanFailingRows) Err() error {
+	return nil
+}
+
+func (r *scanFailingRows) Next() bool {
+	if r.nextCalled {
+		return false
+	}
+	r.nextCalled = true
+	return true
+}
+
+func (r *scanFailingRows) Scan(dest ...any) error {
+	return errors.New("Not Implemented: not yet implemented populating from columns of type list<l: utf8, nullable>")
+}
+
+type castedStringRows struct {
+	nextCalled bool
+}
+
+func (r *castedStringRows) Close() error {
+	return nil
+}
+
+func (r *castedStringRows) Columns() ([]string, error) {
+	return []string{"result"}, nil
+}
+
+func (r *castedStringRows) ColumnTypes() ([]*sql.ColumnType, error) {
+	return []*sql.ColumnType{{}}, nil
+}
+
+func (r *castedStringRows) Err() error {
+	return nil
+}
+
+func (r *castedStringRows) Next() bool {
+	if r.nextCalled {
+		return false
+	}
+	r.nextCalled = true
+	return true
+}
+
+func (r *castedStringRows) Scan(dest ...any) error {
+	ptr, ok := dest[0].(*interface{})
+	if !ok {
+		return errors.New("unexpected scan destination type")
+	}
+	*ptr = "main"
+	return nil
+}
+
+type listScanErrorThenCastConnection struct {
+	queries []string
+}
+
+//nolint:ireturn
+func (c *listScanErrorThenCastConnection) QueryContext(ctx context.Context, query string, args ...any) (Rows, error) {
+	c.queries = append(c.queries, query)
+	if len(c.queries) == 1 {
+		return &scanFailingRows{}, nil
+	}
+	return &castedStringRows{}, nil
+}
+
+func (c *listScanErrorThenCastConnection) ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+//nolint:ireturn
+func (c *listScanErrorThenCastConnection) QueryRowContext(ctx context.Context, query string, args ...any) Row {
+	return nil
+}
 
 func TestDB_Select(t *testing.T) {
 	t.Parallel()
@@ -208,6 +301,46 @@ func TestDB_SelectWithSchema(t *testing.T) {
 	}
 }
 
+func TestDB_SelectWithSchema_ListColumnScanErrorFallsBackToCastedQuery(t *testing.T) {
+	t.Parallel()
+
+	conn := &listScanErrorThenCastConnection{}
+	db := Client{
+		connection: conn,
+		config:     Config{Path: "some/path.db"},
+	}
+
+	result, err := db.SelectWithSchema(t.Context(), &query.Query{Query: "SHOW;"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"result"}, result.Columns)
+	require.Equal(t, [][]interface{}{{"main"}}, result.Rows)
+	require.Len(t, conn.queries, 2)
+	require.Equal(t, "SHOW;", conn.queries[0])
+	assert.Contains(t, conn.queries[1], `CAST("result" AS VARCHAR) AS "result"`)
+}
+
+func TestIsUnsupportedComplexTypeScanError_MatchesDriverMessage(t *testing.T) {
+	t.Parallel()
+	e := errors.New("Not Implemented: not yet implemented populating from columns of type list<l: utf8, nullable>")
+	assert.True(t, isUnsupportedComplexTypeScanError(e))
+}
+
+func TestClient_SelectWithSchema_SHOW_AfterCreateTable(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := t.Context()
+	path := filepath.Join(t.TempDir(), "proof.db")
+	c, err := NewClient(Config{Path: path})
+	require.NoError(t, err)
+	err = c.RunQueryWithoutResult(ctx, &query.Query{Query: "CREATE TABLE t1 (id INT);"})
+	require.NoError(t, err)
+	res, err := c.SelectWithSchema(ctx, &query.Query{Query: "SHOW;"})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Rows)
+}
+
 func TestClient_GetDatabaseSummary(t *testing.T) {
 	t.Parallel()
 
@@ -322,7 +455,6 @@ func (d *delayedConnection) ExecContext(_ context.Context, _ string, _ ...any) (
 	return driver.RowsAffected(0), nil
 }
 
-//nolint:ireturn
 //nolint:ireturn
 func (d *delayedConnection) QueryRowContext(_ context.Context, _ string, _ ...any) Row {
 	time.Sleep(d.delay)

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -313,6 +313,7 @@ func TestDB_SelectWithSchema_ListColumnScanErrorFallsBackToCastedQuery(t *testin
 	result, err := db.SelectWithSchema(t.Context(), &query.Query{Query: "SHOW;"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"result"}, result.Columns)
+	require.Equal(t, []string{"VARCHAR"}, result.ColumnTypes)
 	require.Equal(t, [][]interface{}{{"main"}}, result.Rows)
 	require.Len(t, conn.queries, 2)
 	require.Equal(t, "SHOW;", conn.queries[0])

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -153,8 +153,8 @@ func bufferRows(ctx context.Context, db *sql.DB, originalQuery string, rows *sql
 			if err2 != nil {
 				return nil, err2
 			}
-			// Keep db so a second fallback can run if the driver still reports complex Arrow types for CAST output.
-			return bufferRows(ctx, db, casted, rows2)
+			// Pass nil for db so we only retry once; avoids unbounded recursion if the casted query still fails.
+			return bufferRows(ctx, nil, casted, rows2)
 		}
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func bufferRows(ctx context.Context, db *sql.DB, originalQuery string, rows *sql
 				if err2 != nil {
 					return nil, err2
 				}
-				return bufferRows(ctx, db, casted, rows2)
+				return bufferRows(ctx, nil, casted, rows2)
 			}
 			return nil, err
 		}
@@ -194,7 +194,7 @@ func bufferRows(ctx context.Context, db *sql.DB, originalQuery string, rows *sql
 			if err2 != nil {
 				return nil, err2
 			}
-			return bufferRows(ctx, db, casted, rows2)
+			return bufferRows(ctx, nil, casted, rows2)
 		}
 		return nil, err
 	}

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -92,9 +92,8 @@ func (e *EphemeralConnection) QueryContext(ctx context.Context, query string, ar
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	return bufferRows(rows)
+	return bufferRows(ctx, db, query, rows)
 }
 
 func (e *EphemeralConnection) ExecContext(ctx context.Context, sqlStr string, arguments ...any) (sql.Result, error) {
@@ -125,9 +124,8 @@ func (e *EphemeralConnection) QueryRowContext(ctx context.Context, query string,
 	if err != nil {
 		return &errorRow{err: err}
 	}
-	defer rows.Close()
 
-	buffered, err := bufferRows(rows)
+	buffered, err := bufferRows(ctx, db, query, rows)
 	if err != nil {
 		return &errorRow{err: err}
 	}
@@ -136,7 +134,11 @@ func (e *EphemeralConnection) QueryRowContext(ctx context.Context, query string,
 }
 
 // bufferRows reads all rows into memory and returns a bufferedRows that can iterate over them.
-func bufferRows(rows *sql.Rows) (*bufferedRows, error) {
+// If db and originalQuery are set and the ADBC driver cannot scan Arrow complex types (LIST/STRUCT/MAP),
+// it retries once with CAST(... AS VARCHAR) per column (see buildCastedColumnsQuery in db.go).
+func bufferRows(ctx context.Context, db *sql.DB, originalQuery string, rows *sql.Rows) (*bufferedRows, error) {
+	defer rows.Close()
+
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, err
@@ -144,6 +146,16 @@ func bufferRows(rows *sql.Rows) (*bufferedRows, error) {
 
 	colTypes, err := rows.ColumnTypes()
 	if err != nil {
+		if isUnsupportedComplexTypeScanError(err) && db != nil && originalQuery != "" {
+			_ = rows.Close()
+			casted := buildCastedColumnsQuery(originalQuery, cols)
+			rows2, err2 := db.QueryContext(ctx, casted)
+			if err2 != nil {
+				return nil, err2
+			}
+			// Keep db so a second fallback can run if the driver still reports complex Arrow types for CAST output.
+			return bufferRows(ctx, db, casted, rows2)
+		}
 		return nil, err
 	}
 
@@ -155,6 +167,15 @@ func bufferRows(rows *sql.Rows) (*bufferedRows, error) {
 			ptrs[i] = &values[i]
 		}
 		if err := rows.Scan(ptrs...); err != nil {
+			if isUnsupportedComplexTypeScanError(err) && db != nil && originalQuery != "" {
+				_ = rows.Close()
+				casted := buildCastedColumnsQuery(originalQuery, cols)
+				rows2, err2 := db.QueryContext(ctx, casted)
+				if err2 != nil {
+					return nil, err2
+				}
+				return bufferRows(ctx, db, casted, rows2)
+			}
 			return nil, err
 		}
 		// Deep copy values - strings must be copied because they may reference Arrow buffers
@@ -166,6 +187,15 @@ func bufferRows(rows *sql.Rows) (*bufferedRows, error) {
 	}
 
 	if err := rows.Err(); err != nil {
+		if isUnsupportedComplexTypeScanError(err) && db != nil && originalQuery != "" {
+			_ = rows.Close()
+			casted := buildCastedColumnsQuery(originalQuery, cols)
+			rows2, err2 := db.QueryContext(ctx, casted)
+			if err2 != nil {
+				return nil, err2
+			}
+			return bufferRows(ctx, db, casted, rows2)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This pull request introduces robust handling for DuckDB queries that return complex Arrow types (such as LIST, STRUCT, or MAP) which are not directly supported by the ADBC driver. The main enhancement is a fallback mechanism: when a scan error is detected due to unsupported complex types, the system automatically retries the query by casting all columns to VARCHAR, ensuring queries like SHOW succeed even when complex metadata is present.