### PR TITLE
fix(bruincloud): retry on HTTP 429 with Retry-After backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/vault-client-go v0.4.3
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jackc/pgx/v5 v5.7.5
@@ -170,7 +171,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -9,9 +9,17 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
-const defaultBaseURL = "https://cloud.getbruin.com/api/v1"
+const (
+	defaultBaseURL      = "https://cloud.getbruin.com/api/v1"
+	defaultRetryMax     = 3
+	defaultRetryWaitMin = 1 * time.Second
+	defaultRetryWaitMax = 10 * time.Second
+)
 
 // APIClient is the HTTP client for the Bruin Cloud API.
 type APIClient struct {
@@ -22,11 +30,35 @@ type APIClient struct {
 
 // NewAPIClient creates a new API client with the given API key.
 func NewAPIClient(apiKey string) *APIClient {
+	rc := retryablehttp.NewClient()
+	rc.Logger = nil
+	rc.RetryMax = defaultRetryMax
+	rc.RetryWaitMin = defaultRetryWaitMin
+	rc.RetryWaitMax = defaultRetryWaitMax
+	rc.CheckRetry = retryOn429
+	// Preserve the final response (body + status) when retries are exhausted so
+	// doRequest can surface the upstream APIError instead of an opaque "giving
+	// up after N attempts" message.
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	return &APIClient{
 		baseURL:    defaultBaseURL,
 		apiKey:     apiKey,
-		httpClient: &http.Client{},
+		httpClient: rc.StandardClient(),
 	}
+}
+
+// retryOn429 retries only on HTTP 429 Too Many Requests. Other error statuses
+// (including 5xx) are returned to the caller unchanged — 429 is the only
+// status the server signals as explicitly retryable, and the default backoff
+// respects the Retry-After header automatically.
+func retryOn429(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		return true, nil
+	}
+	return false, err
 }
 
 // doRequest performs an HTTP request and unmarshals the response.

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,6 +109,61 @@ func TestDoRequest_ErrorParsing(t *testing.T) {
 		_, err := client.ListProjects(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse response")
+	})
+}
+
+func TestDoRequest_RetriesOn429(t *testing.T) {
+	t.Parallel()
+
+	t.Run("recovers after 429", func(t *testing.T) {
+		t.Parallel()
+		var attempts atomic.Int32
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			n := attempts.Add(1)
+			if n < 3 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		})
+
+		_, err := client.ListProjects(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, int32(3), attempts.Load())
+	})
+
+	t.Run("returns 429 error after exhausting retries", func(t *testing.T) {
+		t.Parallel()
+		var attempts atomic.Int32
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+		})
+
+		_, err := client.ListProjects(t.Context())
+		require.Error(t, err)
+		var apiErr *APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode)
+		// NewAPIClient configures RetryMax=3, so 1 initial + 3 retries = 4 attempts.
+		assert.Equal(t, int32(defaultRetryMax+1), attempts.Load())
+	})
+
+	t.Run("does not retry on 500", func(t *testing.T) {
+		t.Parallel()
+		var attempts atomic.Int32
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		_, err := client.ListProjects(t.Context())
+		require.Error(t, err)
+		assert.Equal(t, int32(1), attempts.Load())
 	})
 }
 


### PR DESCRIPTION
## Summary
- Every `bruin cloud ...` command funnels through `pkg/bruincloud.APIClient.doRequest`, which returned an `APIError` on the first 429 response — no retry, `Retry-After` header ignored.
- Wrap the underlying `http.Client` with `hashicorp/go-retryablehttp` (already present as an indirect dep, now promoted to direct). Custom `CheckRetry` retries only on 429; `DefaultBackoff` honors `Retry-After` automatically.
- `PassthroughErrorHandler` preserves the final response when retries are exhausted so callers still get a proper `APIError` with the upstream status/message instead of an opaque "giving up after N attempts".

## Test plan
- [x] `go test ./pkg/bruincloud/... -race` passes, including three new tests covering:
  - recovery after 429s (`TestDoRequest_RetriesOn429/recovers_after_429`)
  - exhausted retries surface the 429 `APIError` (`returns_429_error_after_exhausting_retries`)
  - 5xx responses are not retried (`does_not_retry_on_500`)
- [x] `make format` clean
- [x] `make test` full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)