### PR TITLE
feat: add asset-level notification validation rules

### DIFF
--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -122,6 +122,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "valid-asset-discord-notification",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   EnsureDiscordFieldInAssetIsValid,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "materialization-config",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -108,6 +108,20 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			ApplicableLevels: []Level{LevelPipeline},
 		},
 		&SimpleRule{
+			Identifier:       "valid-asset-slack-notification",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   EnsureSlackFieldInAssetIsValid,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
+			Identifier:       "valid-asset-ms-teams-notification",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   EnsureMSTeamsFieldInAssetIsValid,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "materialization-config",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -51,6 +51,11 @@ const (
 	pipelineMSTeamsConnectionFieldNotUnique = "The `connection` attribute under the MS Teams notifications must be unique"
 	pipelineMSTeamsConnectionFieldEmpty     = "MS Teams notifications `connection` attribute must not be empty"
 
+	assetSlackFieldEmptyChannel        = "Asset-level Slack notifications must have a `channel` attribute"
+	assetSlackChannelFieldNotUnique    = "The `channel` attribute under the asset-level Slack notifications must be unique"
+	assetMSTeamsConnectionFieldEmpty   = "Asset-level MS Teams notifications `connection` attribute must not be empty"
+	assetMSTeamsConnectionFieldNotUnique = "The `connection` attribute under the asset-level MS Teams notifications must be unique"
+
 	pipelineConcurrencyMustBePositive    = "Pipeline concurrency must be 1 or greater"
 	pipelineMaxActiveStepsMustBePositive = "Pipeline max_active_steps must be a positive number"
 	assetTierMustBeBetweenOneAndFive     = "Asset tier must be between 1 and 5"
@@ -960,6 +965,55 @@ func EnsureMSTeamsFieldInPipelineIsValid(ctx context.Context, p *pipeline.Pipeli
 		if isStringInArray(MSTeamsConnections, notification.Connection) {
 			issues = append(issues, &Issue{
 				Description: pipelineMSTeamsConnectionFieldNotUnique,
+			})
+		}
+
+		MSTeamsConnections = append(MSTeamsConnections, notification.Connection)
+	}
+
+	return issues, nil
+}
+
+func EnsureSlackFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	issues := make([]*Issue, 0)
+
+	slackChannels := make([]string, 0, len(asset.Notifications.Slack))
+	for _, slack := range asset.Notifications.Slack {
+		channelWithoutHash := strings.TrimPrefix(slack.Channel, "#")
+		if channelWithoutHash == "" {
+			issues = append(issues, &Issue{
+				Description: assetSlackFieldEmptyChannel,
+			})
+			continue
+		}
+
+		if isStringInArray(slackChannels, channelWithoutHash) {
+			issues = append(issues, &Issue{
+				Description: assetSlackChannelFieldNotUnique,
+			})
+		}
+
+		slackChannels = append(slackChannels, channelWithoutHash)
+	}
+
+	return issues, nil
+}
+
+func EnsureMSTeamsFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	issues := make([]*Issue, 0)
+
+	MSTeamsConnections := make([]string, 0, len(asset.Notifications.MSTeams))
+	for _, notification := range asset.Notifications.MSTeams {
+		if notification.Connection == "" {
+			issues = append(issues, &Issue{
+				Description: assetMSTeamsConnectionFieldEmpty,
+			})
+			continue
+		}
+
+		if isStringInArray(MSTeamsConnections, notification.Connection) {
+			issues = append(issues, &Issue{
+				Description: assetMSTeamsConnectionFieldNotUnique,
 			})
 		}
 

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -51,9 +51,9 @@ const (
 	pipelineMSTeamsConnectionFieldNotUnique = "The `connection` attribute under the MS Teams notifications must be unique"
 	pipelineMSTeamsConnectionFieldEmpty     = "MS Teams notifications `connection` attribute must not be empty"
 
-	assetSlackFieldEmptyChannel        = "Asset-level Slack notifications must have a `channel` attribute"
-	assetSlackChannelFieldNotUnique    = "The `channel` attribute under the asset-level Slack notifications must be unique"
-	assetMSTeamsConnectionFieldEmpty   = "Asset-level MS Teams notifications `connection` attribute must not be empty"
+	assetSlackFieldEmptyChannel          = "Asset-level Slack notifications must have a `channel` attribute"
+	assetSlackChannelFieldNotUnique      = "The `channel` attribute under the asset-level Slack notifications must be unique"
+	assetMSTeamsConnectionFieldEmpty     = "Asset-level MS Teams notifications `connection` attribute must not be empty"
 	assetMSTeamsConnectionFieldNotUnique = "The `connection` attribute under the asset-level MS Teams notifications must be unique"
 
 	pipelineConcurrencyMustBePositive    = "Pipeline concurrency must be 1 or greater"
@@ -977,6 +977,10 @@ func EnsureMSTeamsFieldInPipelineIsValid(ctx context.Context, p *pipeline.Pipeli
 func EnsureSlackFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
+	if asset.Notifications == nil {
+		return issues, nil
+	}
+
 	slackChannels := make([]string, 0, len(asset.Notifications.Slack))
 	for _, slack := range asset.Notifications.Slack {
 		channelWithoutHash := strings.TrimPrefix(slack.Channel, "#")
@@ -1001,6 +1005,10 @@ func EnsureSlackFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline, a
 
 func EnsureMSTeamsFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
+
+	if asset.Notifications == nil {
+		return issues, nil
+	}
 
 	MSTeamsConnections := make([]string, 0, len(asset.Notifications.MSTeams))
 	for _, notification := range asset.Notifications.MSTeams {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -55,6 +55,8 @@ const (
 	assetSlackChannelFieldNotUnique      = "The `channel` attribute under the asset-level Slack notifications must be unique"
 	assetMSTeamsConnectionFieldEmpty     = "Asset-level MS Teams notifications `connection` attribute must not be empty"
 	assetMSTeamsConnectionFieldNotUnique = "The `connection` attribute under the asset-level MS Teams notifications must be unique"
+	assetDiscordConnectionFieldEmpty     = "Asset-level Discord notifications `connection` attribute must not be empty"
+	assetDiscordConnectionFieldNotUnique = "The `connection` attribute under the asset-level Discord notifications must be unique"
 
 	pipelineConcurrencyMustBePositive    = "Pipeline concurrency must be 1 or greater"
 	pipelineMaxActiveStepsMustBePositive = "Pipeline max_active_steps must be a positive number"
@@ -1026,6 +1028,34 @@ func EnsureMSTeamsFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline,
 		}
 
 		MSTeamsConnections = append(MSTeamsConnections, notification.Connection)
+	}
+
+	return issues, nil
+}
+
+func EnsureDiscordFieldInAssetIsValid(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	issues := make([]*Issue, 0)
+
+	if asset.Notifications == nil {
+		return issues, nil
+	}
+
+	discordConnections := make([]string, 0, len(asset.Notifications.Discord))
+	for _, notification := range asset.Notifications.Discord {
+		if notification.Connection == "" {
+			issues = append(issues, &Issue{
+				Description: assetDiscordConnectionFieldEmpty,
+			})
+			continue
+		}
+
+		if isStringInArray(discordConnections, notification.Connection) {
+			issues = append(issues, &Issue{
+				Description: assetDiscordConnectionFieldNotUnique,
+			})
+		}
+
+		discordConnections = append(discordConnections, notification.Connection)
 	}
 
 	return issues, nil

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -4439,3 +4439,134 @@ columns:
 		})
 	}
 }
+
+func TestEnsureSlackFieldInAssetIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		asset *pipeline.Asset
+		want  []*Issue
+	}{
+		{
+			name:  "no slack notifications, no issues",
+			asset: &pipeline.Asset{},
+			want:  noIssues,
+		},
+		{
+			name: "valid channel",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					Slack: []pipeline.SlackNotification{{Channel: "#alerts"}},
+				},
+			},
+			want: noIssues,
+		},
+		{
+			name: "valid channel without hash prefix",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					Slack: []pipeline.SlackNotification{{Channel: "alerts"}},
+				},
+			},
+			want: noIssues,
+		},
+		{
+			name: "empty channel",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					Slack: []pipeline.SlackNotification{{Channel: ""}},
+				},
+			},
+			want: []*Issue{{Description: assetSlackFieldEmptyChannel}},
+		},
+		{
+			name: "duplicate channel",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					Slack: []pipeline.SlackNotification{
+						{Channel: "#alerts"},
+						{Channel: "#alerts"},
+					},
+				},
+			},
+			want: []*Issue{{Description: assetSlackChannelFieldNotUnique}},
+		},
+		{
+			name: "duplicate channel with and without hash",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					Slack: []pipeline.SlackNotification{
+						{Channel: "#alerts"},
+						{Channel: "alerts"},
+					},
+				},
+			},
+			want: []*Issue{{Description: assetSlackChannelFieldNotUnique}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues, err := EnsureSlackFieldInAssetIsValid(context.Background(), &pipeline.Pipeline{}, tt.asset)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, issues)
+		})
+	}
+}
+
+func TestEnsureMSTeamsFieldInAssetIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		asset *pipeline.Asset
+		want  []*Issue
+	}{
+		{
+			name:  "no ms teams notifications, no issues",
+			asset: &pipeline.Asset{},
+			want:  noIssues,
+		},
+		{
+			name: "valid connection",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					MSTeams: []pipeline.MSTeamsNotification{{Connection: "teams-webhook"}},
+				},
+			},
+			want: noIssues,
+		},
+		{
+			name: "empty connection",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					MSTeams: []pipeline.MSTeamsNotification{{Connection: ""}},
+				},
+			},
+			want: []*Issue{{Description: assetMSTeamsConnectionFieldEmpty}},
+		},
+		{
+			name: "duplicate connection",
+			asset: &pipeline.Asset{
+				Notifications: pipeline.Notifications{
+					MSTeams: []pipeline.MSTeamsNotification{
+						{Connection: "teams-webhook"},
+						{Connection: "teams-webhook"},
+					},
+				},
+			},
+			want: []*Issue{{Description: assetMSTeamsConnectionFieldNotUnique}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues, err := EnsureMSTeamsFieldInAssetIsValid(context.Background(), &pipeline.Pipeline{}, tt.asset)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, issues)
+		})
+	}
+}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -4570,3 +4570,58 @@ func TestEnsureMSTeamsFieldInAssetIsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureDiscordFieldInAssetIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		asset *pipeline.Asset
+		want  []*Issue
+	}{
+		{
+			name:  "no discord notifications, no issues",
+			asset: &pipeline.Asset{},
+			want:  noIssues,
+		},
+		{
+			name: "valid connection",
+			asset: &pipeline.Asset{
+				Notifications: &pipeline.Notifications{
+					Discord: []pipeline.DiscordNotification{{Connection: "discord-conn"}},
+				},
+			},
+			want: noIssues,
+		},
+		{
+			name: "empty connection",
+			asset: &pipeline.Asset{
+				Notifications: &pipeline.Notifications{
+					Discord: []pipeline.DiscordNotification{{Connection: ""}},
+				},
+			},
+			want: []*Issue{{Description: assetDiscordConnectionFieldEmpty}},
+		},
+		{
+			name: "duplicate connection",
+			asset: &pipeline.Asset{
+				Notifications: &pipeline.Notifications{
+					Discord: []pipeline.DiscordNotification{
+						{Connection: "discord-conn"},
+						{Connection: "discord-conn"},
+					},
+				},
+			},
+			want: []*Issue{{Description: assetDiscordConnectionFieldNotUnique}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues, err := EnsureDiscordFieldInAssetIsValid(context.Background(), &pipeline.Pipeline{}, tt.asset)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, issues)
+		})
+	}
+}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -4456,7 +4456,7 @@ func TestEnsureSlackFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "valid channel",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					Slack: []pipeline.SlackNotification{{Channel: "#alerts"}},
 				},
 			},
@@ -4465,7 +4465,7 @@ func TestEnsureSlackFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "valid channel without hash prefix",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					Slack: []pipeline.SlackNotification{{Channel: "alerts"}},
 				},
 			},
@@ -4474,7 +4474,7 @@ func TestEnsureSlackFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "empty channel",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					Slack: []pipeline.SlackNotification{{Channel: ""}},
 				},
 			},
@@ -4483,7 +4483,7 @@ func TestEnsureSlackFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "duplicate channel",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					Slack: []pipeline.SlackNotification{
 						{Channel: "#alerts"},
 						{Channel: "#alerts"},
@@ -4495,7 +4495,7 @@ func TestEnsureSlackFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "duplicate channel with and without hash",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					Slack: []pipeline.SlackNotification{
 						{Channel: "#alerts"},
 						{Channel: "alerts"},
@@ -4532,7 +4532,7 @@ func TestEnsureMSTeamsFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "valid connection",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					MSTeams: []pipeline.MSTeamsNotification{{Connection: "teams-webhook"}},
 				},
 			},
@@ -4541,7 +4541,7 @@ func TestEnsureMSTeamsFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "empty connection",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					MSTeams: []pipeline.MSTeamsNotification{{Connection: ""}},
 				},
 			},
@@ -4550,7 +4550,7 @@ func TestEnsureMSTeamsFieldInAssetIsValid(t *testing.T) {
 		{
 			name: "duplicate connection",
 			asset: &pipeline.Asset{
-				Notifications: pipeline.Notifications{
+				Notifications: &pipeline.Notifications{
 					MSTeams: []pipeline.MSTeamsNotification{
 						{Connection: "teams-webhook"},
 						{Connection: "teams-webhook"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -823,6 +823,7 @@ type Asset struct { //nolint:recvcheck
 	RerunCooldown     *int               `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 	RetriesDelay      *int               `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
 	RefreshRestricted *bool              `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
+	Notifications     Notifications      `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
 
 	upstream   []*Asset
 	downstream []*Asset

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -823,7 +823,7 @@ type Asset struct { //nolint:recvcheck
 	RerunCooldown     *int               `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 	RetriesDelay      *int               `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
 	RefreshRestricted *bool              `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
-	Notifications     Notifications      `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+	Notifications     *Notifications     `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
 
 	upstream   []*Asset
 	downstream []*Asset

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -316,6 +316,13 @@ type athena struct {
 	QueryResultsPath string `yaml:"query_results_path"`
 }
 
+func notificationsOrNil(n Notifications) *Notifications {
+	if len(n.Slack) == 0 && len(n.MSTeams) == 0 && len(n.Discord) == 0 && len(n.Webhook) == 0 {
+		return nil
+	}
+	return &n
+}
+
 type taskDefinition struct {
 	Name              string            `yaml:"name"`
 	URI               string            `yaml:"uri"`
@@ -524,7 +531,7 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 		Meta:              definition.Meta,
 		RerunCooldown:     definition.RerunCooldown,
 		RefreshRestricted: definition.RefreshRestricted,
-		Notifications:     definition.Notifications,
+		Notifications:     notificationsOrNil(definition.Notifications),
 	}
 
 	for index, check := range definition.CustomChecks {

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -344,6 +344,7 @@ type taskDefinition struct {
 	Meta              map[string]string `yaml:"meta"`
 	RerunCooldown     *int              `yaml:"rerun_cooldown"`
 	RefreshRestricted *bool             `yaml:"refresh_restricted,omitempty"`
+	Notifications     Notifications     `yaml:"notifications"`
 }
 
 func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
@@ -523,6 +524,7 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 		Meta:              definition.Meta,
 		RerunCooldown:     definition.RerunCooldown,
 		RefreshRestricted: definition.RefreshRestricted,
+		Notifications:     definition.Notifications,
 	}
 
 	for index, check := range definition.CustomChecks {


### PR DESCRIPTION
Introduce validation rules for asset-level Slack and MS Teams notifications. This includes checks for empty channel attributes and uniqueness of connection fields. Update the Asset struct to include a Notifications field for notification management.