### PR TITLE
Make cloud diagnose infer project ID

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -151,6 +151,26 @@ func resolveRunID(ctx context.Context, c *cli.Command, client *bruincloud.APICli
 	return "", errors.New("either --run-id or --latest is required")
 }
 
+func resolveProjectID(projectID string, listProjects func() ([]bruincloud.Project, error)) (string, error) {
+	if projectID != "" {
+		return projectID, nil
+	}
+
+	projects, err := listProjects()
+	if err != nil {
+		return "", fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	switch len(projects) {
+	case 0:
+		return "", errors.New("no Bruin Cloud projects found for this account")
+	case 1:
+		return projects[0].ID, nil
+	default:
+		return "", errors.New("--project-id is required when your account has access to multiple projects")
+	}
+}
+
 func printFormattedLogs(result json.RawMessage) {
 	var logResp struct {
 		Logs struct {
@@ -920,16 +940,23 @@ func cloudRunsDiagnose() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
-			project := c.String("project-id")
 			pipeline := c.String("pipeline")
-			if project == "" || pipeline == "" {
-				printError(errors.New("--project-id and --pipeline are required"), output, "Missing required flags")
+			if pipeline == "" {
+				printError(errors.New("--pipeline is required"), output, "Missing required flags")
 				return cli.Exit("", 1)
 			}
 
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			project, err := resolveProjectID(c.String("project-id"), func() ([]bruincloud.Project, error) {
+				return client.ListProjects(ctx)
+			})
+			if err != nil {
+				printError(err, output, "Failed to resolve project ID")
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
@@ -71,6 +73,68 @@ func TestResolveAPIKey_NoKeyError(t *testing.T) {
 
 	err := app.Run(t.Context(), []string{"test"})
 	require.NoError(t, err)
+}
+
+func TestResolveProjectID_UsesExplicitProject(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	projectID, err := resolveProjectID("project-123", func() ([]bruincloud.Project, error) {
+		called = true
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "project-123", projectID)
+	assert.False(t, called)
+}
+
+func TestResolveProjectID_UsesSingleAccessibleProject(t *testing.T) {
+	t.Parallel()
+
+	projectID, err := resolveProjectID("", func() ([]bruincloud.Project, error) {
+		return []bruincloud.Project{{ID: "project-123", Name: "only-project"}}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "project-123", projectID)
+}
+
+func TestResolveProjectID_NoProjects(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveProjectID("", func() ([]bruincloud.Project, error) {
+		return []bruincloud.Project{}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Bruin Cloud projects found")
+}
+
+func TestResolveProjectID_MultipleProjects(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveProjectID("", func() ([]bruincloud.Project, error) {
+		return []bruincloud.Project{
+			{ID: "project-1", Name: "first"},
+			{ID: "project-2", Name: "second"},
+		}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project-id is required")
+}
+
+func TestResolveProjectID_ListProjectsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveProjectID("", func() ([]bruincloud.Project, error) {
+		return nil, errors.New("boom")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+	assert.Contains(t, err.Error(), "boom")
 }
 
 func TestCloudCommand_Help(t *testing.T) {


### PR DESCRIPTION
Allow bruin cloud runs diagnose to work without --project-id when the account only has one project. This adds a small project resolver and tests for explicit, single-project, empty, and ambiguous cases.

Validation: make format, make test.