### PR TITLE
feat(lakehouse): support S3-compatible storage (endpoint, url_style, use_ssl)

### DIFF
--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -288,6 +288,41 @@ storage:
     session_token: "${AWS_SESSION_TOKEN}" # optional
 ```
 
+##### S3-compatible storage (MinIO, R2, B2, Tigris, on-prem)
+
+For S3-compatible backends, three optional fields can be set on the `storage` block. They are passed through to DuckDB's `CREATE SECRET` and behaviour is unchanged when they are omitted (AWS S3 defaults).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | No | (AWS S3) | Custom S3 endpoint, e.g. `minio.local:9000`, `<account>.r2.cloudflarestorage.com`, `fly.storage.tigris.dev` |
+| `url_style` | string | No | `vhost` | `path` is required for MinIO and several other S3-compatible backends |
+| `use_ssl` | bool | No | `true` | Set to `false` for plain-HTTP local dev (e.g. MinIO without TLS) |
+
+```yaml
+# MinIO local dev
+storage:
+  type: s3
+  path: "s3://ducklake/warehouse"
+  endpoint: "minio.local:9000"
+  url_style: "path"
+  use_ssl: false
+  auth:
+    access_key: "${MINIO_ACCESS_KEY}"
+    secret_key: "${MINIO_SECRET_KEY}"
+```
+
+```yaml
+# Cloudflare R2
+storage:
+  type: s3
+  path: "s3://my-bucket/ducklake"
+  region: "auto"
+  endpoint: "<account>.r2.cloudflarestorage.com"
+  auth:
+    access_key: "${R2_ACCESS_KEY_ID}"
+    secret_key: "${R2_SECRET_ACCESS_KEY}"
+```
+
 #### GCS
 
 Bruin currently supports explicit GCS HMAC credentials in the `auth` block (`access_key` and `secret_key`).

--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -318,6 +318,7 @@ storage:
   path: "s3://my-bucket/ducklake"
   region: "auto"
   endpoint: "<account>.r2.cloudflarestorage.com"
+  url_style: "path"
   auth:
     access_key: "${R2_ACCESS_KEY_ID}"
     secret_key: "${R2_SECRET_ACCESS_KEY}"

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -3171,6 +3171,15 @@
         "region": {
           "type": "string"
         },
+        "endpoint": {
+          "type": "string"
+        },
+        "url_style": {
+          "type": "string"
+        },
+        "use_ssl": {
+          "type": "boolean"
+        },
         "auth": {
           "$ref": "#/$defs/StorageAuth"
         }

--- a/pkg/config/lakehouse.go
+++ b/pkg/config/lakehouse.go
@@ -123,13 +123,24 @@ type StorageConfig struct {
 	Type   StorageType `yaml:"type" json:"type" mapstructure:"type"`
 	Path   string      `yaml:"path,omitempty" json:"path,omitempty" mapstructure:"path"`
 	Region string      `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
-	Auth   StorageAuth `yaml:"auth,omitempty" json:"auth,omitempty" mapstructure:"auth"`
+
+	// S3-compatible storage (MinIO, R2, B2, Tigris, on-prem, etc.).
+	// All three are optional pass-throughs to DuckDB's CREATE SECRET; when
+	// unset, behaviour is unchanged (AWS S3 / GCS defaults).
+	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty" mapstructure:"endpoint"`
+	URLStyle string `yaml:"url_style,omitempty" json:"url_style,omitempty" mapstructure:"url_style"`
+	UseSSL   *bool  `yaml:"use_ssl,omitempty" json:"use_ssl,omitempty" mapstructure:"use_ssl"`
+
+	Auth StorageAuth `yaml:"auth,omitempty" json:"auth,omitempty" mapstructure:"auth"`
 }
 
 func (s StorageConfig) IsZero() bool {
 	return s.Type == "" &&
 		s.Path == "" &&
 		s.Region == "" &&
+		s.Endpoint == "" &&
+		s.URLStyle == "" &&
+		s.UseSSL == nil &&
 		s.Auth.IsZero()
 }
 

--- a/pkg/config/lakehouse.go
+++ b/pkg/config/lakehouse.go
@@ -182,5 +182,11 @@ func (lh *LakehouseConfig) Validate() error {
 		return errors.New("empty or unsupported storage type: (supported: s3, gcs)")
 	}
 
+	// DuckDB's CREATE SECRET only accepts "path" or "vhost" for URL_STYLE;
+	// fail fast here rather than at query time.
+	if lh.Storage.URLStyle != "" && !slices.Contains([]string{"path", "vhost"}, lh.Storage.URLStyle) {
+		return fmt.Errorf("unsupported url_style: %q (supported: path, vhost)", lh.Storage.URLStyle)
+	}
+
 	return nil
 }

--- a/pkg/config/lakehouse_test.go
+++ b/pkg/config/lakehouse_test.go
@@ -146,6 +146,49 @@ func TestLakehouseConfig_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "url_style path is valid",
+			lh: &LakehouseConfig{
+				Format: LakehouseFormatDuckLake,
+				Catalog: CatalogConfig{
+					Type: CatalogTypeSQLite,
+				},
+				Storage: StorageConfig{
+					Type:     StorageTypeS3,
+					URLStyle: "path",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "url_style vhost is valid",
+			lh: &LakehouseConfig{
+				Format: LakehouseFormatDuckLake,
+				Catalog: CatalogConfig{
+					Type: CatalogTypeSQLite,
+				},
+				Storage: StorageConfig{
+					Type:     StorageTypeS3,
+					URLStyle: "vhost",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsupported url_style fails",
+			lh: &LakehouseConfig{
+				Format: LakehouseFormatDuckLake,
+				Catalog: CatalogConfig{
+					Type: CatalogTypeSQLite,
+				},
+				Storage: StorageConfig{
+					Type:     StorageTypeS3,
+					URLStyle: "subdomain",
+				},
+			},
+			wantErr: true,
+			errMsg:  "unsupported url_style",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/lakehouse_test.go
+++ b/pkg/config/lakehouse_test.go
@@ -234,6 +234,37 @@ func TestCatalogAuth_IsPostgres(t *testing.T) {
 	}
 }
 
+func TestStorageConfig_IsZero(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(b bool) *bool { return &b }
+	useSSLFalse := boolPtr(false)
+	useSSLTrue := boolPtr(true)
+
+	tests := []struct {
+		name    string
+		storage StorageConfig
+		want    bool
+	}{
+		{"empty config", StorageConfig{}, true},
+		{"with type", StorageConfig{Type: StorageTypeS3}, false},
+		{"with path", StorageConfig{Path: "s3://bucket"}, false},
+		{"with region", StorageConfig{Region: "us-east-1"}, false},
+		{"with endpoint", StorageConfig{Endpoint: "minio.local:9000"}, false},
+		{"with url_style", StorageConfig{URLStyle: "path"}, false},
+		{"with use_ssl=false", StorageConfig{UseSSL: useSSLFalse}, false},
+		{"with use_ssl=true", StorageConfig{UseSSL: useSSLTrue}, false},
+		{"with auth", StorageConfig{Auth: StorageAuth{AccessKey: "k", SecretKey: "s"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.storage.IsZero())
+		})
+	}
+}
+
 func TestStorageAuth_IsS3(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/duckdb/lakehouse.go
+++ b/pkg/duckdb/lakehouse.go
@@ -208,7 +208,7 @@ func (l *LakehouseAttacher) generateS3Secret(name string, storage config.Storage
 		return ""
 	}
 
-	parts := make([]string, 0, 9)
+	parts := make([]string, 0, 12)
 	parts = append(parts, "CREATE OR REPLACE SECRET "+name+" (")
 	parts = append(parts, "    TYPE s3")
 	parts = append(parts, ",   PROVIDER config")
@@ -220,6 +220,15 @@ func (l *LakehouseAttacher) generateS3Secret(name string, storage config.Storage
 	}
 	if storage.Region != "" {
 		parts = append(parts, ",   REGION "+quoteSQLStringLiteral(storage.Region))
+	}
+	if storage.Endpoint != "" {
+		parts = append(parts, ",   ENDPOINT "+quoteSQLStringLiteral(storage.Endpoint))
+	}
+	if storage.URLStyle != "" {
+		parts = append(parts, ",   URL_STYLE "+quoteSQLStringLiteral(storage.URLStyle))
+	}
+	if storage.UseSSL != nil {
+		parts = append(parts, ",   USE_SSL "+strconv.FormatBool(*storage.UseSSL))
 	}
 	scope := "s3://"
 	if storage.Path != "" {

--- a/pkg/duckdb/lakehouse_test.go
+++ b/pkg/duckdb/lakehouse_test.go
@@ -410,6 +410,8 @@ func TestLakehouseAttacher_GenerateS3Secret(t *testing.T) {
 	t.Parallel()
 	attacher := NewLakehouseAttacher()
 
+	boolPtr := func(b bool) *bool { return &b }
+
 	tests := []struct {
 		name    string
 		storage *config.StorageConfig
@@ -480,6 +482,74 @@ func TestLakehouseAttacher_GenerateS3Secret(t *testing.T) {
 				Auth: config.StorageAuth{},
 			},
 			want: "",
+		},
+		{
+			name: "s3-compatible with endpoint only",
+			storage: &config.StorageConfig{
+				Type:     config.StorageTypeS3,
+				Path:     "s3://ducklake/warehouse",
+				Endpoint: "minio.local:9000",
+				Auth: config.StorageAuth{
+					AccessKey: "minioadmin",
+					SecretKey: "minioadmin",
+				},
+			},
+			want: `CREATE OR REPLACE SECRET test_secret (
+    TYPE s3
+,   PROVIDER config
+,   KEY_ID 'minioadmin'
+,   SECRET 'minioadmin'
+,   ENDPOINT 'minio.local:9000'
+,   SCOPE 's3://ducklake/warehouse'
+)`,
+		},
+		{
+			name: "s3-compatible MinIO (endpoint + path style + no SSL)",
+			storage: &config.StorageConfig{
+				Type:     config.StorageTypeS3,
+				Path:     "s3://ducklake/warehouse",
+				Endpoint: "minio.local:9000",
+				URLStyle: "path",
+				UseSSL:   boolPtr(false),
+				Auth: config.StorageAuth{
+					AccessKey: "minioadmin",
+					SecretKey: "minioadmin",
+				},
+			},
+			want: `CREATE OR REPLACE SECRET test_secret (
+    TYPE s3
+,   PROVIDER config
+,   KEY_ID 'minioadmin'
+,   SECRET 'minioadmin'
+,   ENDPOINT 'minio.local:9000'
+,   URL_STYLE 'path'
+,   USE_SSL false
+,   SCOPE 's3://ducklake/warehouse'
+)`,
+		},
+		{
+			name: "s3-compatible Cloudflare R2 (endpoint + region, SSL on)",
+			storage: &config.StorageConfig{
+				Type:     config.StorageTypeS3,
+				Path:     "s3://ducklake/warehouse",
+				Region:   "auto",
+				Endpoint: "abc123.r2.cloudflarestorage.com",
+				UseSSL:   boolPtr(true),
+				Auth: config.StorageAuth{
+					AccessKey: "r2key",
+					SecretKey: "r2secret",
+				},
+			},
+			want: `CREATE OR REPLACE SECRET test_secret (
+    TYPE s3
+,   PROVIDER config
+,   KEY_ID 'r2key'
+,   SECRET 'r2secret'
+,   REGION 'auto'
+,   ENDPOINT 'abc123.r2.cloudflarestorage.com'
+,   USE_SSL true
+,   SCOPE 's3://ducklake/warehouse'
+)`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes #1994.

Adds three optional pass-through fields to the DuckDB lakehouse `storage.s3` block — `endpoint`, `url_style`, `use_ssl` — wiring them straight through to DuckDB's `CREATE SECRET`. When unset, behaviour is unchanged (AWS S3 defaults), so this is fully backwards-compatible.

```yaml
storage:
  type: s3
  path: "s3://ducklake/warehouse"
  endpoint: "minio.local:9000"   # NEW
  url_style: "path"              # NEW
  use_ssl: false                 # NEW
  auth:
    access_key: "${MINIO_ACCESS_KEY}"
    secret_key: "${MINIO_SECRET_KEY}"
```

This unblocks DuckLake on MinIO (local dev), Cloudflare R2, Backblaze B2, Tigris, and on-prem / air-gapped deployments — the dominant adoption pattern in the DuckLake community today.

## Changes

- `pkg/config/lakehouse.go` — three new optional fields on `StorageConfig` (`Endpoint`, `URLStyle`, `UseSSL *bool`); `IsZero()` updated.
- `pkg/duckdb/lakehouse.go` — `generateS3Secret` appends `ENDPOINT` / `URL_STYLE` / `USE_SSL` lines when set.
- `pkg/config/lakehouse_test.go` — new `TestStorageConfig_IsZero` covering all eight zero/non-zero combinations.
- `pkg/duckdb/lakehouse_test.go` — three new `generateS3Secret` cases: endpoint-only, full MinIO, Cloudflare R2.
- `docs/platforms/duckdb.md` — new "S3-compatible storage" subsection with field table + MinIO and R2 examples.

`UseSSL` is `*bool` so "unset" is distinguishable from explicit `false` — DuckDB's default is `true`, and we only emit the field when the user opts in either way.

## Test plan

- [x] `go test -tags=no_duckdb_arrow ./pkg/config/... ./pkg/duckdb/...` passes locally
- [x] `go vet -tags=no_duckdb_arrow ./pkg/config/... ./pkg/duckdb/...` clean
- [x] `gofmt -l` clean on the five touched files
- [ ] CI passes
- [ ] Manual smoke test: DuckLake against MinIO with `endpoint` + `url_style: path` + `use_ssl: false` (intend to run locally against the demo environment that motivated the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)