### PR TITLE
Add BigQuery job ID to console output

### DIFF
--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -310,12 +310,12 @@ func (d *Client) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*
 	bqQuery := d.client.Query(queryObj.String())
 	job, err := bqQuery.Run(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to run query: %w", err)
+		return nil, fmt.Errorf("failed to run query: %w", formatError(err))
 	}
 	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
 	rows, err := job.Read(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read query results: %w", err)
+		return nil, fmt.Errorf("failed to read query results: %w", formatError(err))
 	}
 
 	result := &query.QueryResult{

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -248,12 +248,17 @@ func (d *Client) IsValid(ctx context.Context, query *query.Query) (bool, error) 
 	return true, nil
 }
 
-func (d *Client) RunQueryWithoutResult(ctx context.Context, query *query.Query) error {
+func (d *Client) RunQueryWithoutResult(ctx context.Context, q *query.Query) error {
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return err
 	}
-	q := d.client.Query(query.String())
-	_, err := q.Read(ctx)
+	bqQuery := d.client.Query(q.String())
+	job, err := bqQuery.Run(ctx)
+	if err != nil {
+		return formatError(err)
+	}
+	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
+	_, err = job.Read(ctx)
 	if err != nil {
 		return formatError(err)
 	}
@@ -261,12 +266,17 @@ func (d *Client) RunQueryWithoutResult(ctx context.Context, query *query.Query) 
 	return nil
 }
 
-func (d *Client) Select(ctx context.Context, query *query.Query) ([][]interface{}, error) {
+func (d *Client) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return nil, err
 	}
-	q := d.client.Query(query.String())
-	rows, err := q.Read(ctx)
+	bqQuery := d.client.Query(q.String())
+	job, err := bqQuery.Run(ctx)
+	if err != nil {
+		return nil, formatError(err)
+	}
+	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
+	rows, err := job.Read(ctx)
 	if err != nil {
 		return nil, formatError(err)
 	}
@@ -297,10 +307,15 @@ func (d *Client) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return nil, err
 	}
-	q := d.client.Query(queryObj.String())
-	rows, err := q.Read(ctx)
+	bqQuery := d.client.Query(queryObj.String())
+	job, err := bqQuery.Run(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initiate query read: %w", err)
+		return nil, fmt.Errorf("failed to run query: %w", err)
+	}
+	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
+	rows, err := job.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read query results: %w", err)
 	}
 
 	result := &query.QueryResult{

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -319,20 +319,6 @@ func mockBqHandler(t *testing.T, projectID, jobID string, jsr jobSubmitResponse,
 				t.Fatal(err)
 			}
 			return
-		} else if r.Method == http.MethodPost && strings.HasPrefix(r.RequestURI, fmt.Sprintf("/projects/%s/queries", projectID)) {
-			// Handle jobs.query (used by q.Read, kept for backwards compatibility)
-			w.WriteHeader(jsr.statusCode)
-
-			response, err := json.Marshal(jsr.response)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			_, err = w.Write(response)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return
 		}
 
 		w.WriteHeader(http.StatusInternalServerError)
@@ -850,7 +836,7 @@ func TestDB_SelectWithSchema(t *testing.T) {
 				},
 				statusCode: http.StatusBadRequest,
 			},
-			err: errors.New(`failed to run query: googleapi: Error 400: Syntax error: Expected "(" or keyword SELECT or keyword WITH but got identifier "sselect" at [3:1], invalidQuery`),
+			err: errors.New(`failed to run query: Syntax error: Expected "(" or keyword SELECT or keyword WITH but got identifier "sselect" at [3:1], invalidQuery`),
 		},
 		{
 			name:  "Google API returns 404",
@@ -864,7 +850,7 @@ func TestDB_SelectWithSchema(t *testing.T) {
 				},
 				statusCode: http.StatusNotFound,
 			},
-			err: errors.New("failed to run query: googleapi: Error 404: not found: Table project:schema.table was not found in location ABC"),
+			err: errors.New("failed to run query: not found: Table project:schema.table was not found in location ABC"),
 		},
 		{
 			name:  "successful query with schema",

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -305,18 +305,33 @@ func mockBqHandler(t *testing.T, projectID, jobID string, jsr jobSubmitResponse,
 				t.Fatal(err)
 			}
 			return
-		} else if r.Method == http.MethodPost && strings.HasPrefix(r.RequestURI, fmt.Sprintf("/projects/%s/queries", projectID)) {
+		} else if r.Method == http.MethodPost && strings.HasPrefix(r.RequestURI, fmt.Sprintf("/projects/%s/jobs", projectID)) {
+			// Handle jobs.insert (used by q.Run)
 			w.WriteHeader(jsr.statusCode)
 
 			response, err := json.Marshal(jsr.response)
 			if err != nil {
 				t.Fatal(err)
-			} // Updated error handling
+			}
 
 			_, err = w.Write(response)
 			if err != nil {
 				t.Fatal(err)
-			} // Updated error handling
+			}
+			return
+		} else if r.Method == http.MethodPost && strings.HasPrefix(r.RequestURI, fmt.Sprintf("/projects/%s/queries", projectID)) {
+			// Handle jobs.query (used by q.Read, kept for backwards compatibility)
+			w.WriteHeader(jsr.statusCode)
+
+			response, err := json.Marshal(jsr.response)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = w.Write(response)
+			if err != nil {
+				t.Fatal(err)
+			}
 			return
 		}
 
@@ -324,7 +339,7 @@ func mockBqHandler(t *testing.T, projectID, jobID string, jsr jobSubmitResponse,
 		_, err := w.Write([]byte("there is no test definition found for the given request: " + r.Method + " " + r.RequestURI))
 		if err != nil {
 			t.Fatal(err)
-		} // Updated error handling
+		}
 	})
 }
 
@@ -835,7 +850,7 @@ func TestDB_SelectWithSchema(t *testing.T) {
 				},
 				statusCode: http.StatusBadRequest,
 			},
-			err: errors.New(`failed to initiate query read: googleapi: Error 400: Syntax error: Expected "(" or keyword SELECT or keyword WITH but got identifier "sselect" at [3:1], invalidQuery`),
+			err: errors.New(`failed to run query: googleapi: Error 400: Syntax error: Expected "(" or keyword SELECT or keyword WITH but got identifier "sselect" at [3:1], invalidQuery`),
 		},
 		{
 			name:  "Google API returns 404",
@@ -849,7 +864,7 @@ func TestDB_SelectWithSchema(t *testing.T) {
 				},
 				statusCode: http.StatusNotFound,
 			},
-			err: errors.New("failed to initiate query read: googleapi: Error 404: not found: Table project:schema.table was not found in location ABC"),
+			err: errors.New("failed to run query: googleapi: Error 404: not found: Table project:schema.table was not found in location ABC"),
 		},
 		{
 			name:  "successful query with schema",

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -307,13 +307,17 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 
 	sensorTimeout := helpers.GetSensorTimeout(t)
 	timeout := time.After(sensorTimeout)
+	var lastJobID string
+	sinkCtx := query.WithQueryIDSink(ctx, &lastJobID)
 	for {
 		select {
 		case <-timeout:
+			query.LogQueryID(ctx, "BigQuery", lastJobID)
 			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
-			res, err := conn.Select(ctx, qry[0])
+			res, err := conn.Select(sinkCtx, qry[0])
 			if err != nil {
+				query.LogQueryID(ctx, "BigQuery", lastJobID)
 				return err
 			}
 			intRes, err := helpers.CastResultToInteger(res, true)
@@ -322,9 +326,11 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 			}
 
 			if intRes > 0 {
+				query.LogQueryID(ctx, "BigQuery", lastJobID)
 				return nil
 			}
 			if o.sensorMode == "once" || o.sensorMode == "" {
+				query.LogQueryID(ctx, "BigQuery", lastJobID)
 				return errors.New("Sensor didn't return the expected result")
 			}
 
@@ -395,13 +401,17 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 
 	sensorTimeout := helpers.GetSensorTimeout(t)
 	timeout := time.After(sensorTimeout)
+	var lastJobID string
+	sinkCtx := query.WithQueryIDSink(ctx, &lastJobID)
 	for {
 		select {
 		case <-timeout:
+			query.LogQueryID(ctx, "BigQuery", lastJobID)
 			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
-			res, err := conn.Select(ctx, extractedQuery)
+			res, err := conn.Select(sinkCtx, extractedQuery)
 			if err != nil {
+				query.LogQueryID(ctx, "BigQuery", lastJobID)
 				return err
 			}
 			intRes, err := helpers.CastResultToInteger(res, true)
@@ -410,9 +420,11 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 			}
 
 			if intRes > 0 {
+				query.LogQueryID(ctx, "BigQuery", lastJobID)
 				return nil
 			}
 			if ts.sensorMode == "once" || ts.sensorMode == "" {
+				query.LogQueryID(ctx, "BigQuery", lastJobID)
 				return errors.New("Sensor didn't return the expected result")
 			}
 

--- a/pkg/query/logging.go
+++ b/pkg/query/logging.go
@@ -1,0 +1,48 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/bruin-data/bruin/pkg/executor"
+)
+
+type queryIDSinkKey struct{}
+
+// LogQueryID prints a database query ID to the console writer in the context.
+// It is a no-op if the context has no writer or the queryID is empty.
+func LogQueryID(ctx context.Context, dbType string, queryID string) {
+	if queryID == "" {
+		return
+	}
+
+	writer, ok := ctx.Value(executor.KeyPrinter).(io.Writer)
+	if !ok || writer == nil {
+		return
+	}
+
+	_, _ = fmt.Fprintf(writer, "%s query ID: %s\n", dbType, queryID)
+}
+
+// WithQueryIDSink returns a context that captures query IDs into the given
+// string pointer instead of logging them. This allows callers (e.g. sensors)
+// to control when and whether to log the ID.
+func WithQueryIDSink(ctx context.Context, sink *string) context.Context {
+	return context.WithValue(ctx, queryIDSinkKey{}, sink)
+}
+
+// LogOrSinkQueryID either writes the query ID to the sink in the context
+// (if one was set via WithQueryIDSink) or logs it to the console.
+func LogOrSinkQueryID(ctx context.Context, dbType string, queryID string) {
+	if queryID == "" {
+		return
+	}
+
+	if sink, ok := ctx.Value(queryIDSinkKey{}).(*string); ok && sink != nil {
+		*sink = queryID
+		return
+	}
+
+	LogQueryID(ctx, dbType, queryID)
+}

--- a/pkg/query/logging_test.go
+++ b/pkg/query/logging_test.go
@@ -1,0 +1,78 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/executor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogQueryID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("logs query ID when writer is in context", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := context.WithValue(context.Background(), executor.KeyPrinter, &buf)
+
+		LogQueryID(ctx, "BigQuery", "job-123")
+
+		assert.Equal(t, "BigQuery query ID: job-123\n", buf.String())
+	})
+
+	t.Run("no-op when query ID is empty", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := context.WithValue(context.Background(), executor.KeyPrinter, &buf)
+
+		LogQueryID(ctx, "BigQuery", "")
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("no-op when no writer in context", func(t *testing.T) {
+		t.Parallel()
+		LogQueryID(context.Background(), "BigQuery", "job-123")
+		// should not panic
+	})
+}
+
+func TestLogOrSinkQueryID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("logs when no sink in context", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := context.WithValue(context.Background(), executor.KeyPrinter, &buf)
+
+		LogOrSinkQueryID(ctx, "BigQuery", "job-456")
+
+		assert.Equal(t, "BigQuery query ID: job-456\n", buf.String())
+	})
+
+	t.Run("sinks when sink is in context", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := context.WithValue(context.Background(), executor.KeyPrinter, &buf)
+
+		var sink string
+		ctx = WithQueryIDSink(ctx, &sink)
+
+		LogOrSinkQueryID(ctx, "BigQuery", "job-789")
+
+		assert.Equal(t, "job-789", sink)
+		assert.Empty(t, buf.String(), "should not log when sink is set")
+	})
+
+	t.Run("no-op when query ID is empty", func(t *testing.T) {
+		t.Parallel()
+		var sink string
+		ctx := WithQueryIDSink(context.Background(), &sink)
+
+		LogOrSinkQueryID(ctx, "BigQuery", "")
+
+		assert.Empty(t, sink)
+	})
+}

--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/diff"
-	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/jmoiron/sqlx"
@@ -70,20 +69,13 @@ func (db *DB) initializeDB(ctx context.Context) error {
 // logSnowflakeQueryID tries to read a query ID from the channel and prints it.
 // It is non-blocking, so it is safe to call even if no ID was sent.
 func logSnowflakeQueryID(ctx context.Context, ch <-chan string) {
-	writer, ok := ctx.Value(executor.KeyPrinter).(io.Writer)
-	if !ok {
-		return
-	}
-
 	if ch == nil {
 		return
 	}
 
 	select {
 	case qid := <-ch:
-		if qid != "" {
-			_, _ = fmt.Fprintf(writer, "Snowflake query ID: %s\n", qid)
-		}
+		query.LogQueryID(ctx, "Snowflake", qid)
 	default:
 	}
 }


### PR DESCRIPTION
## Summary
- Surfaces BigQuery job IDs in CLI output for main tasks, column/custom checks, and sensors, making it easy to look up jobs in the BigQuery console for debugging
- Creates a shared `query.LogQueryID` utility with a context-based sink mechanism so sensors only print job IDs on success/failure (not every poll)
- Refactors Snowflake's query ID logging to use the same shared utility, unifying the pattern across databases
- Switches BigQuery's `RunQueryWithoutResult`, `Select`, and `SelectWithSchema` from `q.Read` to `q.Run` + `job.Read` to access the Job object

## Test plan
- [x] `make format` passes
- [x] `make test` passes (all BigQuery, Snowflake, and query package tests)
- [ ] Manual: run a BQ pipeline with main task + quality checks, verify job IDs appear
- [ ] Manual: run a sensor asset, verify only last success/failure job ID is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)