### PR TITLE
feat(snowflake): respect timeout on sf.sensor.query + docs

### DIFF
--- a/docs/platforms/athena.md
+++ b/docs/platforms/athena.md
@@ -151,12 +151,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `table_id` format. `catalogue_id` and `database_id` are then taken from the configuration in `bruin.yml`.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `athena.sensor.query`
 
@@ -168,12 +170,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/bigquery.md
+++ b/docs/platforms/bigquery.md
@@ -136,12 +136,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `project-id.dataset_id.table_id` format, requires all of the identifiers as a full name.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Examples
 
@@ -163,12 +165,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -135,12 +135,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `database.table_id` or (if using `default` database or a database specified in config file) `table_id` format.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `clickhouse.sensor.query`
 
@@ -152,12 +154,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/databricks.md
+++ b/docs/platforms/databricks.md
@@ -168,12 +168,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `databricks.sensor.table`
 
@@ -187,12 +189,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `schema_id.table_id`.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -90,11 +90,13 @@ name: string
 type: string
 parameters:
     query: string
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/motherduck.md
+++ b/docs/platforms/motherduck.md
@@ -77,11 +77,13 @@ type: duckdb.sensor.query
 connection: my_motherduck_connection
 parameters:
     query: string
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/mssql.md
+++ b/docs/platforms/mssql.md
@@ -165,12 +165,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `schema_id.table_id` or (for default schema `dbo`) `table_id` format.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `ms.sensor.query`
 
@@ -182,12 +184,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/mysql.md
+++ b/docs/platforms/mysql.md
@@ -102,12 +102,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `database.table` format, requires the database and table identifiers as a full name.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Examples
 
@@ -129,12 +131,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Check if data exists for a specific date
 

--- a/docs/platforms/postgres.md
+++ b/docs/platforms/postgres.md
@@ -86,12 +86,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `schema_id.table_id` or (for default schema `public`) `table_id` format.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `pg.sensor.query`
 
@@ -103,12 +105,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/redshift.md
+++ b/docs/platforms/redshift.md
@@ -90,12 +90,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `rs.sensor.table`
 
@@ -109,12 +111,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `schema_id.table_id` or (for default schema `public`) `table_id` format.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/s3.md
+++ b/docs/platforms/s3.md
@@ -30,12 +30,14 @@ connection: aws-default
 parameters:
   bucket_name: "my-data-bucket"
   bucket_key: "path/to/expected/file.csv"
+  timeout: 1h
 ```
 
 ## Parameters
 
 - `bucket_name` (required): The name of the S3 bucket to monitor
 - `bucket_key` (required): The key/path of the object to wait for. Supports [wildcard patterns](#wildcard-patterns).
+- `timeout` (optional): How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ## Wildcard Patterns
 
@@ -59,7 +61,7 @@ When a wildcard pattern is used, the sensor lists objects under the common prefi
 The sensor supports different modes, controlled via the `--sensor-mode` flag when running:
 
 - `once` (default): Check once and fail if object doesn't exist
-- `wait`: Continuously poll until object is found (24-hour timeout)
+- `wait`: Continuously poll until object is found (default 24-hour timeout, configurable via `timeout`)
 - `skip`: Skip sensor execution entirely
 
 ## Running the Sensor
@@ -74,7 +76,7 @@ bruin run path/to/your/sensor.asset.yml --sensor-mode wait
 
 - If the region is not specified in the connection, it will be auto-discovered from the bucket
 - In wait  mode, the sensor polls every few seconds (configurable via `poke_interval`) as a parameter
-- Maximum timeout is 24 hours for continuous polling
+- Default timeout is 24 hours for continuous polling. Override with the `timeout` parameter (single-unit duration syntax, e.g. `1h` or `90m`). See [Sensor Timeout](/assets/sensor#timeout).
 - Returns error if object is not found in `once` mode
 
 ## S3 for Data Ingestion

--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -235,12 +235,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: In `database_id.schema_id.table_id` or `schema_id.table_id` format. If `schema_id.table_id` is provided, the database will be taken from the database configuration in the `.bruin.yml`.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `sf.sensor.query`
 

--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -254,12 +254,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters:**
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/synapse.md
+++ b/docs/platforms/synapse.md
@@ -82,12 +82,14 @@ type: string
 parameters:
     table: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `table`: `schema_id.table_id` or (for default schema `dbo`) `table_id` format.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `synapse.sensor.query`
 
@@ -99,12 +101,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters**:
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/docs/platforms/trino.md
+++ b/docs/platforms/trino.md
@@ -66,12 +66,14 @@ type: string
 parameters:
     query: string
     poke_interval: int (optional)
+    timeout: duration (optional)
 ```
 
 **Parameters:**
 
 - `query`: Query you expect to return any results
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
+- `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 #### Example: Partitioned upstream table
 

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -240,25 +240,30 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 		return errors.Errorf("connection '%s' is not a snowflake connection", connName)
 	}
 
+	sensorTimeout := helpers.GetSensorTimeout(t)
+	timeout := time.After(sensorTimeout)
 	for {
-		res, err := conn.SelectOnlyLastResult(ctx, qry[0])
-		if err != nil {
-			return err
-		}
+		select {
+		case <-timeout:
+			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
+		default:
+			res, err := conn.SelectOnlyLastResult(ctx, qry[0])
+			if err != nil {
+				return err
+			}
 
-		intRes, err := helpers.CastResultToInteger(res, true)
-		if err != nil {
-			return errors.Wrap(err, "failed to parse query sensor result")
-		}
+			intRes, err := helpers.CastResultToInteger(res, true)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse query sensor result")
+			}
 
-		if intRes > 0 {
-			break
-		}
+			if intRes > 0 {
+				return nil
+			}
 
-		time.Sleep(time.Duration(o.secondsToSleep) * time.Second)
+			time.Sleep(time.Duration(o.secondsToSleep) * time.Second)
+		}
 	}
-
-	return nil
 }
 
 type MetadataOperator struct {

--- a/pkg/snowflake/operator_test.go
+++ b/pkg/snowflake/operator_test.go
@@ -3,12 +3,14 @@ package snowflake
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockExtractor struct {
@@ -238,4 +240,40 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQuerySensorTimesOutWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	client := new(mockQuerierWithResult)
+	extractor := new(mockExtractor)
+	preExtractor := new(mockExtractor)
+	conn := new(mockConnectionFetcher)
+
+	preExtractor.On("CloneForAsset", mock.Anything, mock.Anything, mock.Anything).
+		Return(extractor, nil)
+	extractor.On("ExtractQueriesFromString", "select 1").
+		Return([]*query.Query{{Query: "select 1"}}, nil)
+	conn.On("GetConnection", mock.Anything).Return(client)
+	// Always return 0 so the sensor never succeeds.
+	client.On("SelectOnlyLastResult", mock.Anything, mock.Anything).Return([][]interface{}{{int64(0)}}, nil)
+
+	sensor := NewQuerySensor(conn, preExtractor, 0)
+
+	start := time.Now()
+	err := sensor.RunTask(t.Context(), &pipeline.Pipeline{}, &pipeline.Asset{
+		Type: pipeline.AssetTypeSnowflakeQuerySensor,
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "test-file.sql",
+			Content: "select 1",
+		},
+		Parameters: pipeline.EmptyStringMap{
+			"query":   "select 1",
+			"timeout": "100ms",
+		},
+	})
+	elapsed := time.Since(start)
+
+	require.ErrorContains(t, err, "Sensor timed out after")
+	assert.Less(t, elapsed, 5*time.Second, "timeout should fire promptly")
 }


### PR DESCRIPTION
## Summary

Two related changes around the sensor `timeout` parameter introduced in #1995:

1. **Code fix** — `pkg/snowflake/operator.go`'s `QuerySensor` had its own loop that ignored `helpers.GetSensorTimeout`, so `timeout` was silently dropped on `sf.sensor.query`. Wrap the loop with the same `time.After` + `select` pattern used by the ansisql and BigQuery sensors so the parameter is actually honored. Adds `TestQuerySensorTimesOutWhenConfigured` mirroring the existing ansisql test.
2. **Docs** — propagate `timeout` to every platform's sensor reference page (the central `docs/assets/sensor.md` already covered it from #1995, but the per-platform pages still listed only `poke_interval`).

### Platforms documented

Covers all sensors backed by `ansisql`, BigQuery, Snowflake, and S3 — i.e. every sensor wired to `helpers.GetSensorTimeout`:

- `bigquery.md` — `bq.sensor.table`, `bq.sensor.query`
- `postgres.md` — `pg.sensor.table`, `pg.sensor.query`
- `redshift.md` — `rs.sensor.query`, `rs.sensor.table`
- `mssql.md` — `ms.sensor.table`, `ms.sensor.query`
- `synapse.md` — `synapse.sensor.table`, `synapse.sensor.query`
- `databricks.md` — `databricks.sensor.query`, `databricks.sensor.table`
- `athena.md` — `athena.sensor.table`, `athena.sensor.query`
- `clickhouse.md` — `clickhouse.sensor.table`, `clickhouse.sensor.query`
- `mysql.md` — `my.sensor.table`, `my.sensor.query`
- `trino.md` — `trino.sensor.query`
- `duckdb.md` — `duckdb.sensor.query`
- `motherduck.md` — `duckdb.sensor.query`
- `snowflake.md` — `sf.sensor.table` and `sf.sensor.query` (now that the code fix makes it work)
- `s3.md` — `s3.sensor.key_sensor` (also fixes the "Maximum timeout is 24 hours" line and the wait-mode bullet)

`fabric.md` only enumerates sensor type names with no parameter sections, so no edit was needed.

## Test plan

- [x] `make test` — full suite passes locally
- [x] `make format` clean
- [x] New `TestQuerySensorTimesOutWhenConfigured` passes (≈100ms timeout fires promptly)
- [ ] Manual: render docs site, click through platform pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)