### PR TITLE
feat(smartsheet): add optional smartsheet_id field and default to gong

### DIFF
--- a/docs/ingestion/smartsheet.md
+++ b/docs/ingestion/smartsheet.md
@@ -21,9 +21,11 @@ connections:
     smartsheet:
         - name: "smartsheet"
           access_token: "access_token"
+          smartsheet_id: "1234567890123456" # optional
 ```
 
-- `access_token`: Your Smartsheet API access token.
+- `access_token` (required): Your Smartsheet API access token.
+- `smartsheet_id` (optional): The default Smartsheet sheet ID for this connection. When set, you can omit `source_table` from the asset and Bruin will fall back to this value. If `source_table` is provided on the asset, it takes priority.
 
 ### Step 2: Create an asset file for data ingestion
 

--- a/docs/ingestion/smartsheet.md
+++ b/docs/ingestion/smartsheet.md
@@ -25,7 +25,7 @@ connections:
 ```
 
 - `access_token` (required): Your Smartsheet API access token.
-- `smartsheet_id` (optional): The default Smartsheet sheet ID for this connection. When set, you can omit `source_table` from the asset and Bruin will fall back to this value. If `source_table` is provided on the asset, it takes priority.
+- `smartsheet_id` (optional): A default Smartsheet sheet ID baked into the connection URI as the `smartsheet_id` query parameter. When set, you can omit `source_table` from the asset. If the asset also sets `source_table`, the asset value is forwarded as `--source-table` to gong and takes priority over the URI parameter.
 
 ### Step 2: Create an asset file for data ingestion
 
@@ -47,7 +47,7 @@ parameters:
 - `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: "postgres" indicates that the ingested data will be stored in a PostgreSQL database.
 - `source_connection`: The name of the Smartsheet connection defined in .bruin.yml.
-- `source_table`: The source table will be the `sheet_id` of the Smartsheet you want to ingest. You can find the sheet_id by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there.
+- `source_table`: The `sheet_id` of the Smartsheet to ingest. You can find the sheet_id by opening the sheet in Smartsheet and going to File > Properties. This field is optional when the connection itself sets `smartsheet_id`; if both are set, the asset's `source_table` wins.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/smartsheet.md
+++ b/docs/ingestion/smartsheet.md
@@ -25,7 +25,7 @@ connections:
 ```
 
 - `access_token` (required): Your Smartsheet API access token.
-- `smartsheet_id` (optional): The default Smartsheet sheet ID for this connection. When set, you can omit `source_table` from the asset and Bruin will fall back to this value. If `source_table` is provided on the asset, it takes priority.
+- `smartsheet_id` (optional): A default sheet ID baked into the connection URI. It is consulted only when the asset's `source_table` is set to the literal value `sheet`; any other `source_table` value (numeric or `sheet:<id>`) wins.
 
 ### Step 2: Create an asset file for data ingestion
 
@@ -47,7 +47,15 @@ parameters:
 - `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: "postgres" indicates that the ingested data will be stored in a PostgreSQL database.
 - `source_connection`: The name of the Smartsheet connection defined in .bruin.yml.
-- `source_table`: The source table will be the `sheet_id` of the Smartsheet you want to ingest. You can find the sheet_id by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there.
+- `source_table`: Identifies the sheet to ingest. You can find the `sheet_id` by opening the sheet in Smartsheet and going to File > Properties. Three forms are accepted:
+
+  | Value | Behaviour |
+  | --- | --- |
+  | `<sheet_id>` | Use the value as the sheet ID. |
+  | `sheet:<sheet_id>` | Strip the `sheet:` prefix and use the rest as the sheet ID. |
+  | `sheet` | Use the connection's `smartsheet_id`. Errors if it isn't set. |
+
+  Use the `sheet` alias when you want the sheet ID to live on the connection (via `smartsheet_id`) rather than on every asset.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/smartsheet.md
+++ b/docs/ingestion/smartsheet.md
@@ -25,7 +25,7 @@ connections:
 ```
 
 - `access_token` (required): Your Smartsheet API access token.
-- `smartsheet_id` (optional): A default Smartsheet sheet ID baked into the connection URI as the `smartsheet_id` query parameter. When set, you can omit `source_table` from the asset. If the asset also sets `source_table`, the asset value is forwarded as `--source-table` to gong and takes priority over the URI parameter.
+- `smartsheet_id` (optional): The default Smartsheet sheet ID for this connection. When set, you can omit `source_table` from the asset and Bruin will fall back to this value. If `source_table` is provided on the asset, it takes priority.
 
 ### Step 2: Create an asset file for data ingestion
 
@@ -47,7 +47,7 @@ parameters:
 - `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: "postgres" indicates that the ingested data will be stored in a PostgreSQL database.
 - `source_connection`: The name of the Smartsheet connection defined in .bruin.yml.
-- `source_table`: The `sheet_id` of the Smartsheet to ingest. You can find the sheet_id by opening the sheet in Smartsheet and going to File > Properties. This field is optional when the connection itself sets `smartsheet_id`; if both are set, the asset's `source_table` wins.
+- `source_table`: The source table will be the `sheet_id` of the Smartsheet you want to ingest. You can find the sheet_id by opening the sheet in Smartsheet and going to File > Properties. The Sheet ID will be listed there.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -2969,6 +2969,9 @@
         },
         "access_token": {
           "type": "string"
+        },
+        "smartsheet_id": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1311,8 +1311,9 @@ func (c SolidgateConnection) GetName() string {
 }
 
 type SmartsheetConnection struct {
-	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
-	AccessToken string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token"`
+	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	AccessToken  string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token"`
+	SmartsheetID string `yaml:"smartsheet_id,omitempty" json:"smartsheet_id,omitempty" mapstructure:"smartsheet_id"`
 }
 
 func (c SmartsheetConnection) GetName() string {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -689,8 +689,9 @@ func TestLoadFromFile(t *testing.T) {
 			},
 			Smartsheet: []SmartsheetConnection{
 				{
-					Name:        "smartsheet-1",
-					AccessToken: "access-token-123",
+					Name:         "smartsheet-1",
+					AccessToken:  "access-token-123",
+					SmartsheetID: "1234567890",
 				},
 			},
 			Attio: []AttioConnection{

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -439,6 +439,7 @@ environments:
       smartsheet:
         - name: "smartsheet-1"
           access_token: "access-token-123"
+          smartsheet_id: "1234567890"
       attio:
         - name: "attio-1"
           api_key: "api-key-123"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -440,6 +440,7 @@ environments:
       smartsheet:
         - name: "smartsheet-1"
           access_token: "access-token-123"
+          smartsheet_id: "1234567890"
       attio:
         - name: "attio-1"
           api_key: "api-key-123"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1219,7 +1219,8 @@ func (m *Manager) AddSmartsheetConnectionFromConfig(connection *config.Smartshee
 	m.mutex.Unlock()
 
 	client, err := smartsheet.NewClient(smartsheet.Config{
-		AccessToken: connection.AccessToken,
+		AccessToken:  connection.AccessToken,
+		SmartsheetID: connection.SmartsheetID,
 	})
 	if err != nil {
 		return err

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -818,6 +818,7 @@ var gongSources = map[string]bool{
 	"jobtread":     true,
 	"posthog":      true,
 	"rabbitmq":     true,
+	"smartsheet":   true,
 	"surveymonkey": true,
 }
 

--- a/pkg/smartsheet/config.go
+++ b/pkg/smartsheet/config.go
@@ -5,11 +5,15 @@ import (
 )
 
 type Config struct {
-	AccessToken string
+	AccessToken  string
+	SmartsheetID string
 }
 
 func (c *Config) GetIngestrURI() string {
 	q := url.Values{}
 	q.Set("access_token", c.AccessToken)
+	if c.SmartsheetID != "" {
+		q.Set("smartsheet_id", c.SmartsheetID)
+	}
 	return "smartsheet://?" + q.Encode()
 }


### PR DESCRIPTION
## Summary
- Add an optional `smartsheet_id` field to the Smartsheet connection definition. When set, it is forwarded to the ingestr URI as the `smartsheet_id` query parameter, so users can omit `source_table` on their assets.
- Asset-level `source_table` keeps priority when both are provided.
- Default Smartsheet ingestr assets to gong by adding `smartsheet` to the `gongSources` map. Smartsheet now uses gong out of the box.
- Update docs (`docs/ingestion/smartsheet.md`) and config testdata to reflect the new optional field.

## Why
Other connectors in our stack already carry the resource identifier inside the connection definition. Surfacing `smartsheet_id` on the connection lets users avoid templating the sheet ID into every asset, while still allowing per-asset overrides via `source_table`.

## Files changed
- `pkg/smartsheet/config.go` — add `SmartsheetID` field, append it to the URI when set.
- `pkg/config/connections.go` — add `smartsheet_id` to `SmartsheetConnection`.
- `pkg/connection/connection.go` — pass `SmartsheetID` through to the smartsheet client config.
- `pkg/ingestr/sources.go` — add `smartsheet` to `gongSources`.
- `docs/ingestion/smartsheet.md` — document the new optional field.
- `pkg/config/testdata/simple.yml` + `simple_win.yml` — populate `smartsheet_id` in fixtures.
- `pkg/config/manager_test.go` — assert the new field round-trips through config loading.

## Test plan
- [x] `go test ./pkg/config/... ./pkg/connection/... ./pkg/ingestr/...`
- [ ] End-to-end: connection with no `smartsheet_id`, asset with `source_table` — works as before
- [ ] End-to-end: connection with `smartsheet_id`, asset with no `source_table` — picks up the default
- [ ] End-to-end: connection with `smartsheet_id` AND asset `source_table` — `source_table` wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)