### PR TITLE
Fix Mixpanel purchase_events always returning 0 in stg_web_sessions

### DIFF
--- a/cmd/ecommerce_assets.go
+++ b/cmd/ecommerce_assets.go
@@ -607,6 +607,19 @@ columns:
 func generateStgWebSessions(c *EcommerceChoices) string {
 	var depends, sourceQuery, dateCast string
 
+	var timeDateCast string
+	switch c.Warehouse {
+	case warehouseClickHouse:
+		dateCast = "toDate(session_raw_date)"
+		timeDateCast = "toDate(e.time)"
+	case warehouseBigQuery:
+		dateCast = "DATE(session_raw_date)"
+		timeDateCast = "DATE(e.time)"
+	case warehouseSnowflake:
+		dateCast = "session_raw_date::DATE"
+		timeDateCast = "e.time::DATE"
+	}
+
 	switch c.Analytics {
 	case analyticsGA4:
 		depends = `  - raw.ga4_sessions
@@ -634,7 +647,7 @@ LEFT JOIN raw.ga4_events e
 	case analyticsMixpanel:
 		depends = `  - raw.mixpanel_events`
 
-		sourceQuery = `SELECT
+		sourceQuery = fmt.Sprintf(`SELECT
     s.session_raw_date,
     s.total_sessions,
     s.new_users,
@@ -643,7 +656,7 @@ LEFT JOIN raw.ga4_events e
     s.channel
 FROM (
     SELECT
-        e.time AS session_raw_date,
+        %s AS session_raw_date,
         COUNT(*) AS total_sessions,
         COUNT(CASE WHEN e.is_new_user = true THEN 1 END) AS new_users,
         COUNT(CASE WHEN e.session_duration > 10 THEN 1 END) AS engaged_sessions,
@@ -660,22 +673,13 @@ FROM (
 ) s
 LEFT JOIN (
     SELECT
-        e.time AS purchase_date,
+        %s AS purchase_date,
         COUNT(*) AS purchase_events
     FROM raw.mixpanel_events e
     WHERE e.event_name = 'purchase'
     GROUP BY purchase_date
 ) p
-    ON s.session_raw_date = p.purchase_date`
-	}
-
-	switch c.Warehouse {
-	case warehouseClickHouse:
-		dateCast = "toDate(session_raw_date)"
-	case warehouseBigQuery:
-		dateCast = "DATE(session_raw_date)"
-	case warehouseSnowflake:
-		dateCast = "session_raw_date::DATE"
+    ON s.session_raw_date = p.purchase_date`, timeDateCast, timeDateCast)
 	}
 
 	return fmt.Sprintf(`/* @bruin

--- a/cmd/ecommerce_assets.go
+++ b/cmd/ecommerce_assets.go
@@ -635,21 +635,38 @@ LEFT JOIN raw.ga4_events e
 		depends = `  - raw.mixpanel_events`
 
 		sourceQuery = `SELECT
-    e.time AS session_raw_date,
-    COUNT(*) AS total_sessions,
-    COUNT(CASE WHEN e.is_new_user = true THEN 1 END) AS new_users,
-    COUNT(CASE WHEN e.session_duration > 10 THEN 1 END) AS engaged_sessions,
-    COUNT(CASE WHEN e.event_name = 'purchase' THEN 1 END) AS purchase_events,
-    CASE
-        WHEN e.utm_source = 'facebook' THEN 'paid_ads'
-        WHEN e.utm_medium = 'email' THEN 'email'
-        WHEN e.utm_medium = 'organic' THEN 'organic_search'
-        WHEN e.utm_medium = 'cpc' THEN 'paid_search'
-        ELSE 'other'
-    END AS channel
-FROM raw.mixpanel_events e
-WHERE e.event_name = 'session_start'
-GROUP BY session_raw_date, channel`
+    s.session_raw_date,
+    s.total_sessions,
+    s.new_users,
+    s.engaged_sessions,
+    COALESCE(p.purchase_events, 0) AS purchase_events,
+    s.channel
+FROM (
+    SELECT
+        e.time AS session_raw_date,
+        COUNT(*) AS total_sessions,
+        COUNT(CASE WHEN e.is_new_user = true THEN 1 END) AS new_users,
+        COUNT(CASE WHEN e.session_duration > 10 THEN 1 END) AS engaged_sessions,
+        CASE
+            WHEN e.utm_source = 'facebook' THEN 'paid_ads'
+            WHEN e.utm_medium = 'email' THEN 'email'
+            WHEN e.utm_medium = 'organic' THEN 'organic_search'
+            WHEN e.utm_medium = 'cpc' THEN 'paid_search'
+            ELSE 'other'
+        END AS channel
+    FROM raw.mixpanel_events e
+    WHERE e.event_name = 'session_start'
+    GROUP BY session_raw_date, channel
+) s
+LEFT JOIN (
+    SELECT
+        e.time AS purchase_date,
+        COUNT(*) AS purchase_events
+    FROM raw.mixpanel_events e
+    WHERE e.event_name = 'purchase'
+    GROUP BY purchase_date
+) p
+    ON s.session_raw_date = p.purchase_date`
 	}
 
 	switch c.Warehouse {


### PR DESCRIPTION
## Summary

- The Mixpanel `stg_web_sessions` query filtered `WHERE event_name = 'session_start'`, making `COUNT(CASE WHEN event_name = 'purchase' ...)` always evaluate to 0. This silently broke conversion-rate and ROAS calculations in `rpt_marketing_roi` and `rpt_daily_kpis`.
- Restructured the query to use a LEFT JOIN pattern (mirroring the GA4 path): session metrics are aggregated from `session_start` events in one subquery, purchase counts in another, joined by date.
- This ensures purchases are correctly counted while channel attribution stays tied to the session's UTM params rather than the purchase event's.

## Test plan

- [ ] Generate an ecommerce pipeline with Mixpanel analytics and verify the `stg_web_sessions` SQL output contains the LEFT JOIN structure
- [ ] Confirm downstream reports (`rpt_marketing_roi`, `rpt_daily_kpis`) produce non-zero `purchase_events` and valid conversion rates with sample Mixpanel data

🤖 Generated with [Claude Code](https://claude.com/claude-code)