### PR TITLE
feat(templates): add bruin-cloud template for Bruin Cloud API ingestion

### DIFF
--- a/templates/bruin-cloud/.bruin.yml
+++ b/templates/bruin-cloud/.bruin.yml
@@ -1,0 +1,10 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      bruin:
+        - name: "bruin-cloud-default"
+          api_token: "your_api_token_here"
+      duckdb:
+        - name: "duckdb-default"
+          path: "duckdb.db"

--- a/templates/bruin-cloud/README.md
+++ b/templates/bruin-cloud/README.md
@@ -1,0 +1,45 @@
+## Bruin - Bruin Cloud Template
+
+This template ingests metadata from the [Bruin Cloud API](https://getbruin.com/docs/bruin/ingestion/bruin.html) into DuckDB under the `bruin_cloud_logs` schema and builds a summary table on top.
+
+The Bruin Cloud source exposes every table available from the API:
+
+- `pipelines` — pipeline metadata (name, project, owner, schedule, default connections, commit, start date).
+- `assets` — asset metadata (name, type, pipeline, project, uri, description, upstreams, downstream, owner, content, columns, materialization, parameters).
+
+### Assets in this pipeline
+
+- `assets/pipelines.asset.yml` — ingestr asset that loads the `pipelines` table into `bruin_cloud_logs.pipelines`.
+- `assets/assets.asset.yml` — ingestr asset that loads the `assets` table into `bruin_cloud_logs.assets`.
+- `assets/pipeline_summary.sql` — per-pipeline summary (asset counts, owner, schedule) materialized as `bruin_cloud_logs.pipeline_summary`.
+
+Every asset includes table-level and column-level descriptions so the catalogue is self-documenting.
+
+### Setup
+
+Edit `.bruin.yml` and replace `your_api_token_here` with an API token created in your Bruin Cloud team settings (Teams → Create API Token → Pipeline List permission).
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      bruin:
+        - name: "bruin-cloud-default"
+          api_token: "your_api_token_here"
+      duckdb:
+        - name: "duckdb-default"
+          path: "duckdb.db"
+```
+
+### Running the pipeline
+
+```shell
+bruin run ./bruin-cloud/pipeline.yml
+```
+
+You can also run a single asset:
+
+```shell
+bruin run assets/pipelines.asset.yml
+```

--- a/templates/bruin-cloud/assets/assets.asset.yml
+++ b/templates/bruin-cloud/assets/assets.asset.yml
@@ -4,7 +4,7 @@ type: ingestr
 description: |
   Flat catalogue of every asset across every pipeline in your Bruin Cloud workspace, ingested from the Bruin Cloud API (`GET /api/v1/pipelines`, asset list).
   Each row represents a single asset (SQL transform, Python script, ingestr load, sensor, etc.) including its lineage relationships, ownership, materialization strategy, parameters, and the raw asset content/code.
-  The table is fully replaced on every run and always reflects the current state of assets in Bruin Cloud. Join to `bruin_cloud_logs.pipelines` on `assets.pipeline = pipelines.name` to enrich with pipeline-level metadata.
+  The table is fully replaced on every run and always reflects the current state of assets in Bruin Cloud. Join to `bruin_cloud_logs.pipelines` on `(assets.pipeline = pipelines.name AND assets.project = pipelines.project)` to enrich with pipeline-level metadata — pipeline names are not unique across projects, so joining on `name` alone can produce a cross-product.
 
 columns:
   - name: name
@@ -19,7 +19,7 @@ columns:
       - name: not_null
   - name: pipeline
     type: varchar
-    description: "Name of the parent pipeline this asset belongs to. Foreign key to `bruin_cloud_logs.pipelines.name`."
+    description: "Name of the parent pipeline this asset belongs to. Combined with `project`, forms the foreign key to (`bruin_cloud_logs.pipelines.name`, `bruin_cloud_logs.pipelines.project`); not unique on its own."
     checks:
       - name: not_null
   - name: project

--- a/templates/bruin-cloud/assets/assets.asset.yml
+++ b/templates/bruin-cloud/assets/assets.asset.yml
@@ -1,0 +1,57 @@
+name: bruin_cloud_logs.assets
+type: ingestr
+
+description: |
+  Flat catalogue of every asset across every pipeline in your Bruin Cloud workspace, ingested from the Bruin Cloud API (`GET /api/v1/pipelines`, asset list).
+  Each row represents a single asset (SQL transform, Python script, ingestr load, sensor, etc.) including its lineage relationships, ownership, materialization strategy, parameters, and the raw asset content/code.
+  The table is fully replaced on every run and always reflects the current state of assets in Bruin Cloud. Join to `bruin_cloud_logs.pipelines` on `assets.pipeline = pipelines.name` to enrich with pipeline-level metadata.
+
+columns:
+  - name: name
+    type: varchar
+    description: "Fully qualified asset name (e.g. `schema.table_name`) as declared in the asset file. Unique within a pipeline; combine with `pipeline` to form a globally unique identifier."
+    checks:
+      - name: not_null
+  - name: type
+    type: varchar
+    description: "Asset type identifier such as `ingestr`, `bq.sql`, `duckdb.sql`, `python`, `sf.sql`, `ms.sensor.query`, etc. Drives which executor Bruin uses to run the asset."
+    checks:
+      - name: not_null
+  - name: pipeline
+    type: varchar
+    description: "Name of the parent pipeline this asset belongs to. Foreign key to `bruin_cloud_logs.pipelines.name`."
+    checks:
+      - name: not_null
+  - name: project
+    type: varchar
+    description: "Bruin Cloud project (workspace folder) that owns the asset's pipeline."
+  - name: uri
+    type: varchar
+    description: "External URI for the asset's underlying physical object (e.g. `bigquery://project.dataset.table` or an `s3://...` path). Used by lineage and external integrations to identify the resource outside Bruin."
+  - name: description
+    type: varchar
+    description: "Human-readable description of the asset, sourced from its `description` field. May be null if the asset has no description."
+  - name: upstreams
+    type: json
+    description: "Array of upstream dependencies declared for this asset (each entry typically `{type, value}` such as `{\"type\": \"asset\", \"value\": \"raw.orders\"}`). Drives the dependency graph used by the scheduler and lineage view."
+  - name: downstream
+    type: json
+    description: "Array of downstream assets that depend on this asset. Computed by Bruin Cloud as the inverse of `upstreams` across all assets in the workspace."
+  - name: owner
+    type: json
+    description: "Asset owner — loaded as JSON because the API may return either a single string or an array of identifiers (typically email addresses or team handles). Falls back to the pipeline-level owner when unset."
+  - name: content
+    type: varchar
+    description: "Raw asset content as stored in the source file: SQL query body for SQL assets, Python source for Python assets, or YAML body for ingestr assets. Useful for code search, diffing, and documentation."
+  - name: columns
+    type: json
+    description: "Array of column definitions declared on the asset (each entry includes `name`, `type`, `description`, `primary_key`, `checks`, etc.). Drives Bruin's data quality checks and column-level lineage."
+  - name: materialization
+    type: json
+    description: "Materialization configuration for the asset (e.g. `{\"type\": \"table\"}`, `{\"type\": \"incremental\", \"strategy\": \"merge\", \"incremental_key\": \"updated_at\"}`). Determines how the executor writes the asset's output."
+  - name: parameters
+    type: json
+    description: "Asset parameters block as declared in the asset file. For ingestr assets this typically contains `source_connection`, `source_table`, `destination`, etc.; for sensor assets it contains the sensor query."
+
+parameters:
+  source_table: assets

--- a/templates/bruin-cloud/assets/pipeline_summary.sql
+++ b/templates/bruin-cloud/assets/pipeline_summary.sql
@@ -1,0 +1,51 @@
+/* @bruin
+
+name: bruin_cloud_logs.pipeline_summary
+type: duckdb.sql
+materialization:
+  type: table
+
+description: |
+  One row per pipeline in the Bruin Cloud workspace, joined to its assets to expose aggregate counts.
+  Produced by joining `bruin_cloud_logs.pipelines` to `bruin_cloud_logs.assets` on (`name`, `project`) so each pipeline's identity is co-located with its asset count and the variety of asset types it uses.
+  Useful as a quick health/inventory dashboard for a Bruin Cloud workspace — e.g. spotting pipelines without assets or pipelines with a heterogeneous mix of asset types.
+
+  Note: this summary intentionally selects only the pipeline columns (`name`, `project`) that are guaranteed to be populated in every Bruin Cloud workspace. Other pipeline fields (`owner`, `description`, `schedule`, `start_date`, `commit`, `default_connections`) are loaded by `bruin_cloud_logs.pipelines` but may be dropped from the destination by dlt's schema inference when every row in the snapshot has a NULL value for them — referencing them here would cause workspace-specific failures. Extend the SELECT below if your workspace populates those fields.
+
+depends:
+  - bruin_cloud_logs.pipelines
+  - bruin_cloud_logs.assets
+
+columns:
+  - name: pipeline_name
+    type: varchar
+    description: "Pipeline name, copied from `bruin_cloud_logs.pipelines.name`. Not unique on its own — combine with `project` to identify a pipeline."
+    checks:
+      - name: not_null
+  - name: project
+    type: varchar
+    description: "Bruin Cloud project (workspace folder) the pipeline belongs to. Combined with `pipeline_name` it forms the unique key for this table."
+  - name: total_assets
+    type: integer
+    description: "Total number of assets attached to this pipeline. Zero indicates a pipeline with no assets defined yet."
+    checks:
+      - name: non_negative
+  - name: distinct_asset_types
+    type: integer
+    description: "Number of distinct asset types in the pipeline (e.g. an `ingestr` + `duckdb.sql` mix counts as 2). Higher values indicate more heterogeneous pipelines."
+    checks:
+      - name: non_negative
+
+@bruin */
+
+SELECT
+    p.name AS pipeline_name,
+    p.project,
+    COUNT(a.name) AS total_assets,
+    COUNT(DISTINCT a.type) AS distinct_asset_types
+FROM bruin_cloud_logs.pipelines p
+LEFT JOIN bruin_cloud_logs.assets a
+       ON a.pipeline = p.name
+      AND a.project  = p.project
+GROUP BY p.name, p.project
+ORDER BY total_assets DESC

--- a/templates/bruin-cloud/assets/pipelines.asset.yml
+++ b/templates/bruin-cloud/assets/pipelines.asset.yml
@@ -4,7 +4,7 @@ type: ingestr
 description: |
   Snapshot of every pipeline registered in your Bruin Cloud workspace, ingested from the Bruin Cloud API (`GET /api/v1/pipelines`).
   Each row represents a single pipeline definition along with its scheduling, ownership, and source-control metadata. The table is fully replaced on every run, so it always reflects the current state of pipelines in Bruin Cloud at the time of ingestion.
-  Use this as the canonical lookup table for joining other Bruin Cloud metadata (such as `bruin_cloud_logs.assets`) on (`name`, `project`).
+  Use this as the canonical lookup table for joining other Bruin Cloud metadata (such as `bruin_cloud_logs.assets`) on the composite key (`name`, `project`) — pipeline names are not unique across projects, so joining on `name` alone can produce a cross-product.
 
   Note on schema inference: ingestr/dlt creates the destination schema from the API response. Optional fields (`description`, `owner`, `default_connections`, `schedule`, `commit`, `start_date`) are only materialized as columns when at least one pipeline in your workspace has a non-NULL value for them. If every pipeline you have leaves a field unset, the column will be missing from the destination — this is expected behaviour, not a load failure.
 

--- a/templates/bruin-cloud/assets/pipelines.asset.yml
+++ b/templates/bruin-cloud/assets/pipelines.asset.yml
@@ -1,0 +1,40 @@
+name: bruin_cloud_logs.pipelines
+type: ingestr
+
+description: |
+  Snapshot of every pipeline registered in your Bruin Cloud workspace, ingested from the Bruin Cloud API (`GET /api/v1/pipelines`).
+  Each row represents a single pipeline definition along with its scheduling, ownership, and source-control metadata. The table is fully replaced on every run, so it always reflects the current state of pipelines in Bruin Cloud at the time of ingestion.
+  Use this as the canonical lookup table for joining other Bruin Cloud metadata (such as `bruin_cloud_logs.assets`) on (`name`, `project`).
+
+  Note on schema inference: ingestr/dlt creates the destination schema from the API response. Optional fields (`description`, `owner`, `default_connections`, `schedule`, `commit`, `start_date`) are only materialized as columns when at least one pipeline in your workspace has a non-NULL value for them. If every pipeline you have leaves a field unset, the column will be missing from the destination — this is expected behaviour, not a load failure.
+
+columns:
+  - name: name
+    type: varchar
+    description: "Pipeline name as defined in `pipeline.yml`. Joins to `bruin_cloud_logs.assets.pipeline`. Note: not globally unique — the same name may appear across different `project`s, so use (`name`, `project`) when a unique key is required."
+    checks:
+      - name: not_null
+  - name: description
+    type: varchar
+    description: "Human-readable description of what the pipeline does, sourced from the `description` field in `pipeline.yml`. May be null if no description was provided."
+  - name: project
+    type: varchar
+    description: "Name of the Bruin Cloud project (workspace folder) the pipeline belongs to. Used to group pipelines that share configuration and connections."
+  - name: owner
+    type: varchar
+    description: "Pipeline owner — typically the email or handle of the user/team accountable for the pipeline. Sourced from the `owner` field in `pipeline.yml`."
+  - name: default_connections
+    type: json
+    description: "Map of asset types to default connection names used when an asset does not specify its own connection (e.g. `{\"google_cloud_platform\": \"gcp-default\"}`). Defined under `default_connections` in `pipeline.yml`."
+  - name: schedule
+    type: varchar
+    description: "Pipeline schedule expression — either a preset (e.g. `daily`, `hourly`) or a cron string. Null when the pipeline is not scheduled."
+  - name: commit
+    type: varchar
+    description: "Git commit SHA representing the version of the pipeline definition that is currently deployed in Bruin Cloud."
+  - name: start_date
+    type: varchar
+    description: "Pipeline start date (ISO-8601 string). Marks the earliest logical date for which the pipeline is allowed to run; used by Bruin's scheduler for backfills and catchups."
+
+parameters:
+  source_table: pipelines

--- a/templates/bruin-cloud/pipeline.yml
+++ b/templates/bruin-cloud/pipeline.yml
@@ -1,0 +1,7 @@
+name: bruin-cloud
+catchup: false
+default:
+  type: ingestr
+  parameters:
+    source_connection: bruin-cloud-default
+    destination: duckdb


### PR DESCRIPTION
## Summary
- New `templates/bruin-cloud` template that uses the built-in `bruin` ingestr connection to load every table exposed by the Bruin Cloud API (`pipelines`, `assets`) into DuckDB under the `bruin_cloud_logs` schema.
- Adds a `pipeline_summary` SQL asset that joins the two raw tables on (`name`, `project`) to expose per-pipeline asset counts.
- Every asset has table-level and column-level descriptions so the ingested catalogue is self-documenting.

## Notes
- The summary deliberately references only `name` and `project` from the pipelines table because dlt's schema inference drops columns whose every value is NULL across the snapshot — referencing optional pipeline fields would cause workspace-specific failures.
- Verified end-to-end against a real Bruin Cloud workspace: 3 assets execute successfully, 7 quality checks pass.

## Test plan
- [x] `bruin validate ./bruin-cloud/pipeline.yml` → no issues
- [x] `bruin run ./bruin-cloud/pipeline.yml` → 3 succeeded / 7 checks succeeded
- [x] Verified `pipelines`, `assets`, and `pipeline_summary` tables populate with sensible data
- [ ] Reviewer: confirm the template appears under `bruin init` template list

🤖 Generated with [Claude Code](https://claude.com/claude-code)