### PR TITLE
docs(python-sdk): sync with upstream SDK and add feature summary

### DIFF
--- a/docs/assets/python-sdk.md
+++ b/docs/assets/python-sdk.md
@@ -6,6 +6,16 @@ outline: deep
 
 The official Python SDK for Bruin CLI. Query databases, access connections, and read pipeline context — all with zero boilerplate.
 
+<p>
+  <a href="https://github.com/bruin-data/python-sdk" target="_blank" rel="noopener">
+    <img alt="GitHub" src="https://img.shields.io/badge/GitHub-bruin--data%2Fpython--sdk-181717?logo=github&logoColor=white">
+  </a>
+  &nbsp;
+  <a href="https://pypi.org/project/bruin-sdk/" target="_blank" rel="noopener">
+    <img alt="PyPI" src="https://img.shields.io/pypi/v/bruin-sdk?logo=pypi&logoColor=white&label=PyPI">
+  </a>
+</p>
+
 ```bruin-python
 """@bruin
 name: my_asset
@@ -16,6 +26,27 @@ from bruin import query, context
 
 df = query(f"SELECT * FROM users WHERE dt >= '{context.start_date}'")
 ```
+
+## Overview
+
+### Features
+- **Zero-boilerplate querying** — `query(sql)` returns a `pandas.DataFrame` (or `None` for DDL/DML) using the asset's default connection automatically.
+- **Typed connection objects** — `get_connection(name)` returns a lazily-initialized, type-appropriate database client.
+- **Pipeline context** — `context.start_date`, `context.vars`, `context.is_full_refresh`, and other `BRUIN_*` values exposed as typed Python attributes (no env-var parsing).
+- **JSON-Schema–aware variables** — `context.vars` coerces values to the types declared in `pipeline.yml`.
+- **Fresh reads, no caching** — every `context` access reads the env var live, so tests can monkeypatch freely.
+- **Automatic query annotation** — each query is tagged with a `@bruin.config` comment for observability and cost tracking.
+- **Lazy client creation** — database clients are only opened on first `.client` access; connections are closable via `.close()` or `with` blocks.
+- **Typed exceptions** — `BruinError` and subclasses (`ConnectionNotFoundError`, `ConnectionParseError`, `ConnectionTypeError`, `QueryError`).
+- **Clear missing-extra errors** — unset optional extras raise `ImportError` with the exact `pip install` command.
+
+### Supported connections
+
+Database: **BigQuery**, **Snowflake**, **PostgreSQL**, **Redshift**, **MSSQL**, **Synapse**, **Microsoft Fabric**, **MySQL**, **DuckDB**, **MotherDuck**, **SQLite**, **Databricks**, **ClickHouse**, **Athena**, **Trino**, **Oracle**, **IBM DB2**, **SAP HANA**, **Cloud Spanner**, **Vertica**.
+
+GCP extras (same connection): **BigQuery**, **Google Sheets**, **Google Cloud Storage**.
+
+Non-database: **Generic** (raw string, e.g. API keys / webhook URLs).
 
 ## Installation
 
@@ -34,8 +65,20 @@ For specific database connections, install the corresponding extras:
 | `bruin-sdk[postgres]` | PostgreSQL |
 | `bruin-sdk[redshift]` | Redshift |
 | `bruin-sdk[mssql]` | Microsoft SQL Server |
+| `bruin-sdk[synapse]` | Azure Synapse |
+| `bruin-sdk[fabric]` | Microsoft Fabric |
 | `bruin-sdk[mysql]` | MySQL |
 | `bruin-sdk[duckdb]` | DuckDB |
+| `bruin-sdk[motherduck]` | MotherDuck |
+| `bruin-sdk[databricks]` | Databricks |
+| `bruin-sdk[clickhouse]` | ClickHouse |
+| `bruin-sdk[athena]` | Amazon Athena |
+| `bruin-sdk[trino]` | Trino |
+| `bruin-sdk[oracle]` | Oracle |
+| `bruin-sdk[db2]` | IBM DB2 |
+| `bruin-sdk[hana]` | SAP HANA |
+| `bruin-sdk[spanner]` | Google Cloud Spanner |
+| `bruin-sdk[vertica]` | Vertica |
 | `bruin-sdk[sheets]` | Google Sheets |
 | `bruin-sdk[all]` | Everything |
 
@@ -92,15 +135,20 @@ from bruin import context
 | Property | Type | Env Var | Description |
 |:---------|:-----|:--------|:------------|
 | `context.start_date` | `date \| None` | `BRUIN_START_DATE` | Pipeline run start date |
-| `context.end_date` | `date \| None` | `BRUIN_END_DATE` | Pipeline run end date |
 | `context.start_datetime` | `datetime \| None` | `BRUIN_START_DATETIME` | Start date with time |
+| `context.start_timestamp` | `datetime \| None` | `BRUIN_START_TIMESTAMP` | Start timestamp with timezone |
+| `context.end_date` | `date \| None` | `BRUIN_END_DATE` | Pipeline run end date |
 | `context.end_datetime` | `datetime \| None` | `BRUIN_END_DATETIME` | End date with time |
+| `context.end_timestamp` | `datetime \| None` | `BRUIN_END_TIMESTAMP` | End timestamp with timezone |
 | `context.execution_date` | `date \| None` | `BRUIN_EXECUTION_DATE` | Execution date |
+| `context.execution_datetime` | `datetime \| None` | `BRUIN_EXECUTION_DATETIME` | Execution date with time |
+| `context.execution_timestamp` | `datetime \| None` | `BRUIN_EXECUTION_TIMESTAMP` | Execution timestamp with timezone |
 | `context.run_id` | `str \| None` | `BRUIN_RUN_ID` | Unique run identifier |
 | `context.pipeline` | `str \| None` | `BRUIN_PIPELINE` | Pipeline name |
 | `context.asset_name` | `str \| None` | `BRUIN_ASSET` | Current asset name |
 | `context.connection` | `str \| None` | `BRUIN_CONNECTION` | Asset's default connection |
 | `context.is_full_refresh` | `bool` | `BRUIN_FULL_REFRESH` | `True` when `--full-refresh` flag is set |
+| `context.commit_hash` | `str \| None` | `BRUIN_COMMIT_HASH` | Git commit hash of the pipeline's repository |
 | `context.vars` | `dict` | `BRUIN_VARS` | Pipeline variables (types preserved from JSON Schema) |
 
 All properties return `None` when the corresponding env var is missing (except `is_full_refresh` which returns `False`, and `vars` which returns `{}`).
@@ -117,6 +165,7 @@ print(context.end_date)         # datetime.date(2024, 6, 2)
 # Pipeline variables (types preserved from pipeline.yml JSON Schema)
 segment = context.vars["segment"]     # str: "enterprise"
 horizon = context.vars["horizon"]     # int: 30
+cohorts = context.vars["cohorts"]     # list[dict]
 
 # Conditional logic
 if context.is_full_refresh:
@@ -160,7 +209,7 @@ query("INSERT INTO audit_log VALUES ('ran_asset', NOW())")
 
 :::
 
-Every query is automatically annotated with `@bruin.config` metadata for observability and cost tracking.
+Every query is automatically annotated with a `@bruin.config` comment for observability and cost tracking.
 
 ### `get_connection(name)`
 
@@ -197,11 +246,24 @@ conn.client  # Lazy-initialized database client
 | `postgres` | `psycopg2.connection` | `bruin-sdk[postgres]` |
 | `redshift` | `psycopg2.connection` | `bruin-sdk[redshift]` |
 | `mssql` | `pymssql.Connection` | `bruin-sdk[mssql]` |
+| `synapse` | `pymssql.Connection` | `bruin-sdk[synapse]` |
+| `fabric` | `pymssql.Connection` | `bruin-sdk[fabric]` |
 | `mysql` | `mysql.connector.Connection` | `bruin-sdk[mysql]` |
 | `duckdb` | `duckdb.DuckDBPyConnection` | `bruin-sdk[duckdb]` |
-| `generic` | N/A (raises error) | — |
+| `motherduck` | `duckdb.DuckDBPyConnection` | `bruin-sdk[motherduck]` |
+| `sqlite` | `sqlite3.Connection` | *(stdlib)* |
+| `databricks` | `databricks.sql.Connection` | `bruin-sdk[databricks]` |
+| `clickhouse` | `clickhouse_connect.driver.Client` | `bruin-sdk[clickhouse]` |
+| `athena` | `pyathena.Connection` | `bruin-sdk[athena]` |
+| `trino` | `trino.dbapi.Connection` | `bruin-sdk[trino]` |
+| `oracle` | `oracledb.Connection` | `bruin-sdk[oracle]` |
+| `db2` | `ibm_db_dbi.Connection` | `bruin-sdk[db2]` |
+| `hana` | `hdbcli.dbapi.Connection` | `bruin-sdk[hana]` |
+| `spanner` | `google.cloud.spanner_dbapi.Connection` | `bruin-sdk[spanner]` |
+| `vertica` | `vertica_python.Connection` | `bruin-sdk[vertica]` |
+| `generic` | N/A (raises `ConnectionTypeError`) | — |
 
-Client creation is **lazy** — the actual database connection is only established when `.client` is first accessed.
+Client creation is **lazy** — the actual database connection is only established when `.client` is first accessed. Call `conn.close()` (or use `with get_connection(...) as conn:`) to release the client when you're done.
 
 #### GCP connections
 
@@ -217,9 +279,14 @@ df = bq_client.query("SELECT 1").to_dataframe()
 # Google Sheets
 sheets_client = conn.sheets()  # requires bruin-sdk[sheets]
 
+# Google Cloud Storage
+gcs_client = conn.storage()  # requires google-cloud-storage
+
 # Raw credentials for any Google API
 creds = conn.credentials  # google.oauth2.Credentials
 ```
+
+Credentials are resolved from the inline `service_account_json` on the connection, or from [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) when `use_application_default_credentials` is set.
 
 #### Generic connections
 


### PR DESCRIPTION
## Summary
- Validated `docs/assets/python-sdk.md` against the `bruin-data/python-sdk` source (v0.5.0 on PyPI) and filled in missing pieces: added `start_timestamp` / `end_timestamp` / `execution_datetime` / `execution_timestamp` / `commit_hash` to the `context` table, expanded install extras and `.client` types to cover `synapse`, `fabric`, `motherduck`, `databricks`, `clickhouse`, `athena`, `trino`, `oracle`, `db2`, `hana`, `spanner`, `vertica`, and `sqlite`, and documented `GCPConnection.storage()` plus `.close()` / context-manager semantics.
- Added an Overview section at the top with bullet-point summaries of features and supported connections.
- Added GitHub and PyPI badge links near the top pointing to `bruin-data/python-sdk` and `pypi.org/project/bruin-sdk/`.

## Test plan
- [ ] Run `npm run docs:dev` and verify the page renders at `/bruin/assets/python-sdk.html`
- [ ] Confirm the GitHub and PyPI badges link out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)