### PR TITLE
Support native IPC serialization for Polars and PyArrow tables

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -3777,6 +3777,8 @@ func TestWorkflowTasks(t *testing.T) {
 								"Finished: mat.yield_batches",
 								"Finished: mat.pandas_df",
 								"Finished: mat.polars_df",
+								"Finished: mat.pyarrow_table",
+								"Finished: mat.pyarrow_tables",
 								"Finished: materialize.country",
 								"materialize() returned None, skipping materialization",
 								"Finished: mat.none_return",
@@ -3859,6 +3861,44 @@ func TestWorkflowTasks(t *testing.T) {
 						Expected: e2e.Output{
 							ExitCode: 0,
 							Output:   "┌─────┐\n│ CNT │\n├─────┤\n│ 3   │\n└─────┘\n",
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByOutputString,
+						},
+					},
+					{
+						Name:    "python_mat: verify pyarrow_table row count",
+						Command: binary,
+						Args: []string{
+							"query",
+							"--env", "env-python-mat",
+							"--connection", "duckdb-python-mat",
+							"--query", "SELECT count(*) AS cnt FROM mat.pyarrow_table",
+						},
+						WorkingDir: currentFolder,
+						Expected: e2e.Output{
+							ExitCode: 0,
+							Output:   "┌─────┐\n│ CNT │\n├─────┤\n│ 3   │\n└─────┘\n",
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByOutputString,
+						},
+					},
+					{
+						Name:    "python_mat: verify pyarrow_tables row count",
+						Command: binary,
+						Args: []string{
+							"query",
+							"--env", "env-python-mat",
+							"--connection", "duckdb-python-mat",
+							"--query", "SELECT count(*) AS cnt FROM mat.pyarrow_tables",
+						},
+						WorkingDir: currentFolder,
+						Expected: e2e.Output{
+							ExitCode: 0,
+							Output:   "┌─────┐\n│ CNT │\n├─────┤\n│ 4   │\n└─────┘\n",
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,

--- a/integration-tests/test-pipelines/python-mat/assets/pyarrow_table.py
+++ b/integration-tests/test-pipelines/python-mat/assets/pyarrow_table.py
@@ -1,0 +1,12 @@
+""" @bruin
+name: mat.pyarrow_table
+materialization:
+    type: table
+connection: duckdb-python-mat
+@bruin """
+
+import pyarrow as pa
+
+
+def materialize():
+    return pa.table({"id": [1, 2, 3], "name": ["a", "b", "c"]})

--- a/integration-tests/test-pipelines/python-mat/assets/pyarrow_tables.py
+++ b/integration-tests/test-pipelines/python-mat/assets/pyarrow_tables.py
@@ -1,0 +1,13 @@
+""" @bruin
+name: mat.pyarrow_tables
+materialization:
+    type: table
+connection: duckdb-python-mat
+@bruin """
+
+import pyarrow as pa
+
+
+def materialize():
+    yield pa.table({"id": [1, 2], "name": ["a", "b"]})
+    yield pa.table({"id": [3, 4], "name": ["c", "d"]})

--- a/integration-tests/test-pipelines/python-mat/requirements.txt
+++ b/integration-tests/test-pipelines/python-mat/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 polars
+pyarrow
 numpy

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -638,6 +638,7 @@ const PythonArrowTemplate = `
 
 import sys
 import importlib.util
+import itertools
 from pathlib import Path
 
 def import_module_from_path(module_path: str, module_name: str):
@@ -664,14 +665,61 @@ def convert_and_write(df):
     except ImportError:
         pl = None
 
-    # Use isinstance() for robust type checking across pandas/polars versions
-    # This works across all pandas versions (including 3.0+) regardless of string representation
-    if pd is not None and isinstance(df, pd.DataFrame):
+    def is_polars_dataframe(obj):
+        if pl is not None and isinstance(obj, pl.DataFrame):
+            return True
+        type_module = type(obj).__module__
+        type_name = type(obj).__name__
+        return 'polars' in type_module and type_name == 'DataFrame'
+
+    def is_pandas_dataframe(obj):
+        if pd is not None and isinstance(obj, pd.DataFrame):
+            return True
+        type_module = type(obj).__module__
+        type_name = type(obj).__name__
+        return 'pandas' in type_module and type_name == 'DataFrame'
+
+    def write_arrow_tables(tables):
+        iterator = iter(tables)
+        try:
+            first_table = next(iterator)
+        except StopIteration:
+            return
+
+        if not isinstance(first_table, pa.Table):
+            raise TypeError(f"Unsupported return type: {type(first_table)}")
+
+        with pa.OSFile("$ARROW_FILE_PATH", 'wb') as f:
+            writer = ipc.new_file(f, first_table.schema)
+            writer.write_table(first_table)
+            for next_table in iterator:
+                if not isinstance(next_table, pa.Table):
+                    raise TypeError(f"Unsupported yielded type: {type(next_table)}. expected pyarrow.Table.")
+                if not next_table.schema.equals(first_table.schema):
+                    raise TypeError("All yielded pyarrow Tables must have the same schema.")
+                writer.write_table(next_table)
+            writer.close()
+
+    # Polars can write Arrow IPC directly, avoiding the extra PyArrow writer
+    # memory peak seen when converting through a PyArrow Table first.
+    if is_polars_dataframe(df):
+        if pl is None:
+            raise TypeError(f"Unsupported return type: {type(df)}. polars DataFrame detected but polars cannot be imported.")
+        df.write_ipc("$ARROW_FILE_PATH")
+        return
+
+    if is_pandas_dataframe(df):
+        if pd is None:
+            raise TypeError(f"Unsupported return type: {type(df)}. pandas DataFrame detected but pandas cannot be imported.")
         table = pa.Table.from_pandas(df)
-    elif pl is not None and isinstance(df, pl.DataFrame):
-        table = df.to_arrow()
+    elif isinstance(df, pa.Table):
+        write_arrow_tables([df])
+        return
     elif isinstance(df, (list, tuple)):
         if not df:
+            return
+        if isinstance(df[0], pa.Table):
+            write_arrow_tables(df)
             return
         table = pa.Table.from_pylist(list(df))
     elif hasattr(df, '__iter__') and not isinstance(df, (str, bytes)):
@@ -682,39 +730,24 @@ def convert_and_write(df):
         # The second pattern is common with paginated APIs where each page
         # returns a list of records. We detect this by checking if the first
         # collected element is a list/tuple and flatten one level if so.
-        rows = list(df)
-        if not rows:
+        iterator = iter(df)
+        try:
+            first_row = next(iterator)
+        except StopIteration:
             return
+
+        if isinstance(first_row, pa.Table):
+            write_arrow_tables(itertools.chain([first_row], iterator))
+            return
+
+        rows = [first_row, *iterator]
         if isinstance(rows[0], (list, tuple)):
             rows = [item for batch in rows for item in batch]
         table = pa.Table.from_pylist(rows)
     else:
-        # Fallback: check type module/name for pandas/polars if isinstance failed
-        # This handles edge cases where pandas/polars might not be importable
-        type_name = type(df).__name__
-        type_module = type(df).__module__
-        if 'pandas' in type_module and type_name == 'DataFrame':
-            # Try to import pandas if not already imported
-            try:
-                import pandas as pd
-                table = pa.Table.from_pandas(df)
-            except ImportError:
-                raise TypeError(f"Unsupported return type: {type(df)}. pandas DataFrame detected but pandas cannot be imported.")
-        elif 'polars' in type_module and type_name == 'DataFrame':
-            # Try to import polars if not already imported
-            try:
-                import polars as pl
-                table = df.to_arrow()
-            except ImportError:
-                raise TypeError(f"Unsupported return type: {type(df)}. polars DataFrame detected but polars cannot be imported.")
-        else:
-            raise TypeError(f"Unsupported return type: {type(df)}")
+        raise TypeError(f"Unsupported return type: {type(df)}")
 
-    # Write to memory mapped file
-    with pa.OSFile("$ARROW_FILE_PATH", 'wb') as f:
-        writer = ipc.new_file(f, table.schema)
-        writer.write_table(table)
-        writer.close()
+    write_arrow_tables([table])
 
 module = import_module_from_path("$REPO_ROOT", "$MODULE_PATH")
 convert_and_write(module.materialize())

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -169,6 +169,44 @@ func containsArg(args []string, value string) bool {
 	return false
 }
 
+func TestPythonArrowTemplate_UsesNativePolarsIPC(t *testing.T) {
+	t.Parallel()
+
+	polarsCheckIndex := strings.Index(PythonArrowTemplate, "if is_polars_dataframe(df):")
+	polarsWriteIndex := strings.Index(PythonArrowTemplate, `df.write_ipc("$ARROW_FILE_PATH")`)
+	pandasCheckIndex := strings.Index(PythonArrowTemplate, "if is_pandas_dataframe(df):")
+	arrowTableIndex := strings.Index(PythonArrowTemplate, "elif isinstance(df, pa.Table):")
+	arrowTablesWriterIndex := strings.Index(PythonArrowTemplate, "def write_arrow_tables(tables):")
+	pyarrowWriteIndex := strings.Index(PythonArrowTemplate, `with pa.OSFile("$ARROW_FILE_PATH", 'wb') as f:`)
+
+	require.NotEqual(t, -1, polarsCheckIndex)
+	require.NotEqual(t, -1, polarsWriteIndex)
+	require.NotEqual(t, -1, pandasCheckIndex)
+	require.NotEqual(t, -1, arrowTableIndex)
+	require.NotEqual(t, -1, arrowTablesWriterIndex)
+	require.NotEqual(t, -1, pyarrowWriteIndex)
+
+	assert.Less(t, arrowTablesWriterIndex, polarsCheckIndex)
+	assert.Less(t, arrowTablesWriterIndex, pyarrowWriteIndex)
+	assert.Less(t, pyarrowWriteIndex, polarsCheckIndex)
+	assert.Less(t, polarsCheckIndex, polarsWriteIndex)
+	assert.Less(t, polarsWriteIndex, pandasCheckIndex)
+	assert.Less(t, pandasCheckIndex, arrowTableIndex)
+	assert.NotContains(t, PythonArrowTemplate, "df.to_arrow()")
+	assert.Contains(t, PythonArrowTemplate, "write_arrow_tables(itertools.chain([first_row], iterator))")
+}
+
+func TestPythonArrowTemplate_PreservesNoDataAndIterableHandling(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, PythonArrowTemplate, "if df is None:")
+	assert.Contains(t, PythonArrowTemplate, "if not df:")
+	assert.Contains(t, PythonArrowTemplate, "first_row = next(iterator)")
+	assert.Contains(t, PythonArrowTemplate, "except StopIteration:")
+	assert.Contains(t, PythonArrowTemplate, "rows = [first_row, *iterator]")
+	assert.Contains(t, PythonArrowTemplate, "rows = [item for batch in rows for item in batch]")
+}
+
 func Test_uvPythonRunner_Run(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Rebased the PR onto latest `main` (`20386b7a2`)
- Use `polars.DataFrame.write_ipc()` for Polars materialization output instead of routing Polars frames through `df.to_arrow()` and the PyArrow IPC writer
- Accept returned `pyarrow.Table` values directly
- Accept yielded/listed `pyarrow.Table` chunks and write them to the same Arrow IPC file without converting them into Python row dicts first
- Keep Pandas, list/tuple, generator, empty iterable, and `None` materialization behavior on the existing path
- Add template-level unit tests plus actual Python asset integration coverage for Pandas, Polars, returned PyArrow tables, yielded PyArrow tables, row generators, batch generators, empty iterables, and `None`

## Benchmark

Benchmarked each strategy in a separate Python process with `pyarrow==18.0.0`, Polars, and RSS sampling.

Numeric frame, 100,000,000 rows x 8 int64 columns:

| Path | Polars estimated size | File size | Write time | Write peak above create peak |
| --- | ---: | ---: | ---: | ---: |
| `df.to_arrow()` + PyArrow IPC writer | 6103 MB | 6104 MB | 7.36s | 505 MB |
| `df.write_ipc()` | 6103 MB | 6104 MB | 5.60s | 0 MB |

String frame, 10,000,000 rows x 4 string columns:

| Path | Polars estimated size | File size | Write time | Write peak above create peak |
| --- | ---: | ---: | ---: | ---: |
| `df.to_arrow()` + PyArrow IPC writer | 606 MB | 911 MB | 0.49s | 397 MB |
| `df.write_ipc()` | 606 MB | 1216 MB | 0.46s | 0 MB |

The original PR's claim that `df.to_arrow()` necessarily creates a full extra copy was too strong. The benchmark shows a real serialization-time peak reduction from `write_ipc()`, but not the claimed universal 5 GB copy.

Returned `pyarrow.Table`, numeric table, 20,000,000 rows x 8 int64 columns:

| Path | Table size | File size | Write time | Write peak above create peak |
| --- | ---: | ---: | ---: | ---: |
| `polars.DataFrame.to_arrow()` + PyArrow IPC writer | 1221 MB | 1221 MB | 0.52s | 2 MB |
| returned `pyarrow.Table` + PyArrow IPC writer | 1221 MB | 1221 MB | 0.46s | 1 MB |
| `polars.DataFrame.write_ipc()` | 1221 MB | 1221 MB | 0.48s | 235 MB |

For direct PyArrow tables, the main win is correctness/support and avoiding the unnecessary failed row-conversion path. The serialization overhead is already low because the table is already in Arrow form.

## Test plan

- [x] `go test ./pkg/python`
- [x] `make build`
- [x] `cd integration-tests && env SILENT=1 go test -tags="no_duckdb_arrow" -v -count=1 -run '^TestWorkflowTasks/python_mat$' .`
- [x] `make format`
- [x] `make test`
