### PR TITLE
Add orphan temp file cleanup to bruin clean

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -10,8 +10,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/git"
+	"github.com/bruin-data/bruin/pkg/python"
 	"github.com/bruin-data/bruin/pkg/telemetry"
 	"github.com/bruin-data/bruin/pkg/user"
 	"github.com/pkg/errors"
@@ -110,13 +112,15 @@ func (r *CleanCommand) Run(inputPath string, cleanUvCache bool) error {
 // cleanOrphanTempFiles removes leftover temp files from crashed materialization runs.
 // When a Python asset crashes (e.g. OOM kill), Go's defer cleanup doesn't run,
 // leaving behind large .arrow files and wrapper scripts in the system temp directory.
+// Files newer than 1 hour are skipped to avoid interfering with running processes.
 func (r *CleanCommand) cleanOrphanTempFiles() {
 	tmpDir := os.TempDir()
 	patterns := []string{
-		filepath.Join(tmpDir, "asset_data_*.arrow"),
-		filepath.Join(tmpDir, "bruin-arrow-*.py"),
+		filepath.Join(tmpDir, python.TempArrowFilePrefix+"*.arrow"),
+		filepath.Join(tmpDir, python.TempArrowScriptPrefix+"*.py"),
 	}
 
+	cutoff := time.Now().Add(-1 * time.Hour)
 	var removed int
 	for _, pattern := range patterns {
 		matches, err := filepath.Glob(pattern)
@@ -124,6 +128,13 @@ func (r *CleanCommand) cleanOrphanTempFiles() {
 			continue
 		}
 		for _, f := range matches {
+			info, err := os.Stat(f)
+			if err != nil {
+				continue
+			}
+			if info.ModTime().After(cutoff) {
+				continue
+			}
 			if err := os.Remove(f); err == nil {
 				removed++
 			}

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -135,6 +135,8 @@ func (r *CleanCommand) cleanOrphanTempFiles() {
 			}
 			if err := os.Remove(f); err == nil {
 				removed++
+			} else {
+				r.errorPrinter.Printf("Warning: could not remove %s: %v\n", f, err)
 			}
 		}
 	}

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -109,9 +109,7 @@ func (r *CleanCommand) Run(inputPath string, cleanUvCache bool) error {
 	return nil
 }
 
-// cleanOrphanTempFiles removes leftover temp files from crashed materialization runs.
-// When a Python asset crashes (e.g. OOM kill), Go's defer cleanup doesn't run,
-// leaving behind large .arrow files and wrapper scripts in the system temp directory.
+// cleanOrphanTempFiles removes leftover temp files from crashed Python materialization runs.
 // Files newer than 1 hour are skipped to avoid interfering with running processes.
 func (r *CleanCommand) cleanOrphanTempFiles() {
 	tmpDir := os.TempDir()

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -73,6 +73,8 @@ func (r *CleanCommand) Run(inputPath string, cleanUvCache bool) error {
 		return errors.Wrap(err, "failed to recreate the home directory")
 	}
 
+	r.cleanOrphanTempFiles()
+
 	repoRoot, err := git.FindRepoFromPath(inputPath)
 	if err != nil {
 		errorPrinter.Printf("Failed to find the git repository root: %v\n", err)
@@ -103,6 +105,34 @@ func (r *CleanCommand) Run(inputPath string, cleanUvCache bool) error {
 	infoPrinter.Printf("Successfully removed %d log files.\n", len(contents))
 
 	return nil
+}
+
+// cleanOrphanTempFiles removes leftover temp files from crashed materialization runs.
+// When a Python asset crashes (e.g. OOM kill), Go's defer cleanup doesn't run,
+// leaving behind large .arrow files and wrapper scripts in the system temp directory.
+func (r *CleanCommand) cleanOrphanTempFiles() {
+	tmpDir := os.TempDir()
+	patterns := []string{
+		filepath.Join(tmpDir, "asset_data_*.arrow"),
+		filepath.Join(tmpDir, "bruin-arrow-*.py"),
+	}
+
+	var removed int
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, f := range matches {
+			if err := os.Remove(f); err == nil {
+				removed++
+			}
+		}
+	}
+
+	if removed > 0 {
+		r.infoPrinter.Printf("Removed %d orphan temp file(s) from %s.\n", removed, tmpDir)
+	}
 }
 
 func (r *CleanCommand) cleanUvCache(bruinHomeDirAbsPath string) error {

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -25,6 +25,13 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	// TempArrowFilePrefix is the prefix used for temporary Arrow data files during materialization.
+	TempArrowFilePrefix = "asset_data_"
+	// TempArrowScriptPrefix is the prefix used for temporary Python wrapper scripts during materialization.
+	TempArrowScriptPrefix = "bruin-arrow-"
+)
+
 var (
 	ingestrInstallMutex      sync.Mutex
 	ingestrInstalledPackages = make(map[string]bool)
@@ -389,12 +396,12 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		return errors.New("only table materialization is supported for Python assets")
 	}
 
-	arrowFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("asset_data_%d.arrow", time.Now().UnixNano()))
+	arrowFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s%d.arrow", TempArrowFilePrefix, time.Now().UnixNano()))
 	defer func(name string) {
 		_ = os.Remove(name)
 	}(arrowFilePath)
 
-	tempPyScript, err := os.CreateTemp("", "bruin-arrow-*.py")
+	tempPyScript, err := os.CreateTemp("", TempArrowScriptPrefix+"*.py")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}


### PR DESCRIPTION
## Summary
- When a Python asset crashes during materialization (e.g. OOM kill), Go's `defer` cleanup doesn't run, leaving behind large `.arrow` files and wrapper scripts in the system temp directory
- These orphan files can silently accumulate and fill up disk space — one user reported a 5GB ghost file after a single crash
- `bruin clean` now removes orphan `asset_data_*.arrow` and `bruin-arrow-*.py` files from the OS temp directory

## Test plan
- [x] Created fake orphan files in temp dir, ran `bruin clean`, verified they were removed
- [x] Verified no output when no orphan files exist
- [x] Verified existing `bruin clean` behavior (logs, home dir, uv cache) is unchanged

## Manual A/B test against `../chess-test` pipeline

Created the same fixtures in `$TMPDIR` on both branches: three files matching the cleanup patterns backdated 2h via `touch -t`, plus one fresh file that should be skipped by the 1-hour cutoff.

Fixtures:
- `asset_data_111.arrow` — 2h old
- `asset_data_222.arrow` — 2h old
- `bruin-arrow-abc.py` — 2h old
- `asset_data_recent.arrow` — fresh

| Branch | `bruin clean ../chess-test/bruin` output | Orphan files after |
|---|---|---|
| `main` | `No log files found, nothing to clean up...` | All 4 still present |
| `fix/clean-orphan-temp-files` | `Removed 3 orphan temp file(s) from /var/folders/.../T/.` | Only `asset_data_recent.arrow` remains |

Confirms the three backdated orphans are removed and the fresh file is correctly preserved by the 1-hour cutoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://linear.app/bruin/issue/BRU-4243/clean-up-temporary-arrow-files-after-failed-runs