### PR TITLE
fix(surveymonkey): rename datacenter to region

### DIFF
--- a/docs/ingestion/surveymonkey.md
+++ b/docs/ingestion/surveymonkey.md
@@ -18,7 +18,7 @@ connections:
 ```
 
 - `access_token` (required): The access token used to authenticate with the SurveyMonkey API.
-- `region` (optional): The region region. Must be `us` (default), `eu`, or `ca`.
+- `region` (optional): The region. Must be `us` (default), `eu`, or `ca`.
 
 For EU or CA accounts:
 

--- a/docs/ingestion/surveymonkey.md
+++ b/docs/ingestion/surveymonkey.md
@@ -18,7 +18,7 @@ connections:
 ```
 
 - `access_token` (required): The access token used to authenticate with the SurveyMonkey API.
-- `datacenter` (optional): The datacenter region. Must be `us` (default), `eu`, or `ca`.
+- `region` (optional): The region region. Must be `us` (default), `eu`, or `ca`.
 
 For EU or CA accounts:
 
@@ -27,7 +27,7 @@ connections:
   surveymonkey:
     - name: "my_surveymonkey_eu"
       access_token: "your-access-token"
-      datacenter: "eu"
+      region: "eu"
 ```
 
 ### Step 2: Create an asset file for data ingestion
@@ -83,4 +83,4 @@ Use these as the `source_table` parameter in the asset configuration.
 5. Copy the **Access Token** from the Credentials section.
 
 > [!NOTE]
-> For EU accounts, use the [EU Developer Portal](https://developer.eu.surveymonkey.com/apps/) and set `datacenter: eu`. For CA accounts, use the [CA Developer Portal](https://developer.ca.surveymonkey.com/apps/) and set `datacenter: ca`.
+> For EU accounts, use the [EU Developer Portal](https://developer.eu.surveymonkey.com/apps/) and set `region: eu`. For CA accounts, use the [CA Developer Portal](https://developer.ca.surveymonkey.com/apps/) and set `region: ca`.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -27,7 +27,7 @@
         "access_token": {
           "type": "string"
         },
-        "datacenter": {
+        "region": {
           "type": "string"
         }
       },

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1530,7 +1530,7 @@ func (c VerticaConnection) GetName() string {
 type SurveyMonkeyConnection struct {
 	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	AccessToken string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token"`
-	Datacenter  string `yaml:"datacenter,omitempty" json:"datacenter,omitempty" mapstructure:"datacenter"`
+	Region      string `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
 }
 
 func (c SurveyMonkeyConnection) GetName() string {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -936,7 +936,7 @@ func (m *Manager) AddSurveyMonkeyConnectionFromConfig(connection *config.SurveyM
 
 	client, err := surveymonkey.NewClient(surveymonkey.Config{
 		AccessToken: connection.AccessToken,
-		Datacenter:  connection.Datacenter,
+		Region:      connection.Region,
 	})
 	if err != nil {
 		return err

--- a/pkg/surveymonkey/config.go
+++ b/pkg/surveymonkey/config.go
@@ -4,13 +4,13 @@ import "net/url"
 
 type Config struct {
 	AccessToken string
-	Datacenter  string
+	Region      string
 }
 
 func (c *Config) GetIngestrURI() string {
 	uri := "surveymonkey://?access_token=" + url.QueryEscape(c.AccessToken)
-	if c.Datacenter != "" {
-		uri += "&datacenter=" + url.QueryEscape(c.Datacenter)
+	if c.Region != "" {
+		uri += "&region=" + url.QueryEscape(c.Region)
 	}
 	return uri
 }


### PR DESCRIPTION
## Summary
- Rename `datacenter` to `region` in SurveyMonkey connection config, schema, and docs
- Matches naming convention used by Intercom and CustomerIO

## Test plan
- [x] `go build ./...` passes
- [x] Config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)