### PR TITLE
feat: add interactive ecommerce pipeline template

### DIFF
--- a/cmd/ecommerce_assets.go
+++ b/cmd/ecommerce_assets.go
@@ -1,0 +1,1147 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// --- Pipeline config generation ---
+
+func generatePipelineYML(c *EcommerceChoices) string {
+	var connKey, connName string
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		connKey = warehouseClickHouse
+		connName = "clickhouse-default"
+	case warehouseBigQuery:
+		connKey = "google_cloud_platform"
+		connName = "bigquery-default"
+	case warehouseSnowflake:
+		connKey = warehouseSnowflake
+		connName = "snowflake-default"
+	}
+
+	return fmt.Sprintf(`name: ecommerce
+schedule: daily
+start_date: "2024-01-01"
+
+default_connections:
+  %s: %s
+`, connKey, connName)
+}
+
+// --- Raw Ingestr Assets ---
+
+const shopifyOrdersAsset = `name: raw.shopify_orders
+type: ingestr
+parameters:
+  source_connection: shopify
+  source_table: orders
+  loader_file_format: jsonl
+  incremental_strategy: merge
+  incremental_key: updated_at
+  primary_key: id
+`
+
+const shopifyCustomersAsset = `name: raw.shopify_customers
+type: ingestr
+parameters:
+  source_connection: shopify
+  source_table: customers
+  loader_file_format: jsonl
+  incremental_strategy: merge
+  incremental_key: updated_at
+  primary_key: id
+`
+
+const shopifyProductsAsset = `name: raw.shopify_products
+type: ingestr
+parameters:
+  source_connection: shopify
+  source_table: products
+  loader_file_format: jsonl
+  incremental_strategy: merge
+  incremental_key: updated_at
+  primary_key: id
+`
+
+const shopifyInventoryAsset = `name: raw.shopify_inventory
+type: ingestr
+parameters:
+  source_connection: shopify
+  source_table: inventory_levels
+  loader_file_format: jsonl
+  incremental_strategy: replace
+`
+
+// Stripe assets
+
+const stripeChargesAsset = `name: raw.stripe_charges
+type: ingestr
+parameters:
+  source_connection: stripe
+  source_table: charges
+  incremental_strategy: merge
+  incremental_key: created
+  primary_key: id
+`
+
+const stripeRefundsAsset = `name: raw.stripe_refunds
+type: ingestr
+parameters:
+  source_connection: stripe
+  source_table: refunds
+  incremental_strategy: merge
+  incremental_key: created
+  primary_key: id
+`
+
+const stripeCustomersAsset = `name: raw.stripe_customers
+type: ingestr
+parameters:
+  source_connection: stripe
+  source_table: customers
+  incremental_strategy: merge
+  incremental_key: created
+  primary_key: id
+`
+
+const stripePayoutsAsset = `name: raw.stripe_payouts
+type: ingestr
+parameters:
+  source_connection: stripe
+  source_table: payouts
+  incremental_strategy: merge
+  incremental_key: created
+  primary_key: id
+`
+
+// Klaviyo assets
+
+const klaviyoCampaignsAsset = `name: raw.klaviyo_campaigns
+type: ingestr
+parameters:
+  source_connection: klaviyo
+  source_table: campaigns
+  incremental_strategy: replace
+`
+
+const klaviyoFlowsAsset = `name: raw.klaviyo_flows
+type: ingestr
+parameters:
+  source_connection: klaviyo
+  source_table: flows
+  incremental_strategy: replace
+`
+
+const klaviyoMetricsAsset = `name: raw.klaviyo_metrics
+type: ingestr
+parameters:
+  source_connection: klaviyo
+  source_table: metrics
+  incremental_strategy: replace
+`
+
+// HubSpot assets
+
+const hubspotContactsAsset = `name: raw.hubspot_contacts
+type: ingestr
+parameters:
+  source_connection: hubspot
+  source_table: contacts
+  incremental_strategy: merge
+  incremental_key: updatedAt
+  primary_key: id
+`
+
+const hubspotDealsAsset = `name: raw.hubspot_deals
+type: ingestr
+parameters:
+  source_connection: hubspot
+  source_table: deals
+  incremental_strategy: merge
+  incremental_key: updatedAt
+  primary_key: id
+`
+
+const hubspotCampaignsAsset = `name: raw.hubspot_campaigns
+type: ingestr
+parameters:
+  source_connection: hubspot
+  source_table: campaigns
+  incremental_strategy: replace
+`
+
+// Facebook Ads assets
+
+const facebookCampaignsAsset = `name: raw.facebook_campaigns
+type: ingestr
+parameters:
+  source_connection: facebook_ads
+  source_table: campaigns
+  incremental_strategy: replace
+`
+
+const facebookAdInsightsAsset = `name: raw.facebook_ad_insights
+type: ingestr
+parameters:
+  source_connection: facebook_ads
+  source_table: insights
+  incremental_strategy: merge
+  incremental_key: date_start
+  primary_key: "date_start,campaign_id"
+`
+
+// Google Ads assets
+
+const googleCampaignsAsset = `name: raw.google_campaigns
+type: ingestr
+parameters:
+  source_connection: google_ads
+  source_table: campaigns
+  incremental_strategy: replace
+`
+
+const googleAdInsightsAsset = `name: raw.google_ad_insights
+type: ingestr
+parameters:
+  source_connection: google_ads
+  source_table: campaign_performance
+  incremental_strategy: merge
+  incremental_key: date
+  primary_key: "date,campaign_id"
+`
+
+// TikTok Ads assets
+
+const tiktokCampaignsAsset = `name: raw.tiktok_campaigns
+type: ingestr
+parameters:
+  source_connection: tiktok_ads
+  source_table: campaigns
+  incremental_strategy: replace
+`
+
+const tiktokAdInsightsAsset = `name: raw.tiktok_ad_insights
+type: ingestr
+parameters:
+  source_connection: tiktok_ads
+  source_table: ads
+  incremental_strategy: merge
+  incremental_key: stat_datetime
+  primary_key: "stat_datetime,campaign_id"
+`
+
+// GA4 assets
+
+const ga4EventsAsset = `name: raw.ga4_events
+type: ingestr
+parameters:
+  source_connection: google_analytics
+  source_table: events
+  incremental_strategy: merge
+  incremental_key: date
+  primary_key: "date,event_name"
+`
+
+const ga4SessionsAsset = `name: raw.ga4_sessions
+type: ingestr
+parameters:
+  source_connection: google_analytics
+  source_table: sessions
+  incremental_strategy: merge
+  incremental_key: date
+  primary_key: date
+`
+
+// Mixpanel assets
+
+const mixpanelEventsAsset = `name: raw.mixpanel_events
+type: ingestr
+parameters:
+  source_connection: mixpanel
+  source_table: events
+  incremental_strategy: merge
+  incremental_key: time
+  primary_key: "distinct_id,time"
+`
+
+const mixpanelFunnelsAsset = `name: raw.mixpanel_funnels
+type: ingestr
+parameters:
+  source_connection: mixpanel
+  source_table: funnels
+  incremental_strategy: replace
+`
+
+// --- Staging SQL Generation ---
+
+func generateStgOrders(c *EcommerceChoices) string {
+	header := `/* @bruin
+name: staging.stg_orders
+type: sql
+materialization:
+  type: table
+depends:
+  - raw.shopify_orders`
+
+	if c.Payments == paymentsStripe {
+		header += "\n  - raw.stripe_charges"
+	}
+
+	header += `
+columns:
+  - name: order_id
+    type: varchar
+    checks:
+      - name: not_null
+      - name: unique
+  - name: order_date
+    type: timestamp
+    checks:
+      - name: not_null
+custom_checks:
+  - name: has_rows
+    query: "SELECT count(*) > 0 FROM staging.stg_orders"
+    value: 1
+@bruin */
+
+`
+
+	var castFn, dateFn, joinClause, extraCols, extraWhere string
+
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		castFn = "CAST"
+		dateFn = "toDate"
+	case warehouseBigQuery:
+		castFn = "SAFE_CAST"
+		dateFn = "DATE"
+		extraWhere = "\nWHERE o.test IS NOT TRUE AND o.financial_status IS NOT NULL\nQUALIFY ROW_NUMBER() OVER (PARTITION BY o.id ORDER BY o.updated_at DESC) = 1"
+	case warehouseSnowflake:
+		castFn = "CAST"
+		dateFn = "" // uses ::DATE
+	}
+
+	if c.Payments == paymentsStripe {
+		extraCols = `,
+    c.amount / 100.0 AS stripe_charge_amount,
+    c.status AS stripe_status,
+    c.paid AS stripe_paid`
+
+		if c.Warehouse == warehouseSnowflake {
+			joinClause = `
+LEFT JOIN raw.stripe_charges c
+    ON o.email = c.receipt_email
+    AND o.created_at::DATE = c.created::DATE`
+		} else {
+			joinClause = fmt.Sprintf(`
+LEFT JOIN raw.stripe_charges c
+    ON o.email = c.receipt_email
+    AND %s(o.created_at) = %s(c.created)`, dateFn, dateFn)
+		}
+	}
+
+	body := fmt.Sprintf(`SELECT
+    o.id AS order_id,
+    o.order_number,
+    o.email AS customer_email,
+    o.created_at AS order_date,
+    o.financial_status AS payment_status,
+    o.fulfillment_status,
+    %s(o.total_price AS DECIMAL(12,2)) AS order_total,
+    %s(o.subtotal_price AS DECIMAL(12,2)) AS subtotal,
+    %s(o.total_tax AS DECIMAL(12,2)) AS tax_amount,
+    %s(o.total_discounts AS DECIMAL(12,2)) AS discount_amount,
+    o.currency,
+    o.cancel_reason,
+    o.cancelled_at%s
+FROM raw.shopify_orders o%s%s
+`, castFn, castFn, castFn, castFn, extraCols, joinClause, extraWhere)
+
+	return header + body
+}
+
+func generateStgCustomers(c *EcommerceChoices) string {
+	header := `/* @bruin
+name: staging.stg_customers
+type: sql
+materialization:
+  type: table
+depends:
+  - raw.shopify_customers`
+
+	if c.Payments == paymentsStripe {
+		header += "\n  - raw.stripe_customers"
+	}
+
+	header += `
+columns:
+  - name: customer_email
+    type: varchar
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+`
+
+	if c.Payments == paymentsStripe {
+		return header + `SELECT
+    COALESCE(sc.email, st.email) AS customer_email,
+    sc.id AS shopify_customer_id,
+    st.id AS stripe_customer_id,
+    sc.first_name,
+    sc.last_name,
+    sc.created_at AS shopify_created_at,
+    st.created AS stripe_created_at,
+    LEAST(sc.created_at, st.created) AS first_seen_at,
+    sc.orders_count,
+    CAST(sc.total_spent AS DECIMAL(12,2)) AS shopify_total_spent,
+    sc.tags AS customer_tags,
+    sc.state AS customer_state
+FROM raw.shopify_customers sc
+FULL OUTER JOIN raw.stripe_customers st
+    ON lower(sc.email) = lower(st.email)
+WHERE COALESCE(sc.email, st.email) IS NOT NULL
+`
+	}
+
+	return header + `SELECT
+    email AS customer_email,
+    id AS shopify_customer_id,
+    first_name,
+    last_name,
+    created_at AS shopify_created_at,
+    created_at AS first_seen_at,
+    orders_count,
+    CAST(total_spent AS DECIMAL(12,2)) AS shopify_total_spent,
+    tags AS customer_tags,
+    state AS customer_state
+FROM raw.shopify_customers
+WHERE email IS NOT NULL
+`
+}
+
+const stgProductsSQL = `/* @bruin
+name: staging.stg_products
+type: sql
+materialization:
+  type: table
+depends:
+  - raw.shopify_products
+columns:
+  - name: product_id
+    type: varchar
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+SELECT
+    id AS product_id,
+    title AS product_name,
+    product_type AS category,
+    vendor,
+    status AS product_status,
+    CAST(price AS DECIMAL(12,2)) AS price,
+    tags,
+    created_at,
+    updated_at
+FROM raw.shopify_products
+WHERE status = 'active'
+`
+
+func generateStgMarketingSpend(c *EcommerceChoices) string {
+	depends := make([]string, 0)
+	var parts []string
+
+	// Add ad platform dependencies and queries
+	for _, ad := range c.Ads {
+		switch ad {
+		case adsFacebook:
+			depends = append(depends, "raw.facebook_ad_insights")
+			parts = append(parts, `-- Facebook Ads spend
+SELECT
+    DATE(date_start) AS spend_date,
+    'paid_ads' AS channel,
+    campaign_name,
+    CAST(spend AS DECIMAL(12,2)) AS spend,
+    CAST(impressions AS INTEGER) AS impressions,
+    CAST(clicks AS INTEGER) AS clicks,
+    CAST(conversions AS INTEGER) AS conversions
+FROM raw.facebook_ad_insights`)
+		case adsGoogle:
+			depends = append(depends, "raw.google_ad_insights")
+			parts = append(parts, `-- Google Ads spend
+SELECT
+    DATE(date) AS spend_date,
+    'paid_ads' AS channel,
+    campaign_name,
+    CAST(spend AS DECIMAL(12,2)) AS spend,
+    CAST(impressions AS INTEGER) AS impressions,
+    CAST(clicks AS INTEGER) AS clicks,
+    CAST(conversions AS INTEGER) AS conversions
+FROM raw.google_ad_insights`)
+		case adsTikTok:
+			depends = append(depends, "raw.tiktok_ad_insights")
+			parts = append(parts, `-- TikTok Ads spend
+SELECT
+    DATE(stat_datetime) AS spend_date,
+    'paid_ads' AS channel,
+    campaign_name,
+    CAST(spend AS DECIMAL(12,2)) AS spend,
+    CAST(impressions AS INTEGER) AS impressions,
+    CAST(clicks AS INTEGER) AS clicks,
+    CAST(conversions AS INTEGER) AS conversions
+FROM raw.tiktok_ad_insights`)
+		}
+	}
+
+	// Add marketing platform
+	switch c.Marketing {
+	case marketingKlaviyo:
+		depends = append(depends, "raw.klaviyo_campaigns", "raw.klaviyo_metrics")
+
+		var dateCast string
+		switch c.Warehouse {
+		case warehouseClickHouse:
+			dateCast = "toDate(send_time)"
+		case warehouseBigQuery:
+			dateCast = "DATE(send_time)"
+		default:
+			dateCast = "send_time::date"
+		}
+
+		parts = append(parts, fmt.Sprintf(`-- Klaviyo email campaigns
+SELECT
+    %s AS spend_date,
+    'email' AS channel,
+    name AS campaign_name,
+    0.00 AS spend,
+    num_recipients AS impressions,
+    CAST(click_count AS INTEGER) AS clicks,
+    CAST(conversion_count AS INTEGER) AS conversions
+FROM raw.klaviyo_campaigns kc
+LEFT JOIN raw.klaviyo_metrics km
+    ON kc.id = km.campaign_id
+WHERE send_time IS NOT NULL`, dateCast))
+	case marketingHubSpot:
+		depends = append(depends, "raw.hubspot_campaigns")
+
+		var dateCast string
+		switch c.Warehouse {
+		case warehouseClickHouse:
+			dateCast = "toDate(updated_at)"
+		case warehouseBigQuery:
+			dateCast = "DATE(updated_at)"
+		default:
+			dateCast = "updated_at::date"
+		}
+
+		parts = append(parts, fmt.Sprintf(`-- HubSpot email campaigns
+SELECT
+    %s AS spend_date,
+    'email' AS channel,
+    name AS campaign_name,
+    0.00 AS spend,
+    CAST(num_included AS INTEGER) AS impressions,
+    CAST(num_clicks AS INTEGER) AS clicks,
+    0 AS conversions
+FROM raw.hubspot_campaigns
+WHERE name IS NOT NULL`, dateCast))
+	}
+
+	// Build header
+	depLines := make([]string, 0, len(depends))
+	for _, d := range depends {
+		depLines = append(depLines, "  - "+d)
+	}
+
+	header := fmt.Sprintf(`/* @bruin
+name: staging.stg_marketing_spend
+type: sql
+materialization:
+  type: table
+depends:
+%s
+columns:
+  - name: spend_date
+    type: date
+    checks:
+      - name: not_null
+@bruin */
+
+`, strings.Join(depLines, "\n"))
+
+	return header + strings.Join(parts, "\n\nUNION ALL\n\n") + "\n"
+}
+
+func generateStgWebSessions(c *EcommerceChoices) string {
+	var depends, sourceQuery, dateCast string
+
+	switch c.Analytics {
+	case analyticsGA4:
+		depends = `  - raw.ga4_sessions
+  - raw.ga4_events`
+
+		sourceQuery = `SELECT
+    s.date AS session_raw_date,
+    s.sessions AS total_sessions,
+    s.new_users,
+    s.engaged_sessions,
+    e.event_count AS purchase_events,
+    CASE
+        WHEN s.source = 'facebook' THEN 'paid_ads'
+        WHEN s.medium = 'email' THEN 'email'
+        WHEN s.medium = 'organic' THEN 'organic_search'
+        WHEN s.medium = 'cpc' THEN 'paid_search'
+        WHEN s.source = '(direct)' THEN 'direct'
+        ELSE 'other'
+    END AS channel
+FROM raw.ga4_sessions s
+LEFT JOIN raw.ga4_events e
+    ON s.date = e.date
+    AND e.event_name = 'purchase'`
+
+	case analyticsMixpanel:
+		depends = `  - raw.mixpanel_events`
+
+		sourceQuery = `SELECT
+    e.time AS session_raw_date,
+    COUNT(*) AS total_sessions,
+    COUNT(CASE WHEN e.is_new_user = true THEN 1 END) AS new_users,
+    COUNT(CASE WHEN e.session_duration > 10 THEN 1 END) AS engaged_sessions,
+    COUNT(CASE WHEN e.event_name = 'purchase' THEN 1 END) AS purchase_events,
+    CASE
+        WHEN e.utm_source = 'facebook' THEN 'paid_ads'
+        WHEN e.utm_medium = 'email' THEN 'email'
+        WHEN e.utm_medium = 'organic' THEN 'organic_search'
+        WHEN e.utm_medium = 'cpc' THEN 'paid_search'
+        ELSE 'other'
+    END AS channel
+FROM raw.mixpanel_events e
+WHERE e.event_name = 'session_start'
+GROUP BY session_raw_date, channel`
+	}
+
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		dateCast = "toDate(session_raw_date)"
+	case warehouseBigQuery:
+		dateCast = "DATE(session_raw_date)"
+	case warehouseSnowflake:
+		dateCast = "session_raw_date::DATE"
+	}
+
+	return fmt.Sprintf(`/* @bruin
+name: staging.stg_web_sessions
+type: sql
+materialization:
+  type: table
+depends:
+%s
+columns:
+  - name: session_date
+    type: date
+    checks:
+      - name: not_null
+@bruin */
+
+WITH source AS (
+    %s
+)
+SELECT
+    %s AS session_date,
+    total_sessions,
+    new_users,
+    engaged_sessions,
+    purchase_events,
+    channel
+FROM source
+`, depends, strings.ReplaceAll(sourceQuery, "\n", "\n    "), dateCast)
+}
+
+// --- Report SQL Generation ---
+
+func generateRptDailyRevenue(c *EcommerceChoices) string {
+	header := `/* @bruin
+name: reports.rpt_daily_revenue
+type: sql
+materialization:
+  type: table
+depends:
+  - staging.stg_orders
+columns:
+  - name: order_date
+    type: date
+    checks:
+      - name: not_null
+      - name: unique
+custom_checks:
+  - name: has_rows
+    query: "SELECT count(*) > 0 FROM reports.rpt_daily_revenue"
+    value: 1
+@bruin */
+
+`
+
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		return header + `SELECT
+    toDate(order_date) AS order_date,
+    count(*) AS total_orders,
+    countIf(payment_status = 'paid') AS paid_orders,
+    countIf(cancel_reason IS NOT NULL) AS cancelled_orders,
+    sum(order_total) AS gross_revenue,
+    sum(CASE WHEN payment_status = 'paid' THEN order_total ELSE 0 END) AS net_revenue,
+    sum(discount_amount) AS total_discounts,
+    sum(tax_amount) AS total_tax,
+    round(net_revenue / nullIf(paid_orders, 0), 2) AS avg_order_value,
+    round(cancelled_orders / nullIf(total_orders, 0) * 100, 2) AS cancellation_rate
+FROM staging.stg_orders
+GROUP BY toDate(order_date)
+ORDER BY order_date
+`
+	case warehouseBigQuery:
+		return header + `SELECT
+    DATE(order_date) AS order_date,
+    count(*) AS total_orders,
+    COUNTIF(payment_status = 'paid') AS paid_orders,
+    COUNTIF(cancel_reason IS NOT NULL) AS cancelled_orders,
+    sum(order_total) AS gross_revenue,
+    sum(CASE WHEN payment_status = 'paid' THEN order_total ELSE 0 END) AS net_revenue,
+    sum(discount_amount) AS total_discounts,
+    sum(tax_amount) AS total_tax,
+    round(sum(CASE WHEN payment_status = 'paid' THEN order_total ELSE 0 END) / NULLIF(COUNTIF(payment_status = 'paid'), 0), 2) AS avg_order_value,
+    round(COUNTIF(cancel_reason IS NOT NULL) / NULLIF(count(*), 0) * 100, 2) AS cancellation_rate
+FROM staging.stg_orders o
+WHERE o.financial_status IN ('paid', 'partially_refunded')
+GROUP BY DATE(order_date)
+ORDER BY order_date
+`
+	default: // snowflake
+		return header + `SELECT
+    order_date::DATE AS order_date,
+    count(*) AS total_orders,
+    COUNT(CASE WHEN payment_status = 'paid' THEN 1 END) AS paid_orders,
+    COUNT(CASE WHEN cancel_reason IS NOT NULL THEN 1 END) AS cancelled_orders,
+    sum(order_total) AS gross_revenue,
+    sum(CASE WHEN payment_status = 'paid' THEN order_total ELSE 0 END) AS net_revenue,
+    sum(discount_amount) AS total_discounts,
+    sum(tax_amount) AS total_tax,
+    round(sum(CASE WHEN payment_status = 'paid' THEN order_total ELSE 0 END) / NULLIF(COUNT(CASE WHEN payment_status = 'paid' THEN 1 END), 0), 2) AS avg_order_value,
+    round(COUNT(CASE WHEN cancel_reason IS NOT NULL THEN 1 END) / NULLIF(count(*), 0) * 100, 2) AS cancellation_rate
+FROM staging.stg_orders
+GROUP BY order_date::DATE
+ORDER BY order_date
+`
+	}
+}
+
+func generateRptCustomerCohorts(c *EcommerceChoices) string {
+	header := `/* @bruin
+name: reports.rpt_customer_cohorts
+type: sql
+materialization:
+  type: table
+depends:
+  - staging.stg_orders
+  - staging.stg_customers
+columns:
+  - name: cohort_month
+    type: date
+    checks:
+      - name: not_null
+@bruin */
+
+`
+
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		return header + `WITH customer_orders AS (
+    SELECT
+        o.customer_email,
+        toStartOfMonth(c.first_seen_at) AS cohort_month,
+        toStartOfMonth(o.order_date) AS order_month,
+        o.order_total
+    FROM staging.stg_orders o
+    INNER JOIN staging.stg_customers c
+        ON o.customer_email = c.customer_email
+    WHERE o.payment_status = 'paid'
+),
+cohort_sizes AS (
+    SELECT
+        cohort_month,
+        count(DISTINCT customer_email) AS cohort_size
+    FROM customer_orders
+    GROUP BY cohort_month
+)
+SELECT
+    co.cohort_month,
+    cs.cohort_size,
+    dateDiff('month', co.cohort_month, co.order_month) AS months_since_first,
+    count(DISTINCT co.customer_email) AS active_customers,
+    round(active_customers / nullIf(cs.cohort_size, 0) * 100, 2) AS retention_rate,
+    sum(co.order_total) AS cohort_revenue,
+    round(cohort_revenue / nullIf(cs.cohort_size, 0), 2) AS revenue_per_customer
+FROM customer_orders co
+INNER JOIN cohort_sizes cs
+    ON co.cohort_month = cs.cohort_month
+GROUP BY co.cohort_month, cs.cohort_size, months_since_first
+ORDER BY co.cohort_month, months_since_first
+`
+	case warehouseBigQuery:
+		return header + `WITH customer_orders AS (
+    SELECT
+        o.customer_email,
+        DATE_TRUNC(c.first_seen_at, MONTH) AS cohort_month,
+        DATE_TRUNC(o.order_date, MONTH) AS order_month,
+        o.order_total
+    FROM staging.stg_orders o
+    INNER JOIN staging.stg_customers c
+        ON o.customer_email = c.customer_email
+    WHERE o.payment_status = 'paid'
+),
+cohort_sizes AS (
+    SELECT
+        cohort_month,
+        count(DISTINCT customer_email) AS cohort_size
+    FROM customer_orders
+    GROUP BY cohort_month
+)
+SELECT
+    co.cohort_month,
+    cs.cohort_size,
+    DATE_DIFF(co.order_month, co.cohort_month, MONTH) AS months_since_first,
+    count(DISTINCT co.customer_email) AS active_customers,
+    round(count(DISTINCT co.customer_email) / NULLIF(cs.cohort_size, 0) * 100, 2) AS retention_rate,
+    sum(co.order_total) AS cohort_revenue,
+    round(sum(co.order_total) / NULLIF(cs.cohort_size, 0), 2) AS revenue_per_customer
+FROM customer_orders co
+INNER JOIN cohort_sizes cs
+    ON co.cohort_month = cs.cohort_month
+GROUP BY co.cohort_month, cs.cohort_size, months_since_first
+ORDER BY co.cohort_month, months_since_first
+`
+	default: // snowflake
+		return header + `WITH customer_orders AS (
+    SELECT
+        o.customer_email,
+        DATE_TRUNC('month', c.first_seen_at) AS cohort_month,
+        DATE_TRUNC('month', o.order_date) AS order_month,
+        o.order_total
+    FROM staging.stg_orders o
+    INNER JOIN staging.stg_customers c
+        ON o.customer_email = c.customer_email
+    WHERE o.payment_status = 'paid'
+),
+cohort_sizes AS (
+    SELECT
+        cohort_month,
+        count(DISTINCT customer_email) AS cohort_size
+    FROM customer_orders
+    GROUP BY cohort_month
+)
+SELECT
+    co.cohort_month,
+    cs.cohort_size,
+    DATEDIFF('month', co.cohort_month, co.order_month) AS months_since_first,
+    count(DISTINCT co.customer_email) AS active_customers,
+    round(count(DISTINCT co.customer_email) / NULLIF(cs.cohort_size, 0) * 100, 2) AS retention_rate,
+    sum(co.order_total) AS cohort_revenue,
+    round(sum(co.order_total) / NULLIF(cs.cohort_size, 0), 2) AS revenue_per_customer
+FROM customer_orders co
+INNER JOIN cohort_sizes cs
+    ON co.cohort_month = cs.cohort_month
+GROUP BY co.cohort_month, cs.cohort_size, months_since_first
+ORDER BY co.cohort_month, months_since_first
+`
+	}
+}
+
+const rptProductPerformanceSQL = `/* @bruin
+name: reports.rpt_product_performance
+type: sql
+materialization:
+  type: table
+depends:
+  - staging.stg_products
+columns:
+  - name: product_id
+    type: varchar
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+SELECT
+    product_id,
+    product_name,
+    category,
+    vendor,
+    price,
+    product_status,
+    created_at,
+    updated_at
+FROM staging.stg_products
+ORDER BY product_name
+`
+
+func generateRptMarketingROI(c *EcommerceChoices) string {
+	header := `/* @bruin
+name: reports.rpt_marketing_roi
+type: sql
+materialization:
+  type: table
+depends:
+  - staging.stg_marketing_spend
+  - staging.stg_web_sessions
+  - staging.stg_orders
+columns:
+  - name: channel
+    type: varchar
+    checks:
+      - name: not_null
+@bruin */
+
+`
+
+	var dateFn, nullIfFn string
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		dateFn = "toDate(order_date)"
+		nullIfFn = "nullIf"
+	case warehouseBigQuery:
+		dateFn = "DATE(order_date)"
+		nullIfFn = "NULLIF"
+	case warehouseSnowflake:
+		dateFn = "order_date::DATE"
+		nullIfFn = "NULLIF"
+	}
+
+	return header + fmt.Sprintf(`WITH channel_spend AS (
+    SELECT
+        spend_date,
+        channel,
+        sum(spend) AS total_spend,
+        sum(impressions) AS total_impressions,
+        sum(clicks) AS total_clicks,
+        sum(conversions) AS total_conversions
+    FROM staging.stg_marketing_spend
+    GROUP BY spend_date, channel
+),
+channel_sessions AS (
+    SELECT
+        session_date,
+        channel,
+        sum(total_sessions) AS sessions,
+        sum(new_users) AS new_users,
+        sum(purchase_events) AS purchases
+    FROM staging.stg_web_sessions
+    GROUP BY session_date, channel
+),
+channel_revenue AS (
+    SELECT
+        %s AS order_date,
+        ws.channel,
+        sum(o.order_total) AS attributed_revenue
+    FROM staging.stg_orders o
+    INNER JOIN staging.stg_web_sessions ws
+        ON %s = ws.session_date
+    WHERE o.payment_status = 'paid'
+    GROUP BY %s, ws.channel
+)
+SELECT
+    cs.spend_date AS report_date,
+    cs.channel,
+    cs.total_spend,
+    cs.total_impressions,
+    cs.total_clicks,
+    cs.total_conversions,
+    sess.sessions,
+    sess.new_users,
+    cr.attributed_revenue,
+    round(cr.attributed_revenue / %s(cs.total_spend, 0), 2) AS roas,
+    round(cs.total_spend / %s(cs.total_conversions, 0), 2) AS cost_per_acquisition,
+    round(cs.total_clicks / %s(cs.total_impressions, 0) * 100, 2) AS click_through_rate
+FROM channel_spend cs
+LEFT JOIN channel_sessions sess
+    ON cs.spend_date = sess.session_date
+    AND cs.channel = sess.channel
+LEFT JOIN channel_revenue cr
+    ON cs.spend_date = cr.order_date
+    AND cs.channel = cr.channel
+ORDER BY cs.spend_date DESC, cs.total_spend DESC
+`, dateFn, dateFn, dateFn, nullIfFn, nullIfFn, nullIfFn)
+}
+
+func generateRptDailyKPIs(c *EcommerceChoices) string {
+	header := `/* @bruin
+name: reports.rpt_daily_kpis
+type: sql
+materialization:
+  type: table
+depends:
+  - reports.rpt_daily_revenue
+  - staging.stg_customers
+  - staging.stg_orders
+  - staging.stg_web_sessions
+  - staging.stg_marketing_spend
+columns:
+  - name: kpi_date
+    type: date
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+`
+
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		return header + `WITH daily_customers AS (
+    SELECT
+        toDate(o.order_date) AS order_date,
+        countIf(toDate(c.first_seen_at) = toDate(o.order_date)) AS new_customers,
+        countIf(toDate(c.first_seen_at) < toDate(o.order_date)) AS returning_customers
+    FROM staging.stg_orders o
+    LEFT JOIN staging.stg_customers c
+        ON o.customer_email = c.customer_email
+    WHERE o.payment_status = 'paid'
+    GROUP BY toDate(o.order_date)
+),
+daily_sessions AS (
+    SELECT
+        session_date,
+        sum(total_sessions) AS sessions,
+        sum(new_users) AS new_visitors,
+        sum(purchase_events) AS purchases
+    FROM staging.stg_web_sessions
+    GROUP BY session_date
+),
+daily_spend AS (
+    SELECT
+        spend_date,
+        sum(spend) AS total_ad_spend
+    FROM staging.stg_marketing_spend
+    GROUP BY spend_date
+)
+SELECT
+    r.order_date AS kpi_date,
+    r.net_revenue,
+    r.total_orders,
+    r.paid_orders,
+    r.avg_order_value,
+    r.cancellation_rate,
+    dc.new_customers,
+    dc.returning_customers,
+    ds.sessions,
+    ds.new_visitors,
+    round(ds.purchases / nullIf(ds.sessions, 0) * 100, 2) AS conversion_rate,
+    sp.total_ad_spend,
+    round(r.net_revenue / nullIf(sp.total_ad_spend, 0), 2) AS overall_roas
+FROM reports.rpt_daily_revenue r
+LEFT JOIN daily_customers dc ON r.order_date = dc.order_date
+LEFT JOIN daily_sessions ds ON r.order_date = ds.session_date
+LEFT JOIN daily_spend sp ON r.order_date = sp.spend_date
+ORDER BY kpi_date DESC
+`
+	case warehouseBigQuery:
+		return header + `WITH daily_customers AS (
+    SELECT
+        DATE(o.order_date) AS order_date,
+        COUNTIF(DATE(c.first_seen_at) = DATE(o.order_date)) AS new_customers,
+        COUNTIF(DATE(c.first_seen_at) < DATE(o.order_date)) AS returning_customers
+    FROM staging.stg_orders o
+    LEFT JOIN staging.stg_customers c
+        ON o.customer_email = c.customer_email
+    WHERE o.payment_status = 'paid'
+    GROUP BY DATE(o.order_date)
+),
+daily_sessions AS (
+    SELECT
+        session_date,
+        sum(total_sessions) AS sessions,
+        sum(new_users) AS new_visitors,
+        sum(purchase_events) AS purchases
+    FROM staging.stg_web_sessions
+    GROUP BY session_date
+),
+daily_spend AS (
+    SELECT
+        spend_date,
+        sum(spend) AS total_ad_spend
+    FROM staging.stg_marketing_spend
+    GROUP BY spend_date
+)
+SELECT
+    r.order_date AS kpi_date,
+    r.net_revenue,
+    r.total_orders,
+    r.paid_orders,
+    r.avg_order_value,
+    r.cancellation_rate,
+    dc.new_customers,
+    dc.returning_customers,
+    ds.sessions,
+    ds.new_visitors,
+    round(ds.purchases / NULLIF(ds.sessions, 0) * 100, 2) AS conversion_rate,
+    sp.total_ad_spend,
+    round(r.net_revenue / NULLIF(sp.total_ad_spend, 0), 2) AS overall_roas
+FROM reports.rpt_daily_revenue r
+LEFT JOIN daily_customers dc ON r.order_date = dc.order_date
+LEFT JOIN daily_sessions ds ON r.order_date = ds.session_date
+LEFT JOIN daily_spend sp ON r.order_date = sp.spend_date
+ORDER BY kpi_date DESC
+`
+	default: // snowflake
+		return header + `WITH daily_customers AS (
+    SELECT
+        o.order_date::DATE AS order_date,
+        COUNT(CASE WHEN c.first_seen_at::DATE = o.order_date::DATE THEN 1 END) AS new_customers,
+        COUNT(CASE WHEN c.first_seen_at::DATE < o.order_date::DATE THEN 1 END) AS returning_customers
+    FROM staging.stg_orders o
+    LEFT JOIN staging.stg_customers c
+        ON o.customer_email = c.customer_email
+    WHERE o.payment_status = 'paid'
+    GROUP BY o.order_date::DATE
+),
+daily_sessions AS (
+    SELECT
+        session_date,
+        sum(total_sessions) AS sessions,
+        sum(new_users) AS new_visitors,
+        sum(purchase_events) AS purchases
+    FROM staging.stg_web_sessions
+    GROUP BY session_date
+),
+daily_spend AS (
+    SELECT
+        spend_date,
+        sum(spend) AS total_ad_spend
+    FROM staging.stg_marketing_spend
+    GROUP BY spend_date
+)
+SELECT
+    r.order_date AS kpi_date,
+    r.net_revenue,
+    r.total_orders,
+    r.paid_orders,
+    r.avg_order_value,
+    r.cancellation_rate,
+    dc.new_customers,
+    dc.returning_customers,
+    ds.sessions,
+    ds.new_visitors,
+    round(ds.purchases / NULLIF(ds.sessions, 0) * 100, 2) AS conversion_rate,
+    sp.total_ad_spend,
+    round(r.net_revenue / NULLIF(sp.total_ad_spend, 0), 2) AS overall_roas
+FROM reports.rpt_daily_revenue r
+LEFT JOIN daily_customers dc ON r.order_date = dc.order_date
+LEFT JOIN daily_sessions ds ON r.order_date = ds.session_date
+LEFT JOIN daily_spend sp ON r.order_date = sp.spend_date
+ORDER BY kpi_date DESC
+`
+	}
+}

--- a/cmd/ecommerce_assets.go
+++ b/cmd/ecommerce_assets.go
@@ -461,40 +461,67 @@ func generateStgMarketingSpend(c *EcommerceChoices) string {
 		switch ad {
 		case adsFacebook:
 			depends = append(depends, "raw.facebook_ad_insights")
-			parts = append(parts, `-- Facebook Ads spend
+			var fbDate string
+			switch c.Warehouse {
+			case warehouseClickHouse:
+				fbDate = "toDate(date_start)"
+			case warehouseSnowflake:
+				fbDate = "date_start::DATE"
+			default:
+				fbDate = "DATE(date_start)"
+			}
+			parts = append(parts, fmt.Sprintf(`-- Facebook Ads spend
 SELECT
-    DATE(date_start) AS spend_date,
+    %s AS spend_date,
     'paid_ads' AS channel,
     campaign_name,
     CAST(spend AS DECIMAL(12,2)) AS spend,
     CAST(impressions AS INTEGER) AS impressions,
     CAST(clicks AS INTEGER) AS clicks,
     CAST(conversions AS INTEGER) AS conversions
-FROM raw.facebook_ad_insights`)
+FROM raw.facebook_ad_insights`, fbDate))
 		case adsGoogle:
 			depends = append(depends, "raw.google_ad_insights")
-			parts = append(parts, `-- Google Ads spend
+			var gaDate string
+			switch c.Warehouse {
+			case warehouseClickHouse:
+				gaDate = "toDate(date)"
+			case warehouseSnowflake:
+				gaDate = "date::DATE"
+			default:
+				gaDate = "DATE(date)"
+			}
+			parts = append(parts, fmt.Sprintf(`-- Google Ads spend
 SELECT
-    DATE(date) AS spend_date,
+    %s AS spend_date,
     'paid_ads' AS channel,
     campaign_name,
     CAST(spend AS DECIMAL(12,2)) AS spend,
     CAST(impressions AS INTEGER) AS impressions,
     CAST(clicks AS INTEGER) AS clicks,
     CAST(conversions AS INTEGER) AS conversions
-FROM raw.google_ad_insights`)
+FROM raw.google_ad_insights`, gaDate))
 		case adsTikTok:
 			depends = append(depends, "raw.tiktok_ad_insights")
-			parts = append(parts, `-- TikTok Ads spend
+			var ttDate string
+			switch c.Warehouse {
+			case warehouseClickHouse:
+				ttDate = "toDate(stat_datetime)"
+			case warehouseSnowflake:
+				ttDate = "stat_datetime::DATE"
+			default:
+				ttDate = "DATE(stat_datetime)"
+			}
+			parts = append(parts, fmt.Sprintf(`-- TikTok Ads spend
 SELECT
-    DATE(stat_datetime) AS spend_date,
+    %s AS spend_date,
     'paid_ads' AS channel,
     campaign_name,
     CAST(spend AS DECIMAL(12,2)) AS spend,
     CAST(impressions AS INTEGER) AS impressions,
     CAST(clicks AS INTEGER) AS clicks,
     CAST(conversions AS INTEGER) AS conversions
-FROM raw.tiktok_ad_insights`)
+FROM raw.tiktok_ad_insights`, ttDate))
 		}
 	}
 
@@ -910,10 +937,10 @@ columns:
 	var dateFn, nullIfFn string
 	switch c.Warehouse {
 	case warehouseClickHouse:
-		dateFn = "toDate(order_date)"
+		dateFn = "toDate(o.order_date)"
 		nullIfFn = "nullIf"
 	case warehouseBigQuery:
-		dateFn = "DATE(order_date)"
+		dateFn = "DATE(o.order_date)"
 		nullIfFn = "NULLIF"
 	case warehouseSnowflake:
 		dateFn = "order_date::DATE"

--- a/cmd/ecommerce_config.go
+++ b/cmd/ecommerce_config.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// generateBruinYML generates the .bruin.yml content based on the user's ecommerce stack choices.
+func generateBruinYML(c *EcommerceChoices) string {
+	var connections []string
+
+	// Warehouse connection
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		connections = append(connections, `      clickhouse:
+        - name: "clickhouse-default"
+          host: "your-host.clickhouse.cloud"
+          port: 9440
+          username: "default"
+          password: "your-password"
+          database: "default"
+          ssl_mode: "true"`)
+	case warehouseBigQuery:
+		connections = append(connections, `      google_cloud_platform:
+        - name: "bigquery-default"
+          project_id: "your-gcp-project-id"
+          service_account_file: "/path/to/your-service-account.json"`)
+	case warehouseSnowflake:
+		connections = append(connections, `      snowflake:
+        - name: "snowflake-default"
+          account: "your-account-id"
+          username: "your-username"
+          password: "your-password"
+          database: "your-database"
+          warehouse: "your-warehouse"
+          schema: "PUBLIC"`)
+	}
+
+	// Shopify connection (always)
+	connections = append(connections, `      shopify:
+        - name: "shopify"
+          api_key: "your-shopify-admin-api-key"
+          url: "your-store.myshopify.com"`)
+
+	// Payments connection
+	if c.Payments == paymentsStripe {
+		connections = append(connections, `      stripe:
+        - name: "stripe"
+          api_key: "sk_live_your-stripe-secret-key"`)
+	}
+
+	// Marketing connection
+	switch c.Marketing {
+	case marketingKlaviyo:
+		connections = append(connections, `      klaviyo:
+        - name: "klaviyo"
+          api_key: "your-klaviyo-api-key"`)
+	case marketingHubSpot:
+		connections = append(connections, `      hubspot:
+        - name: "hubspot"
+          api_key: "your-hubspot-api-key"`)
+	}
+
+	// Ads connections
+	for _, ad := range c.Ads {
+		switch ad {
+		case adsFacebook:
+			connections = append(connections, `      facebook_ads:
+        - name: "facebook_ads"
+          access_token: "your-facebook-access-token"
+          account_id: "your-ad-account-id"`)
+		case adsGoogle:
+			connections = append(connections, `      google_ads:
+        - name: "google_ads"
+          developer_token: "your-developer-token"
+          client_id: "your-client-id"
+          client_secret: "your-client-secret"
+          refresh_token: "your-refresh-token"
+          customer_id: "your-customer-id"`)
+		case adsTikTok:
+			connections = append(connections, `      tiktok_ads:
+        - name: "tiktok_ads"
+          access_token: "your-tiktok-access-token"
+          advertiser_id: "your-advertiser-id"`)
+		}
+	}
+
+	// Analytics connection
+	switch c.Analytics {
+	case analyticsGA4:
+		connections = append(connections, `      google_analytics:
+        - name: "google_analytics"
+          service_account_file: "/path/to/your-ga4-service-account.json"
+          property_id: "your-ga4-property-id"`)
+	case analyticsMixpanel:
+		connections = append(connections, `      mixpanel:
+        - name: "mixpanel"
+          api_secret: "your-mixpanel-api-secret"
+          project_id: "your-mixpanel-project-id"`)
+	}
+
+	return fmt.Sprintf(`default_environment: default
+
+environments:
+  default:
+    connections:
+%s
+`, strings.Join(connections, "\n"))
+}
+
+// printEcommerceSummary prints a summary of what was generated.
+func printEcommerceSummary(c *EcommerceChoices) {
+	infoPrinter.Println("\n  Stack summary:")
+	infoPrinter.Printf("    Warehouse:  %s\n", c.Warehouse)
+	infoPrinter.Printf("    Payments:   %s\n", c.Payments)
+	infoPrinter.Printf("    Marketing:  %s\n", c.Marketing)
+	infoPrinter.Printf("    Ads:        %s\n", strings.Join(c.Ads, ", "))
+	infoPrinter.Printf("    Analytics:  %s\n", c.Analytics)
+}

--- a/cmd/ecommerce_constants.go
+++ b/cmd/ecommerce_constants.go
@@ -1,0 +1,33 @@
+package cmd
+
+// Warehouse identifiers.
+const (
+	warehouseClickHouse = "clickhouse"
+	warehouseBigQuery   = "bigquery"
+	warehouseSnowflake  = "snowflake"
+)
+
+// Payment provider identifiers.
+const (
+	paymentsStripe         = "stripe"
+	paymentsShopifyPayment = "shopify-payments"
+)
+
+// Marketing platform identifiers.
+const (
+	marketingKlaviyo = "klaviyo"
+	marketingHubSpot = "hubspot"
+)
+
+// Ad platform identifiers.
+const (
+	adsFacebook = "facebook-ads"
+	adsGoogle   = "google-ads"
+	adsTikTok   = "tiktok-ads"
+)
+
+// Analytics platform identifiers.
+const (
+	analyticsGA4      = "ga4"
+	analyticsMixpanel = "mixpanel"
+)

--- a/cmd/ecommerce_init.go
+++ b/cmd/ecommerce_init.go
@@ -1,0 +1,326 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+)
+
+// EcommerceChoices holds the user's stack selections.
+type EcommerceChoices struct {
+	Warehouse string
+	Payments  string
+	Marketing string
+	Ads       []string
+	Analytics string
+}
+
+type stepOption struct {
+	ID    string
+	Label string
+}
+
+type ecommerceStep struct {
+	Title       string
+	Description string
+	Options     []stepOption
+	MultiSelect bool
+}
+
+var ecommerceSteps = []ecommerceStep{
+	{
+		Title:       "Data Warehouse",
+		Description: "Choose where your data will be stored",
+		Options: []stepOption{
+			{ID: warehouseClickHouse, Label: "ClickHouse - Column-oriented analytics database"},
+			{ID: warehouseBigQuery, Label: "BigQuery - Google Cloud serverless warehouse"},
+			{ID: warehouseSnowflake, Label: "Snowflake - Multi-cloud data warehouse"},
+		},
+	},
+	{
+		Title:       "Payments",
+		Description: "Choose your payment processor",
+		Options: []stepOption{
+			{ID: paymentsShopifyPayment, Label: "Shopify Payments - Built-in Shopify payment processing"},
+			{ID: paymentsStripe, Label: "Stripe - Independent payment platform"},
+		},
+	},
+	{
+		Title:       "Email Marketing",
+		Description: "Choose your email marketing platform",
+		Options: []stepOption{
+			{ID: marketingKlaviyo, Label: "Klaviyo - Ecommerce email & SMS marketing"},
+			{ID: marketingHubSpot, Label: "HubSpot - CRM & marketing automation"},
+		},
+	},
+	{
+		Title:       "Advertising",
+		Description: "Select your ad platforms (you can choose multiple)",
+		Options: []stepOption{
+			{ID: adsFacebook, Label: "Facebook Ads - Meta advertising platform"},
+			{ID: adsGoogle, Label: "Google Ads - Google advertising platform"},
+			{ID: adsTikTok, Label: "TikTok Ads - TikTok advertising platform"},
+		},
+		MultiSelect: true,
+	},
+	{
+		Title:       "Web Analytics",
+		Description: "Choose your web analytics platform",
+		Options: []stepOption{
+			{ID: analyticsGA4, Label: "GA4 - Google Analytics 4"},
+			{ID: analyticsMixpanel, Label: "Mixpanel - Product analytics"},
+		},
+	},
+}
+
+type ecommerceModel struct {
+	step     int
+	cursor   int
+	selected map[int]bool // for multi-select (ads step)
+	choices  EcommerceChoices
+	quitting bool
+	height   int
+}
+
+func newEcommerceModel() ecommerceModel {
+	return ecommerceModel{
+		selected: make(map[int]bool),
+		height:   getTerminalHeight(),
+	}
+}
+
+func (m ecommerceModel) Init() tea.Cmd {
+	return tea.EnterAltScreen
+}
+
+func (m ecommerceModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		currentStep := ecommerceSteps[m.step]
+		switch msg.String() {
+		case keyCtrlC, "q", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		case "enter":
+			if currentStep.MultiSelect {
+				// Collect selected items
+				var selectedIDs []string
+				for i, opt := range currentStep.Options {
+					if m.selected[i] {
+						selectedIDs = append(selectedIDs, opt.ID)
+					}
+				}
+				if len(selectedIDs) == 0 {
+					// Must select at least one
+					return m, nil
+				}
+				m.choices.Ads = selectedIDs
+			} else {
+				opt := currentStep.Options[m.cursor]
+				switch m.step {
+				case 0:
+					m.choices.Warehouse = opt.ID
+				case 1:
+					m.choices.Payments = opt.ID
+				case 2:
+					m.choices.Marketing = opt.ID
+				case 4:
+					m.choices.Analytics = opt.ID
+				}
+			}
+
+			m.step++
+			m.cursor = 0
+			m.selected = make(map[int]bool)
+
+			if m.step >= len(ecommerceSteps) {
+				return m, tea.Quit
+			}
+			return m, nil
+		case "down", "j":
+			m.cursor++
+			if m.cursor >= len(currentStep.Options) {
+				m.cursor = 0
+			}
+		case "up", "k":
+			m.cursor--
+			if m.cursor < 0 {
+				m.cursor = len(currentStep.Options) - 1
+			}
+		case " ":
+			if currentStep.MultiSelect {
+				m.selected[m.cursor] = !m.selected[m.cursor]
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m ecommerceModel) View() string {
+	if m.step >= len(ecommerceSteps) {
+		return ""
+	}
+
+	s := strings.Builder{}
+	step := ecommerceSteps[m.step]
+
+	fmt.Fprintf(&s, "  Ecommerce Pipeline Setup (%d/%d)\n", m.step+1, len(ecommerceSteps))
+	fmt.Fprintf(&s, "  %s\n", step.Title)
+	fmt.Fprintf(&s, "  %s\n\n", step.Description)
+
+	for i, opt := range step.Options {
+		cursor := "  "
+		if m.cursor == i {
+			cursor = "> "
+		}
+
+		if step.MultiSelect {
+			check := "[ ]"
+			if m.selected[i] {
+				check = "[x]"
+			}
+			fmt.Fprintf(&s, " %s%s %s\n", cursor, check, opt.Label)
+		} else {
+			radio := "( )"
+			if m.cursor == i {
+				radio = "(*)"
+			}
+			fmt.Fprintf(&s, " %s%s %s\n", cursor, radio, opt.Label)
+		}
+	}
+
+	s.WriteString("\n")
+	if step.MultiSelect {
+		s.WriteString("  space = toggle, enter = confirm, q = quit\n")
+	} else {
+		s.WriteString("  enter = select, q = quit\n")
+	}
+	return s.String()
+}
+
+// runEcommerceStackPicker launches the interactive stack picker and returns the user's choices.
+func runEcommerceStackPicker() (*EcommerceChoices, error) {
+	if !term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // Fd() returns uintptr, safe to convert
+		return nil, errors.New("ecommerce template requires an interactive terminal")
+	}
+
+	p := tea.NewProgram(newEcommerceModel())
+	result, err := p.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error running stack picker: %w", err)
+	}
+
+	m, ok := result.(ecommerceModel)
+	if !ok || m.quitting {
+		return nil, nil
+	}
+
+	if m.step < len(ecommerceSteps) {
+		return nil, nil
+	}
+
+	return &m.choices, nil
+}
+
+// generateEcommerceTemplate generates all files for the ecommerce template based on user choices.
+func generateEcommerceTemplate(basePath string, choices *EcommerceChoices) error {
+	files := buildEcommerceFiles(choices)
+
+	for relPath, content := range files {
+		fullPath := filepath.Join(basePath, relPath)
+		dir := filepath.Dir(fullPath)
+
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil { //nolint:gosec
+			return fmt.Errorf("could not create directory %s: %w", dir, err)
+		}
+
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil { //nolint:gosec
+			return fmt.Errorf("could not write file %s: %w", fullPath, err)
+		}
+	}
+
+	return nil
+}
+
+// buildEcommerceFiles returns all files to be generated, keyed by relative path.
+func buildEcommerceFiles(c *EcommerceChoices) map[string]string {
+	files := make(map[string]string)
+
+	// Pipeline config
+	files["pipeline.yml"] = generatePipelineYML(c)
+
+	// Shopify raw assets (always included)
+	files["assets/raw/shopify_orders.asset.yml"] = shopifyOrdersAsset
+	files["assets/raw/shopify_customers.asset.yml"] = shopifyCustomersAsset
+	files["assets/raw/shopify_products.asset.yml"] = shopifyProductsAsset
+	files["assets/raw/shopify_inventory.asset.yml"] = shopifyInventoryAsset
+
+	// Payments
+	if c.Payments == paymentsStripe {
+		files["assets/raw/stripe_charges.asset.yml"] = stripeChargesAsset
+		files["assets/raw/stripe_refunds.asset.yml"] = stripeRefundsAsset
+		files["assets/raw/stripe_customers.asset.yml"] = stripeCustomersAsset
+		files["assets/raw/stripe_payouts.asset.yml"] = stripePayoutsAsset
+	}
+
+	// Marketing
+	switch c.Marketing {
+	case marketingKlaviyo:
+		files["assets/raw/klaviyo_campaigns.asset.yml"] = klaviyoCampaignsAsset
+		files["assets/raw/klaviyo_flows.asset.yml"] = klaviyoFlowsAsset
+		files["assets/raw/klaviyo_metrics.asset.yml"] = klaviyoMetricsAsset
+	case marketingHubSpot:
+		files["assets/raw/hubspot_contacts.asset.yml"] = hubspotContactsAsset
+		files["assets/raw/hubspot_deals.asset.yml"] = hubspotDealsAsset
+		files["assets/raw/hubspot_campaigns.asset.yml"] = hubspotCampaignsAsset
+	}
+
+	// Ads (multi-select)
+	for _, ad := range c.Ads {
+		switch ad {
+		case adsFacebook:
+			files["assets/raw/facebook_campaigns.asset.yml"] = facebookCampaignsAsset
+			files["assets/raw/facebook_ad_insights.asset.yml"] = facebookAdInsightsAsset
+		case adsGoogle:
+			files["assets/raw/google_campaigns.asset.yml"] = googleCampaignsAsset
+			files["assets/raw/google_ad_insights.asset.yml"] = googleAdInsightsAsset
+		case adsTikTok:
+			files["assets/raw/tiktok_campaigns.asset.yml"] = tiktokCampaignsAsset
+			files["assets/raw/tiktok_ad_insights.asset.yml"] = tiktokAdInsightsAsset
+		}
+	}
+
+	// Analytics
+	switch c.Analytics {
+	case analyticsGA4:
+		files["assets/raw/ga4_events.asset.yml"] = ga4EventsAsset
+		files["assets/raw/ga4_sessions.asset.yml"] = ga4SessionsAsset
+	case analyticsMixpanel:
+		files["assets/raw/mixpanel_events.asset.yml"] = mixpanelEventsAsset
+		files["assets/raw/mixpanel_funnels.asset.yml"] = mixpanelFunnelsAsset
+	}
+
+	// Staging SQL
+	files["assets/staging/stg_orders.sql"] = generateStgOrders(c)
+	files["assets/staging/stg_customers.sql"] = generateStgCustomers(c)
+	files["assets/staging/stg_products.sql"] = stgProductsSQL
+	files["assets/staging/stg_marketing_spend.sql"] = generateStgMarketingSpend(c)
+	files["assets/staging/stg_web_sessions.sql"] = generateStgWebSessions(c)
+
+	// Reports SQL
+	files["assets/reports/rpt_daily_revenue.sql"] = generateRptDailyRevenue(c)
+	files["assets/reports/rpt_customer_cohorts.sql"] = generateRptCustomerCohorts(c)
+	files["assets/reports/rpt_product_performance.sql"] = rptProductPerformanceSQL
+	files["assets/reports/rpt_marketing_roi.sql"] = generateRptMarketingROI(c)
+	files["assets/reports/rpt_daily_kpis.sql"] = generateRptDailyKPIs(c)
+
+	return files
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -328,6 +328,51 @@ func Init() *cli.Command {
 				bruinYmlPath = filepath.Join(repoRoot.Path, ".bruin.yml")
 			}
 
+			// Handle ecommerce template with interactive stack picker
+			if templateName == "ecommerce" {
+				ecommerceChoices, err := runEcommerceStackPicker()
+				if err != nil {
+					errorPrinter.Printf("Error during stack selection: %v\n", err)
+					return cli.Exit("", 1)
+				}
+				if ecommerceChoices == nil {
+					return nil // user cancelled
+				}
+
+				// Generate .bruin.yml with selected connections
+				bruinContent := generateBruinYML(ecommerceChoices)
+				if err := os.WriteFile(bruinYmlPath, []byte(bruinContent), 0o644); err != nil { //nolint:gosec
+					errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)
+					return cli.Exit("", 1)
+				}
+
+				// Generate all pipeline files
+				if err := generateEcommerceTemplate(inputPath, ecommerceChoices); err != nil {
+					errorPrinter.Printf("Could not generate ecommerce template: %v\n", err)
+					return cli.Exit("", 1)
+				}
+
+				telemetry.SetTemplateName(templateName)
+				telemetry.SendEvent("template_selected", map[string]interface{}{
+					"template_name": templateName,
+					"interactive":   true,
+					"warehouse":     ecommerceChoices.Warehouse,
+					"payments":      ecommerceChoices.Payments,
+					"marketing":     ecommerceChoices.Marketing,
+					"ads":           ecommerceChoices.Ads,
+					"analytics":     ecommerceChoices.Analytics,
+				})
+
+				successPrinter.Printf("\n\nEcommerce pipeline created successfully in folder '%s'.\n", inputPath)
+				printEcommerceSummary(ecommerceChoices)
+				infoPrinter.Println("\nNext steps:")
+				infoPrinter.Printf("  1. Edit .bruin.yml to add your real connection credentials\n")
+				infoPrinter.Printf("  2. Run: bruin validate %s\n", inputPath)
+				infoPrinter.Printf("  3. Run: bruin run %s\n\n", inputPath)
+
+				return nil
+			}
+
 			centralConfig, err := config.LoadOrCreateWithoutPathAbsolutization(afero.NewOsFs(), bruinYmlPath)
 			if err != nil {
 				errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -339,9 +339,26 @@ func Init() *cli.Command {
 					return nil // user cancelled
 				}
 
-				// Generate .bruin.yml with selected connections
+				// Load or create .bruin.yml, then merge ecommerce connections into it
+				centralConfig, err := config.LoadOrCreateWithoutPathAbsolutization(afero.NewOsFs(), bruinYmlPath)
+				if err != nil {
+					errorPrinter.Printf("Could not load .bruin.yml file: %v\n", err)
+					return cli.Exit("", 1)
+				}
+
 				bruinContent := generateBruinYML(ecommerceChoices)
-				if err := os.WriteFile(bruinYmlPath, []byte(bruinContent), 0o644); err != nil { //nolint:gosec
+				if err := mergeTemplateConfig(centralConfig, []byte(bruinContent)); err != nil {
+					errorPrinter.Printf("Could not merge ecommerce config: %v\n", err)
+					return cli.Exit("", 1)
+				}
+
+				configBytes, err := yaml.Marshal(centralConfig)
+				if err != nil {
+					errorPrinter.Printf("Could not marshal .bruin.yml: %v\n", err)
+					return cli.Exit("", 1)
+				}
+
+				if err := os.WriteFile(bruinYmlPath, configBytes, 0o644); err != nil { //nolint:gosec
 					errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)
 					return cli.Exit("", 1)
 				}

--- a/templates/ecommerce/README.md
+++ b/templates/ecommerce/README.md
@@ -1,0 +1,22 @@
+# Ecommerce Pipeline Template
+
+An interactive template that sets up a complete ecommerce analytics pipeline.
+
+## What's included
+
+- **Data Ingestion**: Shopify + your choice of payments, marketing, ads, and analytics sources
+- **Staging Layer**: Cleaned and joined data across all sources
+- **Reports**: Daily revenue, customer cohorts, product performance, marketing ROI, and daily KPIs
+
+## Usage
+
+```bash
+bruin init ecommerce
+```
+
+You'll be prompted to select your tech stack:
+- **Data Warehouse**: ClickHouse, BigQuery, or Snowflake
+- **Payments**: Shopify Payments or Stripe
+- **Email Marketing**: Klaviyo or HubSpot
+- **Advertising**: Facebook Ads, Google Ads, TikTok Ads (multi-select)
+- **Web Analytics**: GA4 or Mixpanel


### PR DESCRIPTION
## Summary
- Adds a new `bruin init ecommerce` template with an interactive BubbleTea-based stack picker (warehouse, payments, marketing, ads, analytics)
- Dynamically generates a complete ecommerce analytics pipeline (raw ingestion → staging → reports) with warehouse-specific SQL for ClickHouse, BigQuery, and Snowflake
- Supports Shopify, Stripe, Klaviyo, HubSpot, Facebook/Google/TikTok Ads, GA4, and Mixpanel as data sources

## Test plan
- [ ] Run `go build -o bruin . && ./bruin init ecommerce my-pipeline` and verify the interactive picker works
- [ ] Verify generated SQL uses correct dialect for each warehouse option
- [ ] Verify multi-select ad platforms generate proper UNION ALL queries
- [ ] Run `make test` and `make format` to confirm CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)