### PR TITLE
query: fall back to plain output for --dry-run --output csv

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -175,7 +175,8 @@ func Query() *cli.Command {
 				}
 				output := c.String("output")
 				if output == "csv" {
-					return handleError(output, errors.New("CSV output is not supported for --dry-run; use 'plain' or 'json'"))
+					fmt.Fprintln(os.Stderr, "CSV output is not supported for --dry-run; falling back to plain.")
+					output = outputFormatPlain
 				}
 
 				dryRunner, ok := conn.(query.QueryDryRunner)


### PR DESCRIPTION
## Summary
- `bruin query --dry-run --output csv` previously errored out because CSV has no clean shape for dry-run results (mix of summary scalars, referenced tables, schema, explain plan).
- Now it prints a notice to stderr (`CSV output is not supported for --dry-run; falling back to plain.`) and renders the plain output instead.

## Test plan
- [ ] `bruin query --dry-run --output csv -c <bq>` shows the warning on stderr and prints the plain dry-run output on stdout
- [ ] `bruin query --dry-run --output json` and `--output plain` still behave as before
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)