### PR TITLE
Use ADBC low-level API for DuckDB to support LIST/STRUCT/MAP columns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -179,6 +179,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - repro_adbc_list
 formatters:
   enable:
     - gci
@@ -197,3 +198,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - repro_adbc_list

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -115,11 +115,26 @@ type Row interface {
 	Err() error
 }
 
+// ColumnType holds column metadata for result processing.
+type ColumnType struct {
+	name           string
+	databaseType   string
+	precision      int64
+	scale          int64
+	hasDecimalInfo bool
+}
+
+func (ct *ColumnType) Name() string             { return ct.name }
+func (ct *ColumnType) DatabaseTypeName() string { return ct.databaseType }
+func (ct *ColumnType) DecimalSize() (precision, scale int64, ok bool) {
+	return ct.precision, ct.scale, ct.hasDecimalInfo
+}
+
 // Rows interface abstracts sql.Rows to allow custom implementations that manage connection lifecycle.
 type Rows interface {
 	Close() error
 	Columns() ([]string, error)
-	ColumnTypes() ([]*sql.ColumnType, error)
+	ColumnTypes() ([]*ColumnType, error)
 	Err() error
 	Next() bool
 	Scan(dest ...any) error
@@ -141,9 +156,38 @@ func newSqlxWrapper(db *sqlx.DB) *sqlxWrapper {
 	return &sqlxWrapper{db: db}
 }
 
+// sqlRowsAdapter wraps *sql.Rows to implement the Rows interface,
+// adapting []*sql.ColumnType to []*ColumnType.
+type sqlRowsAdapter struct {
+	*sql.Rows
+}
+
+func (a *sqlRowsAdapter) ColumnTypes() ([]*ColumnType, error) {
+	cts, err := a.Rows.ColumnTypes()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*ColumnType, len(cts))
+	for i, ct := range cts {
+		p, s, ok := ct.DecimalSize()
+		result[i] = &ColumnType{
+			name:           ct.Name(),
+			databaseType:   ct.DatabaseTypeName(),
+			precision:      p,
+			scale:          s,
+			hasDecimalInfo: ok,
+		}
+	}
+	return result, nil
+}
+
 //nolint:ireturn
 func (w *sqlxWrapper) QueryContext(ctx context.Context, query string, args ...any) (Rows, error) {
-	return w.db.QueryContext(ctx, query, args...) //nolint:rowserrcheck
+	rows, err := w.db.QueryContext(ctx, query, args...) //nolint:rowserrcheck
+	if err != nil {
+		return nil, err
+	}
+	return &sqlRowsAdapter{rows}, nil
 }
 
 func (w *sqlxWrapper) ExecContext(ctx context.Context, sql string, arguments ...any) (sql.Result, error) {
@@ -337,7 +381,7 @@ func (c *Client) SelectWithSchema(ctx context.Context, queryObject *query.Query)
 	return result, nil
 }
 
-func (c *Client) convertValueWithType(val interface{}, colType *sql.ColumnType) interface{} {
+func (c *Client) convertValueWithType(val interface{}, colType *ColumnType) interface{} {
 	// The ADBC sqldriver returns data from Arrow buffers that may be memory-mapped.
 	// We need to copy certain types to ensure we own the memory before the rows are closed.
 
@@ -367,7 +411,7 @@ func (c *Client) convertValueWithType(val interface{}, colType *sql.ColumnType) 
 }
 
 // convertDecimal128 converts a decimal128.Num to float64 with proper scale.
-func convertDecimal128(v decimal128.Num, colType *sql.ColumnType) float64 {
+func convertDecimal128(v decimal128.Num, colType *ColumnType) float64 {
 	var scale int64
 	if colType != nil {
 		_, s, ok := colType.DecimalSize()
@@ -390,7 +434,7 @@ func roundToScale(value float64, scale int64) float64 {
 }
 
 // tryConvertDecimal attempts to convert a value to float64 if it's a decimal struct.
-func tryConvertDecimal(val interface{}, colType *sql.ColumnType) interface{} {
+func tryConvertDecimal(val interface{}, colType *ColumnType) interface{} {
 	// Check if the value is a decimal128.Num type
 	if d, ok := val.(decimal128.Num); ok {
 		return convertDecimal128(d, colType)

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -332,12 +332,12 @@ func (d *delayedConnection) QueryRowContext(_ context.Context, _ string, _ ...an
 // emptyRows implements Rows with no data.
 type emptyRows struct{}
 
-func (r *emptyRows) Close() error                            { return nil }
-func (r *emptyRows) Columns() ([]string, error)              { return nil, nil }
-func (r *emptyRows) ColumnTypes() ([]*sql.ColumnType, error) { return nil, nil }
-func (r *emptyRows) Err() error                              { return nil }
-func (r *emptyRows) Next() bool                              { return false }
-func (r *emptyRows) Scan(_ ...any) error                     { return sql.ErrNoRows }
+func (r *emptyRows) Close() error                        { return nil }
+func (r *emptyRows) Columns() ([]string, error)          { return nil, nil }
+func (r *emptyRows) ColumnTypes() ([]*ColumnType, error) { return nil, nil }
+func (r *emptyRows) Err() error                          { return nil }
+func (r *emptyRows) Next() bool                          { return false }
+func (r *emptyRows) Scan(_ ...any) error                 { return sql.ErrNoRows }
 
 func TestClient_ReadOnly_AllowsParallelQueries(t *testing.T) {
 	t.Parallel()
@@ -591,6 +591,61 @@ func TestRoundToScale_SymmetricRounding(t *testing.T) {
 			result := roundToScale(tt.value, tt.scale)
 
 			assert.InDelta(t, tt.expected, result, 0.0000001, "expected %v but got %v", tt.expected, result)
+		})
+	}
+}
+
+func TestInlineQueryArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		query    string
+		args     []any
+		expected string
+	}{
+		{
+			name:     "no args returns query unchanged",
+			query:    "SELECT * FROM t",
+			args:     nil,
+			expected: "SELECT * FROM t",
+		},
+		{
+			name:     "single string arg",
+			query:    "SELECT * FROM t WHERE name = ?",
+			args:     []any{"hello"},
+			expected: "SELECT * FROM t WHERE name = 'hello'",
+		},
+		{
+			name:     "string with single quote is escaped",
+			query:    "SELECT * FROM t WHERE name = ?",
+			args:     []any{"O'Brien"},
+			expected: "SELECT * FROM t WHERE name = 'O''Brien'",
+		},
+		{
+			name:     "multiple args",
+			query:    "SELECT * FROM t WHERE schema = ? AND name = ?",
+			args:     []any{"main", "users"},
+			expected: "SELECT * FROM t WHERE schema = 'main' AND name = 'users'",
+		},
+		{
+			name:     "integer arg",
+			query:    "SELECT * FROM t WHERE id = ?",
+			args:     []any{42},
+			expected: "SELECT * FROM t WHERE id = 42",
+		},
+		{
+			name:     "string arg containing question mark",
+			query:    "SELECT * FROM t WHERE schema = ? AND name = ?",
+			args:     []any{"what?", "users"},
+			expected: "SELECT * FROM t WHERE schema = 'what?' AND name = 'users'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, inlineQueryArgs(tt.query, tt.args))
 		})
 	}
 }

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -640,6 +640,12 @@ func TestInlineQueryArgs(t *testing.T) {
 			args:     []any{"what?", "users"},
 			expected: "SELECT * FROM t WHERE schema = 'what?' AND name = 'users'",
 		},
+		{
+			name:     "more args than placeholders returns query unchanged",
+			query:    "SELECT * FROM t WHERE id = ?",
+			args:     []any{1, 2},
+			expected: "SELECT * FROM t WHERE id = ?",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/duckdb/db_test.go
+++ b/pkg/duckdb/db_test.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/jmoiron/sqlx"
@@ -322,7 +325,6 @@ func (d *delayedConnection) ExecContext(_ context.Context, _ string, _ ...any) (
 	return driver.RowsAffected(0), nil
 }
 
-//nolint:ireturn
 //nolint:ireturn
 func (d *delayedConnection) QueryRowContext(_ context.Context, _ string, _ ...any) Row {
 	time.Sleep(d.delay)
@@ -654,4 +656,274 @@ func TestInlineQueryArgs(t *testing.T) {
 			assert.Equal(t, tt.expected, inlineQueryArgs(tt.query, tt.args))
 		})
 	}
+}
+
+func TestExtractArrowValue_ScalarTypes(t *testing.T) {
+	t.Parallel()
+	alloc := memory.NewGoAllocator()
+
+	t.Run("boolean", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewBooleanBuilder(alloc)
+		defer bldr.Release()
+		bldr.Append(true)
+		bldr.Append(false)
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.Equal(t, true, extractArrowValue(arr, 0))
+		assert.Equal(t, false, extractArrowValue(arr, 1))
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewInt64Builder(alloc)
+		defer bldr.Release()
+		bldr.Append(42)
+		bldr.Append(-7)
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.Equal(t, int64(42), extractArrowValue(arr, 0))
+		assert.Equal(t, int64(-7), extractArrowValue(arr, 1))
+	})
+
+	t.Run("int32 widens to int64", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewInt32Builder(alloc)
+		defer bldr.Release()
+		bldr.Append(100)
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.Equal(t, int64(100), extractArrowValue(arr, 0))
+	})
+
+	t.Run("uint64 cast to int64", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewUint64Builder(alloc)
+		defer bldr.Release()
+		bldr.Append(999)
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.Equal(t, int64(999), extractArrowValue(arr, 0))
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewFloat64Builder(alloc)
+		defer bldr.Release()
+		bldr.Append(3.14)
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.InDelta(t, 3.14, extractArrowValue(arr, 0), 0.001)
+	})
+
+	t.Run("float32 widens to float64", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewFloat32Builder(alloc)
+		defer bldr.Release()
+		bldr.Append(2.5)
+		arr := bldr.NewArray()
+		defer arr.Release()
+		val, ok := extractArrowValue(arr, 0).(float64)
+		require.True(t, ok)
+		assert.InDelta(t, 2.5, val, 0.001)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewStringBuilder(alloc)
+		defer bldr.Release()
+		bldr.Append("hello")
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.Equal(t, "hello", extractArrowValue(arr, 0))
+	})
+
+	t.Run("binary", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewBinaryBuilder(alloc, arrow.BinaryTypes.Binary)
+		defer bldr.Release()
+		bldr.Append([]byte{0xDE, 0xAD})
+		arr := bldr.NewArray()
+		defer arr.Release()
+		assert.Equal(t, []byte{0xDE, 0xAD}, extractArrowValue(arr, 0))
+	})
+}
+
+func TestExtractArrowValue_List(t *testing.T) {
+	t.Parallel()
+	alloc := memory.NewGoAllocator()
+
+	t.Run("list of int64", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewListBuilder(alloc, arrow.PrimitiveTypes.Int64)
+		defer bldr.Release()
+
+		vb := bldr.ValueBuilder().(*array.Int64Builder)
+		bldr.Append(true)
+		vb.Append(1)
+		vb.Append(2)
+		vb.Append(3)
+
+		arr := bldr.NewListArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := []any{int64(1), int64(2), int64(3)}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("list with null element", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewListBuilder(alloc, arrow.PrimitiveTypes.Int64)
+		defer bldr.Release()
+
+		vb := bldr.ValueBuilder().(*array.Int64Builder)
+		bldr.Append(true)
+		vb.Append(10)
+		vb.AppendNull()
+		vb.Append(30)
+
+		arr := bldr.NewListArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := []any{int64(10), nil, int64(30)}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewListBuilder(alloc, arrow.PrimitiveTypes.Int64)
+		defer bldr.Release()
+
+		bldr.Append(true)
+		// no values appended
+
+		arr := bldr.NewListArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := []any{}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("list of strings", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewListBuilder(alloc, arrow.BinaryTypes.String)
+		defer bldr.Release()
+
+		vb := bldr.ValueBuilder().(*array.StringBuilder)
+		bldr.Append(true)
+		vb.Append("a")
+		vb.Append("b")
+
+		arr := bldr.NewListArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := []any{"a", "b"}
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestExtractArrowValue_Struct(t *testing.T) {
+	t.Parallel()
+	alloc := memory.NewGoAllocator()
+
+	t.Run("struct with mixed fields", func(t *testing.T) {
+		t.Parallel()
+		dt := arrow.StructOf(
+			arrow.Field{Name: "name", Type: arrow.BinaryTypes.String},
+			arrow.Field{Name: "age", Type: arrow.PrimitiveTypes.Int64},
+		)
+		bldr := array.NewStructBuilder(alloc, dt)
+		defer bldr.Release()
+
+		nameBldr := bldr.FieldBuilder(0).(*array.StringBuilder)
+		ageBldr := bldr.FieldBuilder(1).(*array.Int64Builder)
+
+		bldr.Append(true)
+		nameBldr.Append("Alice")
+		ageBldr.Append(30)
+
+		arr := bldr.NewStructArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := map[string]any{"name": "Alice", "age": int64(30)}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("struct with null field", func(t *testing.T) {
+		t.Parallel()
+		dt := arrow.StructOf(
+			arrow.Field{Name: "x", Type: arrow.PrimitiveTypes.Int64},
+			arrow.Field{Name: "y", Type: arrow.PrimitiveTypes.Int64},
+		)
+		bldr := array.NewStructBuilder(alloc, dt)
+		defer bldr.Release()
+
+		xBldr := bldr.FieldBuilder(0).(*array.Int64Builder)
+		yBldr := bldr.FieldBuilder(1).(*array.Int64Builder)
+
+		bldr.Append(true)
+		xBldr.Append(5)
+		yBldr.AppendNull()
+
+		arr := bldr.NewStructArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := map[string]any{"x": int64(5), "y": nil}
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestExtractArrowValue_Map(t *testing.T) {
+	t.Parallel()
+	alloc := memory.NewGoAllocator()
+
+	t.Run("map string to int", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewMapBuilder(alloc, arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int64, false)
+		defer bldr.Release()
+
+		kb := bldr.KeyBuilder().(*array.StringBuilder)
+		vb := bldr.ItemBuilder().(*array.Int64Builder)
+
+		bldr.Append(true)
+		kb.Append("a")
+		vb.Append(1)
+		kb.Append("b")
+		vb.Append(2)
+
+		arr := bldr.NewMapArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := map[string]any{"a": int64(1), "b": int64(2)}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("map with null value", func(t *testing.T) {
+		t.Parallel()
+		bldr := array.NewMapBuilder(alloc, arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int64, false)
+		defer bldr.Release()
+
+		kb := bldr.KeyBuilder().(*array.StringBuilder)
+		vb := bldr.ItemBuilder().(*array.Int64Builder)
+
+		bldr.Append(true)
+		kb.Append("x")
+		vb.Append(10)
+		kb.Append("y")
+		vb.AppendNull()
+
+		arr := bldr.NewMapArray()
+		defer arr.Release()
+
+		result := extractArrowValue(arr, 0)
+		expected := map[string]any{"x": int64(10), "y": nil}
+		assert.Equal(t, expected, result)
+	})
 }

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -311,9 +311,46 @@ func extractArrowValue(col arrow.Array, i int) any {
 		return arr.Value(i).ToTime(arr.DataType().(*arrow.TimestampType).Unit)
 	case *array.Decimal128:
 		return arr.Value(i)
+	case *array.List:
+		start, end := arr.ValueOffsets(i)
+		vals := make([]any, end-start)
+		inner := arr.ListValues()
+		for k := start; k < end; k++ {
+			if inner.IsNull(int(k)) {
+				vals[k-start] = nil
+			} else {
+				vals[k-start] = extractArrowValue(inner, int(k))
+			}
+		}
+		return vals
+	case *array.Struct:
+		m := make(map[string]any, arr.NumField())
+		dt := arr.DataType().(*arrow.StructType)
+		for k := range arr.NumField() {
+			field := arr.Field(k)
+			if field.IsNull(i) {
+				m[dt.Field(k).Name] = nil
+			} else {
+				m[dt.Field(k).Name] = extractArrowValue(field, i)
+			}
+		}
+		return m
+	case *array.Map:
+		keys := arr.Keys()
+		items := arr.Items()
+		start, end := arr.ValueOffsets(i)
+		m := make(map[string]any, end-start)
+		for k := start; k < end; k++ {
+			key := fmt.Sprintf("%v", extractArrowValue(keys, int(k)))
+			if items.IsNull(int(k)) {
+				m[key] = nil
+			} else {
+				m[key] = extractArrowValue(items, int(k))
+			}
+		}
+		return m
 	default:
-		// Complex types (LIST, STRUCT, MAP, UNION, etc.) and any unhandled types
-		// are returned as their string representation.
+		// Any remaining unhandled types are returned as their string representation.
 		return copyString(col.ValueStr(i))
 	}
 }

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -280,7 +280,7 @@ func extractArrowValue(col arrow.Array, i int) any {
 	case *array.Uint32:
 		return int64(arr.Value(i))
 	case *array.Uint64:
-		return arr.Value(i)
+		return int64(arr.Value(i)) //nolint:gosec // overflow is acceptable; returning raw uint64 causes silent zeroing in convertAssign
 	case *array.Float32:
 		return float64(arr.Value(i))
 	case *array.Float64:
@@ -340,6 +340,9 @@ func inlineQueryArgs(queryStr string, args []any) string {
 		return queryStr
 	}
 	parts := strings.SplitN(queryStr, "?", len(args)+1)
+	if len(parts) < len(args)+1 {
+		return queryStr
+	}
 	var b strings.Builder
 	for i, arg := range args {
 		b.WriteString(parts[i])

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -35,6 +35,8 @@ func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
 
 // openADBC creates an ADBC database and connection, including lakehouse setup.
 // The caller must close both the connection and database when done.
+//
+//nolint:ireturn
 func (e *EphemeralConnection) openADBC(ctx context.Context) (adbc.Database, adbc.Connection, error) {
 	path := e.config.ToDBConnectionURI()
 	opts := map[string]string{
@@ -229,9 +231,9 @@ func bufferArrowReader(reader array.RecordReader) (*bufferedRows, error) {
 		record := reader.RecordBatch()
 		numRows := int(record.NumRows())
 		numCols := int(record.NumCols())
-		for i := 0; i < numRows; i++ {
+		for i := range numRows {
 			row := make([]any, numCols)
-			for j := 0; j < numCols; j++ {
+			for j := range numCols {
 				col := record.Column(j)
 				if col.IsNull(i) {
 					row[j] = nil

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -8,8 +8,17 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"reflect"
+	"strings"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/drivermgr"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
+// EphemeralConnection uses the ADBC low-level API to query DuckDB directly,
+// bypassing the database/sql adapter which doesn't support complex Arrow types
+// (LIST, STRUCT, MAP).
 type EphemeralConnection struct {
 	config DuckDBConfig
 }
@@ -24,26 +33,41 @@ func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
 	}, nil
 }
 
-func (e *EphemeralConnection) openDB(ctx context.Context) (*sql.DB, error) {
+// openADBC creates an ADBC database and connection, including lakehouse setup.
+// The caller must close both the connection and database when done.
+func (e *EphemeralConnection) openADBC(ctx context.Context) (adbc.Database, adbc.Connection, error) {
 	path := e.config.ToDBConnectionURI()
-	connStr := "driver=duckdb;path=" + path
+	opts := map[string]string{
+		"driver": "duckdb",
+		"path":   path,
+	}
 
 	if cfg, ok := e.config.(Config); ok && cfg.ReadOnly {
-		connStr += ";access_mode=read_only"
+		opts["access_mode"] = "read_only"
 	}
 
-	db, err := sql.Open("adbc_duckdb", connStr)
+	var drv drivermgr.Driver
+	adb, err := drv.NewDatabase(opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to create ADBC database: %w", err)
 	}
-	if err := e.setupLakehouse(ctx, db); err != nil {
-		db.Close()
-		return nil, err
+
+	conn, err := adb.Open(ctx)
+	if err != nil {
+		adb.Close()
+		return nil, nil, fmt.Errorf("failed to open ADBC connection: %w", err)
 	}
-	return db, nil
+
+	if err := e.setupLakehouseADBC(ctx, conn); err != nil {
+		conn.Close()
+		adb.Close()
+		return nil, nil, err
+	}
+
+	return adb, conn, nil
 }
 
-func (e *EphemeralConnection) setupLakehouse(ctx context.Context, db *sql.DB) error {
+func (e *EphemeralConnection) setupLakehouseADBC(ctx context.Context, conn adbc.Connection) error {
 	cfg, ok := e.config.(Config)
 	if !ok || !cfg.HasLakehouse() {
 		return nil
@@ -59,75 +83,128 @@ func (e *EphemeralConnection) setupLakehouse(ctx context.Context, db *sql.DB) er
 		return fmt.Errorf("failed to generate lakehouse statements: %w", err)
 	}
 
-	for _, stmt := range statements {
-		if err := e.execLakehouseStatement(ctx, db, stmt); err != nil {
-			return err
+	for _, sqlStr := range statements {
+		if err := execADBCStatement(ctx, conn, sqlStr); err != nil {
+			return fmt.Errorf("failed to execute lakehouse statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func (e *EphemeralConnection) execLakehouseStatement(ctx context.Context, db *sql.DB, stmt string) error {
-	rows, err := db.QueryContext(ctx, stmt)
+func execADBCStatement(ctx context.Context, conn adbc.Connection, sqlStr string) error {
+	stmt, err := conn.NewStatement()
 	if err != nil {
-		return fmt.Errorf("failed to execute lakehouse statement: %w", err)
+		return err
 	}
-	defer rows.Close()
+	defer stmt.Close()
 
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("failed to execute lakehouse statement: %w", err)
+	if err := stmt.SetSqlQuery(sqlStr); err != nil {
+		return err
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return err
+	}
+	if reader != nil {
+		reader.Release()
 	}
 	return nil
 }
 
 //nolint:ireturn
-func (e *EphemeralConnection) QueryContext(ctx context.Context, query string, args ...any) (Rows, error) {
-	db, err := e.openDB(ctx)
+func (e *EphemeralConnection) QueryContext(ctx context.Context, queryStr string, args ...any) (Rows, error) {
+	adb, conn, err := e.openADBC(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
+	defer adb.Close()
+	defer conn.Close()
 
-	rows, err := db.QueryContext(ctx, query, args...)
+	stmt, err := conn.NewStatement()
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer stmt.Close()
 
-	return bufferRows(rows)
+	if err := stmt.SetSqlQuery(inlineQueryArgs(queryStr, args)); err != nil {
+		return nil, err
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if reader == nil {
+		return &bufferedRows{
+			columns:     []string{},
+			columnTypes: []*ColumnType{},
+			index:       -1,
+		}, nil
+	}
+	defer reader.Release()
+
+	return bufferArrowReader(reader)
 }
 
 func (e *EphemeralConnection) ExecContext(ctx context.Context, sqlStr string, arguments ...any) (sql.Result, error) {
-	db, err := e.openDB(ctx)
+	adb, conn, err := e.openADBC(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
+	defer adb.Close()
+	defer conn.Close()
 
-	rows, err := db.QueryContext(ctx, sqlStr, arguments...)
+	stmt, err := conn.NewStatement()
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer stmt.Close()
 
-	return driver.RowsAffected(0), rows.Err()
+	if err := stmt.SetSqlQuery(inlineQueryArgs(sqlStr, arguments)); err != nil {
+		return nil, err
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if reader != nil {
+		reader.Release()
+	}
+
+	return driver.RowsAffected(0), nil
 }
 
 //nolint:ireturn
-func (e *EphemeralConnection) QueryRowContext(ctx context.Context, query string, args ...any) Row {
-	db, err := e.openDB(ctx)
+func (e *EphemeralConnection) QueryRowContext(ctx context.Context, queryStr string, args ...any) Row {
+	adb, conn, err := e.openADBC(ctx)
 	if err != nil {
 		return &errorRow{err: err}
 	}
-	defer db.Close()
+	defer adb.Close()
+	defer conn.Close()
 
-	rows, err := db.QueryContext(ctx, query, args...)
+	stmt, err := conn.NewStatement()
 	if err != nil {
 		return &errorRow{err: err}
 	}
-	defer rows.Close()
+	defer stmt.Close()
 
-	buffered, err := bufferRows(rows)
+	if err := stmt.SetSqlQuery(inlineQueryArgs(queryStr, args)); err != nil {
+		return &errorRow{err: err}
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return &errorRow{err: err}
+	}
+	if reader == nil {
+		return &errorRow{err: sql.ErrNoRows}
+	}
+	defer reader.Release()
+
+	buffered, err := bufferArrowReader(reader)
 	if err != nil {
 		return &errorRow{err: err}
 	}
@@ -135,37 +212,38 @@ func (e *EphemeralConnection) QueryRowContext(ctx context.Context, query string,
 	return &bufferedRow{rows: buffered}
 }
 
-// bufferRows reads all rows into memory and returns a bufferedRows that can iterate over them.
-func bufferRows(rows *sql.Rows) (*bufferedRows, error) {
-	cols, err := rows.Columns()
-	if err != nil {
-		return nil, err
-	}
+// bufferArrowReader reads all records from an Arrow RecordReader into memory.
+func bufferArrowReader(reader array.RecordReader) (*bufferedRows, error) {
+	schema := reader.Schema()
+	numFields := schema.NumFields()
+	cols := make([]string, numFields)
+	colTypes := make([]*ColumnType, numFields)
 
-	colTypes, err := rows.ColumnTypes()
-	if err != nil {
-		return nil, err
+	for i, field := range schema.Fields() {
+		cols[i] = field.Name
+		colTypes[i] = arrowFieldToColumnType(field)
 	}
 
 	var data [][]any
-	for rows.Next() {
-		values := make([]any, len(cols))
-		ptrs := make([]any, len(cols))
-		for i := range values {
-			ptrs[i] = &values[i]
+	for reader.Next() {
+		record := reader.RecordBatch()
+		numRows := int(record.NumRows())
+		numCols := int(record.NumCols())
+		for i := 0; i < numRows; i++ {
+			row := make([]any, numCols)
+			for j := 0; j < numCols; j++ {
+				col := record.Column(j)
+				if col.IsNull(i) {
+					row[j] = nil
+				} else {
+					row[j] = extractArrowValue(col, i)
+				}
+			}
+			data = append(data, row)
 		}
-		if err := rows.Scan(ptrs...); err != nil {
-			return nil, err
-		}
-		// Deep copy values - strings must be copied because they may reference Arrow buffers
-		row := make([]any, len(values))
-		for i, v := range values {
-			row[i] = copyValue(v)
-		}
-		data = append(data, row)
 	}
 
-	if err := rows.Err(); err != nil {
+	if err := reader.Err(); err != nil {
 		return nil, err
 	}
 
@@ -177,10 +255,107 @@ func bufferRows(rows *sql.Rows) (*bufferedRows, error) {
 	}, nil
 }
 
+// extractArrowValue extracts a native Go value from an Arrow array at position i.
+// Scalar types are returned as their natural Go equivalents.
+// Complex types (LIST, STRUCT, MAP) are returned as their string representation,
+// which is the key advantage over the database/sql adapter that cannot handle these types.
+func extractArrowValue(col arrow.Array, i int) any {
+	switch arr := col.(type) {
+	case *array.Boolean:
+		return arr.Value(i)
+	case *array.Int8:
+		return int64(arr.Value(i))
+	case *array.Int16:
+		return int64(arr.Value(i))
+	case *array.Int32:
+		return int64(arr.Value(i))
+	case *array.Int64:
+		return arr.Value(i)
+	case *array.Uint8:
+		return int64(arr.Value(i))
+	case *array.Uint16:
+		return int64(arr.Value(i))
+	case *array.Uint32:
+		return int64(arr.Value(i))
+	case *array.Uint64:
+		return arr.Value(i)
+	case *array.Float32:
+		return float64(arr.Value(i))
+	case *array.Float64:
+		return arr.Value(i)
+	case *array.String:
+		return copyString(arr.Value(i))
+	case *array.LargeString:
+		return copyString(arr.Value(i))
+	case *array.Binary:
+		v := arr.Value(i)
+		cp := make([]byte, len(v))
+		copy(cp, v)
+		return cp
+	case *array.LargeBinary:
+		v := arr.Value(i)
+		cp := make([]byte, len(v))
+		copy(cp, v)
+		return cp
+	case *array.Date32:
+		return arr.Value(i).ToTime()
+	case *array.Date64:
+		return arr.Value(i).ToTime()
+	case *array.Time32:
+		return arr.Value(i).ToTime(arr.DataType().(*arrow.Time32Type).Unit)
+	case *array.Time64:
+		return arr.Value(i).ToTime(arr.DataType().(*arrow.Time64Type).Unit)
+	case *array.Timestamp:
+		return arr.Value(i).ToTime(arr.DataType().(*arrow.TimestampType).Unit)
+	case *array.Decimal128:
+		return arr.Value(i)
+	default:
+		// Complex types (LIST, STRUCT, MAP, UNION, etc.) and any unhandled types
+		// are returned as their string representation.
+		return copyString(col.ValueStr(i))
+	}
+}
+
+// arrowFieldToColumnType converts an Arrow schema field to a ColumnType.
+func arrowFieldToColumnType(field arrow.Field) *ColumnType {
+	ct := &ColumnType{
+		name:         field.Name,
+		databaseType: normalizeTypeName(field.Type.String()),
+	}
+	if dt, ok := field.Type.(*arrow.Decimal128Type); ok {
+		ct.precision = int64(dt.Precision)
+		ct.scale = int64(dt.Scale)
+		ct.hasDecimalInfo = true
+	}
+	return ct
+}
+
+// inlineQueryArgs substitutes positional ? parameters with their escaped values.
+// This is used for internal queries (e.g. information_schema lookups) where
+// parameters are controlled by Bruin, not user input.
+func inlineQueryArgs(queryStr string, args []any) string {
+	if len(args) == 0 {
+		return queryStr
+	}
+	parts := strings.SplitN(queryStr, "?", len(args)+1)
+	var b strings.Builder
+	for i, arg := range args {
+		b.WriteString(parts[i])
+		switch v := arg.(type) {
+		case string:
+			b.WriteString("'" + strings.ReplaceAll(v, "'", "''") + "'")
+		default:
+			fmt.Fprintf(&b, "%v", v)
+		}
+	}
+	b.WriteString(parts[len(args)])
+	return b.String()
+}
+
 // bufferedRows holds rows data in memory and implements the Rows interface.
 type bufferedRows struct {
 	columns     []string
-	columnTypes []*sql.ColumnType
+	columnTypes []*ColumnType
 	data        [][]any
 	index       int
 	err         error
@@ -194,7 +369,7 @@ func (r *bufferedRows) Columns() ([]string, error) {
 	return r.columns, nil
 }
 
-func (r *bufferedRows) ColumnTypes() ([]*sql.ColumnType, error) {
+func (r *bufferedRows) ColumnTypes() ([]*ColumnType, error) {
 	return r.columnTypes, nil
 }
 
@@ -258,27 +433,6 @@ func (r *errorRow) Scan(_ ...any) error {
 
 func (r *errorRow) Err() error {
 	return r.err
-}
-
-// copyValue creates a deep copy of a value, ensuring strings and byte slices
-// don't reference Arrow buffer memory that may be freed.
-func copyValue(v any) any {
-	switch val := v.(type) {
-	case string:
-		// Copy string to new backing array
-		b := make([]byte, len(val))
-		copy(b, val)
-		return string(b)
-	case []byte:
-		if val == nil {
-			return nil
-		}
-		cp := make([]byte, len(val))
-		copy(cp, val)
-		return cp
-	default:
-		return v
-	}
 }
 
 // convertAssign copies src to dest, handling pointer destinations.


### PR DESCRIPTION
The ADBC `database/sql` adapter can't scan complex Arrow types (LIST, STRUCT, MAP), failing with `not yet implemented populating from columns of type list<>`. This switches `EphemeralConnection` from the `database/sql` wrapper to the direct ADBC `Statement`/`RecordReader` API, reading Arrow record batches natively and using `ValueStr()` for complex types.

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make integration-test-light`)
- [x] Manual test: `bruin query` against a DuckDB table with LIST columns works

🤖 Generated with [Claude Code](https://claude.com/claude-code)