### PR TITLE
ingestr: add parameters.version to pin ingestr/gong per asset

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -594,12 +594,12 @@ func Run(isDebug *bool) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:   "use-gong",
-				Usage:  "use gong binary for execution",
+				Usage:  "force gong for all ingestr assets in this run (overridden per-asset by parameters.version=v0)",
 				Hidden: true,
 			},
 			&cli.StringFlag{
 				Name:   "gong-path",
-				Usage:  "path to the gong binary (when using --use-gong)",
+				Usage:  "path to a pre-installed gong binary; overrides per-asset gong installation for the run",
 				Hidden: true,
 			},
 			&cli.StringFlag{
@@ -676,7 +676,7 @@ func Run(isDebug *bool) *cli.Command {
 				if gongPath == "" {
 					// Auto-install gong if no custom path provided
 					gongChecker := &gong.Checker{}
-					installedPath, err := gongChecker.EnsureGongInstalled(ctx)
+					installedPath, err := gongChecker.EnsureGongInstalled(ctx, "")
 					if err != nil {
 						return cli.Exit(fmt.Sprintf("failed to install gong: %v", err), 1)
 					}
@@ -907,7 +907,7 @@ func Run(isDebug *bool) *cli.Command {
 						if gongPath == "" {
 							// Auto-install gong if no custom path provided
 							gongChecker := &gong.Checker{}
-							installedPath, gongErr := gongChecker.EnsureGongInstalled(runCtx)
+							installedPath, gongErr := gongChecker.EnsureGongInstalled(runCtx, "")
 							if gongErr != nil {
 								return cli.Exit(fmt.Sprintf("CDC mode detected but failed to install gong: %v", gongErr), 1)
 							}

--- a/pkg/gong/gong.go
+++ b/pkg/gong/gong.go
@@ -32,17 +32,61 @@ const (
 )
 
 // Checker handles checking and installing the gong binary.
+// It supports installing multiple versions side-by-side; concurrent installs of
+// the same version are deduplicated, while different versions install in parallel.
 type Checker struct {
-	mut sync.Mutex
+	mu    sync.Mutex
+	slots map[string]*installSlot
+}
+
+type installSlot struct {
+	once sync.Once
+	path string
+	err  error
 }
 
 // EnsureGongInstalled checks if gong is installed and installs it if not present, then returns the full path of the binary.
-func (g *Checker) EnsureGongInstalled(ctx context.Context) (string, error) {
-	g.mut.Lock()
-	defer g.mut.Unlock()
+// An empty version uses the bundled default from version.txt.
+func (g *Checker) EnsureGongInstalled(ctx context.Context, version string) (string, error) {
+	resolvedVersion := strings.TrimSpace(version)
+	if resolvedVersion == "" {
+		resolvedVersion = strings.TrimSpace(Version)
+	}
 
-	Version = strings.TrimSpace(Version)
+	slot := g.slotFor(resolvedVersion)
+	slot.once.Do(func() {
+		slot.path, slot.err = g.ensureInstalled(ctx, resolvedVersion)
+		if slot.err != nil {
+			// Drop the slot so a subsequent caller retries the install.
+			g.dropSlot(resolvedVersion, slot)
+		}
+	})
+	return slot.path, slot.err
+}
 
+func (g *Checker) slotFor(version string) *installSlot {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.slots == nil {
+		g.slots = make(map[string]*installSlot)
+	}
+	slot, ok := g.slots[version]
+	if !ok {
+		slot = &installSlot{}
+		g.slots[version] = slot
+	}
+	return slot
+}
+
+func (g *Checker) dropSlot(version string, slot *installSlot) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if current, ok := g.slots[version]; ok && current == slot {
+		delete(g.slots, version)
+	}
+}
+
+func (g *Checker) binaryPath(version string) (string, error) {
 	m := user.NewConfigManager(afero.NewOsFs())
 	bruinHomeDirAbsPath, err := m.EnsureAndGetBruinHomeDir()
 	if err != nil {
@@ -54,15 +98,21 @@ func (g *Checker) EnsureGongInstalled(ctx context.Context) (string, error) {
 		return "", errors.Wrap(err, "failed to create bin directory")
 	}
 
-	binaryName := "gong"
+	binaryName := "gong-" + version
 	if runtime.GOOS == "windows" {
-		binaryName = "gong.exe"
+		binaryName += ".exe"
+	}
+	return filepath.Join(binDirPath, binaryName), nil
+}
+
+func (g *Checker) ensureInstalled(ctx context.Context, version string) (string, error) {
+	gongBinaryPath, err := g.binaryPath(version)
+	if err != nil {
+		return "", err
 	}
 
-	gongBinaryPath := filepath.Join(binDirPath, binaryName)
 	if _, err := os.Stat(gongBinaryPath); errors.Is(err, os.ErrNotExist) {
-		err = g.downloadGong(ctx, gongBinaryPath)
-		if err != nil {
+		if err := g.downloadGong(ctx, version, gongBinaryPath); err != nil {
 			return "", err
 		}
 		return gongBinaryPath, nil
@@ -75,9 +125,8 @@ func (g *Checker) EnsureGongInstalled(ctx context.Context) (string, error) {
 		installedVersion = parseVersionOutput(strings.TrimSpace(string(output)))
 	}
 
-	if installedVersion != Version {
-		err = g.downloadGong(ctx, gongBinaryPath)
-		if err != nil {
+	if installedVersion != version {
+		if err := g.downloadGong(ctx, version, gongBinaryPath); err != nil {
 			return "", err
 		}
 	}
@@ -86,10 +135,10 @@ func (g *Checker) EnsureGongInstalled(ctx context.Context) (string, error) {
 }
 
 // buildDownloadURL constructs the download URL for the gong binary based on OS and architecture.
-func buildDownloadURL() string {
+func buildDownloadURL(version string) string {
 	osName := getOSName()
 	archName := getArchName()
-	return fmt.Sprintf("%s/releases/%s/%s/gong_%s", BaseURL, strings.TrimSpace(Version), osName, archName)
+	return fmt.Sprintf("%s/releases/%s/%s/gong_%s", BaseURL, version, osName, archName)
 }
 
 func getOSName() string {
@@ -132,18 +181,18 @@ func parseVersionOutput(output string) string {
 	return ver
 }
 
-func (g *Checker) downloadGong(ctx context.Context, destPath string) error {
+func (g *Checker) downloadGong(ctx context.Context, version, destPath string) error {
 	var output io.Writer = os.Stdout
 	if printer, ok := ctx.Value(executor.KeyPrinter).(io.Writer); ok {
 		output = printer
 	}
 
 	_, _ = fmt.Fprintf(output, "===============================\n")
-	_, _ = fmt.Fprintf(output, "Installing gong %s...\n", Version)
+	_, _ = fmt.Fprintf(output, "Installing gong %s...\n", version)
 	_, _ = fmt.Fprintf(output, "This is a one-time operation.\n")
 	_, _ = fmt.Fprintf(output, "\n")
 
-	downloadURL := buildDownloadURL()
+	downloadURL := buildDownloadURL(version)
 	_, _ = fmt.Fprintf(output, "Downloading from %s\n", downloadURL)
 
 	client := &http.Client{
@@ -162,7 +211,7 @@ func (g *Checker) downloadGong(ctx context.Context, destPath string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download gong: server returned status %d", resp.StatusCode)
+		return fmt.Errorf("failed to download gong %s: server returned status %d", version, resp.StatusCode)
 	}
 
 	// Create a temporary file in the same directory to ensure atomic write
@@ -202,7 +251,7 @@ func (g *Checker) downloadGong(ctx context.Context, destPath string) error {
 	tmpPath = "" // Prevent cleanup of the renamed file
 
 	_, _ = fmt.Fprintf(output, "\n")
-	_, _ = fmt.Fprintf(output, "Installed gong %s, continuing...\n", Version)
+	_, _ = fmt.Fprintf(output, "Installed gong %s, continuing...\n", version)
 	_, _ = fmt.Fprintf(output, "===============================\n")
 	_, _ = fmt.Fprintf(output, "\n")
 

--- a/pkg/gong/gong_test.go
+++ b/pkg/gong/gong_test.go
@@ -3,15 +3,17 @@ package gong
 import (
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildDownloadURL(t *testing.T) {
 	t.Parallel()
 
-	url := buildDownloadURL()
+	url := buildDownloadURL(strings.TrimSpace(Version))
 
 	// URL should contain the base URL
 	assert.Contains(t, url, BaseURL)
@@ -81,9 +83,62 @@ func TestParseVersionOutput(t *testing.T) {
 func TestBuildDownloadURL_Format(t *testing.T) {
 	t.Parallel()
 
-	url := buildDownloadURL()
+	url := buildDownloadURL(strings.TrimSpace(Version))
 
 	// Verify the URL matches the expected pattern
 	// Format: {BaseURL}/releases/{Version}/{os}/gong_{arch}
 	assert.Regexp(t, `^https://storage\.googleapis\.com/gong-release/releases/v\d+\.\d+\.\d+/(darwin|linux|windows)/gong_(amd64|arm64)$`, url)
+}
+
+func TestBuildDownloadURL_RespectsRequestedVersion(t *testing.T) {
+	t.Parallel()
+
+	url := buildDownloadURL("v9.9.9")
+	assert.Contains(t, url, "/releases/v9.9.9/")
+}
+
+func TestChecker_SlotPerVersion(t *testing.T) {
+	t.Parallel()
+
+	c := &Checker{}
+	a := c.slotFor("v1.0.0")
+	b := c.slotFor("v1.0.0")
+	d := c.slotFor("v1.0.5")
+
+	assert.Same(t, a, b, "same version returns the same slot")
+	assert.NotSame(t, a, d, "different versions get different slots")
+
+	// dropSlot must remove only the matching slot.
+	c.dropSlot("v1.0.0", a)
+	a2 := c.slotFor("v1.0.0")
+	assert.NotSame(t, a, a2, "slot should be regenerated after drop")
+
+	// dropSlot with a stale pointer is a no-op.
+	c.dropSlot("v1.0.0", a)
+	a3 := c.slotFor("v1.0.0")
+	assert.Same(t, a2, a3, "stale drop must not evict a fresh slot")
+}
+
+func TestChecker_SlotForIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	c := &Checker{}
+
+	const goroutines = 32
+	results := make([]*installSlot, goroutines)
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = c.slotFor("v1.0.0")
+		}(i)
+	}
+	wg.Wait()
+
+	require.NotNil(t, results[0])
+	for _, slot := range results {
+		assert.Same(t, results[0], slot, "all goroutines must observe the same slot for the same version")
+	}
 }

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
@@ -12,10 +14,120 @@ import (
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/gong"
 	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/python"
 	"github.com/bruin-data/bruin/pkg/scheduler"
 	"github.com/pkg/errors"
 )
+
+// versionPattern matches the bare family marker (v0/v1) or a fully-qualified
+// vMAJOR.MINOR.PATCH where MAJOR is 0 or 1.
+var versionPattern = regexp.MustCompile(`^v(0|1)(\.\d+\.\d+)?$`)
+
+const (
+	versionFamilyIngestr = "v0"
+	versionFamilyGong    = "v1"
+)
+
+// resolvedEngine is the outcome of parsing parameters.version on an ingestr asset.
+type resolvedEngine struct {
+	// family is "v0" (ingestr) or "v1" (gong).
+	family string
+	// ingestrVersion is the PyPI version string (no leading "v"), empty for the bundled default.
+	ingestrVersion string
+	// gongVersion is the gong release tag (with leading "v"), empty for the bundled default.
+	gongVersion string
+}
+
+// resolveIngestrEngine reads parameters.version, validates it, and returns the
+// resolved engine. An empty version defaults to v1 (gong). When parameters.version
+// is set, use_gong is ignored with a deprecation warning.
+func resolveIngestrEngine(asset *pipeline.Asset) (resolvedEngine, error) {
+	versionParam := strings.TrimSpace(asset.Parameters["version"])
+	useGongLegacy := asset.Parameters["use_gong"] == "true"
+
+	if versionParam == "" {
+		// Legacy: no version, fall back to use_gong (or the v1 default if neither is set).
+		// Either way the family is v1 — explicit use_gong is a no-op equivalent.
+		_ = useGongLegacy
+		return resolvedEngine{family: versionFamilyGong}, nil
+	}
+
+	if !versionPattern.MatchString(versionParam) {
+		return resolvedEngine{}, fmt.Errorf("invalid parameters.version %q: expected v0, v1, or vMAJOR.MINOR.PATCH where MAJOR is 0 or 1", versionParam)
+	}
+
+	if useGongLegacy {
+		fmt.Fprintf(os.Stderr, "Warning: parameters.use_gong is ignored when parameters.version is set; version=%q wins.\n", versionParam)
+	}
+
+	if strings.HasPrefix(versionParam, versionFamilyIngestr) {
+		out := resolvedEngine{family: versionFamilyIngestr}
+		if versionParam != versionFamilyIngestr {
+			// Strip the leading "v" to get the PyPI version (e.g. v0.14.2 -> 0.14.2).
+			out.ingestrVersion = strings.TrimPrefix(versionParam, "v")
+		}
+		return out, nil
+	}
+
+	out := resolvedEngine{family: versionFamilyGong}
+	if versionParam != versionFamilyGong {
+		out.gongVersion = versionParam
+	}
+	return out, nil
+}
+
+// applyIngestrEngine applies the resolved engine choice to ctx and asset:
+//   - For v0: clears use_gong (so downstream code paths run ingestr) and sets
+//     CtxIngestrVersion when an exact version was requested. Warns if the source
+//     or destination scheme is in gongSources/gongDestinations.
+//   - For v1: ensures gong is installed (using the requested version) and sets
+//     CtxGongPath, plus use_gong for legacy code paths that still inspect it.
+func applyIngestrEngine(ctx context.Context, asset *pipeline.Asset, engine resolvedEngine, sourceScheme, destScheme string, installer gongInstaller) (context.Context, error) {
+	if engine.family == versionFamilyIngestr {
+		_, srcAuto := gongSources[sourceScheme]
+		_, dstAuto := gongDestinations[destScheme]
+		if srcAuto || dstAuto {
+			fmt.Fprintf(os.Stderr,
+				"Warning: parameters.version=v0 selected but source/destination (%s/%s) typically requires gong; running on ingestr anyway.\n",
+				sourceScheme, destScheme,
+			)
+		}
+		// Make sure no stale use_gong leaks through to downstream (e.g. the auto-enable
+		// blocks earlier in Run set it). The user explicitly asked for v0.
+		delete(asset.Parameters, "use_gong")
+		if engine.ingestrVersion != "" {
+			ctx = context.WithValue(ctx, python.CtxIngestrVersion, engine.ingestrVersion)
+		}
+		return ctx, nil
+	}
+
+	// v1 (gong)
+	if asset.Parameters == nil {
+		asset.Parameters = make(map[string]string)
+	}
+	asset.Parameters["use_gong"] = "true"
+
+	if ctx.Value(python.CtxGongPath) != nil {
+		// Already installed for this run (e.g. via --gong-path or a prior asset).
+		return ctx, nil
+	}
+	if installer == nil {
+		return ctx, errors.New("gong installer is not available but is required for parameters.version=v1")
+	}
+	gongPath, err := installer.EnsureGongInstalled(ctx, engine.gongVersion)
+	if err != nil {
+		return ctx, fmt.Errorf("failed to install gong %s: %w", displayGongVersion(engine.gongVersion), err)
+	}
+	return context.WithValue(ctx, python.CtxGongPath, gongPath), nil
+}
+
+func displayGongVersion(v string) string {
+	if v == "" {
+		return "(default)"
+	}
+	return v
+}
 
 type repoFinder interface {
 	Repo(path string) (*git.Repo, error)
@@ -26,7 +138,7 @@ type ingestrRunner interface {
 }
 
 type gongInstaller interface {
-	EnsureGongInstalled(ctx context.Context) (string, error)
+	EnsureGongInstalled(ctx context.Context, version string) (string, error)
 }
 
 type BasicOperator struct {
@@ -245,18 +357,25 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		defer duck.UnlockDatabase(sourceURI)
 	}
 
-	if asset.Parameters["use_gong"] == "true" && ctx.Value(python.CtxGongPath) == nil {
-		if o.gong == nil {
-			return errors.New("use_gong is set but gong installer is not available")
-		}
-		gongPath, err := o.gong.EnsureGongInstalled(ctx)
-		if err != nil {
-			return fmt.Errorf("use_gong is set but failed to install gong: %w", err)
-		}
-		ctx = context.WithValue(ctx, python.CtxGongPath, gongPath)
+	engine, err := resolveIngestrEngine(asset)
+	if err != nil {
+		return err
+	}
+	sourceScheme, destScheme := schemeOf(sourceURI), schemeOf(destURI)
+	ctx, err = applyIngestrEngine(ctx, asset, engine, sourceScheme, destScheme, o.gong)
+	if err != nil {
+		return err
 	}
 
 	return o.runner.RunIngestr(ctx, cmdArgs, extraPackages, repo)
+}
+
+func schemeOf(uri string) string {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	return parsed.Scheme
 }
 
 func applyClickHouseEngineParams(destURI string, params map[string]string) string {
@@ -385,15 +504,13 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		return errors.Wrap(err, "failed to find repo to run Ingestr")
 	}
 
-	if asset.Parameters["use_gong"] == "true" && ctx.Value(python.CtxGongPath) == nil {
-		if o.gong == nil {
-			return errors.New("use_gong is set but gong installer is not available")
-		}
-		gongPath, err := o.gong.EnsureGongInstalled(ctx)
-		if err != nil {
-			return fmt.Errorf("use_gong is set but failed to install gong: %w", err)
-		}
-		ctx = context.WithValue(ctx, python.CtxGongPath, gongPath)
+	engine, err := resolveIngestrEngine(asset)
+	if err != nil {
+		return err
+	}
+	ctx, err = applyIngestrEngine(ctx, asset, engine, schemeOf(sourceURI), schemeOf(destURI), o.gong)
+	if err != nil {
+		return err
 	}
 
 	return o.runner.RunIngestr(ctx, cmdArgs, extraPackages, repo)

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -20,9 +20,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// versionPattern matches the bare family marker (v0/v1) or a fully-qualified
-// vMAJOR.MINOR.PATCH where MAJOR is 0 or 1.
-var versionPattern = regexp.MustCompile(`^v(0|1)(\.\d+\.\d+)?$`)
+// versionPattern matches the bare family marker (vMAJOR) or a fully-qualified
+// vMAJOR.MINOR.PATCH. MAJOR is any non-negative integer with no leading zero
+// (other than the literal "0"). Family selection is decided separately:
+// MAJOR == 0 routes to ingestr, anything else routes to gong.
+var versionPattern = regexp.MustCompile(`^v(0|[1-9]\d*)(\.\d+\.\d+)?$`)
 
 const (
 	versionFamilyIngestr = "v0"
@@ -55,15 +57,17 @@ func resolveIngestrEngine(asset *pipeline.Asset) (resolvedEngine, error) {
 		return resolvedEngine{family: versionFamilyIngestr}, nil
 	}
 
-	if !versionPattern.MatchString(versionParam) {
-		return resolvedEngine{}, fmt.Errorf("invalid parameters.version %q: expected v0, v1, or vMAJOR.MINOR.PATCH where MAJOR is 0 or 1", versionParam)
+	match := versionPattern.FindStringSubmatch(versionParam)
+	if match == nil {
+		return resolvedEngine{}, fmt.Errorf("invalid parameters.version %q: expected vMAJOR or vMAJOR.MINOR.PATCH", versionParam)
 	}
 
 	if useGongLegacy {
 		fmt.Fprintf(os.Stderr, "Warning: parameters.use_gong is ignored when parameters.version is set; version=%q wins.\n", versionParam)
 	}
 
-	if strings.HasPrefix(versionParam, versionFamilyIngestr) {
+	major := match[1]
+	if major == "0" {
 		out := resolvedEngine{family: versionFamilyIngestr}
 		if versionParam != versionFamilyIngestr {
 			// Strip the leading "v" to get the PyPI version (e.g. v0.14.2 -> 0.14.2).
@@ -73,7 +77,9 @@ func resolveIngestrEngine(asset *pipeline.Asset) (resolvedEngine, error) {
 	}
 
 	out := resolvedEngine{family: versionFamilyGong}
-	if versionParam != versionFamilyGong {
+	// Only fully-qualified versions get pinned; bare family markers (v1, v2, ...)
+	// fall back to bruin's bundled gong default.
+	if match[2] != "" {
 		out.gongVersion = versionParam
 	}
 	return out, nil

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -40,17 +40,19 @@ type resolvedEngine struct {
 }
 
 // resolveIngestrEngine reads parameters.version, validates it, and returns the
-// resolved engine. An empty version defaults to v1 (gong). When parameters.version
-// is set, use_gong is ignored with a deprecation warning.
+// resolved engine. An empty version defaults to v0 (ingestr) unless use_gong is
+// set — preserving the legacy auto-enable for gong-required sources/destinations.
+// When parameters.version is set explicitly, use_gong is ignored with a
+// deprecation warning.
 func resolveIngestrEngine(asset *pipeline.Asset) (resolvedEngine, error) {
 	versionParam := strings.TrimSpace(asset.Parameters["version"])
 	useGongLegacy := asset.Parameters["use_gong"] == "true"
 
 	if versionParam == "" {
-		// Legacy: no version, fall back to use_gong (or the v1 default if neither is set).
-		// Either way the family is v1 — explicit use_gong is a no-op equivalent.
-		_ = useGongLegacy
-		return resolvedEngine{family: versionFamilyGong}, nil
+		if useGongLegacy {
+			return resolvedEngine{family: versionFamilyGong}, nil
+		}
+		return resolvedEngine{family: versionFamilyIngestr}, nil
 	}
 
 	if !versionPattern.MatchString(versionParam) {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1325,12 +1325,12 @@ func TestResolveIngestrEngine(t *testing.T) {
 		expectErr string
 	}{
 		{
-			name:   "unset defaults to v1",
+			name:   "unset defaults to v0",
 			params: map[string]string{},
-			want:   resolvedEngine{family: versionFamilyGong},
+			want:   resolvedEngine{family: versionFamilyIngestr},
 		},
 		{
-			name:   "use_gong true with no version still v1",
+			name:   "use_gong true with no version routes to v1",
 			params: map[string]string{"use_gong": "true"},
 			want:   resolvedEngine{family: versionFamilyGong},
 		},
@@ -1435,7 +1435,25 @@ func TestBasicOperator_Version(t *testing.T) {
 		}
 	}
 
-	t.Run("version unset defaults to v1 (gong installed)", func(t *testing.T) {
+	t.Run("version unset defaults to v0 (no gong)", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(contextCapturingRunner)
+		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
+
+		gongInst := new(mockGongInstaller)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(nil)}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+		require.NoError(t, o.Run(ctx, &ti))
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
+		assert.Nil(t, runner.capturedCtx.Value(python.CtxGongPath))
+		assert.Nil(t, runner.capturedCtx.Value(python.CtxIngestrVersion))
+	})
+
+	t.Run("use_gong=true with no version routes to v1", func(t *testing.T) {
 		t.Parallel()
 
 		runner := new(contextCapturingRunner)
@@ -1445,13 +1463,12 @@ func TestBasicOperator_Version(t *testing.T) {
 		gongInst.On("EnsureGongInstalled", mock.Anything, "").Return("/path/to/gong", nil)
 
 		o := makeOperator(runner, gongInst)
-		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(nil)}
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"use_gong": "true"})}
 		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
 
 		require.NoError(t, o.Run(ctx, &ti))
 		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything, "")
 		assert.Equal(t, "/path/to/gong", runner.capturedCtx.Value(python.CtxGongPath))
-		assert.Nil(t, runner.capturedCtx.Value(python.CtxIngestrVersion))
 	})
 
 	t.Run("version v0.14.2 sets CtxIngestrVersion and skips gong", func(t *testing.T) {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -73,8 +73,8 @@ type mockGongInstaller struct {
 	mock.Mock
 }
 
-func (m *mockGongInstaller) EnsureGongInstalled(ctx context.Context) (string, error) {
-	res := m.Called(ctx)
+func (m *mockGongInstaller) EnsureGongInstalled(ctx context.Context, version string) (string, error) {
+	res := m.Called(ctx, version)
 	return res.String(0), res.Error(1)
 }
 
@@ -421,11 +421,15 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
 			executionDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
+			gongInst := new(mockGongInstaller)
+			gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("/path/to/gong", nil).Maybe()
+
 			o := &BasicOperator{
 				conn:          &fetcher,
 				finder:        finder,
 				runner:        runner,
 				jinjaRenderer: jinja.NewRendererWithStartEndDatesAndMacros(&startDate, &endDate, &executionDate, "ingestr-test", "ingestr-test", nil, ""),
+				gong:          gongInst,
 			}
 
 			ti := scheduler.AssetInstance{
@@ -470,11 +474,15 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand_IntervalStartAndEnd(t
 		"--interval-end", "2025-01-02T00:00:00Z",
 	}, []string{"pyodbc==5.1.0"}, repo).Return(nil)
 
+	gongInst := new(mockGongInstaller)
+	gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("/path/to/gong", nil).Maybe()
+
 	o := &BasicOperator{
 		conn:          &fetcher,
 		finder:        finder,
 		runner:        runner,
 		jinjaRenderer: jinja.NewRendererWithYesterday("ingestr-test", "ingestr-test"),
+		gong:          gongInst,
 	}
 
 	ti := scheduler.AssetInstance{
@@ -633,10 +641,14 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 			runner := new(mockRunner)
 			runner.On("RunIngestr", mock.Anything, tt.want, tt.extraPackages, repo).Return(nil)
 
+			gongInst := new(mockGongInstaller)
+			gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("/path/to/gong", nil).Maybe()
+
 			o := &SeedOperator{
 				conn:   &fetcher,
 				finder: finder,
 				runner: runner,
+				gong:   gongInst,
 			}
 
 			ti := scheduler.AssetInstance{
@@ -909,11 +921,15 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 			endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
 			executionDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
+			gongInst := new(mockGongInstaller)
+			gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("/path/to/gong", nil).Maybe()
+
 			o := &BasicOperator{
 				conn:          &fetcher,
 				finder:        finder,
 				runner:        runner,
 				jinjaRenderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, &executionDate, "ingestr-test", "ingestr-test", nil),
+				gong:          gongInst,
 			}
 
 			ti := scheduler.AssetInstance{
@@ -1056,7 +1072,7 @@ func TestBasicOperator_UseGong(t *testing.T) {
 		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
 
 		gongInst := new(mockGongInstaller)
-		gongInst.On("EnsureGongInstalled", mock.Anything).Return("/path/to/gong", nil)
+		gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("/path/to/gong", nil)
 
 		startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 		endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -1087,7 +1103,7 @@ func TestBasicOperator_UseGong(t *testing.T) {
 
 		err := o.Run(ctx, &ti)
 		require.NoError(t, err)
-		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything)
+		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
 		assert.Equal(t, "/path/to/gong", runner.capturedCtx.Value(python.CtxGongPath))
 	})
 
@@ -1130,7 +1146,7 @@ func TestBasicOperator_UseGong(t *testing.T) {
 
 		err := o.Run(ctx, &ti)
 		require.NoError(t, err)
-		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything)
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
 	})
 
 	t.Run("use_gong returns error when install fails", func(t *testing.T) {
@@ -1139,7 +1155,7 @@ func TestBasicOperator_UseGong(t *testing.T) {
 		runner := new(mockRunner)
 
 		gongInst := new(mockGongInstaller)
-		gongInst.On("EnsureGongInstalled", mock.Anything).Return("", fmt.Errorf("download failed")) //nolint
+		gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("", fmt.Errorf("download failed")) //nolint
 
 		startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 		endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -1170,10 +1186,10 @@ func TestBasicOperator_UseGong(t *testing.T) {
 
 		err := o.Run(ctx, &ti)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "use_gong is set but failed to install gong")
+		require.Contains(t, err.Error(), "failed to install gong")
 	})
 
-	t.Run("no use_gong does not call EnsureGongInstalled", func(t *testing.T) {
+	t.Run("version v0 does not call EnsureGongInstalled", func(t *testing.T) {
 		t.Parallel()
 
 		runner := new(mockRunner)
@@ -1201,6 +1217,7 @@ func TestBasicOperator_UseGong(t *testing.T) {
 				Parameters: map[string]string{
 					"source_connection": "sf",
 					"source_table":      "source-table",
+					"version":           "v0",
 				},
 			},
 		}
@@ -1209,7 +1226,7 @@ func TestBasicOperator_UseGong(t *testing.T) {
 
 		err := o.Run(ctx, &ti)
 		require.NoError(t, err)
-		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything)
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
 	})
 }
 
@@ -1234,7 +1251,7 @@ func TestSeedOperator_UseGong(t *testing.T) {
 		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
 
 		gongInst := new(mockGongInstaller)
-		gongInst.On("EnsureGongInstalled", mock.Anything).Return("/path/to/gong", nil)
+		gongInst.On("EnsureGongInstalled", mock.Anything, mock.Anything).Return("/path/to/gong", nil)
 
 		o := &SeedOperator{
 			conn:   &fetcher,
@@ -1259,11 +1276,11 @@ func TestSeedOperator_UseGong(t *testing.T) {
 
 		err := o.Run(ctx, &ti)
 		require.NoError(t, err)
-		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything)
+		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
 		assert.Equal(t, "/path/to/gong", runner.capturedCtx.Value(python.CtxGongPath))
 	})
 
-	t.Run("no use_gong does not call EnsureGongInstalled", func(t *testing.T) {
+	t.Run("version v0 does not call EnsureGongInstalled", func(t *testing.T) {
 		t.Parallel()
 
 		runner := new(mockRunner)
@@ -1284,7 +1301,8 @@ func TestSeedOperator_UseGong(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "bq",
 				Parameters: map[string]string{
-					"path": "seed.csv",
+					"path":    "seed.csv",
+					"version": "v0",
 				},
 			},
 		}
@@ -1293,6 +1311,233 @@ func TestSeedOperator_UseGong(t *testing.T) {
 
 		err := o.Run(ctx, &ti)
 		require.NoError(t, err)
-		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything)
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
+	})
+}
+
+func TestResolveIngestrEngine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		params    map[string]string
+		want      resolvedEngine
+		expectErr string
+	}{
+		{
+			name:   "unset defaults to v1",
+			params: map[string]string{},
+			want:   resolvedEngine{family: versionFamilyGong},
+		},
+		{
+			name:   "use_gong true with no version still v1",
+			params: map[string]string{"use_gong": "true"},
+			want:   resolvedEngine{family: versionFamilyGong},
+		},
+		{
+			name:   "bare v0 selects ingestr default",
+			params: map[string]string{"version": "v0"},
+			want:   resolvedEngine{family: versionFamilyIngestr},
+		},
+		{
+			name:   "v0.14.2 selects exact ingestr version",
+			params: map[string]string{"version": "v0.14.2"},
+			want:   resolvedEngine{family: versionFamilyIngestr, ingestrVersion: "0.14.2"},
+		},
+		{
+			name:   "bare v1 selects gong default",
+			params: map[string]string{"version": "v1"},
+			want:   resolvedEngine{family: versionFamilyGong},
+		},
+		{
+			name:   "v1.0.5 selects exact gong version",
+			params: map[string]string{"version": "v1.0.5"},
+			want:   resolvedEngine{family: versionFamilyGong, gongVersion: "v1.0.5"},
+		},
+		{
+			name:      "v0.14 partial is rejected",
+			params:    map[string]string{"version": "v0.14"},
+			expectErr: "invalid parameters.version",
+		},
+		{
+			name:      "v2.0.0 is rejected",
+			params:    map[string]string{"version": "v2.0.0"},
+			expectErr: "invalid parameters.version",
+		},
+		{
+			name:      "non-prefixed version is rejected",
+			params:    map[string]string{"version": "0.14.2"},
+			expectErr: "invalid parameters.version",
+		},
+		{
+			name:      "latest is rejected",
+			params:    map[string]string{"version": "latest"},
+			expectErr: "invalid parameters.version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveIngestrEngine(&pipeline.Asset{Parameters: tt.params})
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBasicOperator_Version(t *testing.T) {
+	t.Parallel()
+
+	mockSf := new(mockConnection)
+	mockSf.On("GetIngestrURI").Return("snowflake://uri-here", nil)
+	mockBq := new(mockConnection)
+	mockBq.On("GetIngestrURI").Return("bigquery://uri-here", nil)
+
+	fetcher := simpleConnectionFetcher{
+		connections: map[string]*mockConnection{
+			"sf": mockSf,
+			"bq": mockBq,
+		},
+	}
+	finder := new(mockFinder)
+
+	makeOperator := func(runner ingestrRunner, gongInst gongInstaller) *BasicOperator {
+		startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+		executionDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		return &BasicOperator{
+			conn:          &fetcher,
+			finder:        finder,
+			runner:        runner,
+			jinjaRenderer: jinja.NewRendererWithStartEndDatesAndMacros(&startDate, &endDate, &executionDate, "ingestr-test", "ingestr-test", nil, ""),
+			gong:          gongInst,
+		}
+	}
+
+	makeAsset := func(extra map[string]string) *pipeline.Asset {
+		params := map[string]string{
+			"source_connection": "sf",
+			"source_table":      "source-table",
+		}
+		for k, v := range extra {
+			params[k] = v
+		}
+		return &pipeline.Asset{
+			Name:       "asset-name",
+			Connection: "bq",
+			Parameters: params,
+		}
+	}
+
+	t.Run("version unset defaults to v1 (gong installed)", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(contextCapturingRunner)
+		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
+
+		gongInst := new(mockGongInstaller)
+		gongInst.On("EnsureGongInstalled", mock.Anything, "").Return("/path/to/gong", nil)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(nil)}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+		require.NoError(t, o.Run(ctx, &ti))
+		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything, "")
+		assert.Equal(t, "/path/to/gong", runner.capturedCtx.Value(python.CtxGongPath))
+		assert.Nil(t, runner.capturedCtx.Value(python.CtxIngestrVersion))
+	})
+
+	t.Run("version v0.14.2 sets CtxIngestrVersion and skips gong", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(contextCapturingRunner)
+		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
+
+		gongInst := new(mockGongInstaller)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"version": "v0.14.2"})}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+		require.NoError(t, o.Run(ctx, &ti))
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
+		assert.Equal(t, "0.14.2", runner.capturedCtx.Value(python.CtxIngestrVersion))
+		assert.Nil(t, runner.capturedCtx.Value(python.CtxGongPath))
+	})
+
+	t.Run("version v1.0.5 forwards version to gong installer", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(contextCapturingRunner)
+		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
+
+		gongInst := new(mockGongInstaller)
+		gongInst.On("EnsureGongInstalled", mock.Anything, "v1.0.5").Return("/path/to/gong-v1.0.5", nil)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"version": "v1.0.5"})}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+		require.NoError(t, o.Run(ctx, &ti))
+		gongInst.AssertCalled(t, "EnsureGongInstalled", mock.Anything, "v1.0.5")
+		assert.Equal(t, "/path/to/gong-v1.0.5", runner.capturedCtx.Value(python.CtxGongPath))
+	})
+
+	t.Run("version v0 wins over use_gong=true", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(mockRunner)
+		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
+
+		gongInst := new(mockGongInstaller)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"version": "v0", "use_gong": "true"})}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+		require.NoError(t, o.Run(ctx, &ti))
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
+	})
+
+	t.Run("malformed version returns an error before runner is called", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(mockRunner)
+		gongInst := new(mockGongInstaller)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"version": "latest"})}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+		err := o.Run(ctx, &ti)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid parameters.version")
+		runner.AssertNotCalled(t, "RunIngestr", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
+	})
+
+	t.Run("--gong-path in context skips per-asset install", func(t *testing.T) {
+		t.Parallel()
+
+		runner := new(contextCapturingRunner)
+		runner.On("RunIngestr", mock.Anything, mock.Anything, mock.Anything, repo).Return(nil)
+
+		gongInst := new(mockGongInstaller)
+
+		o := makeOperator(runner, gongInst)
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"version": "v1.0.5"})}
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+		ctx = context.WithValue(ctx, python.CtxGongPath, "/already/set/gong")
+
+		require.NoError(t, o.Run(ctx, &ti))
+		gongInst.AssertNotCalled(t, "EnsureGongInstalled", mock.Anything, mock.Anything)
+		assert.Equal(t, "/already/set/gong", runner.capturedCtx.Value(python.CtxGongPath))
 	})
 }

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1355,13 +1355,23 @@ func TestResolveIngestrEngine(t *testing.T) {
 			want:   resolvedEngine{family: versionFamilyGong, gongVersion: "v1.0.5"},
 		},
 		{
+			name:   "future major v2 routes to gong",
+			params: map[string]string{"version": "v2"},
+			want:   resolvedEngine{family: versionFamilyGong},
+		},
+		{
+			name:   "future major v2.0.0 pins gong release",
+			params: map[string]string{"version": "v2.0.0"},
+			want:   resolvedEngine{family: versionFamilyGong, gongVersion: "v2.0.0"},
+		},
+		{
 			name:      "v0.14 partial is rejected",
 			params:    map[string]string{"version": "v0.14"},
 			expectErr: "invalid parameters.version",
 		},
 		{
-			name:      "v2.0.0 is rejected",
-			params:    map[string]string{"version": "v2.0.0"},
+			name:      "leading-zero major is rejected",
+			params:    map[string]string{"version": "v01"},
 			expectErr: "invalid parameters.version",
 		},
 		{

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -318,7 +318,7 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 	if v, exists := asset.Parameters["version"]; exists && v != "" && !ingestrVersionPattern.MatchString(v) {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: fmt.Sprintf("Invalid 'version' value %q: must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1", v),
+			Description: fmt.Sprintf("Invalid 'version' value %q: must be 'vMAJOR' or fully-qualified 'vMAJOR.MINOR.PATCH'", v),
 		})
 	}
 	if value, exists := asset.Parameters["incremental_strategy"]; exists && value == "merge" {
@@ -649,8 +649,8 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 
 var arnPattern = regexp.MustCompile(`^arn:[^:\n]*:[^:\n]*:[^:\n]*:[^:\n]*:(?:[^:\/\n]*[:\/])?.*$`)
 
-// ingestrVersionPattern matches the bare family marker (v0/v1) or a fully-qualified vMAJOR.MINOR.PATCH where MAJOR is 0 or 1.
-var ingestrVersionPattern = regexp.MustCompile(`^v(0|1)(\.\d+\.\d+)?$`)
+// ingestrVersionPattern matches the bare family marker (vMAJOR) or a fully-qualified vMAJOR.MINOR.PATCH. MAJOR has no leading zero (other than the literal "0").
+var ingestrVersionPattern = regexp.MustCompile(`^v(0|[1-9]\d*)(\.\d+\.\d+)?$`)
 
 func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0)

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -315,6 +315,12 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 			Description: "Invalid 'cdc_mode' value: must be 'stream' or 'batch'",
 		})
 	}
+	if v, exists := asset.Parameters["version"]; exists && v != "" && !ingestrVersionPattern.MatchString(v) {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: fmt.Sprintf("Invalid 'version' value %q: must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1", v),
+		})
+	}
 	if value, exists := asset.Parameters["incremental_strategy"]; exists && value == "merge" {
 		// Skip PK validation for CDC mode - PKs are determined by the source
 		if asset.Parameters["cdc"] != "true" {
@@ -642,6 +648,9 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 }
 
 var arnPattern = regexp.MustCompile(`^arn:[^:\n]*:[^:\n]*:[^:\n]*:[^:\n]*:(?:[^:\/\n]*[:\/])?.*$`)
+
+// ingestrVersionPattern matches the bare family marker (v0/v1) or a fully-qualified vMAJOR.MINOR.PATCH where MAJOR is 0 or 1.
+var ingestrVersionPattern = regexp.MustCompile(`^v(0|1)(\.\d+\.\d+)?$`)
 
 func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0)

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -2026,6 +2026,90 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			wantErrMessage: "",
 			wantErr:        assert.NoError,
 		},
+		{
+			name: "valid version v0",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "v0",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "valid version v0.14.2",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "v0.14.2",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "valid version v1",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "v1",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "rejected partial version v0.14",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "v0.14",
+				},
+			},
+			wantErrMessage: `Invalid 'version' value "v0.14": must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1`,
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "rejected version v2.0.0",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "v2.0.0",
+				},
+			},
+			wantErrMessage: `Invalid 'version' value "v2.0.0": must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1`,
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "rejected version latest",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "latest",
+				},
+			},
+			wantErrMessage: `Invalid 'version' value "latest": must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1`,
+			wantErr:        assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -2069,6 +2069,20 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			wantErr:        assert.NoError,
 		},
 		{
+			name: "valid future major v2.0.0",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "t",
+					"destination":       "bigquery",
+					"version":           "v2.0.0",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
 			name: "rejected partial version v0.14",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
@@ -2079,21 +2093,21 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 					"version":           "v0.14",
 				},
 			},
-			wantErrMessage: `Invalid 'version' value "v0.14": must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1`,
+			wantErrMessage: `Invalid 'version' value "v0.14": must be 'vMAJOR' or fully-qualified 'vMAJOR.MINOR.PATCH'`,
 			wantErr:        assert.NoError,
 		},
 		{
-			name: "rejected version v2.0.0",
+			name: "rejected leading-zero major",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
 				Parameters: map[string]string{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
-					"version":           "v2.0.0",
+					"version":           "v01",
 				},
 			},
-			wantErrMessage: `Invalid 'version' value "v2.0.0": must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1`,
+			wantErrMessage: `Invalid 'version' value "v01": must be 'vMAJOR' or fully-qualified 'vMAJOR.MINOR.PATCH'`,
 			wantErr:        assert.NoError,
 		},
 		{
@@ -2107,7 +2121,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 					"version":           "latest",
 				},
 			},
-			wantErrMessage: `Invalid 'version' value "latest": must be 'v0', 'v1', or fully-qualified 'vMAJOR.MINOR.PATCH' where MAJOR is 0 or 1`,
+			wantErrMessage: `Invalid 'version' value "latest": must be 'vMAJOR' or fully-qualified 'vMAJOR.MINOR.PATCH'`,
 			wantErr:        assert.NoError,
 		},
 	}

--- a/pkg/python/debug.go
+++ b/pkg/python/debug.go
@@ -6,4 +6,6 @@ const (
 	LocalIngestr contextKey = "local_ingestr"
 	// CtxGongPath is a context key for the gong binary path to use instead of ingestr (when --use-gong).
 	CtxGongPath contextKey = "gong_path"
+	// CtxIngestrVersion overrides the bundled ingestr PyPI version for the asset (e.g. "0.14.2").
+	CtxIngestrVersion contextKey = "ingestr_version"
 )

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -197,7 +197,7 @@ type pipelineConnection interface {
 }
 
 type GongInstaller interface {
-	EnsureGongInstalled(ctx context.Context) (string, error)
+	EnsureGongInstalled(ctx context.Context, version string) (string, error)
 }
 
 type UvPythonRunner struct {
@@ -560,7 +560,7 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		if u.Gong == nil {
 			return errors.New("use_gong is set but gong installer is not available")
 		}
-		gongPath, gongErr := u.Gong.EnsureGongInstalled(ingestrCtx)
+		gongPath, gongErr := u.Gong.EnsureGongInstalled(ingestrCtx, "")
 		if gongErr != nil {
 			return fmt.Errorf("use_gong is set but failed to install gong: %w", gongErr)
 		}
@@ -635,6 +635,11 @@ func (u *UvPythonRunner) ingestrPackage(ctx context.Context) (string, bool) {
 		if ok && ingestrPath != "" {
 			// maybe verify that the destination exists?
 			return ingestrPath, true
+		}
+	}
+	if v := ctx.Value(CtxIngestrVersion); v != nil {
+		if version, ok := v.(string); ok && version != "" {
+			return "ingestr@" + version, false
 		}
 	}
 	return "ingestr@" + ingestrVersion, false

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -185,6 +185,39 @@ func Test_buildIngestrPackageKey(t *testing.T) {
 	}
 }
 
+func Test_ingestrPackage_HonorsCtxIngestrVersion(t *testing.T) {
+	t.Parallel()
+
+	u := &UvPythonRunner{}
+
+	defaultPkg, _ := u.ingestrPackage(t.Context())
+	assert.Equal(t, "ingestr@"+ingestrVersion, defaultPkg)
+
+	pinnedCtx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.2")
+	pinnedPkg, isLocal := u.ingestrPackage(pinnedCtx)
+	assert.Equal(t, "ingestr@0.14.2", pinnedPkg)
+	assert.False(t, isLocal)
+
+	// LocalIngestr (debug-ingestr-src) takes precedence over CtxIngestrVersion.
+	localCtx := context.WithValue(pinnedCtx, LocalIngestr, "/local/path/to/ingestr")
+	localPkg, isLocal := u.ingestrPackage(localCtx)
+	assert.Equal(t, "/local/path/to/ingestr", localPkg)
+	assert.True(t, isLocal)
+}
+
+func Test_buildIngestrPackageKey_DiffersByVersion(t *testing.T) {
+	t.Parallel()
+
+	u := &UvPythonRunner{}
+	defaultKey := u.buildIngestrPackageKey(t.Context(), nil)
+
+	pinnedCtx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.2")
+	pinnedKey := u.buildIngestrPackageKey(pinnedCtx, nil)
+
+	assert.NotEqual(t, defaultKey, pinnedKey)
+	assert.Equal(t, "ingestr@0.14.2:", pinnedKey)
+}
+
 func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) { //nolint:paralleltest
 	ResetIngestrInstallCache()
 	defer ResetIngestrInstallCache()


### PR DESCRIPTION
Adds a `version` parameter on ingestr-type assets that selects the engine family and exact tool version: `v0[.X.Y]` resolves to the ingestr Python package, `v1[.X.Y]` resolves to the gong binary. When unset, defaults to v1 (gong) — flipping the previous default so users who need the legacy ingestr path opt in via `version: v0`.

Wires a per-asset `CtxIngestrVersion` through to uv's `ingestr@<ver>` install command, makes the gong installer version-aware with side-by-side per-version binaries, validates the version format in the existing ingestr lint rule, and replaces the inline `use_gong` blocks in BasicOperator/SeedOperator with a shared resolver that warns on `use_gong` + `version` conflicts and on `version: v0` for sources that typically require gong.