### PR TITLE
[codex] Fix DuckDB SCD2 timestamp zones

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -442,6 +442,8 @@ When changes are detected in non-primary key columns:
 - `_valid_until`: TIMESTAMP when the record version became inactive (set to `TIMESTAMP('9999-12-31')` for current records, or uses `incremental_key` value when a record is expired due to changes)
 - `_is_current`: BOOLEAN indicating if this is the current version of the record
 
+For DuckDB and MotherDuck, `_valid_from` and `_valid_until` are created as `TIMESTAMP WITH TIME ZONE`.
+
 **Optional: Using `incremental_key` for timestamps:**
 
 By default, `_valid_from` and `_valid_until` are set using `CURRENT_TIMESTAMP()`. However, if your source data has a column that indicates when changes actually occurred (e.g., an `updated_at` timestamp), you can specify it using the `incremental_key` option:
@@ -596,6 +598,8 @@ The strategy tracks changes based on the time values in the `incremental_key` co
 - `_valid_from`: TIMESTAMP when the record version became active (derived from the `incremental_key`)
 - `_valid_until`: TIMESTAMP when the record version became inactive (set to `TIMESTAMP('9999-12-31')` for current records)
 - `_is_current`: BOOLEAN indicating if this is the current version of the record
+
+For DuckDB and MotherDuck, `_valid_from` and `_valid_until` are created as `TIMESTAMP WITH TIME ZONE`.
 
 Here's an example of an asset with `scd2_by_time` materialization:
 

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -2242,7 +2242,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-02: run pipeline with full refresh",
 						Command: binary,
-						Args:    []string{"run", "--full-refresh", "--env", "env-scd2-by-column", filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline")},
+						Args:    []string{"run", "--full-refresh", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--env", "env-scd2-by-column", filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline")},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -2254,11 +2254,35 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-03: query the initial table",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-column", "--query", "SELECT ID, Name, Price, _is_current FROM test.menu ORDER BY ID, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-column", "--query", "SELECT ID, Name, Price, _is_current FROM test.menu ORDER BY ID, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
 							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_expected_initial.csv"),
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByCSV,
+						},
+					},
+					{
+						Name:    "scd2-col-03b: verify metadata timestamp types",
+						Command: binary,
+						Args: []string{
+							"query",
+							"--config-file",
+							filepath.Join(currentFolder, ".bruin.yml"),
+							"--connection",
+							"duckdb-scd2-by-column",
+							"--query",
+							"SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'test' AND table_name = 'menu' AND column_name IN ('_valid_from', '_valid_until') ORDER BY column_name;",
+							"--output",
+							"csv",
+						},
+						Env: []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_metadata_types.csv"),
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
@@ -2290,7 +2314,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-05: query the updated table 01",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-column", "--query", "SELECT ID, Name, Price, _is_current FROM test.menu ORDER BY ID, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-column", "--query", "SELECT ID, Name, Price, _is_current FROM test.menu ORDER BY ID, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -2326,7 +2350,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-07: query the updated table 02",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-column", "--query", "SELECT ID, Name, Price, _is_current FROM test.menu ORDER BY ID, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-column", "--query", "SELECT ID, Name, Price, _is_current FROM test.menu ORDER BY ID, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -2395,11 +2419,35 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-time-03: query the initial table",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-time", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-time", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
 							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-time-pipeline/expectations/scd2_by_time_expected_initial.csv"),
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByCSV,
+						},
+					},
+					{
+						Name:    "scd2-time-03b: verify metadata timestamp types",
+						Command: binary,
+						Args: []string{
+							"query",
+							"--config-file",
+							filepath.Join(currentFolder, ".bruin.yml"),
+							"--connection",
+							"duckdb-scd2-by-time",
+							"--query",
+							"SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'test' AND table_name = 'products' AND column_name IN ('_valid_from', '_valid_until') ORDER BY column_name;",
+							"--output",
+							"csv",
+						},
+						Env: []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-time-pipeline/expectations/scd2_by_time_metadata_types.csv"),
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
@@ -2431,7 +2479,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-time-05: query the updated table 01",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-time", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-time", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -2467,7 +2515,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-time-07: query the updated table 02",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-time", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-time", "--query", "SELECT product_id,product_name,stock,_is_current,_valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -2536,11 +2584,35 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-ik-03: query the initial table",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-column-incremental-key", "--query", "SELECT product_id, product_name, price, _is_current, _valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-column-incremental-key", "--query", "SELECT product_id, product_name, price, _is_current, _valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
 							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-column-incremental-key-pipeline/expectations/scd2_by_col_ik_expected_initial.csv"),
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByCSV,
+						},
+					},
+					{
+						Name:    "scd2-col-ik-03b: verify metadata timestamp types",
+						Command: binary,
+						Args: []string{
+							"query",
+							"--config-file",
+							filepath.Join(currentFolder, ".bruin.yml"),
+							"--connection",
+							"duckdb-scd2-by-column-incremental-key",
+							"--query",
+							"SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'test' AND table_name = 'products' AND column_name IN ('_valid_from', '_valid_until') ORDER BY column_name;",
+							"--output",
+							"csv",
+						},
+						Env: []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-scd2-tests/scd2-by-column-incremental-key-pipeline/expectations/scd2_by_col_ik_metadata_types.csv"),
 						},
 						Asserts: []func(*e2e.Task) error{
 							e2e.AssertByExitCode,
@@ -2572,7 +2644,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-ik-05: query the updated table 01",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-column-incremental-key", "--query", "SELECT product_id, product_name, price, _is_current, _valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-column-incremental-key", "--query", "SELECT product_id, product_name, price, _is_current, _valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,
@@ -2608,7 +2680,7 @@ func TestWorkflowTasks(t *testing.T) {
 					{
 						Name:    "scd2-col-ik-07: query the updated table 02",
 						Command: binary,
-						Args:    []string{"query", "--connection", "duckdb-scd2-by-column-incremental-key", "--query", "SELECT product_id, product_name, price, _is_current, _valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
+						Args:    []string{"query", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--connection", "duckdb-scd2-by-column-incremental-key", "--query", "SELECT product_id, product_name, price, _is_current, _valid_from FROM test.products ORDER BY product_id, _valid_from;", "--output", "csv"},
 						Env:     []string{},
 						Expected: e2e.Output{
 							ExitCode: 0,

--- a/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-incremental-key-pipeline/expectations/scd2_by_col_ik_metadata_types.csv
+++ b/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-incremental-key-pipeline/expectations/scd2_by_col_ik_metadata_types.csv
@@ -1,0 +1,3 @@
+column_name,data_type
+_valid_from,TIMESTAMP WITH TIME ZONE
+_valid_until,TIMESTAMP WITH TIME ZONE

--- a/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_metadata_types.csv
+++ b/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-column-pipeline/expectations/scd2_by_col_metadata_types.csv
@@ -1,0 +1,3 @@
+column_name,data_type
+_valid_from,TIMESTAMP WITH TIME ZONE
+_valid_until,TIMESTAMP WITH TIME ZONE

--- a/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-time-pipeline/expectations/scd2_by_time_metadata_types.csv
+++ b/integration-tests/test-pipelines/duckdb-scd2-tests/scd2-by-time-pipeline/expectations/scd2_by_time_metadata_types.csv
@@ -1,0 +1,3 @@
+column_name,data_type
+_valid_from,TIMESTAMP WITH TIME ZONE
+_valid_until,TIMESTAMP WITH TIME ZONE

--- a/pkg/duckdb/materialization.go
+++ b/pkg/duckdb/materialization.go
@@ -38,6 +38,39 @@ var matMap = pipeline.AssetMaterializationMap{
 	},
 }
 
+const (
+	duckDBCurrentTimestamp = "CURRENT_TIMESTAMP"
+	duckDBMaxTimestamp     = "TIMESTAMPTZ '9999-12-31 23:59:59+00'"
+)
+
+func duckDBTimestampWithTimeZone(expr, columnType string) string {
+	lcType := strings.ToLower(columnType)
+	if strings.Contains(lcType, "time zone") || strings.Contains(lcType, "timestamptz") {
+		return fmt.Sprintf("CAST(%s AS TIMESTAMPTZ)", expr)
+	}
+
+	return fmt.Sprintf("CAST(%s AS TIMESTAMP) AT TIME ZONE 'UTC'", expr)
+}
+
+func duckDBIncrementalKeyType(asset *pipeline.Asset, strategy string) (string, error) {
+	incrementalKey := asset.Materialization.IncrementalKey
+	if incrementalKey == "" {
+		return "", nil
+	}
+
+	col := asset.GetColumnWithName(incrementalKey)
+	if col == nil {
+		return "", fmt.Errorf("incremental_key column %s not found", incrementalKey)
+	}
+
+	lcType := strings.ToLower(col.Type)
+	if !strings.Contains(lcType, "timestamp") && lcType != "date" {
+		return "", fmt.Errorf("incremental_key must be TIMESTAMP or DATE in %s strategy", strategy)
+	}
+
+	return col.Type, nil
+}
+
 func errorMaterializer(asset *pipeline.Asset, query string) (string, error) {
 	return "", fmt.Errorf("materialization strategy %s is not supported for materialization type %s and asset type %s", asset.Materialization.Strategy, asset.Materialization.Type, asset.Type)
 }
@@ -227,6 +260,10 @@ func buildSCD2ByColumnQuery(asset *pipeline.Asset, query string) (string, error)
 	)
 
 	incrementalKey := asset.Materialization.IncrementalKey
+	incrementalKeyType, err := duckDBIncrementalKeyType(asset, "SCD2_by_column")
+	if err != nil {
+		return "", err
+	}
 
 	for _, col := range asset.Columns {
 		switch col.Name {
@@ -285,15 +322,15 @@ func buildSCD2ByColumnQuery(asset *pipeline.Asset, query string) (string, error)
 	validFromExpr := "(SELECT now FROM time_now)"
 	validUntilUpdateExpr := "(SELECT now FROM time_now)"
 	if incrementalKey != "" {
-		validFromExpr = fmt.Sprintf("CAST(s.%s AS TIMESTAMP)", incrementalKey)
-		validUntilUpdateExpr = fmt.Sprintf("CAST(s.%s AS TIMESTAMP)", incrementalKey)
+		validFromExpr = duckDBTimestampWithTimeZone("s."+incrementalKey, incrementalKeyType)
+		validUntilUpdateExpr = duckDBTimestampWithTimeZone("s."+incrementalKey, incrementalKeyType)
 	}
 
 	sqlLines := []string{
 		"CREATE OR REPLACE TABLE " + asset.Name + " AS",
 		"WITH",
 		"time_now AS (",
-		"\tSELECT CURRENT_TIMESTAMP AS now",
+		fmt.Sprintf("\tSELECT %s AS now", duckDBCurrentTimestamp),
 		"),",
 		"source AS (",
 		fmt.Sprintf("\tSELECT %s,", userColList),
@@ -331,7 +368,7 @@ func buildSCD2ByColumnQuery(asset *pipeline.Asset, query string) (string, error)
 		"to_insert AS (",
 		fmt.Sprintf("\tSELECT %s,", strings.Join(toInsertSelectCols, ", ")),
 		fmt.Sprintf("\t%s AS _valid_from,", validFromExpr),
-		"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,",
+		fmt.Sprintf("\t%s AS _valid_until,", duckDBMaxTimestamp),
 		"\tTRUE AS _is_current",
 		"\tFROM source s",
 		fmt.Sprintf("\tLEFT JOIN current_data t ON (%s)", joinCondition),
@@ -353,6 +390,10 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 	}
 
 	incrementalKey := asset.Materialization.IncrementalKey
+	incrementalKeyType, err := duckDBIncrementalKeyType(asset, "SCD2_by_time")
+	if err != nil {
+		return "", err
+	}
 
 	var (
 		primaryKeys = make([]string, 0, 4)
@@ -363,12 +404,6 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 		switch col.Name {
 		case "_is_current", "_valid_from", "_valid_until":
 			return "", fmt.Errorf("column name %s is reserved for SCD-2 and cannot be used", col.Name)
-		}
-		if col.Name == asset.Materialization.IncrementalKey {
-			lcType := strings.ToLower(col.Type)
-			if lcType != "timestamp" && lcType != "date" {
-				return "", errors.New("incremental_key must be TIMESTAMP or DATE in SCD2_by_time strategy")
-			}
 		}
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, col.Name)
@@ -387,7 +422,8 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 	}
 	joinCondition := strings.Join(onConds, " AND ")
 
-	changeCondition := fmt.Sprintf("CAST(s.%s AS TIMESTAMP) > t._valid_from", incrementalKey)
+	incrementalKeyTimestamp := duckDBTimestampWithTimeZone("s."+incrementalKey, incrementalKeyType)
+	changeCondition := incrementalKeyTimestamp + " > t._valid_from"
 
 	// Build user column list for SELECTs
 	userColList := strings.Join(userCols, ", ")
@@ -412,7 +448,7 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 		"CREATE OR REPLACE TABLE " + asset.Name + " AS",
 		"WITH",
 		"time_now AS (",
-		"\tSELECT CURRENT_TIMESTAMP AS now",
+		fmt.Sprintf("\tSELECT %s AS now", duckDBCurrentTimestamp),
 		"),",
 		"source AS (",
 		fmt.Sprintf("\tSELECT %s,", userColList),
@@ -434,7 +470,7 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("\tSELECT %s,", strings.Join(toKeepSelectCols, ", ")),
 		"\tt._valid_from,",
 		"\t\tCASE",
-		fmt.Sprintf("\t\t\tWHEN _matched_by_source IS NOT NULL AND (%s) THEN CAST(s.%s AS TIMESTAMP)", changeCondition, incrementalKey),
+		fmt.Sprintf("\t\t\tWHEN _matched_by_source IS NOT NULL AND (%s) THEN %s", changeCondition, incrementalKeyTimestamp),
 		"\t\t\tWHEN _matched_by_source IS NULL THEN (SELECT now FROM time_now)",
 		"\t\t\tELSE t._valid_until",
 		"\t\tEND AS _valid_until,",
@@ -449,8 +485,8 @@ func buildSCD2ByTimeQuery(asset *pipeline.Asset, query string) (string, error) {
 		"--new/updated rows from source",
 		"to_insert AS (",
 		fmt.Sprintf("\tSELECT %s,", strings.Join(toInsertSelectCols, ", ")),
-		fmt.Sprintf("\tCAST(s.%s AS TIMESTAMP) AS _valid_from,", incrementalKey),
-		"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,",
+		fmt.Sprintf("\t%s AS _valid_from,", incrementalKeyTimestamp),
+		fmt.Sprintf("\t%s AS _valid_until,", duckDBMaxTimestamp),
 		"\tTRUE AS _is_current",
 		"\tFROM source s",
 		fmt.Sprintf("\tLEFT JOIN current_data t ON (%s)", joinCondition),
@@ -473,6 +509,10 @@ func buildSCD2ByTimefullRefresh(asset *pipeline.Asset, query string) (string, er
 	if len(primaryKeys) == 0 {
 		return "", errors.New("materialization strategy 'SCD2_by_time' requires the `primary_key` field to be set on at least one column")
 	}
+	incrementalKeyType, err := duckDBIncrementalKeyType(asset, "SCD2_by_time")
+	if err != nil {
+		return "", err
+	}
 
 	srcCols := make([]string, len(asset.Columns))
 	for i, col := range asset.Columns {
@@ -482,14 +522,15 @@ func buildSCD2ByTimefullRefresh(asset *pipeline.Asset, query string) (string, er
 	createQuery := fmt.Sprintf(
 		"CREATE OR REPLACE TABLE %s AS\n"+
 			"SELECT %s,\n"+
-			"CAST(src.%s AS TIMESTAMP) AS _valid_from,\n"+
-			"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n"+
+			"%s AS _valid_from,\n"+
+			"%s AS _valid_until,\n"+
 			"TRUE AS _is_current\n"+
 			"FROM (%s\n"+
 			") AS src;",
 		asset.Name,
 		strings.Join(srcCols, ", "),
-		asset.Materialization.IncrementalKey,
+		duckDBTimestampWithTimeZone("src."+asset.Materialization.IncrementalKey, incrementalKeyType),
+		duckDBMaxTimestamp,
 		strings.TrimSpace(query),
 	)
 
@@ -507,22 +548,27 @@ func buildSCD2ByColumnfullRefresh(asset *pipeline.Asset, query string) (string, 
 		srcCols[i] = "src." + col.Name
 	}
 
-	validFromExpr := "CURRENT_TIMESTAMP"
+	validFromExpr := duckDBCurrentTimestamp
 	if asset.Materialization.IncrementalKey != "" {
-		validFromExpr = fmt.Sprintf("CAST(src.%s AS TIMESTAMP)", asset.Materialization.IncrementalKey)
+		incrementalKeyType, err := duckDBIncrementalKeyType(asset, "SCD2_by_column")
+		if err != nil {
+			return "", err
+		}
+		validFromExpr = duckDBTimestampWithTimeZone("src."+asset.Materialization.IncrementalKey, incrementalKeyType)
 	}
 
 	createQuery := fmt.Sprintf(
 		"CREATE OR REPLACE TABLE %s AS\n"+
 			"SELECT %s,\n"+
 			"%s AS _valid_from,\n"+
-			"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n"+
+			"%s AS _valid_until,\n"+
 			"TRUE AS _is_current\n"+
 			"FROM (%s\n"+
 			") AS src;",
 		asset.Name,
 		strings.Join(srcCols, ", "),
 		validFromExpr,
+		duckDBMaxTimestamp,
 		strings.TrimSpace(query),
 	)
 

--- a/pkg/duckdb/materialization_test.go
+++ b/pkg/duckdb/materialization_test.go
@@ -432,6 +432,15 @@ func TestBuildDDLQuery(t *testing.T) {
 	}
 }
 
+func TestDuckDBTimestampWithTimeZone(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "CAST(s.updated_at AS TIMESTAMP) AT TIME ZONE 'UTC'", duckDBTimestampWithTimeZone("s.updated_at", "TIMESTAMP"))
+	assert.Equal(t, "CAST(s.updated_at AS TIMESTAMP) AT TIME ZONE 'UTC'", duckDBTimestampWithTimeZone("s.updated_at", "DATE"))
+	assert.Equal(t, "CAST(s.updated_at AS TIMESTAMPTZ)", duckDBTimestampWithTimeZone("s.updated_at", "TIMESTAMP WITH TIME ZONE"))
+	assert.Equal(t, "CAST(s.updated_at AS TIMESTAMPTZ)", duckDBTimestampWithTimeZone("s.updated_at", "TIMESTAMPTZ"))
+}
+
 func TestBuildSCD2ByColumnQuery(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -508,6 +517,23 @@ func TestBuildSCD2ByColumnQuery(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "scd2_invalid_incremental_key_type",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategySCD2ByColumn,
+					IncrementalKey: "updated_at",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true},
+					{Name: "updated_at", Type: "VARCHAR"},
+				},
+			},
+			query:   "SELECT id, updated_at from source_table",
+			wantErr: true,
+		},
+		{
 			name: "scd2_basic_column_change_detection and partitioning",
 			asset: &pipeline.Asset{
 				Name: "my.asset",
@@ -564,7 +590,7 @@ func TestBuildSCD2ByColumnQuery(t *testing.T) {
 				"to_insert AS (\n" +
 				"\tSELECT s.id AS id, s.col1 AS col1, s.col2 AS col2,\n" +
 				"\t(SELECT now FROM time_now) AS _valid_from,\n" +
-				"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"\tTIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"\tTRUE AS _is_current\n" +
 				"\tFROM source s\n" +
 				"\tLEFT JOIN current_data t ON (t.id = s.id)\n" +
@@ -630,7 +656,7 @@ func TestBuildSCD2ByColumnQuery(t *testing.T) {
 				"to_insert AS (\n" +
 				"\tSELECT s.id AS id, s.category AS category, s.name AS name,\n" +
 				"\t(SELECT now FROM time_now) AS _valid_from,\n" +
-				"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"\tTIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"\tTRUE AS _is_current\n" +
 				"\tFROM source s\n" +
 				"\tLEFT JOIN current_data t ON (t.id = s.id AND t.category = s.category)\n" +
@@ -681,7 +707,7 @@ func TestBuildSCD2ByColumnQuery(t *testing.T) {
 				"\tSELECT t.id, t.col1, t.updated_at,\n" +
 				"\tt._valid_from,\n" +
 				"\t\tCASE\n" +
-				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (t.col1 != s.col1 OR t.updated_at != s.updated_at) THEN CAST(s.updated_at AS TIMESTAMP)\n" +
+				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (t.col1 != s.col1 OR t.updated_at != s.updated_at) THEN CAST(s.updated_at AS TIMESTAMP) AT TIME ZONE 'UTC'\n" +
 				"\t\t\tWHEN _matched_by_source IS NULL THEN (SELECT now FROM time_now)\n" +
 				"\t\t\tELSE t._valid_until\n" +
 				"\t\tEND AS _valid_until,\n" +
@@ -696,8 +722,8 @@ func TestBuildSCD2ByColumnQuery(t *testing.T) {
 				"--new/updated rows from source\n" +
 				"to_insert AS (\n" +
 				"\tSELECT s.id AS id, s.col1 AS col1, s.updated_at AS updated_at,\n" +
-				"\tCAST(s.updated_at AS TIMESTAMP) AS _valid_from,\n" +
-				"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"\tCAST(s.updated_at AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"\tTIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"\tTRUE AS _is_current\n" +
 				"\tFROM source s\n" +
 				"\tLEFT JOIN current_data t ON (t.id = s.id)\n" +
@@ -771,7 +797,7 @@ func TestBuildSCD2ByColumnFullRefreshQuery(t *testing.T) {
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.name, src.price,\n" +
 				"CURRENT_TIMESTAMP AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, name, price from source_table\n" +
 				") AS src;",
@@ -796,7 +822,7 @@ func TestBuildSCD2ByColumnFullRefreshQuery(t *testing.T) {
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.category, src.name, src.price,\n" +
 				"CURRENT_TIMESTAMP AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, category, name, price from source_table\n" +
 				") AS src;",
@@ -821,7 +847,7 @@ func TestBuildSCD2ByColumnFullRefreshQuery(t *testing.T) {
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.name, src.price,\n" +
 				"CURRENT_TIMESTAMP AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, name, price from source_table\n" +
 				") AS src;",
@@ -846,8 +872,8 @@ func TestBuildSCD2ByColumnFullRefreshQuery(t *testing.T) {
 			query:       "SELECT id, name, price, updated_at from source_table",
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.name, src.price, src.updated_at,\n" +
-				"CAST(src.updated_at AS TIMESTAMP) AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"CAST(src.updated_at AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, name, price, updated_at from source_table\n" +
 				") AS src;",
@@ -1026,12 +1052,12 @@ func TestBuildSCD2ByTimeQuery(t *testing.T) {
 				"\tSELECT t.id, t.event_name, t.ts,\n" +
 				"\tt._valid_from,\n" +
 				"\t\tCASE\n" +
-				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) > t._valid_from) THEN CAST(s.ts AS TIMESTAMP)\n" +
+				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' > t._valid_from) THEN CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC'\n" +
 				"\t\t\tWHEN _matched_by_source IS NULL THEN (SELECT now FROM time_now)\n" +
 				"\t\t\tELSE t._valid_until\n" +
 				"\t\tEND AS _valid_until,\n" +
 				"\t\tCASE\n" +
-				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) > t._valid_from) THEN FALSE\n" +
+				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' > t._valid_from) THEN FALSE\n" +
 				"\t\t\tWHEN _matched_by_source IS NULL THEN FALSE\n" +
 				"\t\t\tELSE t._is_current\n" +
 				"\t\tEND AS _is_current\n" +
@@ -1041,12 +1067,12 @@ func TestBuildSCD2ByTimeQuery(t *testing.T) {
 				"--new/updated rows from source\n" +
 				"to_insert AS (\n" +
 				"\tSELECT s.id AS id, s.event_name AS event_name, s.ts AS ts,\n" +
-				"\tCAST(s.ts AS TIMESTAMP) AS _valid_from,\n" +
-				"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"\tCAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"\tTIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"\tTRUE AS _is_current\n" +
 				"\tFROM source s\n" +
 				"\tLEFT JOIN current_data t ON (t.id = s.id)\n" +
-				"\tWHERE (_matched_by_target IS NULL) OR (CAST(s.ts AS TIMESTAMP) > t._valid_from)\n" +
+				"\tWHERE (_matched_by_target IS NULL) OR (CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' > t._valid_from)\n" +
 				")\n" +
 				"SELECT id, event_name, ts, _valid_from, _valid_until, _is_current FROM to_keep\n" +
 				"UNION ALL\n" +
@@ -1093,12 +1119,12 @@ func TestBuildSCD2ByTimeQuery(t *testing.T) {
 				"\tSELECT t.id, t.event_name, t.ts,\n" +
 				"\tt._valid_from,\n" +
 				"\t\tCASE\n" +
-				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) > t._valid_from) THEN CAST(s.ts AS TIMESTAMP)\n" +
+				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' > t._valid_from) THEN CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC'\n" +
 				"\t\t\tWHEN _matched_by_source IS NULL THEN (SELECT now FROM time_now)\n" +
 				"\t\t\tELSE t._valid_until\n" +
 				"\t\tEND AS _valid_until,\n" +
 				"\t\tCASE\n" +
-				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) > t._valid_from) THEN FALSE\n" +
+				"\t\t\tWHEN _matched_by_source IS NOT NULL AND (CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' > t._valid_from) THEN FALSE\n" +
 				"\t\t\tWHEN _matched_by_source IS NULL THEN FALSE\n" +
 				"\t\t\tELSE t._is_current\n" +
 				"\t\tEND AS _is_current\n" +
@@ -1108,12 +1134,12 @@ func TestBuildSCD2ByTimeQuery(t *testing.T) {
 				"--new/updated rows from source\n" +
 				"to_insert AS (\n" +
 				"\tSELECT s.id AS id, s.event_name AS event_name, s.ts AS ts,\n" +
-				"\tCAST(s.ts AS TIMESTAMP) AS _valid_from,\n" +
-				"\tTIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"\tCAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"\tTIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"\tTRUE AS _is_current\n" +
 				"\tFROM source s\n" +
 				"\tLEFT JOIN current_data t ON (t.id = s.id AND t.event_name = s.event_name)\n" +
-				"\tWHERE (_matched_by_target IS NULL) OR (CAST(s.ts AS TIMESTAMP) > t._valid_from)\n" +
+				"\tWHERE (_matched_by_target IS NULL) OR (CAST(s.ts AS TIMESTAMP) AT TIME ZONE 'UTC' > t._valid_from)\n" +
 				")\n" +
 				"SELECT id, event_name, ts, _valid_from, _valid_until, _is_current FROM to_keep\n" +
 				"UNION ALL\n" +
@@ -1202,8 +1228,8 @@ func TestBuildSCD2ByTimeFullRefreshQuery(t *testing.T) {
 			query:       "SELECT id, event_name, ts from source_table",
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.event_name, src.ts,\n" +
-				"CAST(src.ts AS TIMESTAMP) AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"CAST(src.ts AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, event_name, ts from source_table\n" +
 				") AS src;",
@@ -1228,8 +1254,8 @@ func TestBuildSCD2ByTimeFullRefreshQuery(t *testing.T) {
 			query:       "SELECT id, category, event_name, ts from source_table",
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.category, src.event_name, src.ts,\n" +
-				"CAST(src.ts AS TIMESTAMP) AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"CAST(src.ts AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, category, event_name, ts from source_table\n" +
 				") AS src;",
@@ -1254,8 +1280,8 @@ func TestBuildSCD2ByTimeFullRefreshQuery(t *testing.T) {
 			query:       "SELECT id, event_name, ts from source_table",
 			want: "CREATE OR REPLACE TABLE my.asset AS\n" +
 				"SELECT src.id, src.event_name, src.ts,\n" +
-				"CAST(src.ts AS TIMESTAMP) AS _valid_from,\n" +
-				"TIMESTAMP '9999-12-31 23:59:59' AS _valid_until,\n" +
+				"CAST(src.ts AS TIMESTAMP) AT TIME ZONE 'UTC' AS _valid_from,\n" +
+				"TIMESTAMPTZ '9999-12-31 23:59:59+00' AS _valid_until,\n" +
 				"TRUE AS _is_current\n" +
 				"FROM (SELECT id, event_name, ts from source_table\n" +
 				") AS src;",


### PR DESCRIPTION
Fixes DuckDB/MotherDuck SCD2 metadata timestamps so both `_valid_from` and `_valid_until` are `TIMESTAMP WITH TIME ZONE`.

Naive incremental keys are treated as UTC to preserve existing SCD2 values.

Validated with `make format`, `make test`, and `make integration-test`.
