### PR TITLE
feat: configurable timeout for sensor assets

### DIFF
--- a/docs/assets/sensor.md
+++ b/docs/assets/sensor.md
@@ -38,6 +38,21 @@ parameters:
     poke_interval: 10 # seconds // [!code focus]
 ```
 
+### Timeout
+
+By default a sensor gives up after 24 hours and the asset fails. You can shorten that bound with the `timeout` parameter. The value uses the same single-unit duration syntax as pipeline `interval_modifiers`: a number followed by `s`, `m`, `h`, `d`, `ms`, or `ns`. Combinators like `1h30m` are not supported — use `90m` instead. The `M` (months) suffix is not supported for `timeout` because a month is not a fixed duration.
+
+```yaml
+name: my_sensor
+type: bq.sensor.query
+parameters:
+    query: select count(*) > 0 from `your-project-id.raw.external_asset`
+    poke_interval: 60
+    timeout: 1h # [!code focus]
+```
+
+If `timeout` is unset, invalid, or zero, the default `24h` applies.
+
 ## Definition Schema
 
 Sensors are defined as YAML files, with the naming schema `<name>.asset.yml`.

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -1318,6 +1318,23 @@ func TestIndividualTasks(t *testing.T) {
 			},
 		},
 		{
+			name: "duckdb-sensor-timeout",
+			task: e2e.Task{
+				Name:    "duckdb-sensor-timeout",
+				Command: binary,
+				Args:    []string{"run", "--sensor-mode", "wait", filepath.Join(currentFolder, "test-pipelines/duckdb-sensor-timeout")},
+				Env:     []string{},
+				Expected: e2e.Output{
+					ExitCode: 1,
+					Contains: []string{"Sensor timed out after 3s"},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
 			name: "test-truncate-insert-validate",
 			task: e2e.Task{
 				Name:       "test-truncate-insert-validate",

--- a/integration-tests/test-pipelines/duckdb-sensor-timeout/assets/sensor.asset.yml
+++ b/integration-tests/test-pipelines/duckdb-sensor-timeout/assets/sensor.asset.yml
@@ -1,0 +1,6 @@
+name: duckdb_sensor_timeout.always_false
+type: duckdb.sensor.query
+parameters:
+    query: SELECT FALSE
+    poke_interval: "1"
+    timeout: 3s

--- a/integration-tests/test-pipelines/duckdb-sensor-timeout/pipeline.yml
+++ b/integration-tests/test-pipelines/duckdb-sensor-timeout/pipeline.yml
@@ -1,0 +1,6 @@
+name: duckdb_sensor_timeout
+schedule: daily
+start_date: "2024-01-01"
+
+default_connections:
+  duckdb: duckdb-default

--- a/pkg/ansisql/operator.go
+++ b/pkg/ansisql/operator.go
@@ -70,14 +70,15 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 		fmt.Fprintln(printer, "Poking:", qry[0].Query)
 	}
 
-	timeout := time.After(24 * time.Hour)
+	sensorTimeout := helpers.GetSensorTimeout(t)
+	timeout := time.After(sensorTimeout)
 	for {
 		select {
 		case <-timeout:
 			if printerExists {
-				fmt.Fprintln(printer, "Sensor timed out after 24 hours")
+				fmt.Fprintln(printer, "Sensor timed out after", sensorTimeout)
 			}
-			return errors.New("Sensor timed out after 24 hours")
+			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
 			if querier, ok := conn.(interface {
 				Select(ctx context.Context, q *query.Query) ([][]interface{}, error)
@@ -187,14 +188,15 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		fmt.Fprintln(printer, "Poking:", tableName)
 	}
 
-	timeout := time.After(24 * time.Hour)
+	sensorTimeout := helpers.GetSensorTimeout(t)
+	timeout := time.After(sensorTimeout)
 	for {
 		select {
 		case <-timeout:
 			if printerExists {
-				fmt.Fprintln(printer, "Sensor timed out after 24 hours")
+				fmt.Fprintln(printer, "Sensor timed out after", sensorTimeout)
 			}
-			return errors.New("Sensor timed out after 24 hours")
+			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 
 		default:
 			res, err := tableChecker.Select(ctx, extractedQuery)

--- a/pkg/ansisql/operator_test.go
+++ b/pkg/ansisql/operator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockConnectionGetter struct {
@@ -260,7 +261,7 @@ func TestTableSensorTimesOutWhenConfigured(t *testing.T) {
 	})
 	elapsed := time.Since(start)
 
-	assert.ErrorContains(t, err, "Sensor timed out after")
+	require.ErrorContains(t, err, "Sensor timed out after")
 	assert.Less(t, elapsed, 5*time.Second, "timeout should fire promptly")
 }
 

--- a/pkg/ansisql/operator_test.go
+++ b/pkg/ansisql/operator_test.go
@@ -3,6 +3,7 @@ package ansisql
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
@@ -227,6 +228,40 @@ func TestNewTableSensorExtractQueriesFromStringError(t *testing.T) {
 	})
 
 	assert.ErrorContains(t, err, "failed to extract table exists query")
+}
+
+func TestTableSensorTimesOutWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	mockConn := &MockConnectionGetter{}
+	mockTableExistsChecker := &MockTableExistsChecker{}
+	mockExtractor := &MockQueryExtractor{}
+
+	mockConn.On("GetConnection", "gcp-default").Return(mockTableExistsChecker)
+	mockTableExistsChecker.On("BuildTableExistsQuery", "database.test.table").Return("SELECT 1", nil)
+	mockExtractor.On("ExtractQueriesFromString", "SELECT 1").Return([]*query.Query{{Query: "SELECT 1"}}, nil)
+	// Always return 0 so the sensor never succeeds.
+	mockTableExistsChecker.On("Select", mock.Anything, mock.Anything).Return([][]interface{}{{int64(0)}}, nil)
+
+	ts := NewTableSensor(mockConn, "wait", mockExtractor)
+
+	start := time.Now()
+	err := ts.RunTask(t.Context(), &pipeline.Pipeline{}, &pipeline.Asset{
+		Type: pipeline.AssetTypeBigqueryQuery,
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "test-file.sql",
+			Content: "some content",
+		},
+		Parameters: pipeline.EmptyStringMap{
+			"table":         "database.test.table",
+			"timeout":       "100ms",
+			"poke_interval": "0",
+		},
+	})
+	elapsed := time.Since(start)
+
+	assert.ErrorContains(t, err, "Sensor timed out after")
+	assert.Less(t, elapsed, 5*time.Second, "timeout should fire promptly")
 }
 
 func TestNewTableSensorgNoQueries(t *testing.T) {

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -305,11 +305,12 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 		fmt.Fprintln(printer, "Poking:", qry[0].Query)
 	}
 
-	timeout := time.After(24 * time.Hour)
+	sensorTimeout := helpers.GetSensorTimeout(t)
+	timeout := time.After(sensorTimeout)
 	for {
 		select {
 		case <-timeout:
-			return errors.New("Sensor timed out after 24 hours")
+			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
 			res, err := conn.Select(ctx, qry[0])
 			if err != nil {
@@ -392,11 +393,12 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		fmt.Fprintln(printer, "Poking:", tableName)
 	}
 
-	timeout := time.After(24 * time.Hour)
+	sensorTimeout := helpers.GetSensorTimeout(t)
+	timeout := time.After(sensorTimeout)
 	for {
 		select {
 		case <-timeout:
-			return errors.New("Sensor timed out after 24 hours")
+			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
 			res, err := conn.Select(ctx, extractedQuery)
 			if err != nil {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -300,7 +300,7 @@ func ParseSensorDuration(raw string) (time.Duration, error) {
 	case 'd':
 		return time.Duration(n) * 24 * time.Hour, nil
 	case 'M':
-		return 0, fmt.Errorf("M (months) is not supported for timeout; use d, h, m, or s")
+		return 0, errors.New("M (months) is not supported for timeout; use d, h, m, or s")
 	default:
 		return 0, fmt.Errorf("unknown unit %q in %q; use s, m, h, d, ms, or ns", string(suffix), raw)
 	}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -251,4 +252,70 @@ func GetPokeInterval(ctx context.Context, t *pipeline.Asset) int64 {
 		pokeInterval = 30
 	}
 	return pokeInterval
+}
+
+const DefaultSensorTimeout = 24 * time.Hour
+
+// ParseSensorDuration parses a single-unit duration string using the same
+// suffix syntax as pipeline interval_modifiers (s, m, h, d, ms, ns).
+// Combinators like "1h30m" are not supported; use "90m" instead.
+// "M" (months) is rejected because a month is not a fixed time.Duration.
+func ParseSensorDuration(raw string) (time.Duration, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, errors.New("empty duration")
+	}
+
+	if len(s) >= 3 {
+		twoCharSuffix := s[len(s)-2:]
+		if twoCharSuffix == "ms" || twoCharSuffix == "ns" {
+			n, err := strconv.Atoi(s[:len(s)-2])
+			if err != nil {
+				return 0, fmt.Errorf("invalid numeric portion in %q", raw)
+			}
+			if twoCharSuffix == "ms" {
+				return time.Duration(n) * time.Millisecond, nil
+			}
+			return time.Duration(n) * time.Nanosecond, nil
+		}
+	}
+
+	if len(s) < 2 {
+		return 0, fmt.Errorf("invalid duration %q; expected a number followed by s, m, h, d, ms, or ns", raw)
+	}
+
+	suffix := s[len(s)-1]
+	n, err := strconv.Atoi(s[:len(s)-1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid numeric portion in %q", raw)
+	}
+
+	switch suffix {
+	case 's':
+		return time.Duration(n) * time.Second, nil
+	case 'm':
+		return time.Duration(n) * time.Minute, nil
+	case 'h':
+		return time.Duration(n) * time.Hour, nil
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour, nil
+	case 'M':
+		return 0, fmt.Errorf("M (months) is not supported for timeout; use d, h, m, or s")
+	default:
+		return 0, fmt.Errorf("unknown unit %q in %q; use s, m, h, d, ms, or ns", string(suffix), raw)
+	}
+}
+
+// GetSensorTimeout returns the configured sensor timeout for an asset, falling
+// back to DefaultSensorTimeout when unset, invalid, or non-positive.
+func GetSensorTimeout(t *pipeline.Asset) time.Duration {
+	raw, ok := t.Parameters["timeout"]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return DefaultSensorTimeout
+	}
+	d, err := ParseSensorDuration(raw)
+	if err != nil || d <= 0 {
+		return DefaultSensorTimeout
+	}
+	return d
 }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -273,6 +273,9 @@ func ParseSensorDuration(raw string) (time.Duration, error) {
 			if err != nil {
 				return 0, fmt.Errorf("invalid numeric portion in %q", raw)
 			}
+			if n <= 0 {
+				return 0, fmt.Errorf("duration must be positive, got %d", n)
+			}
 			if twoCharSuffix == "ms" {
 				return time.Duration(n) * time.Millisecond, nil
 			}
@@ -288,6 +291,9 @@ func ParseSensorDuration(raw string) (time.Duration, error) {
 	n, err := strconv.Atoi(s[:len(s)-1])
 	if err != nil {
 		return 0, fmt.Errorf("invalid numeric portion in %q", raw)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("duration must be positive, got %d", n)
 	}
 
 	switch suffix {

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -255,6 +255,80 @@ func TestParseJSONOutputs(t *testing.T) {
 	}
 }
 
+func TestParseSensorDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "1h", input: "1h", want: time.Hour},
+		{name: "30m", input: "30m", want: 30 * time.Minute},
+		{name: "90m", input: "90m", want: 90 * time.Minute},
+		{name: "45s", input: "45s", want: 45 * time.Second},
+		{name: "2d", input: "2d", want: 48 * time.Hour},
+		{name: "100ms", input: "100ms", want: 100 * time.Millisecond},
+		{name: "500ns", input: "500ns", want: 500 * time.Nanosecond},
+		{name: "trim spaces", input: "  1h  ", want: time.Hour},
+
+		{name: "empty", input: "", wantErr: "empty"},
+		{name: "blank", input: "   ", wantErr: "empty"},
+		{name: "month rejected", input: "1M", wantErr: "M (months) is not supported"},
+		{name: "unknown unit y", input: "1y", wantErr: "unknown unit"},
+		{name: "no unit", input: "10", wantErr: "unknown unit"},
+		{name: "non-numeric", input: "abh", wantErr: "invalid numeric portion"},
+		{name: "single char", input: "h", wantErr: "invalid duration"},
+		{name: "combinator unsupported", input: "1h30m", wantErr: "invalid numeric portion"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseSensorDuration(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetSensorTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		want   time.Duration
+	}{
+		{name: "unset returns default", params: nil, want: DefaultSensorTimeout},
+		{name: "empty returns default", params: map[string]string{"timeout": ""}, want: DefaultSensorTimeout},
+		{name: "blank returns default", params: map[string]string{"timeout": "   "}, want: DefaultSensorTimeout},
+		{name: "valid 1h", params: map[string]string{"timeout": "1h"}, want: time.Hour},
+		{name: "valid 90m", params: map[string]string{"timeout": "90m"}, want: 90 * time.Minute},
+		{name: "valid 1d", params: map[string]string{"timeout": "1d"}, want: 24 * time.Hour},
+		{name: "invalid falls back to default", params: map[string]string{"timeout": "foo"}, want: DefaultSensorTimeout},
+		{name: "month suffix falls back to default", params: map[string]string{"timeout": "1M"}, want: DefaultSensorTimeout},
+		{name: "zero falls back to default", params: map[string]string{"timeout": "0s"}, want: DefaultSensorTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			asset := &pipeline.Asset{Parameters: pipeline.EmptyStringMap{}}
+			for k, v := range tt.params {
+				asset.Parameters[k] = v
+			}
+			assert.Equal(t, tt.want, GetSensorTimeout(asset))
+		})
+	}
+}
+
 func TestCastResultToInteger(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -281,6 +281,10 @@ func TestParseSensorDuration(t *testing.T) {
 		{name: "non-numeric", input: "abh", wantErr: "invalid numeric portion"},
 		{name: "single char", input: "h", wantErr: "invalid duration"},
 		{name: "combinator unsupported", input: "1h30m", wantErr: "invalid numeric portion"},
+		{name: "negative h", input: "-1h", wantErr: "duration must be positive"},
+		{name: "negative ms", input: "-100ms", wantErr: "duration must be positive"},
+		{name: "zero s", input: "0s", wantErr: "duration must be positive"},
+		{name: "zero ns", input: "0ns", wantErr: "duration must be positive"},
 	}
 
 	for _, tt := range tests {
@@ -315,6 +319,7 @@ func TestGetSensorTimeout(t *testing.T) {
 		{name: "invalid falls back to default", params: map[string]string{"timeout": "foo"}, want: DefaultSensorTimeout},
 		{name: "month suffix falls back to default", params: map[string]string{"timeout": "1M"}, want: DefaultSensorTimeout},
 		{name: "zero falls back to default", params: map[string]string{"timeout": "0s"}, want: DefaultSensorTimeout},
+		{name: "negative falls back to default", params: map[string]string{"timeout": "-1h"}, want: DefaultSensorTimeout},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -163,6 +163,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "valid-sensor-timeout",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   ValidateSensorTimeout,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "valid-ingestr",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1427,17 +1427,10 @@ func ValidateSensorTimeout(ctx context.Context, p *pipeline.Pipeline, asset *pip
 		return issues, nil
 	}
 
-	d, err := helpers.ParseSensorDuration(raw)
-	switch {
-	case err != nil:
+	if _, err := helpers.ParseSensorDuration(raw); err != nil {
 		issues = append(issues, &Issue{
 			Task:        asset,
 			Description: "parameters.timeout is invalid: " + err.Error(),
-		})
-	case d <= 0:
-		issues = append(issues, &Issue{
-			Task:        asset,
-			Description: "parameters.timeout must be a positive duration",
 		})
 	}
 

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1428,15 +1428,13 @@ func ValidateSensorTimeout(ctx context.Context, p *pipeline.Pipeline, asset *pip
 	}
 
 	d, err := helpers.ParseSensorDuration(raw)
-	if err != nil {
+	switch {
+	case err != nil:
 		issues = append(issues, &Issue{
 			Task:        asset,
 			Description: "parameters.timeout is invalid: " + err.Error(),
 		})
-		return issues, nil
-	}
-
-	if d <= 0 {
+	case d <= 0:
 		issues = append(issues, &Issue{
 			Task:        asset,
 			Description: "parameters.timeout must be a positive duration",

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/glossary"
+	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -1409,6 +1410,40 @@ func validateTableNameFormat(assetType pipeline.AssetType, tableName string) str
 	}
 
 	return ""
+}
+
+// ValidateSensorTimeout validates the optional `timeout` parameter on sensor
+// assets. It uses the same single-unit duration syntax as pipeline
+// interval_modifiers (s, m, h, d, ms, ns); combinators like "1h30m" and
+// month suffix "M" are not supported.
+func ValidateSensorTimeout(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	issues := make([]*Issue, 0)
+	if !strings.Contains(string(asset.Type), ".sensor.") {
+		return issues, nil
+	}
+
+	raw, ok := asset.Parameters["timeout"]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return issues, nil
+	}
+
+	d, err := helpers.ParseSensorDuration(raw)
+	if err != nil {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "parameters.timeout is invalid: " + err.Error(),
+		})
+		return issues, nil
+	}
+
+	if d <= 0 {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "parameters.timeout must be a positive duration",
+		})
+	}
+
+	return issues, nil
 }
 
 func EnsureBigQueryQuerySensorHasQueryParameterForASingleAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1678,6 +1678,175 @@ func TestEnsureBigqueryQuerySensorHasQueryParameter(t *testing.T) {
 	}
 }
 
+func TestValidateSensorTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		p       *pipeline.Pipeline
+		want    []string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "non-sensor asset is skipped even with bogus timeout",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuery,
+						Parameters: map[string]string{
+							"timeout": "bogus",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "sensor without timeout param is fine",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuerySensor,
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "empty timeout string is fine (uses default)",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuerySensor,
+						Parameters: map[string]string{
+							"timeout": "",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid 1h",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuerySensor,
+						Parameters: map[string]string{
+							"timeout": "1h",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "valid 2d",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeDuckDBQuerySensor,
+						Parameters: map[string]string{
+							"timeout": "2d",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "month suffix rejected",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuerySensor,
+						Parameters: map[string]string{
+							"timeout": "1M",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want:    []string{"parameters.timeout is invalid: M (months) is not supported for timeout; use d, h, m, or s"},
+		},
+		{
+			name: "negative duration rejected",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuerySensor,
+						Parameters: map[string]string{
+							"timeout": "-1h",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want:    []string{"parameters.timeout is invalid: duration must be positive, got -1"},
+		},
+		{
+			name: "zero duration rejected",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeS3KeySensor,
+						Parameters: map[string]string{
+							"timeout": "0s",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want:    []string{"parameters.timeout is invalid: duration must be positive, got 0"},
+		},
+		{
+			name: "garbage value rejected",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "task1",
+						Type: pipeline.AssetTypeBigqueryQuerySensor,
+						Parameters: map[string]string{
+							"timeout": "foo",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want:    []string{"parameters.timeout is invalid: invalid numeric portion in \"foo\""},
+		},
+	}
+	ctx := t.Context()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CallFuncForEveryAsset(ValidateSensorTimeout)(ctx, tt.p)
+			if !tt.wantErr(t, err) {
+				return
+			}
+
+			if tt.want != nil {
+				gotMessages := make([]string, len(got))
+				for i, issue := range got {
+					gotMessages[i] = issue.Description
+				}
+				assert.Equal(t, tt.want, gotMessages)
+			} else {
+				assert.Equal(t, []*Issue{}, got)
+			}
+		})
+	}
+}
+
 func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/s3/operator.go
+++ b/pkg/s3/operator.go
@@ -220,11 +220,12 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 
 	isWildcard := containsWildcard(bucketKey)
 
-	timeout := time.After(24 * time.Hour)
+	sensorTimeout := helpers.GetSensorTimeout(t)
+	timeout := time.After(sensorTimeout)
 	for {
 		select {
 		case <-timeout:
-			return errors.New("Sensor timed out after 24 hours")
+			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
 			if isWildcard {
 				found, err := matchWildcard(ctx, s3Client, bucketName, bucketKey)


### PR DESCRIPTION
## Summary

Adds a `timeout` parameter to sensor assets so users can override the hardcoded 24h cap. The current behavior — `time.After(24 * time.Hour)` baked into every sensor implementation — leaves users with no way to fail a stuck sensor faster than a full day.

```yaml
name: raw.external_asset
type: bq.sensor.query
parameters:
    query: select count(*) > 0 from `proj.raw.external_asset`
    poke_interval: 60
    timeout: 1h          # new
```

### Syntax

`timeout` reuses the same single-unit duration syntax as pipeline `interval_modifiers` (`pkg/pipeline/pipeline.go` `parseTimeModifier`):

| Unit | Meaning | Example |
|---|---|---|
| `s` | seconds | `30s` |
| `m` | minutes | `90m` |
| `h` | hours | `1h` |
| `d` | days | `2d` |
| `ms` | milliseconds | `100ms` |
| `ns` | nanoseconds | `500ns` |

- Single unit only — combinators like `1h30m` are not supported (use `90m`).
- `M` (months) is rejected because a month isn't a fixed `time.Duration`.
- Unset / empty / invalid / non-positive → falls back to the 24h default, preserving today's behavior for every existing pipeline.
- Lint catches typos (`timeout: foo`, `timeout: 1M`) up front so they don't silently revert to 24h at runtime.

### Files touched

- `pkg/helpers/helpers.go` — new `ParseSensorDuration` + `GetSensorTimeout` helpers.
- `pkg/{ansisql,bigquery,s3}/operator.go` — five hardcoded `time.After(24*time.Hour)` sites switched to the helper.
- `pkg/lint/rules.go`, `pkg/lint/list.go` — new `valid-sensor-timeout` rule.
- `pkg/helpers/helpers_test.go`, `pkg/ansisql/operator_test.go` — unit tests for the parser, the helper, and one end-to-end timeout-fires test.
- `docs/assets/sensor.md` — new "Timeout" subsection.

## Heads-up: duration-syntax inconsistency in the codebase

This PR adds yet another duration syntax to a codebase that already has three. Worth flagging for a future cleanup:

| Field | Where | Syntax | Combinators? | `d`? |
|---|---|---|---|---|
| `poke_interval` | sensor `parameters` | plain integer **seconds** | n/a | n/a |
| `interval_modifiers.start/end` | `pipeline.yml` | `parseTimeModifier` (s/m/h/d/M/ms/ns) | no | yes |
| `timeout` (EMR / Dataproc jobs) | `parameters` | Go `time.ParseDuration` (ns/us/ms/s/m/h) | yes | no |
| `timeout` (sensors, **this PR**) | `parameters` | matches `interval_modifiers` (s/m/h/d/ms/ns) | no | yes |

The most jarring sibling is `poke_interval`: it lives in the same `parameters:` block as the new `timeout`, but takes a bare integer-seconds value. So a user will write `poke_interval: 60, timeout: 1h` in adjacent lines and never know the two fields are parsed completely differently. Worth a follow-up to either accept duration strings on `poke_interval` (with backwards-compat for ints), or to converge all duration fields on one parser.

## Test plan

- [x] `make format`
- [x] `make test` (full suite passes)
- [x] New unit tests pass (`TestParseSensorDuration`, `TestGetSensorTimeout`, `TestTableSensorTimesOutWhenConfigured`)
- [ ] Manual: build, point a sensor at a query that always returns 0 with `timeout: 30s`, confirm `Sensor timed out after 30s` after ~30s
- [ ] Manual: confirm default 24h still applies when `timeout` is absent
- [ ] Manual: `bruin lint` rejects `timeout: foo` and `timeout: 1M`

🤖 Generated with [Claude Code](https://claude.com/claude-code)