### PR TITLE
Fix placeholder description matching

### DIFF
--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -105,6 +105,69 @@ var placeholderDescriptions = []string{
 	"work in progress",
 }
 
+var descriptionTokenPattern = regexp.MustCompile(`[a-z0-9]+`)
+
+type placeholderDescriptionMatcher struct {
+	phrase string
+	tokens []string
+}
+
+var placeholderDescriptionMatchers = buildPlaceholderDescriptionMatchers(placeholderDescriptions)
+
+func buildPlaceholderDescriptionMatchers(placeholders []string) []placeholderDescriptionMatcher {
+	matchers := make([]placeholderDescriptionMatcher, 0, len(placeholders))
+	for _, placeholder := range placeholders {
+		tokens := descriptionTokenPattern.FindAllString(strings.ToLower(placeholder), -1)
+		if len(tokens) == 0 {
+			continue
+		}
+
+		matchers = append(matchers, placeholderDescriptionMatcher{
+			phrase: placeholder,
+			tokens: tokens,
+		})
+	}
+
+	return matchers
+}
+
+func findPlaceholderDescription(description string) (string, bool) {
+	descriptionTokens := descriptionTokenPattern.FindAllString(strings.ToLower(strings.TrimSpace(description)), -1)
+	if len(descriptionTokens) == 0 {
+		return "", false
+	}
+
+	for _, matcher := range placeholderDescriptionMatchers {
+		if containsTokenSequence(descriptionTokens, matcher.tokens) {
+			return matcher.phrase, true
+		}
+	}
+
+	return "", false
+}
+
+func containsTokenSequence(tokens []string, sequence []string) bool {
+	if len(sequence) == 0 || len(sequence) > len(tokens) {
+		return false
+	}
+
+	for start := 0; start <= len(tokens)-len(sequence); start++ {
+		matched := true
+		for offset := range sequence {
+			if tokens[start+offset] != sequence[offset] {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
 var builtinRules = map[string]validators{
 	"asset-name-is-lowercase": {
 		Asset: func(ctx context.Context, pipeline *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -347,33 +410,19 @@ var builtinRules = map[string]validators{
 		Asset: func(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 			var issues []*Issue
 
-			lowerAssetDesc := strings.ToLower(strings.TrimSpace(asset.Description))
-			if lowerAssetDesc != "" {
-				for _, placeholder := range placeholderDescriptions {
-					if strings.Contains(lowerAssetDesc, placeholder) {
-						issues = append(issues, &Issue{
-							Task:        asset,
-							Description: "Asset description appears to contain placeholder text: '" + placeholder + "'",
-						})
-						break
-					}
-				}
+			if placeholder, found := findPlaceholderDescription(asset.Description); found {
+				issues = append(issues, &Issue{
+					Task:        asset,
+					Description: "Asset description appears to contain placeholder text: '" + placeholder + "'",
+				})
 			}
 
 			for _, col := range asset.Columns {
-				lowerColDesc := strings.ToLower(strings.TrimSpace(col.Description))
-				if lowerColDesc == "" {
-					continue
-				}
-
-				for _, placeholder := range placeholderDescriptions {
-					if strings.Contains(lowerColDesc, placeholder) {
-						issues = append(issues, &Issue{
-							Task:        asset,
-							Description: "Column '" + col.Name + "' description appears to contain placeholder text: '" + placeholder + "'",
-						})
-						break
-					}
+				if placeholder, found := findPlaceholderDescription(col.Description); found {
+					issues = append(issues, &Issue{
+						Task:        asset,
+						Description: "Column '" + col.Name + "' description appears to contain placeholder text: '" + placeholder + "'",
+					})
 				}
 			}
 

--- a/pkg/lint/policy_test.go
+++ b/pkg/lint/policy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/sqlparser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockSQLParser struct {
@@ -228,5 +229,77 @@ func TestPolicyRuleSet(t *testing.T) {
 		mockParser := new(mockSQLParser)
 		_, err := spec.Rules(mockParser)
 		assert.Error(t, err)
+	})
+}
+
+func TestDescriptionMustNotBePlaceholderPolicy(t *testing.T) {
+	t.Parallel()
+
+	newRule := func(t *testing.T) lint.Rule {
+		t.Helper()
+
+		spec := &lint.PolicySpecification{
+			RuleSets: []lint.RuleSet{
+				{
+					Name:  "placeholder-description",
+					Rules: []string{"description-must-not-be-placeholder"},
+				},
+			},
+		}
+
+		rules, err := spec.Rules(nil)
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+		return rules[0]
+	}
+
+	t.Run("does not match placeholders inside larger words", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Description: "Tracks orders with wiped status records.",
+			Columns: []pipeline.Column{
+				{
+					Name:        "attempt_count",
+					Description: "Number of attempts to process the order.",
+				},
+			},
+		}
+
+		issues, err := newRule(t).ValidateAsset(t.Context(), &pipeline.Pipeline{}, asset)
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+
+	t.Run("matches single-word placeholder tokens", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Description: "TODO: add the real asset description.",
+		}
+
+		issues, err := newRule(t).ValidateAsset(t.Context(), &pipeline.Pipeline{}, asset)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].Description, "'todo'")
+	})
+
+	t.Run("matches multi-word placeholder tokens", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Description: "Order data synchronized from Shopify.",
+			Columns: []pipeline.Column{
+				{
+					Name:        "status",
+					Description: "Description goes here.",
+				},
+			},
+		}
+
+		issues, err := newRule(t).ValidateAsset(t.Context(), &pipeline.Pipeline{}, asset)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].Description, "'description goes here'")
 	})
 }


### PR DESCRIPTION
Fixes placeholder policy false positives like `wiped` matching `wip` and `attempts` matching `temp`.\n\nAdds regression coverage for whole-token placeholder matching.\n\nTests: `make format`, `make test`.