### PR TITLE
feat(query): add --split-rows flag for splitting large CSV exports

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -93,6 +93,10 @@ func Query() *cli.Command {
 				Name:  "export",
 				Usage: "export results to a CSV file ",
 			},
+			&cli.IntFlag{
+				Name:  "split-rows",
+				Usage: "split export into multiple CSV files with at most this many rows per file (requires --export)",
+			},
 			&cli.StringFlag{
 				Name:    "config-file",
 				Sources: cli.EnvVars("BRUIN_CONFIG_FILE"),
@@ -164,6 +168,11 @@ func Query() *cli.Command {
 
 			if c.IsSet("limit") && parser != nil {
 				queryStr = addLimitToQuery(queryStr, c.Int64("limit"), conn, parser, dialect)
+			}
+
+			// Validate split-rows is only used with export
+			if c.IsSet("split-rows") && !c.Bool("export") {
+				return handleError(c.String("output"), errors.New("--split-rows requires --export flag"))
 			}
 
 			if c.Bool("dry-run") {
@@ -239,11 +248,18 @@ func Query() *cli.Command {
 				}
 
 				// Output result based on format specified
-				var resultsPath string
 				if c.Bool("export") {
-					resultsPath, err = exportResultsToCSV(result, inputPath)
-					if err != nil {
-						return handleError(c.String("output"), errors.Wrap(err, "failed to export results to CSV"))
+					splitRows := c.Int("split-rows")
+					if splitRows > 0 {
+						resultsPaths, exportErr := exportResultsToMultipleCSV(result, inputPath, splitRows)
+						if exportErr != nil {
+							return handleError(c.String("output"), errors.Wrap(exportErr, "failed to export results to CSV"))
+						}
+						return handleMultipleFilesSuccess(c.String("output"), resultsPaths)
+					}
+					resultsPath, exportErr := exportResultsToCSV(result, inputPath)
+					if exportErr != nil {
+						return handleError(c.String("output"), errors.Wrap(exportErr, "failed to export results to CSV"))
 					}
 					successMessage := "Results Successfully exported to " + resultsPath
 					return handleSuccess(c.String("output"), successMessage)
@@ -725,6 +741,90 @@ func exportResultsToCSV(results *query.QueryResult, inputPath string) (string, e
 	return resultsPath, nil
 }
 
+func exportResultsToMultipleCSV(results *query.QueryResult, inputPath string, splitRows int) ([]string, error) {
+	if inputPath == "" {
+		inputPath = "."
+	}
+	repoRoot, err := git.FindRepoFromPath(inputPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = git.EnsureGivenPatternIsInGitignore(afero.NewOsFs(), repoRoot.Path, "logs/exports")
+	if err != nil {
+		return nil, err
+	}
+
+	exportsDir := filepath.Join(repoRoot.Path, "logs/exports")
+	err = os.MkdirAll(exportsDir, 0o755)
+	if err != nil {
+		return nil, err
+	}
+
+	totalRows := len(results.Rows)
+	if totalRows == 0 {
+		resultName := fmt.Sprintf("query_result_%d_part1.csv", time.Now().UnixMilli())
+		resultsPath := filepath.Join(exportsDir, resultName)
+		if err = writeCSVFile(resultsPath, results.Columns, nil); err != nil {
+			return nil, err
+		}
+		return []string{resultsPath}, nil
+	}
+
+	numFiles := (totalRows + splitRows - 1) / splitRows
+	timestamp := time.Now().UnixMilli()
+	resultsPaths := make([]string, 0, numFiles)
+
+	for i := range numFiles {
+		startIdx := i * splitRows
+		endIdx := startIdx + splitRows
+		if endIdx > totalRows {
+			endIdx = totalRows
+		}
+
+		resultName := fmt.Sprintf("query_result_%d_part%d.csv", timestamp, i+1)
+		resultsPath := filepath.Join(exportsDir, resultName)
+
+		if err = writeCSVFile(resultsPath, results.Columns, results.Rows[startIdx:endIdx]); err != nil {
+			return nil, err
+		}
+		resultsPaths = append(resultsPaths, resultsPath)
+	}
+
+	return resultsPaths, nil
+}
+
+func writeCSVFile(path string, columns []string, rows [][]interface{}) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	if err = writer.Write(columns); err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		rowStrings := make([]string, len(row))
+		for i, val := range row {
+			if val == nil {
+				rowStrings[i] = ""
+			} else {
+				rowStrings[i] = fmt.Sprintf("%v", formatQueryCellForDisplay(val))
+			}
+		}
+		if err = writer.Write(rowStrings); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func applySchemaPrefix(_ context.Context, queryStr, dialect string, parser *sqlparser.SQLParser, pipelineInfo *ppInfo, conn interface{}) (string, error) {
 	if dialect == "" {
 		// If no dialect, we can't rewrite the query
@@ -793,6 +893,27 @@ func handleSuccess(output string, message string) error {
 		fmt.Println(string(jsonSuccessMessage))
 	} else {
 		successPrinter.Printf("%s\n", message)
+	}
+	return nil
+}
+
+func handleMultipleFilesSuccess(output string, paths []string) error {
+	if output == "json" {
+		jsonSuccessMessage, err := json.Marshal(map[string]interface{}{
+			"message": "Results successfully exported",
+			"files":   paths,
+			"count":   len(paths),
+		})
+		if err != nil {
+			fmt.Println("Error:", err.Error())
+			return cli.Exit("", 1)
+		}
+		fmt.Println(string(jsonSuccessMessage))
+	} else {
+		successPrinter.Printf("Results successfully exported to %d files:\n", len(paths))
+		for _, p := range paths {
+			successPrinter.Printf("  - %s\n", p)
+		}
 	}
 	return nil
 }

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -460,6 +464,165 @@ func TestFormatQueryRowsForJSON_Marshal(t *testing.T) {
 			payload, err := json.Marshal(rows)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, string(payload))
+		})
+	}
+}
+
+func TestWriteCSVFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		columns  []string
+		rows     [][]interface{}
+		expected [][]string
+	}{
+		{
+			name:    "basic data",
+			columns: []string{"id", "name"},
+			rows: [][]interface{}{
+				{1, "alice"},
+				{2, "bob"},
+			},
+			expected: [][]string{
+				{"id", "name"},
+				{"1", "alice"},
+				{"2", "bob"},
+			},
+		},
+		{
+			name:    "with nil values",
+			columns: []string{"id", "value"},
+			rows: [][]interface{}{
+				{1, nil},
+				{2, "test"},
+			},
+			expected: [][]string{
+				{"id", "value"},
+				{"1", ""},
+				{"2", "test"},
+			},
+		},
+		{
+			name:     "empty rows",
+			columns:  []string{"col1", "col2"},
+			rows:     nil,
+			expected: [][]string{{"col1", "col2"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.csv")
+
+			err := writeCSVFile(tmpFile, tt.columns, tt.rows)
+			require.NoError(t, err)
+
+			file, err := os.Open(tmpFile)
+			require.NoError(t, err)
+			defer file.Close()
+
+			reader := csv.NewReader(file)
+			records, err := reader.ReadAll()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, records)
+		})
+	}
+}
+
+func TestExportResultsToMultipleCSV(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		numRows       int
+		splitRows     int
+		expectedFiles int
+		rowsPerFile   []int
+	}{
+		{
+			name:          "exact split",
+			numRows:       10,
+			splitRows:     5,
+			expectedFiles: 2,
+			rowsPerFile:   []int{5, 5},
+		},
+		{
+			name:          "with remainder",
+			numRows:       10,
+			splitRows:     4,
+			expectedFiles: 3,
+			rowsPerFile:   []int{4, 4, 2},
+		},
+		{
+			name:          "single file when rows less than split",
+			numRows:       3,
+			splitRows:     10,
+			expectedFiles: 1,
+			rowsPerFile:   []int{3},
+		},
+		{
+			name:          "empty result creates single file",
+			numRows:       0,
+			splitRows:     10,
+			expectedFiles: 1,
+			rowsPerFile:   []int{0},
+		},
+		{
+			name:          "one million rows example from issue",
+			numRows:       1000000,
+			splitRows:     400000,
+			expectedFiles: 3,
+			rowsPerFile:   []int{400000, 400000, 200000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+
+			err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755)
+			require.NoError(t, err)
+
+			columns := []string{"id", "name", "value"}
+			rows := make([][]interface{}, tt.numRows)
+			for i := range tt.numRows {
+				rows[i] = []interface{}{i, fmt.Sprintf("name_%d", i), i * 100}
+			}
+
+			result := &query.QueryResult{
+				Columns: columns,
+				Rows:    rows,
+			}
+
+			paths, err := exportResultsToMultipleCSV(result, tmpDir, tt.splitRows)
+			require.NoError(t, err)
+			assert.Len(t, paths, tt.expectedFiles)
+
+			for i, path := range paths {
+				assert.FileExists(t, path)
+
+				file, err := os.Open(path)
+				require.NoError(t, err)
+				defer file.Close()
+
+				reader := csv.NewReader(file)
+				records, err := reader.ReadAll()
+				require.NoError(t, err)
+
+				expectedRowsWithHeader := tt.rowsPerFile[i] + 1
+				assert.Len(t, records, expectedRowsWithHeader, "file %d should have %d rows (including header)", i+1, expectedRowsWithHeader)
+
+				assert.Equal(t, columns, records[0], "header should match columns")
+
+				assert.Contains(t, filepath.Base(path), fmt.Sprintf("_part%d.csv", i+1))
+			}
 		})
 	}
 }

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -23,6 +23,7 @@ You can run it in three modes:
 | `--timeout`          | `-t`  | Timeout for query execution in seconds (default: 1000).                    |
 | `--output [format]`  | `-o`  | Output type: `plain`, `json`, `csv`.                                       |
 | `--export`           |       | Export results to a CSV file.                                              |
+| `--split-rows`       |       | Split export into multiple CSV files with at most this many rows per file (requires `--export`). |
 | `--config-file`      |       | The path to the `.bruin.yml` file.                                         |
 
 ## Example
@@ -42,3 +43,25 @@ bruin query --connection my_connection --query "SELECT * FROM table"
 | Value7      | Value8      | Value9         |
 +-------------+-------------+----------------+
 ```
+
+## Splitting Large Exports
+
+When exporting large query results, you can use `--split-rows` to split the output into multiple CSV files. This is useful when:
+
+- Your query returns millions of rows that are too large for a single file
+- You need to process the data in chunks
+- You're working with tools that have file size limitations
+
+**Example:**
+
+```bash
+# Export a large table, splitting into files of 400,000 rows each
+bruin query --connection my_connection --query "SELECT * FROM large_table" --export --split-rows 400000
+```
+
+If your query returns 1,000,000 rows with `--split-rows 400000`, you'll get 3 files:
+- `query_result_<timestamp>_part1.csv` (400,000 rows)
+- `query_result_<timestamp>_part2.csv` (400,000 rows)
+- `query_result_<timestamp>_part3.csv` (200,000 rows)
+
+Each file includes the header row with column names.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds a new `--split-rows` flag to the `bruin query` command that allows users to split large CSV exports into multiple files with at most the specified number of rows per file.

## Problem

When exporting large query results (e.g., millions of rows), the resulting CSV file can become too large to handle effectively. Users may need to:
- Process data in smaller chunks
- Work with tools that have file size limitations  
- Distribute data across multiple files for parallel processing

## Solution

Added a `--split-rows` flag that works with the existing `--export` flag to automatically split output into multiple files:

```bash
# Export a large table, splitting into files of 400,000 rows each
bruin query --connection my_conn --query "SELECT * FROM large_table" \
  --export --split-rows 400000
```

For a query returning 1,000,000 rows with `--split-rows 400000`, this creates 3 files:
- `query_result_<timestamp>_part1.csv` (400,000 rows)
- `query_result_<timestamp>_part2.csv` (400,000 rows)
- `query_result_<timestamp>_part3.csv` (200,000 rows)

Each file includes the header row with column names.

## Changes

- **cmd/fetch.go**: 
  - Added `--split-rows` flag definition
  - Added `exportResultsToMultipleCSV()` function for splitting exports
  - Added `writeCSVFile()` helper function
  - Added `handleMultipleFilesSuccess()` for proper output formatting
  - Added validation that `--split-rows` requires `--export`

- **cmd/fetch_test.go**:
  - Added `TestWriteCSVFile` for the new helper function
  - Added `TestExportResultsToMultipleCSV` with various test cases including the 1M rows example

- **docs/commands/query.md**:
  - Added documentation for the new `--split-rows` flag
  - Added "Splitting Large Exports" section with examples

## Testing

All existing and new unit tests pass:
```
go test -tags="no_duckdb_arrow" -race -p 50 -vet=off -timeout 10m ./cmd/...
ok  	github.com/bruin-data/bruin/cmd	23.526s
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1776095918973489?thread_ts=1776095918.973489&cid=C094932THFW)

<div><a href="https://cursor.com/agents/bc-2c3fbda8-0a51-5aba-a84a-04c13b7ba422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c3fbda8-0a51-5aba-a84a-04c13b7ba422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

