### PR TITLE
Enhance documentation for quality check notifications

### DIFF
--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -60,6 +60,6 @@ The structure of the quality checks is rather simple:
 | `name`          | String | yes  | The name of the quality check, see [Quality](../quality/overview) |
 | `blocking`      | Bool   | no   | Whether the check should block the downstreams, default `true`    |
 | `value`         | Any    | no   | Check-specific expected value                                     |
-| `notifications` | Object | no   | Per-check notification config. If omitted, no notification is sent for this check (asset-level notifications do not apply to individual checks). |
+| `notifications` | Object | no   | Per-check notification config. If omitted, no notification is sent for this check (asset-level notifications do not apply to individual checks). Uses the same structure as [asset-level notifications](/cloud/notifications). |
 
 For more details on the quality checks, please refer to the  [Quality](../quality/overview) documentation.

--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -55,10 +55,11 @@ Each column will have the following keys:
 
 The structure of the quality checks is rather simple:
 
-| key        | type   | req? | description                                                       |
-|------------|--------|------|-------------------------------------------------------------------|
-| `name`     | String | yes  | The name of the quality check, see [Quality](../quality/overview) |
-| `blocking` | Bool   | no   | Whether the check should block the downstreams, default `true`    |
-| `value`    | Any    | no   | Check-specific expected value                                     |
+| key             | type   | req? | description                                                       |
+|-----------------|--------|------|-------------------------------------------------------------------|
+| `name`          | String | yes  | The name of the quality check, see [Quality](../quality/overview) |
+| `blocking`      | Bool   | no   | Whether the check should block the downstreams, default `true`    |
+| `value`         | Any    | no   | Check-specific expected value                                     |
+| `notifications` | Object | no   | Per-check notification config. If omitted, no notification is sent for this check (asset-level notifications do not apply to individual checks). |
 
 For more details on the quality checks, please refer to the  [Quality](../quality/overview) documentation.

--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -304,3 +304,4 @@ custom_checks:
 | `query` | str | - | The SQL query to execute. |
 | `value` | int | `0` | The expected integer value the query should return to pass. |
 | `blocking` | bool | `false` | Whether a failure of this check should block downstream assets. |
+| `notifications` | object | - | Per-check notification config. If omitted, no notification is sent for this check (asset-level notifications do not apply to individual checks). Uses the same structure as asset-level notifications. |

--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -6,7 +6,7 @@ Bruin Cloud supports notifications across Slack, Microsoft Teams, Discord, and g
 |-------|---------------|-----------------------|
 | **Pipeline** | When an entire pipeline run succeeds or fails | `pipeline.yml` |
 | **Asset** | When a single asset succeeds or fails | Asset definition file |
-| **Check** | When a quality check (column or custom) succeeds or fails | Asset definition file |
+| **Check** | When a quality check with its own `notifications` block succeeds or fails | Asset definition file |
 
 All three scopes share the same `notifications` block structure and the same `success`/`failure` flags. The `success` and `failure` flags default to `true`, so omitting them means notifications are sent for both outcomes.
 
@@ -91,7 +91,7 @@ notifications:
     # Notified when the asset succeeds or fails (does not cover individual checks).
     - channel: "#data-quality"
 
-    # Notified only when something goes wrong: a check fails or the asset fails.
+    # Notified only when the asset fails.
     - channel: "#data-alerts"
       success: false
 
@@ -102,7 +102,7 @@ columns:
       - name: unique
       - name: accepted_values
         value: ["pending", "shipped", "delivered"]
-        # This check overrides the asset-level notifications — only sent to #data-alerts on failure
+        # This check has its own notifications — sent to #data-alerts on failure only
         notifications:
           slack:
             - channel: "#data-alerts"
@@ -112,7 +112,7 @@ custom_checks:
   - name: order count is positive
     query: SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM orders.curated
     value: 1
-    # This check overrides the asset-level notifications with its own config
+    # This check has its own notifications configured
     notifications:
       slack:
         - channel: "#data-quality"
@@ -130,7 +130,7 @@ Checks without their own `notifications` block send no notification — asset-le
 - **Custom check** — fires immediately when that custom check task completes (pass or fail).
 - **Asset success** — fires after all checks have passed (i.e., the asset is fully complete including all checks).
 
-These are distinct events. An asset with 5 column checks may produce up to 5 check notifications plus 1 asset success notification per run.
+These are distinct events. Only checks with their own `notifications` block produce check notifications. An asset success notification fires once regardless of how many checks pass.
 
 ---
 

--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -78,7 +78,7 @@ Asset success notifications fire after the asset task **and all its quality chec
 
 Check notifications fire for each individual quality check that runs against an asset — both **column-level checks** (defined under `columns[].checks`) and **custom checks** (defined under `custom_checks`).
 
-The same `notifications` block on the asset controls check notifications. The `success`/`failure` flags apply to check outcomes as well.
+By default, checks inherit the asset-level `notifications` block. Individual checks can also have their own `notifications` block that **overrides** the asset-level config for that check only. This lets you route specific checks to dedicated channels while keeping a catch-all at the asset level.
 
 ```bruin-sql
 /* @bruin
@@ -88,11 +88,11 @@ type: bq.sql
 
 notifications:
   slack:
-    # This channel gets notified when the asset succeeds AND when any check succeeds or fails
-    - channel: "#channel1"
+    # Notified on every outcome: each check passing, each check failing, and the asset succeeding or failing.
+    - channel: "#data-quality"
 
-    # This channel gets only check/asset failure alerts
-    - channel: "#channel2"
+    # Notified only when something goes wrong: a check fails or the asset fails.
+    - channel: "#data-alerts"
       success: false
 
 columns:
@@ -100,16 +100,29 @@ columns:
     checks:
       - name: not_null
       - name: unique
+      - name: accepted_values
+        value: ["pending", "shipped", "delivered"]
+        # This check overrides the asset-level notifications — only sent to #data-alerts on failure
+        notifications:
+          slack:
+            - channel: "#data-alerts"
+              success: false
 
 custom_checks:
   - name: order count is positive
     query: SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM orders.curated
     value: 1
+    # This check overrides the asset-level notifications with its own config
+    notifications:
+      slack:
+        - channel: "#data-quality"
 
 @bruin */
 
 SELECT ...
 ```
+
+Checks without their own `notifications` block send no notification — asset-level notifications only cover the asset success/failure event, not individual checks.
 
 ### Check notification timing
 

--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -78,7 +78,7 @@ Asset success notifications fire after the asset task **and all its quality chec
 
 Check notifications fire for each individual quality check that runs against an asset — both **column-level checks** (defined under `columns[].checks`) and **custom checks** (defined under `custom_checks`).
 
-By default, checks inherit the asset-level `notifications` block. Individual checks can also have their own `notifications` block that **overrides** the asset-level config for that check only. This lets you route specific checks to dedicated channels while keeping a catch-all at the asset level.
+Check notifications are **opt-in per check** — asset-level notifications do not apply to individual checks. To receive a notification for a specific check, add a `notifications` block directly on that check.
 
 ```bruin-sql
 /* @bruin
@@ -88,7 +88,7 @@ type: bq.sql
 
 notifications:
   slack:
-    # Notified on every outcome: each check passing, each check failing, and the asset succeeding or failing.
+    # Notified when the asset succeeds or fails (does not cover individual checks).
     - channel: "#data-quality"
 
     # Notified only when something goes wrong: a check fails or the asset fails.


### PR DESCRIPTION
- Added `notifications` key to quality check definitions in `columns.md` and `definition-schema.md`, allowing per-check notification configurations.
- Updated `notifications.md` to clarify that individual checks can override asset-level notification settings, enabling more granular control over notification channels for check outcomes.