### PR TITLE
feat(snowflake): consolidate query sensor onto ansisql.QuerySensor

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1845,7 +1845,7 @@ func SetupExecutors(
 
 		sfCheckRunner := snowflake.NewColumnCheckOperator(conn)
 
-		sfQuerySensor := snowflake.NewQuerySensor(conn, wholeFileExtractor, 30)
+		sfQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
 		sfTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		sfMetadataPushOperator := snowflake.NewMetadataPushOperator(conn)

--- a/pkg/ansisql/operator.go
+++ b/pkg/ansisql/operator.go
@@ -20,6 +20,13 @@ type TableExistsChecker interface {
 	BuildTableExistsQuery(tableName string) (string, error)
 }
 
+// LastResultSelector is an optional connection capability for query sensors.
+// Connections that can run multi-statement queries (e.g. Snowflake) implement
+// this so the sensor uses only the final result set instead of the first.
+type LastResultSelector interface {
+	SelectOnlyLastResult(ctx context.Context, q *query.Query) ([][]interface{}, error)
+}
+
 type QuerySensor struct {
 	connection config.ConnectionGetter
 	extractor  query.QueryExtractor
@@ -80,16 +87,14 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 			}
 			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
 		default:
-			if querier, ok := conn.(interface {
-				Select(ctx context.Context, q *query.Query) ([][]interface{}, error)
-			}); ok {
-				res, err := querier.Select(ctx, qry[0])
-				if err != nil {
-					if printerExists {
-						fmt.Fprintln(printer, "Error: Sensor query failed:", err)
-					}
-					return err
+			res, ok, err := selectForSensor(ctx, conn, qry[0])
+			if err != nil {
+				if printerExists {
+					fmt.Fprintln(printer, "Error: Sensor query failed:", err)
 				}
+				return err
+			}
+			if ok {
 				intRes, err := helpers.CastResultToInteger(res, true)
 				if err != nil {
 					return errors.Wrap(err, "failed to parse query sensor result")
@@ -110,6 +115,24 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 			}
 		}
 	}
+}
+
+// selectForSensor runs the sensor probe against conn, preferring
+// SelectOnlyLastResult when the connection implements LastResultSelector.
+// The boolean indicates whether the connection supports either capability;
+// when false, the caller proceeds without a result.
+func selectForSensor(ctx context.Context, conn any, q *query.Query) ([][]interface{}, bool, error) {
+	if last, ok := conn.(LastResultSelector); ok {
+		res, err := last.SelectOnlyLastResult(ctx, q)
+		return res, true, err
+	}
+	if querier, ok := conn.(interface {
+		Select(ctx context.Context, q *query.Query) ([][]interface{}, error)
+	}); ok {
+		res, err := querier.Select(ctx, q)
+		return res, true, err
+	}
+	return nil, false, nil
 }
 
 type TableSensor struct {

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -3,13 +3,11 @@ package snowflake
 import (
 	"context"
 	"io"
-	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/devenv"
 	"github.com/bruin-data/bruin/pkg/executor"
-	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/scheduler"
@@ -191,74 +189,6 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 		"accepted_values": &AcceptedValuesCheck{conn: manager},
 		"pattern":         &PatternCheck{conn: manager},
 	})
-}
-
-type QuerySensor struct {
-	connection     config.ConnectionGetter
-	extractor      query.QueryExtractor
-	secondsToSleep int64
-}
-
-func NewQuerySensor(conn config.ConnectionGetter, extractor query.QueryExtractor, secondsToSleep int64) *QuerySensor {
-	return &QuerySensor{
-		connection:     conn,
-		extractor:      extractor,
-		secondsToSleep: secondsToSleep,
-	}
-}
-
-func (o *QuerySensor) Run(ctx context.Context, ti scheduler.TaskInstance) error {
-	return o.RunTask(ctx, ti.GetPipeline(), ti.GetAsset())
-}
-
-func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Asset) error {
-	qq, ok := t.Parameters["query"]
-	if !ok {
-		return errors.New("query sensor requires a parameter named 'query'")
-	}
-	extractor, err := o.extractor.CloneForAsset(ctx, p, t)
-	if err != nil {
-		return errors.Wrapf(err, "failed to clone extractor for asset %s", t.Name)
-	}
-	qry, err := extractor.ExtractQueriesFromString(qq)
-	if err != nil {
-		return errors.Wrap(err, "failed to render query sensor query")
-	}
-
-	connName, err := p.GetConnectionNameForAsset(t)
-	if err != nil {
-		return err
-	}
-
-	rawConn := o.connection.GetConnection(connName)
-	if rawConn == nil {
-		return config.NewConnectionNotFoundError(ctx, "", connName)
-	}
-
-	conn, ok := rawConn.(SfClient)
-	if !ok {
-		return errors.Errorf("connection '%s' is not a snowflake connection", connName)
-	}
-
-	for {
-		res, err := conn.SelectOnlyLastResult(ctx, qry[0])
-		if err != nil {
-			return err
-		}
-
-		intRes, err := helpers.CastResultToInteger(res, true)
-		if err != nil {
-			return errors.Wrap(err, "failed to parse query sensor result")
-		}
-
-		if intRes > 0 {
-			break
-		}
-
-		time.Sleep(time.Duration(o.secondsToSleep) * time.Second)
-	}
-
-	return nil
 }
 
 type MetadataOperator struct {


### PR DESCRIPTION
## Summary

- Snowflake's bespoke `QuerySensor` diverged from the shared `ansisql.QuerySensor` in two ways: it ignored the `poke_interval` parameter (hardcoded 30s) and ignored `--sensor-mode` (always behaved as `wait`).
- Adds an opt-in `ansisql.LastResultSelector` interface so backends like Snowflake — which need `SelectOnlyLastResult` for multi-statement queries — can plug into the shared sensor without changing behavior for Postgres/MSSQL/Trino/etc.
- Deletes `snowflake.QuerySensor` and switches `cmd/run.go` to `ansisql.NewQuerySensor`. Snowflake now honors `timeout`, `poke_interval`, and `--sensor-mode` for free, matching the `TableSensor` precedent that already delegates to ansisql.

Continues from #2003.

## Test plan

- [x] `make test` — `pkg/ansisql`, `pkg/snowflake`, and `cmd` all pass
- [x] `make format` — no diff
- [ ] Manual smoke: run a Snowflake query sensor with `poke_interval` set and confirm it sleeps the configured interval, and with `--sensor-mode once` to confirm single-poke behavior
- [ ] Manual smoke: confirm a multi-statement Snowflake sensor query still reads the last result set

🤖 Generated with [Claude Code](https://claude.com/claude-code)