### PR TITLE
fix(checks): show source file location when a custom check fails

### DIFF
--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -18,44 +18,60 @@ import (
 )
 
 type JSONRPCRequest struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      interface{} `json:"id"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params,omitempty"`
+	JSONRPC string `json:"jsonrpc"`
+
+	ID interface{} `json:"id"`
+
+	Method string `json:"method"`
+
+	Params interface{} `json:"params,omitempty"`
 }
 
 type JSONRPCResponse struct {
-	JSONRPC string        `json:"jsonrpc"`
-	ID      interface{}   `json:"id"`
-	Result  interface{}   `json:"result,omitempty"`
-	Error   *JSONRPCError `json:"error,omitempty"`
+	JSONRPC string `json:"jsonrpc"`
+
+	ID interface{} `json:"id"`
+
+	Result interface{} `json:"result,omitempty"`
+
+	Error *JSONRPCError `json:"error,omitempty"`
 }
 
 type JSONRPCError struct {
-	Code    int    `json:"code"`
+	Code int `json:"code"`
+
 	Message string `json:"message"`
 }
 
 // This will be a long-running process that communicates with Cursor IDE via stdin/stdout.
+
 // using the Model Context Protocol (JSON-RPC).
+
 func MCPCmd() *cli.Command {
 	return &cli.Command{
-		Name:        "mcp",
-		Usage:       "Start MCP server for Cursor IDE integration",
+		Name: "mcp",
+
+		Usage: "Start MCP server for Cursor IDE integration",
+
 		Description: "Runs a Model Context Protocol server to provide Bruin context to Cursor IDE",
+
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:  "debug",
+				Name: "debug",
+
 				Usage: "Enable debug logging for MCP server",
+
 				Value: false,
 			},
 		},
+
 		Action: func(ctx context.Context, c *cli.Command) error {
 			debug := c.Bool("debug")
 
 			if debug {
 				fmt.Fprintf(os.Stderr, "Starting Bruin MCP server...\n")
 			}
+
 			return runMCPServer(debug)
 		},
 	}
@@ -69,6 +85,7 @@ func runMCPServer(debug bool) error {
 	})
 
 	// Main loop: read requests from stdin, process them, write responses to stdout
+
 	for scanner.Scan() {
 		request := strings.TrimSpace(scanner.Text())
 
@@ -77,16 +94,19 @@ func runMCPServer(debug bool) error {
 		}
 
 		var rpcRequest JSONRPCRequest
+
 		if err := json.Unmarshal([]byte(request), &rpcRequest); err != nil {
 			if debug {
 				fmt.Fprintf(os.Stderr, "Failed to parse JSON-RPC request: %v\n", err)
 			}
+
 			continue
 		}
 
 		if debug {
 			fmt.Fprintf(os.Stderr, "Processing method: %s\n", rpcRequest.Method)
 		}
+
 		response := processRequest(rpcRequest, debug)
 
 		if response.JSONRPC != "" && response.ID != nil {
@@ -95,6 +115,7 @@ func runMCPServer(debug bool) error {
 				if debug {
 					fmt.Fprintf(os.Stderr, "Failed to marshal response: %v\n", err)
 				}
+
 				continue
 			}
 
@@ -116,78 +137,113 @@ func runMCPServer(debug bool) error {
 func processRequest(req JSONRPCRequest, debug bool) JSONRPCResponse {
 	switch req.Method {
 	// this is the mcp handshake
+
 	case "initialize":
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Result: map[string]interface{}{
 				"protocolVersion": "2024-11-05",
+
 				"capabilities": map[string]interface{}{
 					"tools": map[string]interface{}{},
 				},
+
 				"serverInfo": map[string]interface{}{
-					"name":    "bruin",
+					"name": "bruin",
+
 					"version": "0.1.0",
 				},
 			},
 		}
+
 	case "initialized", "notifications/initialized":
+
 		if req.ID == nil {
 			return JSONRPCResponse{}
 		}
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
-			Result:  nil,
+
+			ID: req.ID,
+
+			Result: nil,
 		}
+
 	case "tools/list":
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Result: map[string]interface{}{
 				"tools": []map[string]interface{}{
 					{
-						"name":        "bruin_get_overview",
+						"name": "bruin_get_overview",
+
 						"description": "Get information about Bruin's features and capabilities",
-						"inputSchema": map[string]interface{}{
-							"type":       "object",
-							"properties": map[string]interface{}{},
-						},
-					},
-					{
-						"name":        "bruin_get_docs_tree",
-						"description": "Get tree view of documentation files for Bruin, including all the supported platforms, data sources and destinations.",
-						"inputSchema": map[string]interface{}{
-							"type":       "object",
-							"properties": map[string]interface{}{},
-						},
-					},
-					{
-						"name":        "bruin_get_doc_content",
-						"description": "Get the contents of a specific documentation file from Bruin CLI docs. Use bruin_get_docs_tree first to see all available directories and files. You can access files in subdirectories (e.g., 'ingestion/shopify', 'platforms/bigquery', 'commands/run') or root-level files (e.g., 'overview', 'index'). The .md extension is optional.",
+
 						"inputSchema": map[string]interface{}{
 							"type": "object",
+
+							"properties": map[string]interface{}{},
+						},
+					},
+
+					{
+						"name": "bruin_get_docs_tree",
+
+						"description": "Get tree view of documentation files for Bruin, including all the supported platforms, data sources and destinations.",
+
+						"inputSchema": map[string]interface{}{
+							"type": "object",
+
+							"properties": map[string]interface{}{},
+						},
+					},
+
+					{
+						"name": "bruin_get_doc_content",
+
+						"description": "Get the contents of a specific documentation file from Bruin CLI docs. Use bruin_get_docs_tree first to see all available directories and files. You can access files in subdirectories (e.g., 'ingestion/shopify', 'platforms/bigquery', 'commands/run') or root-level files (e.g., 'overview', 'index'). The .md extension is optional.",
+
+						"inputSchema": map[string]interface{}{
+							"type": "object",
+
 							"properties": map[string]interface{}{
 								"filename": map[string]interface{}{
-									"type":        "string",
+									"type": "string",
+
 									"description": "Path to the markdown file (e.g., 'ingestion/shopify', 'platforms/bigquery', 'overview'). The .md extension is optional.",
 								},
 							},
+
 							"required": []string{"filename"},
 						},
 					},
 				},
 			},
 		}
+
 	case "tools/call":
+
 		return handleToolCall(req, debug)
 
 	default:
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Error: &JSONRPCError{
-				Code:    -32601,
+				Code: -32601,
+
 				Message: "Method not found: " + req.Method,
 			},
 		}
@@ -201,6 +257,7 @@ func handleToolCall(req JSONRPCRequest, debug bool) JSONRPCResponse {
 	}
 
 	params, ok := req.Params.(map[string]interface{})
+
 	if !ok {
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
@@ -213,6 +270,7 @@ func handleToolCall(req JSONRPCRequest, debug bool) JSONRPCResponse {
 	}
 
 	toolName, ok := params["name"].(string)
+
 	if !ok {
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
@@ -226,58 +284,80 @@ func handleToolCall(req JSONRPCRequest, debug bool) JSONRPCResponse {
 
 	switch toolName {
 	case "bruin_get_overview":
+
 		telemetry.SendEvent("mcp_tool_call", analytics.Properties{
 			"tool_name": "bruin_get_overview",
 		})
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Result: map[string]interface{}{
 				"content": []map[string]interface{}{
 					{
 						"type": "text",
+
 						"text": getBruinInfo(),
 					},
 				},
 			},
 		}
+
 	case "bruin_get_docs_tree":
+
 		telemetry.SendEvent("mcp_tool_call", analytics.Properties{
 			"tool_name": "bruin_get_docs_tree",
 		})
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Result: map[string]interface{}{
 				"content": []map[string]interface{}{
 					{
 						"type": "text",
+
 						"text": getTreeList(),
 					},
 				},
 			},
 		}
+
 	case "bruin_get_doc_content":
+
 		// Extract filename parameter
+
 		args, ok := params["arguments"].(map[string]interface{})
+
 		if !ok {
 			return JSONRPCResponse{
 				JSONRPC: "2.0",
-				ID:      req.ID,
+
+				ID: req.ID,
+
 				Error: &JSONRPCError{
-					Code:    -32602,
+					Code: -32602,
+
 					Message: "Invalid arguments",
 				},
 			}
 		}
 
 		filename, ok := args["filename"].(string)
+
 		if !ok {
 			return JSONRPCResponse{
 				JSONRPC: "2.0",
-				ID:      req.ID,
+
+				ID: req.ID,
+
 				Error: &JSONRPCError{
-					Code:    -32602,
+					Code: -32602,
+
 					Message: "Missing or invalid filename parameter",
 				},
 			}
@@ -285,16 +365,20 @@ func handleToolCall(req JSONRPCRequest, debug bool) JSONRPCResponse {
 
 		telemetry.SendEvent("mcp_tool_call", analytics.Properties{
 			"tool_name": "bruin_get_doc_content",
-			"filename":  filename,
+
+			"filename": filename,
 		})
 
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Result: map[string]interface{}{
 				"content": []map[string]interface{}{
 					{
 						"type": "text",
+
 						"text": getDocContent(filename),
 					},
 				},
@@ -302,11 +386,15 @@ func handleToolCall(req JSONRPCRequest, debug bool) JSONRPCResponse {
 		}
 
 	default:
+
 		return JSONRPCResponse{
 			JSONRPC: "2.0",
-			ID:      req.ID,
+
+			ID: req.ID,
+
 			Error: &JSONRPCError{
-				Code:    -32601,
+				Code: -32601,
+
 				Message: "Unknown tool: " + toolName,
 			},
 		}
@@ -318,12 +406,15 @@ func getBruinInfo() string {
 	if err != nil {
 		return fmt.Sprintf("Error: Could not read overview.md: %v", err)
 	}
+
 	return string(content)
 }
 
 func getTreeList() string {
 	tree := treeprint.NewWithRoot("Bruin Documentation")
+
 	buildDocTree(tree, ".")
+
 	return "```\n" + tree.String() + "```\n"
 }
 
@@ -334,7 +425,9 @@ func buildDocTree(branch treeprint.Tree, dir string) {
 	}
 
 	var dirs []fs.DirEntry
+
 	var files []fs.DirEntry
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			dirs = append(dirs, entry)
@@ -344,14 +437,18 @@ func buildDocTree(branch treeprint.Tree, dir string) {
 	}
 
 	sort.Slice(dirs, func(i, j int) bool { return dirs[i].Name() < dirs[j].Name() })
+
 	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
 
 	for _, entry := range dirs {
 		childPath := dir + "/" + entry.Name()
+
 		if dir == "." {
 			childPath = entry.Name()
 		}
+
 		childBranch := branch.AddBranch(entry.Name())
+
 		buildDocTree(childBranch, childPath)
 	}
 
@@ -362,12 +459,15 @@ func buildDocTree(branch treeprint.Tree, dir string) {
 
 func getDocContent(filename string) string {
 	// Ensure filename has .md extension
+
 	if !strings.HasSuffix(filename, ".md") {
 		filename += ".md"
 	}
 
 	// Try to read the file directly (handles both root-level and nested files)
+
 	content, err := docs.DocsFS.ReadFile(filename)
+
 	if err == nil {
 		return string(content)
 	}
@@ -378,7 +478,9 @@ func getDocContent(filename string) string {
 	}
 
 	var validDirs []string
+
 	var rootFiles []string
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			validDirs = append(validDirs, entry.Name()+"/")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -73,37 +73,50 @@ const LogsFolder = "logs"
 
 var pythonCacheGitignorePatterns = []string{
 	"__pycache__/",
+
 	"*.py[cod]",
 }
 
 var errUsePipDeprecated = errors.New("flag --use-pip is no longer supported: Bruin now always runs Python assets with uv")
 
 type PipelineInfo struct {
-	Pipeline           *pipeline.Pipeline
-	RunningForAnAsset  bool
+	Pipeline *pipeline.Pipeline
+
+	RunningForAnAsset bool
+
 	RunDownstreamTasks bool
 }
 
 type ExecutionSummary struct {
-	TotalTasks      int
-	SuccessfulTasks int
-	FailedTasks     int
-	SkippedTasks    int
+	TotalTasks int
 
-	Assets       TaskTypeStats
+	SuccessfulTasks int
+
+	FailedTasks int
+
+	SkippedTasks int
+
+	Assets TaskTypeStats
+
 	ColumnChecks TaskTypeStats
+
 	CustomChecks TaskTypeStats
+
 	MetadataPush TaskTypeStats
 
 	Duration time.Duration
 }
 
 type TaskTypeStats struct {
-	Total             int
-	Succeeded         int
-	Failed            int // Failed in main execution
+	Total int
+
+	Succeeded int
+
+	Failed int // Failed in main execution
+
 	FailedDueToChecks int // Failed only due to checks (main execution succeeded)
-	Skipped           int
+
+	Skipped int
 }
 
 func (s TaskTypeStats) HasAny() bool {
@@ -114,59 +127,96 @@ func (s TaskTypeStats) SuccessRate() float64 {
 	if s.Total == 0 {
 		return 0
 	}
+
 	return float64(s.Succeeded) / float64(s.Total) * 100
 }
 
 func printExecutionTable(results []*scheduler.TaskExecutionResult, s *scheduler.Scheduler) {
 	// Group results by asset
+
 	assetResults := make(map[string]map[string]*scheduler.TaskExecutionResult)
+
 	assetOrder := make([]string, 0)
 
 	for _, result := range results {
+
 		assetName := result.Instance.GetAsset().Name
+
 		if _, exists := assetResults[assetName]; !exists {
+
 			assetResults[assetName] = make(map[string]*scheduler.TaskExecutionResult)
+
 			assetOrder = append(assetOrder, assetName)
+
 		}
 
 		switch instance := result.Instance.(type) {
+
 		case *scheduler.AssetInstance:
+
 			assetResults[assetName]["main"] = result
+
 		case *scheduler.ColumnCheckInstance:
+
 			key := fmt.Sprintf("column:%s:%s", instance.Column.Name, instance.Check.Name)
+
 			assetResults[assetName][key] = result
+
 		case *scheduler.CustomCheckInstance:
+
 			key := "custom:" + instance.Check.Name
+
 			assetResults[assetName][key] = result
+
 		}
+
 	}
 
 	// Only add upstream failed assets (skip the "skipped" ones entirely)
+
 	upstreamFailedTasks := s.GetTaskInstancesByStatus(scheduler.UpstreamFailed)
 
 	for _, task := range upstreamFailedTasks {
+
 		assetName := task.GetAsset().Name
+
 		if _, exists := assetResults[assetName]; !exists {
+
 			assetResults[assetName] = make(map[string]*scheduler.TaskExecutionResult)
+
 			assetOrder = append(assetOrder, assetName)
+
 		}
 
 		// Create a fake result for upstream failed task
+
 		upstreamFailedResult := &scheduler.TaskExecutionResult{
 			Instance: task,
-			Error:    nil, // We'll use nil to indicate upstream failed
+
+			Error: nil, // We'll use nil to indicate upstream failed
+
 		}
 
 		switch instance := task.(type) {
+
 		case *scheduler.AssetInstance:
+
 			assetResults[assetName]["main"] = upstreamFailedResult
+
 		case *scheduler.ColumnCheckInstance:
+
 			key := fmt.Sprintf("column:%s:%s", instance.Column.Name, instance.Check.Name)
+
 			assetResults[assetName][key] = upstreamFailedResult
+
 		case *scheduler.CustomCheckInstance:
+
 			key := "custom:" + instance.Check.Name
+
 			assetResults[assetName][key] = upstreamFailedResult
+
 		}
+
 	}
 
 	if len(assetOrder) == 0 {
@@ -176,47 +226,74 @@ func printExecutionTable(results []*scheduler.TaskExecutionResult, s *scheduler.
 	fmt.Println("\n" + strings.Repeat("=", 50) + "\n")
 
 	for _, assetName := range assetOrder {
+
 		results := assetResults[assetName]
+
 		mainResult := results["main"]
 
 		// Asset name with status
+
 		var assetStatus string
+
 		var assetColor *color.Color
 
 		if mainResult == nil { // nolint:gocritic
+
 			// Asset not executed
+
 			assetStatus = "SKIP"
+
 			assetColor = color.New(color.Faint)
+
 		} else if mainResult.Error == nil {
+
 			// Check if this is upstream failed
+
 			_, isUpstreamFailed := find(upstreamFailedTasks, mainResult.Instance)
 
 			if isUpstreamFailed {
+
 				assetStatus = "UPSTREAM FAILED"
+
 				assetColor = color.New(color.FgYellow)
+
 			} else {
+
 				assetStatus = "PASS"
+
 				assetColor = color.New(color.FgGreen)
+
 			}
+
 		} else {
+
 			assetStatus = "FAIL"
+
 			assetColor = color.New(color.FgRed)
+
 		}
 
 		fmt.Printf("%s %s ", assetColor.Sprint(assetStatus), assetName)
 
 		// Print dots for quality checks
+
 		checkCount := 0
+
 		for key, result := range results {
+
 			if key == "main" {
 				continue
 			}
 
 			checkCount++
+
 			if result == nil { // nolint:gocritic
+
 				fmt.Print(faint("."))
 			} else if result.Error == nil {
+
 				// Check if upstream failed
+
 				_, isUpstreamFailed := find(upstreamFailedTasks, result.Instance)
 
 				if isUpstreamFailed {
@@ -224,85 +301,118 @@ func printExecutionTable(results []*scheduler.TaskExecutionResult, s *scheduler.
 				} else {
 					fmt.Print(color.New(color.FgGreen).Sprint("."))
 				}
+
 			} else {
 				fmt.Print(color.New(color.FgRed).Sprint("F"))
 			}
+
 		}
 
 		fmt.Println()
+
 	}
 }
 
 func find(slice []scheduler.TaskInstance, item scheduler.TaskInstance) (int, bool) { // nolint:unparam
+
 	for i, v := range slice {
 		if v == item {
 			return i, true
 		}
 	}
+
 	return -1, false
 }
 
 func printExecutionSummary(results []*scheduler.TaskExecutionResult, s *scheduler.Scheduler, duration time.Duration, _ int) {
 	summary := analyzeResults(results, s)
+
 	summary.Duration = duration
 
 	// Print execution table first
+
 	printExecutionTable(results, s)
 
 	// Determine overall status
+
 	hasFailures := summary.FailedTasks > 0
 
 	// Header with status and task count
+
 	if hasFailures {
 		summaryPrinter.Printf("\n\nbruin run completed with %s in %s\n\n",
+
 			color.New(color.FgRed).Sprint("failures"),
+
 			duration.Truncate(time.Millisecond).String())
 	} else {
 		summaryPrinter.Printf("\n\nbruin run completed %s in %s\n\n",
+
 			color.New(color.FgGreen).Sprint("successfully"),
+
 			duration.Truncate(time.Millisecond).String())
 	}
 
 	// Assets executed (only actual assets, not including quality checks)
+
 	if summary.Assets.HasAny() {
 		if summary.Assets.Failed > 0 || summary.Assets.FailedDueToChecks > 0 || summary.Assets.Skipped > 0 {
 			summaryPrinter.Printf(" %s Assets executed      %s\n",
+
 				color.New(color.FgRed).Sprint("✗"),
+
 				formatCountWithSkipped(summary.Assets.Total, summary.Assets.Failed, summary.Assets.FailedDueToChecks, summary.Assets.Skipped))
 		} else {
 			summaryPrinter.Printf(" %s Assets executed      %s\n",
+
 				color.New(color.FgGreen).Sprint("✓"),
+
 				color.New(color.FgGreen).Sprintf("%d succeeded", summary.Assets.Succeeded))
 		}
 	}
 
 	// Quality checks
+
 	totalChecks := summary.ColumnChecks.Total + summary.CustomChecks.Total
+
 	totalCheckFailures := summary.ColumnChecks.Failed + summary.CustomChecks.Failed
+
 	totalCheckSkipped := summary.ColumnChecks.Skipped + summary.CustomChecks.Skipped
+
 	if totalChecks > 0 {
 		if totalCheckFailures > 0 || totalCheckSkipped > 0 {
 			summaryPrinter.Printf(" %s Quality checks       %s\n",
+
 				color.New(color.FgRed).Sprint("✗"),
+
 				formatCountWithSkipped(totalChecks, totalCheckFailures, 0, totalCheckSkipped))
 		} else {
 			summaryPrinter.Printf(" %s Quality checks       %s\n",
+
 				color.New(color.FgGreen).Sprint("✓"),
+
 				color.New(color.FgGreen).Sprintf("%d succeeded", summary.ColumnChecks.Succeeded+summary.CustomChecks.Succeeded))
 		}
 	}
 
 	// Metadata push
+
 	if summary.MetadataPush.HasAny() {
+
 		metadataExecuted := summary.MetadataPush.Succeeded + summary.MetadataPush.Failed
+
 		if summary.MetadataPush.Failed > 0 {
 			summaryPrinter.Printf(" %s Metadata pushed      %s\n",
+
 				color.New(color.FgRed).Sprint("✗"),
+
 				formatCount(metadataExecuted, summary.MetadataPush.Failed))
 		} else {
 			summaryPrinter.Printf(" %s Metadata pushed      %d\n",
+
 				color.New(color.FgGreen).Sprint("✓"), metadataExecuted)
 		}
+
 	}
 }
 
@@ -310,9 +420,13 @@ func formatCount(total, failed int) string {
 	if failed == 0 {
 		return strconv.Itoa(total)
 	}
+
 	succeeded := total - failed
+
 	return fmt.Sprintf("%s / %s",
+
 		color.New(color.FgRed).Sprintf("%d failed", failed),
+
 		color.New(color.FgGreen).Sprintf("%d succeeded", succeeded))
 }
 
@@ -320,15 +434,19 @@ func formatCountWithSkipped(total, failed, failedDueToChecks, skipped int) strin
 	succeeded := total - failed - failedDueToChecks - skipped
 
 	var parts []string
+
 	if failed > 0 {
 		parts = append(parts, color.New(color.FgRed).Sprintf("%d failed", failed))
 	}
+
 	if failedDueToChecks > 0 {
 		parts = append(parts, color.New(color.FgYellow).Sprintf("%d failed due to checks", failedDueToChecks))
 	}
+
 	if succeeded > 0 {
 		parts = append(parts, color.New(color.FgGreen).Sprintf("%d succeeded", succeeded))
 	}
+
 	if skipped > 0 {
 		parts = append(parts, color.New(color.Faint).Sprintf("%d skipped", skipped))
 	}
@@ -336,6 +454,7 @@ func formatCountWithSkipped(total, failed, failedDueToChecks, skipped int) strin
 	if len(parts) == 0 {
 		return "0"
 	}
+
 	if len(parts) == 1 && failed == 0 && failedDueToChecks == 0 && skipped == 0 {
 		return strconv.Itoa(succeeded)
 	}
@@ -347,16 +466,23 @@ func analyzeResults(results []*scheduler.TaskExecutionResult, s *scheduler.Sched
 	summary := ExecutionSummary{}
 
 	// Track asset status by asset name
-	assetMainStatus := make(map[string]bool)       // true if main execution succeeded
+
+	assetMainStatus := make(map[string]bool) // true if main execution succeeded
+
 	assetHasCheckFailures := make(map[string]bool) // true if any check failed
-	assetNames := make(map[string]bool)            // all assets seen
+
+	assetNames := make(map[string]bool) // all assets seen
 
 	// Count all tasks by type and status
+
 	for _, result := range results {
+
 		summary.TotalTasks++
 
 		// Determine if task succeeded
+
 		succeeded := result.Error == nil
+
 		if succeeded {
 			summary.SuccessfulTasks++
 		} else {
@@ -364,135 +490,206 @@ func analyzeResults(results []*scheduler.TaskExecutionResult, s *scheduler.Sched
 		}
 
 		// Categorize by task type
+
 		switch instance := result.Instance.(type) {
+
 		case *scheduler.AssetInstance:
+
 			assetName := instance.GetAsset().Name
+
 			assetNames[assetName] = true
+
 			assetMainStatus[assetName] = succeeded
 
 		case *scheduler.ColumnCheckInstance:
+
 			assetName := instance.GetAsset().Name
+
 			assetNames[assetName] = true
+
 			if !succeeded {
 				assetHasCheckFailures[assetName] = true
 			}
+
 			summary.ColumnChecks.Total++
+
 			if succeeded {
 				summary.ColumnChecks.Succeeded++
 			} else {
 				summary.ColumnChecks.Failed++
 			}
+
 		case *scheduler.CustomCheckInstance:
+
 			assetName := instance.GetAsset().Name
+
 			assetNames[assetName] = true
+
 			if !succeeded {
 				assetHasCheckFailures[assetName] = true
 			}
+
 			summary.CustomChecks.Total++
+
 			if succeeded {
 				summary.CustomChecks.Succeeded++
 			} else {
 				summary.CustomChecks.Failed++
 			}
+
 		case *scheduler.MetadataPushInstance:
+
 			summary.MetadataPush.Total++
+
 			if succeeded {
 				summary.MetadataPush.Succeeded++
 			} else {
 				summary.MetadataPush.Failed++
 			}
+
 		}
+
 	}
 
 	// Analyze asset-level results
+
 	for assetName := range assetNames {
+
 		mainSucceeded, mainSeen := assetMainStatus[assetName]
+
 		if !mainSeen {
 			continue
 		}
 
 		summary.Assets.Total++
+
 		hasCheckFailures := assetHasCheckFailures[assetName]
 
 		if mainSucceeded && !hasCheckFailures { // nolint:gocritic
+
 			summary.Assets.Succeeded++
 		} else if !mainSucceeded {
 			summary.Assets.Failed++ // Failed in main execution
 		} else if mainSucceeded && hasCheckFailures {
 			summary.Assets.FailedDueToChecks++ // Main succeeded but checks failed
 		}
+
 	}
 
 	// Don't count truly skipped tasks (those filtered out) in the summary
 
 	// Count upstream failed tasks (they should be shown as skipped in summary)
+
 	upstreamFailedTasks := s.GetTaskInstancesByStatus(scheduler.UpstreamFailed)
+
 	upstreamFailedAssets := make(map[string]bool)
+
 	for _, t := range upstreamFailedTasks {
+
 		summary.SkippedTasks++
 
 		assetName := t.GetAsset().Name
+
 		if !upstreamFailedAssets[assetName] {
+
 			upstreamFailedAssets[assetName] = true
+
 			// Only add to asset counts if this asset wasn't already counted
+
 			// from the executed results. An asset whose main task failed will
+
 			// have its checks marked UpstreamFailed, but the asset itself was
+
 			// already counted as failed above — don't double-count it as skipped.
+
 			if !assetNames[assetName] {
+
 				summary.Assets.Total++
+
 				summary.Assets.Skipped++
+
 			}
+
 		}
 
 		// Also count individual check tasks as skipped
+
 		switch t.(type) {
+
 		case *scheduler.ColumnCheckInstance:
+
 			summary.ColumnChecks.Total++
+
 			summary.ColumnChecks.Skipped++
+
 		case *scheduler.CustomCheckInstance:
+
 			summary.CustomChecks.Total++
+
 			summary.CustomChecks.Skipped++
+
 		case *scheduler.MetadataPushInstance:
+
 			summary.MetadataPush.Total++
+
 			summary.MetadataPush.Skipped++
+
 		}
+
 	}
 
 	// Update total tasks to include skipped ones
+
 	summary.TotalTasks += summary.SkippedTasks
 
 	return summary
 }
 
 var (
-	yesterday            = time.Now().AddDate(0, 0, -1)
-	defaultStartDate     = time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)
-	defaultEndDate       = time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 23, 59, 59, 0, time.UTC)
+	yesterday = time.Now().AddDate(0, 0, -1)
+
+	defaultStartDate = time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)
+
+	defaultEndDate = time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 23, 59, 59, 0, time.UTC)
+
 	defaultExecutionDate = time.Now().UTC()
 
 	startDateFlag = &cli.StringFlag{
-		Name:        "start-date",
-		Usage:       "the start date of the range the pipeline will run for in YYYY-MM-DD, YYYY-MM-DD HH:MM:SS or YYYY-MM-DD HH:MM:SS.ffffff format",
+		Name: "start-date",
+
+		Usage: "the start date of the range the pipeline will run for in YYYY-MM-DD, YYYY-MM-DD HH:MM:SS or YYYY-MM-DD HH:MM:SS.ffffff format",
+
 		DefaultText: "beginning of yesterday, e.g. " + defaultStartDate.Format("2006-01-02 15:04:05.000000"),
-		Value:       defaultStartDate.Format("2006-01-02 15:04:05.000000"),
-		Sources:     cli.EnvVars("BRUIN_START_DATE"),
+
+		Value: defaultStartDate.Format("2006-01-02 15:04:05.000000"),
+
+		Sources: cli.EnvVars("BRUIN_START_DATE"),
 	}
+
 	endDateFlag = &cli.StringFlag{
-		Name:        "end-date",
-		Usage:       "the end date of the range the pipeline will run for in YYYY-MM-DD, YYYY-MM-DD HH:MM:SS or YYYY-MM-DD HH:MM:SS.ffffff format",
+		Name: "end-date",
+
+		Usage: "the end date of the range the pipeline will run for in YYYY-MM-DD, YYYY-MM-DD HH:MM:SS or YYYY-MM-DD HH:MM:SS.ffffff format",
+
 		DefaultText: "end of yesterday, e.g. " + defaultEndDate.Format("2006-01-02 15:04:05") + ".999999",
-		Value:       defaultEndDate.Format("2006-01-02 15:04:05") + ".999999",
-		Sources:     cli.EnvVars("BRUIN_END_DATE"),
+
+		Value: defaultEndDate.Format("2006-01-02 15:04:05") + ".999999",
+
+		Sources: cli.EnvVars("BRUIN_END_DATE"),
 	}
 )
 
 func setApplyIntervalModifiers(c *cli.Command) bool {
 	fullRefresh := c.Bool("full-refresh")
+
 	applyIntervalModifiers := c.Bool("apply-interval-modifiers")
 
 	if fullRefresh && applyIntervalModifiers {
+
 		warningPrinter.Println("Warning: --apply-interval-modifiers flag is ignored when --full-refresh is enabled.")
+
 		return false
+
 	}
 
 	return applyIntervalModifiers
@@ -500,372 +697,597 @@ func setApplyIntervalModifiers(c *cli.Command) bool {
 
 func Run(isDebug *bool) *cli.Command {
 	return &cli.Command{
-		Name:      "run",
-		Usage:     "run a Bruin pipeline",
+		Name: "run",
+
+		Usage: "run a Bruin pipeline",
+
 		ArgsUsage: "[path to the task file]",
+
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:  "downstream",
+				Name: "downstream",
+
 				Usage: "pass this flag if you'd like to run all the downstream tasks as well",
 			},
+
 			&cli.IntFlag{
-				Name:  "workers",
+				Name: "workers",
+
 				Usage: "number of workers to run the tasks in parallel",
+
 				Value: 16,
 			},
+
 			startDateFlag,
+
 			endDateFlag,
+
 			&cli.StringFlag{
-				Name:    "environment",
+				Name: "environment",
+
 				Aliases: []string{"e", "env"},
-				Usage:   "the environment to use",
+
+				Usage: "the environment to use",
 			},
+
 			&cli.BoolFlag{
-				Name:  "push-metadata",
+				Name: "push-metadata",
+
 				Usage: "push the metadata to the destination database if supports, currently supported: BigQuery",
 			},
+
 			&cli.BoolFlag{
-				Name:    "force",
+				Name: "force",
+
 				Aliases: []string{"f"},
-				Usage:   "force the validation even if the environment is a production environment",
+
+				Usage: "force the validation even if the environment is a production environment",
 			},
+
 			&cli.BoolFlag{
-				Name:  "no-log-file",
+				Name: "no-log-file",
+
 				Usage: "do not create a log file for this run",
 			},
+
 			&cli.StringFlag{
-				Name:        "sensor-mode",
+				Name: "sensor-mode",
+
 				DefaultText: "'once' (default), 'skip', 'wait'",
-				Usage:       "Set sensor mode: 'skip' to bypass, 'once' to run once, or 'wait' to loop until expected result",
+
+				Usage: "Set sensor mode: 'skip' to bypass, 'once' to run once, or 'wait' to loop until expected result",
 			},
+
 			&cli.BoolFlag{
-				Name:    "full-refresh",
+				Name: "full-refresh",
+
 				Aliases: []string{"r"},
-				Usage:   "truncate the table before running",
+
+				Usage: "truncate the table before running",
+
 				Sources: cli.EnvVars("BRUIN_FULL_REFRESH"),
 			},
+
 			&cli.BoolFlag{
-				Name:        "apply-interval-modifiers",
-				Usage:       "apply interval modifiers",
+				Name: "apply-interval-modifiers",
+
+				Usage: "apply interval modifiers",
+
 				DefaultText: "false",
 			},
+
 			&cli.BoolFlag{
-				Name:  "continue",
+				Name: "continue",
+
 				Usage: "use continue to run the pipeline from the last failed asset",
 			},
+
 			&cli.StringFlag{
-				Name:  "selector",
+				Name: "selector",
+
 				Usage: "select assets using dbt-style selector syntax, including tag:, path:, file:, fqn:, +, n+, @, space unions, and comma intersections",
 			},
+
 			&cli.StringFlag{
-				Name:    "tag",
+				Name: "tag",
+
 				Aliases: []string{"t"},
-				Usage:   "pick the assets with the given tag",
+
+				Usage: "pick the assets with the given tag",
 			},
+
 			&cli.StringFlag{
-				Name:  "single-check",
+				Name: "single-check",
+
 				Usage: "runs a single column or custom check by ID",
 			},
+
 			&cli.StringFlag{
-				Name:    "exclude-tag",
+				Name: "exclude-tag",
+
 				Aliases: []string{"x"},
-				Usage:   "exclude the assets with given tag",
+
+				Usage: "exclude the assets with given tag",
 			},
+
 			&cli.StringSliceFlag{
-				Name:        "only",
+				Name: "only",
+
 				DefaultText: "'main', 'checks', 'push-metadata'",
-				Usage:       "limit the types of tasks to run. By default it will run main and checks, while push-metadata is optional if defined in the pipeline definition",
+
+				Usage: "limit the types of tasks to run. By default it will run main and checks, while push-metadata is optional if defined in the pipeline definition",
 			},
+
 			&cli.BoolFlag{
-				Name:  "modified",
+				Name: "modified",
+
 				Usage: "run only assets whose files have been modified compared to the default branch",
 			},
+
 			&cli.BoolFlag{
-				Name:  "exp-use-winget-for-uv",
+				Name: "exp-use-winget-for-uv",
+
 				Usage: "use powershell to manage and install uv on windows, on non-windows systems this has no effect.",
 			},
+
 			&cli.BoolFlag{
-				Name:   "use-pip",
-				Usage:  "deprecated compatibility flag; passing this flag returns an explicit deprecation error",
+				Name: "use-pip",
+
+				Usage: "deprecated compatibility flag; passing this flag returns an explicit deprecation error",
+
 				Hidden: true,
 			},
+
 			&cli.StringFlag{
-				Name:  "debug-ingestr-src",
+				Name: "debug-ingestr-src",
+
 				Usage: "Use ingestr from the given path instead of the builtin version.",
 			},
+
 			&cli.BoolFlag{
-				Name:   "use-gong",
-				Usage:  "force gong for all ingestr assets in this run (overridden per-asset by parameters.version=v0)",
+				Name: "use-gong",
+
+				Usage: "force gong for all ingestr assets in this run (overridden per-asset by parameters.version=v0)",
+
 				Hidden: true,
 			},
+
 			&cli.StringFlag{
-				Name:   "gong-path",
-				Usage:  "path to a pre-installed gong binary; overrides per-asset gong installation for the run",
+				Name: "gong-path",
+
+				Usage: "path to a pre-installed gong binary; overrides per-asset gong installation for the run",
+
 				Hidden: true,
 			},
+
 			&cli.StringFlag{
-				Name:    "config-file",
+				Name: "config-file",
+
 				Sources: cli.EnvVars("BRUIN_CONFIG_FILE"),
-				Usage:   "the path to the .bruin.yml file",
+
+				Usage: "the path to the .bruin.yml file",
 			},
+
 			&cli.StringFlag{
-				Name:    "secrets-backend",
+				Name: "secrets-backend",
+
 				Sources: cli.EnvVars("BRUIN_SECRETS_BACKEND"),
-				Usage:   "the source of secrets if different from .bruin.yml. Possible values: 'vault', 'doppler', 'aws', 'azure'",
+
+				Usage: "the source of secrets if different from .bruin.yml. Possible values: 'vault', 'doppler', 'aws', 'azure'",
 			},
+
 			&cli.BoolFlag{
-				Name:  "no-validation",
+				Name: "no-validation",
+
 				Usage: "skip validation for this run.",
 			},
+
 			&cli.BoolFlag{
-				Name:  "no-timestamp",
+				Name: "no-timestamp",
+
 				Usage: "skip logging timestamps for this run.",
 			},
+
 			&cli.BoolFlag{
-				Name:  "no-color",
+				Name: "no-color",
+
 				Usage: "plain log output for this run.",
 			},
+
 			&cli.BoolFlag{
-				Name:  "verbose",
+				Name: "verbose",
+
 				Usage: "print verbose output including SQL queries",
 			},
+
 			&cli.BoolFlag{
-				Name:   "minimal-logs",
-				Usage:  "skip initial pipeline analysis logs for this run",
+				Name: "minimal-logs",
+
+				Usage: "skip initial pipeline analysis logs for this run",
+
 				Hidden: true,
 			},
+
 			&cli.BoolFlag{
-				Name:    "interactive",
+				Name: "interactive",
+
 				Aliases: []string{"i"},
-				Usage:   "use an interactive TUI that shows live progress of asset execution",
+
+				Usage: "use an interactive TUI that shows live progress of asset execution",
 			},
+
 			&cli.StringSliceFlag{
-				Name:    "var",
-				Usage:   "override pipeline variables with custom values",
+				Name: "var",
+
+				Usage: "override pipeline variables with custom values",
+
 				Sources: cli.EnvVars("BRUIN_VARS"),
 			},
+
 			&cli.StringFlag{
-				Name:  "variant",
+				Name: "variant",
+
 				Usage: "name of the variant to materialize for a variant pipeline",
 			},
+
 			&cli.IntFlag{
-				Name:  "timeout",
+				Name: "timeout",
+
 				Usage: "timeout for the entire pipeline run in seconds",
+
 				Value: 604800, // 7 days default
+
 			},
+
 			&cli.StringFlag{
-				Name:  "query-annotations",
+				Name: "query-annotations",
+
 				Usage: fmt.Sprintf("JSON string containing annotations to be added as comments to queries. Use '%s' to only include default annotations.", ansisql.DefaultQueryAnnotations),
 			},
 		},
+
 		DisableSliceFlagSeparator: true,
+
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
 
 			logger := makeLogger(*isDebug)
+
 			if c.IsSet("use-pip") {
 				return cli.Exit(errUsePipDeprecated, 1)
 			}
+
 			fullRefresh := c.Bool("full-refresh")
+
 			applyIntervalModifiers := setApplyIntervalModifiers(c)
 
 			useGong := c.Bool("use-gong")
+
 			gongPath := c.String("gong-path")
 
 			// When using gong, ensure binary is available
+
 			if useGong {
 				if gongPath == "" {
+
 					// Auto-install gong if no custom path provided
+
 					gongChecker := &gong.Checker{}
+
 					installedPath, err := gongChecker.EnsureGongInstalled(ctx, "")
 					if err != nil {
 						return cli.Exit(fmt.Sprintf("failed to install gong: %v", err), 1)
 					}
+
 					gongPath = installedPath
+
 				} else {
+
 					// User provided custom path - verify it exists and is executable
+
 					info, err := os.Stat(gongPath)
 					if err != nil {
+
 						if os.IsNotExist(err) {
 							return cli.Exit("gong binary not found at path: "+gongPath, 1)
 						}
+
 						return cli.Exit(fmt.Sprintf("failed to access gong binary at path '%s': %v", gongPath, err), 1)
+
 					}
+
 					if info.Mode()&0o111 == 0 {
 						return cli.Exit(fmt.Sprintf("gong binary at path '%s' is not executable", gongPath), 1)
 					}
+
 				}
 			}
 
 			runConfig := &scheduler.RunConfig{
-				Downstream:             c.Bool("downstream"),
-				StartDate:              c.String("start-date"),
-				EndDate:                c.String("end-date"),
-				Workers:                c.Int("workers"),
-				Environment:            c.String("environment"),
-				Force:                  c.Bool("force"),
-				PushMetadata:           c.Bool("push-metadata"),
-				NoLogFile:              c.Bool("no-log-file"),
-				FullRefresh:            fullRefresh,
-				Selector:               c.String("selector"),
-				Tag:                    c.String("tag"),
-				ExcludeTag:             c.String("exclude-tag"),
-				Only:                   c.StringSlice("only"),
-				Output:                 c.String("output"),
-				ExpUseWingetForUv:      c.Bool("exp-use-winget-for-uv"),
-				ConfigFilePath:         c.String("config-file"),
-				SensorMode:             c.String("sensor-mode"),
+				Downstream: c.Bool("downstream"),
+
+				StartDate: c.String("start-date"),
+
+				EndDate: c.String("end-date"),
+
+				Workers: c.Int("workers"),
+
+				Environment: c.String("environment"),
+
+				Force: c.Bool("force"),
+
+				PushMetadata: c.Bool("push-metadata"),
+
+				NoLogFile: c.Bool("no-log-file"),
+
+				FullRefresh: fullRefresh,
+
+				Selector: c.String("selector"),
+
+				Tag: c.String("tag"),
+
+				ExcludeTag: c.String("exclude-tag"),
+
+				Only: c.StringSlice("only"),
+
+				Output: c.String("output"),
+
+				ExpUseWingetForUv: c.Bool("exp-use-winget-for-uv"),
+
+				ConfigFilePath: c.String("config-file"),
+
+				SensorMode: c.String("sensor-mode"),
+
 				ApplyIntervalModifiers: applyIntervalModifiers,
-				Annotations:            c.String("query-annotations"),
-				UseGong:                useGong,
+
+				Annotations: c.String("query-annotations"),
+
+				UseGong: useGong,
 			}
 
 			var startDate, endDate time.Time
 
 			var err error
+
 			startDate, endDate, inputPath, err := ValidateRunConfig(runConfig, c.Args().Get(0), logger)
 			if err != nil {
 				return err
 			}
+
 			repoRoot, err := git.FindRepoFromPath(inputPath)
 			if err != nil {
+
 				errorPrinter.Printf("Failed to find the git repository root: %v\n", err)
+
 				return cli.Exit("", 1)
+
 			}
 
 			configFilePath := runConfig.ConfigFilePath
+
 			if configFilePath == "" {
 				configFilePath = path2.Join(repoRoot.Path, ".bruin.yml")
 			}
+
 			cm, err := config.LoadOrCreate(afero.NewOsFs(), configFilePath)
 			if err != nil {
+
 				errorPrinter.Printf("Failed to load the config file at '%s': %v\n", configFilePath, err)
+
 				return cli.Exit("", 1)
+
 			}
+
 			err = switchEnvironment(runConfig.Environment, runConfig.Force, cm, os.Stdin, runConfig.Only)
 			if err != nil {
 				return err
 			}
+
 			if cm.SelectedEnvironment.SchemaPrefix != "" {
 				// schema prefix implies a developer environment being configured where different assets within this
+
 				// execution will be built under prefixed schemas. This requires not just modifying the queries,
+
 				// but also modifying the asset names so that quality checks actually run against the tables in the new schema.
+
 				// Since we change the asset names, we need to also prefix the upstream since their names would be changed as well.
+
 				DefaultPipelineBuilder.AddAssetMutator(func(ctx context.Context, asset *pipeline.Asset, foundPipeline *pipeline.Pipeline) (*pipeline.Asset, error) {
 					asset.PrefixSchema(cm.SelectedEnvironment.SchemaPrefix)
+
 					asset.PrefixUpstreams(cm.SelectedEnvironment.SchemaPrefix)
+
 					return asset, nil
 				})
 			}
 
 			variantName := c.String("variant")
+
 			vars := c.StringSlice("var")
+
 			if variantName != "" && len(vars) > 0 {
+
 				printError(errors.New("--var and --variant cannot be used together"), c.String("output"), "Invalid flags")
+
 				return cli.Exit("", 1)
+
 			}
+
 			if len(vars) > 0 {
 				DefaultPipelineBuilder.AddPipelineMutator(variableOverridesMutator(vars))
 			}
+
 			variantOpts := []pipeline.CreatePipelineOption{}
+
 			if variantName != "" {
 				variantOpts = append(variantOpts, pipeline.WithVariant(variantName))
 			}
 
 			runID := NewRunID()
+
 			runCtx := context.WithValue(ctx, pipeline.RunConfigFullRefresh, runConfig.FullRefresh)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigStartDate, startDate)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigEndDate, endDate)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigExecutionDate, defaultExecutionDate)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigApplyIntervalModifiers, applyIntervalModifiers)
+
 			runCtx = context.WithValue(runCtx, executor.KeyIsDebug, isDebug)
+
 			runCtx = context.WithValue(runCtx, executor.KeyVerbose, c.Bool("verbose"))
+
 			runCtx = context.WithValue(runCtx, python.CtxUseWingetForUv, runConfig.ExpUseWingetForUv) //nolint:staticcheck
+
 			runCtx = context.WithValue(runCtx, python.LocalIngestr, c.String("debug-ingestr-src"))
+
 			runCtx = context.WithValue(runCtx, config.EnvironmentContextKey, cm.SelectedEnvironment)
+
 			runCtx = context.WithValue(runCtx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+
 			runCtx = context.WithValue(runCtx, config.ConfigFilePathContextKey, configFilePath)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigRunID, runID)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigFullRefresh, runConfig.FullRefresh)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigQueryAnnotations, runConfig.Annotations)
+
 			runCtx = context.WithValue(runCtx, config.SecretsBackendContextKey, c.String("secrets-backend"))
 
 			// Preview load uses WithOnlyPipeline so we can introspect the
+
 			// pipeline.yml metadata (notably .Variants) before requiring the user
+
 			// to pick one. The full load below passes WithVariant so the builder
+
 			// materializes the right one.
+
 			preview, err := GetPipeline(runCtx, inputPath, runConfig, logger, pipeline.WithOnlyPipeline())
 			if err != nil {
 				return err
 			}
 
 			if variantName == "" && len(preview.Pipeline.Variants) > 0 {
+
 				printError(fmt.Errorf("pipeline %q declares variants %v; --variant is required", preview.Pipeline.Name, preview.Pipeline.Variants.Names()), c.String("output"), "Variant required")
+
 				return cli.Exit("", 1)
+
 			}
+
 			if variantName != "" {
+
 				if len(preview.Pipeline.Variants) == 0 {
+
 					printError(fmt.Errorf("pipeline %q does not declare any variants but --variant=%q was provided", preview.Pipeline.Name, variantName), c.String("output"), "Variant not supported")
+
 					return cli.Exit("", 1)
+
 				}
+
 				// Materialize the preview pipeline too, so downstream code that
+
 				// reads preview.Pipeline.Name (e.g. the state path) sees the
+
 				// rendered name.
+
 				if err := preview.Pipeline.MaterializeVariant(variantName, jinja.VariantRendererFactory); err != nil {
+
 					printError(err, c.String("output"), "Failed to materialize variant")
+
 					return cli.Exit("", 1)
+
 				}
+
 			}
 
 			var task *pipeline.Asset
+
 			if preview.RunningForAnAsset && c.Args().Len() == 1 {
+
 				task, err = DefaultPipelineBuilder.CreateAssetFromFile(inputPath, preview.Pipeline)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to build asset: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
+
 				task, err = DefaultPipelineBuilder.MutateAsset(runCtx, task, preview.Pipeline)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to mutate asset: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
+
 				if task == nil {
+
 					errorPrinter.Printf("Failed to create asset from file '%s'\n", inputPath)
+
 					return cli.Exit("", 1)
+
 				}
+
 			}
 
 			statePath := filepath.Join(repoRoot.Path, "logs/runs", preview.Pipeline.Name)
+
 			err = git.EnsureGivenPatternIsInGitignore(afero.NewOsFs(), repoRoot.Path, "logs/runs")
 			if err != nil {
+
 				errorPrinter.Printf("Failed to add the run state folder to .gitignore: %v\n", err)
+
 				return cli.Exit("", 1)
+
 			}
 
 			// Initialize selectedAssets early (will be populated later if multiple assets are specified)
+
 			var selectedAssets []*pipeline.Asset
 
 			singleCheckID := c.String("single-check")
+
 			filter := &Filter{
-				IncludeTag:        runConfig.Tag,
-				OnlyTaskTypes:     runConfig.Only,
+				IncludeTag: runConfig.Tag,
+
+				OnlyTaskTypes: runConfig.Only,
+
 				IncludeDownstream: preview.RunDownstreamTasks,
-				PushMetaData:      runConfig.PushMetadata,
-				SingleTask:        task,
-				SelectedAssets:    selectedAssets,
-				Selector:          runConfig.Selector,
-				ExcludeTag:        runConfig.ExcludeTag,
+
+				PushMetaData: runConfig.PushMetadata,
+
+				SingleTask: task,
+
+				SelectedAssets: selectedAssets,
+
+				Selector: runConfig.Selector,
+
+				ExcludeTag: runConfig.ExcludeTag,
+
 				singleCheckID: scheduler.CheckUniqueID{
-					ID:    singleCheckID,
+					ID: singleCheckID,
+
 					Asset: task,
 				},
 			}
+
 			var pipelineState *scheduler.PipelineState
+
 			if c.Bool("continue") {
+
 				pipelineState, err = ReadState(afero.NewOsFs(), statePath, filter)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to restore state: %v\n", err)
+
 					return err
+
 				}
 
 				runConfig = &pipelineState.Parameters
@@ -874,23 +1296,32 @@ func Run(isDebug *bool) *cli.Command {
 				if err != nil {
 					return cli.Exit("", 1)
 				}
+
 				startDate = parsedStartDate
+
 				endDate = parsedEndDate
+
 			}
 
 			// Set gong context after --continue restores RunConfig to ensure consistency
+
 			if runConfig.UseGong {
 				runCtx = context.WithValue(runCtx, python.CtxGongPath, gongPath)
 			}
 
 			// Load macros from the pipeline's macros directory
+
 			macroContent, err := jinja.LoadMacros(fs, preview.Pipeline.MacrosPath)
 			if err != nil {
+
 				logger.Error("Failed to load macros", "error", err)
+
 				return cli.Exit("", 1)
+
 			}
 
 			renderer := jinja.NewRendererWithStartEndDatesAndMacros(&startDate, &endDate, &defaultExecutionDate, preview.Pipeline.Name, runID, nil, macroContent)
+
 			DefaultPipelineBuilder.AddAssetMutator(renderAssetParamsMutator(renderer))
 
 			pipelineInfo, err := GetPipeline(runCtx, inputPath, runConfig, logger, variantOpts...)
@@ -899,272 +1330,434 @@ func Run(isDebug *bool) *cli.Command {
 			}
 
 			// Auto-enable gong for CDC mode assets
+
 			if !runConfig.UseGong {
 				for _, asset := range pipelineInfo.Pipeline.Assets {
 					if asset.Type == pipeline.AssetTypeIngestr && asset.Parameters["cdc"] == "true" {
+
 						// CDC mode detected, enable gong
+
 						runConfig.UseGong = true
 
 						if gongPath == "" {
+
 							// Auto-install gong if no custom path provided
+
 							gongChecker := &gong.Checker{}
+
 							installedPath, gongErr := gongChecker.EnsureGongInstalled(runCtx, "")
+
 							if gongErr != nil {
 								return cli.Exit(fmt.Sprintf("CDC mode detected but failed to install gong: %v", gongErr), 1)
 							}
+
 							gongPath = installedPath
+
 						} else {
+
 							// User provided custom path - verify it exists and is executable
+
 							info, gongErr := os.Stat(gongPath)
+
 							if gongErr != nil {
+
 								if os.IsNotExist(gongErr) {
 									return cli.Exit("CDC mode detected but gong binary not found at path: "+gongPath+"\nPlease install gong or remove cdc: true from your asset.", 1)
 								}
+
 								return cli.Exit(fmt.Sprintf("CDC mode detected but failed to access gong binary at path '%s': %v", gongPath, gongErr), 1)
+
 							}
+
 							if info.Mode()&0o111 == 0 {
 								return cli.Exit(fmt.Sprintf("CDC mode detected but gong binary at path '%s' is not executable", gongPath), 1)
 							}
+
 						}
 
 						runCtx = context.WithValue(runCtx, python.CtxGongPath, gongPath) //nolint
+
 						break
+
 					}
 				}
 			}
 
 			// Load assets from positional arguments
+
 			// This allows: bruin run asset1.sql asset2.sql asset3.sql
+
 			// Pipeline is inferred from the first asset file
+
 			var assetPaths []string
+
 			if c.Args().Len() > 1 && pipelineInfo.RunningForAnAsset {
+
 				// Cannot use --single-check with multiple assets
+
 				if singleCheckID != "" {
+
 					errorPrinter.Printf("Cannot use --single-check flag when running multiple assets. --single-check can only be used with a single asset.\n")
+
 					return cli.Exit("", 1)
+
 				}
+
 				assetPaths = c.Args().Slice()
+
 				preview.RunningForAnAsset = false
+
 				pipelineInfo.RunningForAnAsset = false
+
 				task = nil
+
 				filter.SingleTask = nil
+
 				filter.singleCheckID = scheduler.CheckUniqueID{}
+
 				// Clear local variable to prevent incorrect output formatting
+
 				singleCheckID = ""
+
 			}
+
 			if len(assetPaths) > 0 {
+
 				// Cannot use --single-check with multiple assets
+
 				if singleCheckID != "" {
+
 					errorPrinter.Printf("Cannot use --single-check flag when running multiple assets. --single-check can only be used with a single asset.\n")
+
 					return cli.Exit("", 1)
+
 				}
+
 				// Get current working directory for path resolution
+
 				cwd, err := os.Getwd()
 				if err != nil {
 					cwd = repoRoot.Path // Fallback to repo root
 				}
+
 				selectedAssets, err = loadAssetsFromPaths(assetPaths, pipelineInfo.Pipeline, repoRoot.Path, cwd)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to load assets: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				if len(selectedAssets) == 0 {
+
 					errorPrinter.Printf("No valid assets found from the provided paths\n")
+
 					return cli.Exit("", 1)
+
 				}
 
 				// Update filter with loaded assets
+
 				filter.SelectedAssets = selectedAssets
+
 				// Clear local variable to prevent incorrect output formatting
+
 				singleCheckID = ""
+
 			}
 
 			// Handle --modified flag: detect changed files and map to assets
+
 			if c.Bool("modified") {
+
 				if pipelineInfo.RunningForAnAsset {
+
 					errorPrinter.Printf("Cannot use --modified when running a single asset file directly\n")
+
 					return cli.Exit("", 1)
+
 				}
+
 				if len(filter.SelectedAssets) > 0 {
+
 					errorPrinter.Printf("Cannot use --modified when specifying assets\n")
+
 					return cli.Exit("", 1)
+
 				}
 
 				baseBranch, err := git.DefaultBranch(repoRoot.Path)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to detect default branch: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				changedFiles, err := git.ChangedFilesFromBase(repoRoot.Path, baseBranch)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to get changed files: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				if len(changedFiles) == 0 {
+
 					infoPrinter.Printf("No files changed compared to '%s', nothing to run.\n", baseBranch)
+
 					return nil
+
 				}
 
 				modifiedAssets := findAssetsFromChangedFiles(changedFiles, pipelineInfo.Pipeline, repoRoot.Path)
+
 				if len(modifiedAssets) == 0 {
+
 					infoPrinter.Printf("No assets matched the %d changed file(s) compared to '%s', nothing to run.\n", len(changedFiles), baseBranch)
+
 					return nil
+
 				}
 
 				filter.ModifiedAssets = modifiedAssets
+
 			}
 
 			if filter.Selector != "" {
+
 				switch {
+
 				case preview.RunningForAnAsset:
+
 					errorPrinter.Printf("Cannot use --selector when running a single asset file directly.\n")
+
 					return cli.Exit("", 1)
+
 				case len(assetPaths) > 0:
+
 					errorPrinter.Printf("Cannot use --selector together with positional asset arguments.\n")
+
 					return cli.Exit("", 1)
+
 				case runConfig.Tag != "":
+
 					errorPrinter.Printf("Cannot use --selector together with --tag. Use tag: selectors instead.\n")
+
 					return cli.Exit("", 1)
+
 				case runConfig.Downstream:
+
 					errorPrinter.Printf("Cannot use --selector together with --downstream. Use +, n+, or @ in the selector instead.\n")
+
 					return cli.Exit("", 1)
+
 				case singleCheckID != "":
+
 					errorPrinter.Printf("Cannot use --selector together with --single-check.\n")
+
 					return cli.Exit("", 1)
+
 				case c.Bool("modified"):
+
 					errorPrinter.Printf("Cannot use --selector together with --modified.\n")
+
 					return cli.Exit("", 1)
+
 				}
 
 				selectedAssets, err = pipeline.ResolveSelectorAssets(filter.Selector, pipelineInfo.Pipeline)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to resolve selector: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				filter.SelectedAssets = selectedAssets
+
 				filter.selectedBySelector = true
+
 			}
 
 			// Re-determine start date based on pipeline configuration and full-refresh flag
+
 			startDate, err = DetermineStartDate(runConfig.StartDate, pipelineInfo.Pipeline, runConfig.FullRefresh, logger)
 			if err != nil {
 				return err
 			}
 
 			// Parse end date directly from CLI
+
 			endDate, err = date.ParseTime(runConfig.EndDate)
 			if err != nil {
 				return err
 			}
+
 			// Validate date range
+
 			if err := ValidateDateRange(startDate, endDate); err != nil {
 				return err
 			}
 
 			// Update renderer with the finalized start/end dates
+
 			renderer = jinja.NewRendererWithStartEndDatesAndMacros(&startDate, &endDate, &defaultExecutionDate, pipelineInfo.Pipeline.Name, runID, nil, macroContent)
+
 			DefaultPipelineBuilder.AddAssetMutator(renderAssetParamsMutator(renderer))
 
 			// Update context with the finalized dates
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigStartDate, startDate)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigEndDate, endDate)
+
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigExecutionDate, defaultExecutionDate)
 
 			if err := renderPipelineHooks(runCtx, pipelineInfo.Pipeline, renderer); err != nil {
+
 				errorPrinter.Printf("Failed to render hooks: %v\n", err)
+
 				return cli.Exit("", 1)
+
 			}
 
 			// handle log files
+
 			executionStartLog := "Starting execution..."
+
 			if !c.Bool("minimal-logs") {
+
 				infoPrinter.Printf("Analyzed the pipeline '%s' with %d assets.\n", pipelineInfo.Pipeline.Name, len(pipelineInfo.Pipeline.Assets))
 
 				switch {
+
 				case pipelineInfo.RunningForAnAsset:
+
 					infoPrinter.Printf("Running only the asset '%s'\n", task.Name)
+
 				case len(filter.ModifiedAssets) > 0:
+
 					assetNames := make([]string, len(filter.ModifiedAssets))
+
 					for i, asset := range filter.ModifiedAssets {
 						assetNames[i] = asset.Name
 					}
+
 					msg := fmt.Sprintf("Running %d modified asset(s): %s", len(filter.ModifiedAssets), strings.Join(assetNames, ", "))
+
 					if filter.IncludeDownstream {
 						msg += " (with downstream)"
 					}
+
 					infoPrinter.Println(msg)
+
 				case len(filter.SelectedAssets) > 0:
+
 					assetNames := make([]string, len(filter.SelectedAssets))
+
 					for i, asset := range filter.SelectedAssets {
 						assetNames[i] = asset.Name
 					}
+
 					infoPrinter.Printf("Running selected assets: %s\n", strings.Join(assetNames, ", "))
+
 				}
+
 				executionStartLog = "Starting the pipeline execution..."
+
 			}
 
 			var connectionManager config.ConnectionAndDetailsGetter
+
 			var errs []error
 
 			secretsBackend := c.String("secrets-backend")
+
 			switch secretsBackend {
+
 			case "vault":
+
 				connectionManager, err = secrets.NewVaultClientFromEnv(logger) //nolint:contextcheck
 				if err != nil {
 					errs = append(errs, errors.Wrap(err, "failed to initialize vault client"))
 				}
+
 			case "doppler":
+
 				connectionManager, err = secrets.NewDopplerClientFromEnv(logger)
 				if err != nil {
 					errs = append(errs, errors.Wrap(err, "failed to initialize doppler client"))
 				}
+
 			case "aws":
+
 				connectionManager, err = secrets.NewAWSSecretsManagerClientFromEnv(logger)
 				if err != nil {
 					errs = append(errs, errors.Wrap(err, "failed to initialize AWS Secrets Manager client"))
 				}
+
 			case "azure":
+
 				connectionManager, err = secrets.NewAzureKeyVaultClientFromEnv(logger)
 				if err != nil {
 					errs = append(errs, errors.Wrap(err, "failed to initialize Azure Key Vault client"))
 				}
+
 			default:
+
 				connectionManager, errs = connection.NewManagerFromConfigWithContext(ctx, cm)
+
 			}
 
 			if len(errs) > 0 {
+
 				printErrors(errs, runConfig.Output, "Errors occurred while initializing connection manager")
+
 				return cli.Exit("", 1)
+
 			}
 
 			foundPipeline := pipelineInfo.Pipeline
 
 			if runConfig.Downstream {
+
 				infoPrinter.Println("The downstream tasks will be executed as well.")
+
 				pipelineInfo.RunDownstreamTasks = true
+
 			}
 
 			noColor := c.Bool("no-color")
+
 			minimalLogs := c.Bool("minimal-logs")
 
 			// Use the interactive TUI only when explicitly requested via --interactive flag
+
 			useTUI := c.Bool("interactive") &&
+
 				term.IsTerminal(int(os.Stdout.Fd())) && //nolint:gosec // G115: safe uintptr->int for terminal check
+
 				runConfig.Output != "json" &&
+
 				!noColor
 
 			// Save the real terminal fd BEFORE logOutput replaces os.Stdout
+
 			var realTerminal *os.File
+
 			if useTUI {
 				realTerminal = os.Stdout
 			}
 
 			if !runConfig.NoLogFile {
+
 				logFileName := fmt.Sprintf("%s__%s", runID, foundPipeline.Name)
+
 				if pipelineInfo.RunningForAnAsset {
 					logFileName = fmt.Sprintf("%s__%s__%s", runID, foundPipeline.Name, task.Name)
 				} else if len(filter.SelectedAssets) > 0 {
@@ -1173,36 +1766,55 @@ func Run(isDebug *bool) *cli.Command {
 
 				logPath, err := filepath.Abs(fmt.Sprintf("%s/%s/%s.log", repoRoot.Path, LogsFolder, logFileName))
 				if err != nil {
+
 					errorPrinter.Printf("Failed to create log file: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				// In TUI mode, worker output goes to log file only (TUI handles terminal display).
+
 				// In legacy mode, worker output goes to both terminal and log file.
+
 				var termWriter io.Writer
+
 				if useTUI {
 					termWriter = io.Discard
 				}
+
 				fn, err2 := logOutput(logPath, termWriter)
+
 				if err2 != nil {
+
 					errorPrinter.Printf("Failed to create log file: %v\n", err2)
+
 					return cli.Exit("", 1)
+
 				}
 
 				defer fn()
+
 				color.Output = os.Stdout
 
 				err = git.EnsureGivenPatternIsInGitignore(afero.NewOsFs(), repoRoot.Path, LogsFolder+"/*.log")
 				if err != nil {
+
 					errorPrinter.Printf("Failed to add the log file to .gitignore: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
+
 			}
 
 			err = ensurePythonCacheGitignore(afero.NewOsFs(), repoRoot.Path)
 			if err != nil {
+
 				errorPrinter.Printf("Failed to add Python cache patterns to .gitignore: %v\n", err)
+
 				return cli.Exit("", 1)
+
 			}
 
 			if filter.PushMetaData {
@@ -1213,48 +1825,71 @@ func Run(isDebug *bool) *cli.Command {
 
 			if c.Bool("continue") {
 				if err := s.RestoreState(pipelineState); err != nil {
+
 					errorPrinter.Printf("Failed to restore state: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 			}
 
 			if !c.Bool("continue") {
 				// Apply the filter to mark assets based on include/exclude tags
+
 				if err := ApplyAllFilters(context.Background(), filter, s, foundPipeline); err != nil { //nolint:contextcheck
+
 					errorPrinter.Printf("Failed to filter assets: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 			}
 
 			if s.InstanceCountByStatus(scheduler.Pending) == 0 {
+
 				warningPrinter.Println("No tasks to run.")
+
 				return nil
+
 			}
 
 			shouldValidate := !c.Bool("no-validation")
+
 			if err := Validate(shouldValidate, s, CheckLint, runCtx, pipelineInfo.Pipeline, inputPath, logger); err != nil {
 				return err
 			}
 
 			sendTelemetry(s, c)
+
 			if !minimalLogs && !useTUI {
+
 				infoPrinter.Printf("\nInterval: %s - %s\n", startDate.Format(time.RFC3339), endDate.Format(time.RFC3339))
+
 				infoPrinter.Printf("\n%s\n\n", executionStartLog)
+
 			}
+
 			if runConfig.SensorMode != "" {
 				if runConfig.SensorMode != "skip" && runConfig.SensorMode != "once" && runConfig.SensorMode != "wait" {
+
 					errorPrinter.Printf("invalid value for '--mode' flag: '%s', valid options are --skip ,--once, --wait", runConfig.SensorMode)
+
 					return cli.Exit("", 1)
+
 				}
 			}
 
 			var parser *sqlparser.SQLParser
+
 			if cm.SelectedEnvironment.SchemaPrefix != "" {
+
 				// we use the sql parser to rename the tables for dev mode
+
 				parser, err = sqlparser.NewSQLParser(false)
 				if err != nil {
 					printError(err, c.String("output"), "Could not initialize sql parser")
 				}
+
 				defer parser.Close()
 
 				go func() {
@@ -1263,79 +1898,115 @@ func Run(isDebug *bool) *cli.Command {
 						printError(err, c.String("output"), "Could not start sql parser")
 					}
 				}()
+
 			}
 
 			mainExecutors, err := SetupExecutors(s, connectionManager, startDate, endDate, defaultExecutionDate, foundPipeline.Name, runID, runConfig.FullRefresh, runConfig.SensorMode, renderer, parser, foundPipeline.Commit)
 			if err != nil {
+
 				errorPrinter.Println(err.Error())
+
 				return cli.Exit("", 1)
+
 			}
+
 			formatOpts := executor.FormattingOptions{
 				DoNotLogTimestamp: c.Bool("no-timestamp"),
-				DoNotLogTaskName:  preview.RunningForAnAsset,
-				NoColor:           noColor,
-				MinimalLogs:       minimalLogs,
+
+				DoNotLogTaskName: preview.RunningForAnAsset,
+
+				NoColor: noColor,
+
+				MinimalLogs: minimalLogs,
 			}
 
 			// Create a context with timeout
+
 			timeoutDuration := time.Duration(c.Int("timeout")) * time.Second
+
 			timeoutCtx, timeoutCancel := context.WithTimeout(runCtx, timeoutDuration)
+
 			defer timeoutCancel()
 
 			// Combine timeout context with signal handling
+
 			exeCtx, cancel := signal.NotifyContext(timeoutCtx, syscall.SIGINT, syscall.SIGTERM)
+
 			defer cancel()
 
 			// Check ADC credentials for BigQuery connections used by pending assets
+
 			pendingAssets := getPendingAssets(s)
+
 			if err := bigquery.CheckADCCredentialsForPipeline(runCtx, foundPipeline, pendingAssets, connectionManager); err != nil {
+
 				errorPrinter.Printf("Failed to verify BigQuery ADC credentials: %v\n", err)
+
 				return cli.Exit("", 1)
+
 			}
 
 			if useTUI {
+
 				// === TUI mode ===
+
 				tui := NewTUIRenderer(realTerminal, s, foundPipeline.Name)
 
 				// Register scheduler status change callback
+
 				s.SetOnStatusChange(func(event scheduler.StatusChangeEvent) {
 					tui.OnStatusChange(event)
 				})
 
 				// Wire worker callbacks for precise timing
+
 				formatOpts.TUIMode = true
+
 				// In TUI mode, worker output goes to os.Stdout which is either:
+
 				// - the pipe (when log file enabled) -> goes to log file only
+
 				// - the real terminal (when --no-log-file) -> use io.Discard to avoid interference
+
 				if runConfig.NoLogFile {
 					formatOpts.LogOnlyWriter = io.Discard
 				} else {
 					formatOpts.LogOnlyWriter = os.Stdout
 				}
+
 				formatOpts.OnTaskStart = func(inst scheduler.TaskInstance) {
 					tui.OnTaskStarted(inst)
 				}
+
 				formatOpts.OnTaskEnd = func(inst scheduler.TaskInstance, err error, dur time.Duration) {
 					tui.OnTaskEnded(inst, err, dur)
 				}
 
 				ex, err := executor.NewConcurrent(logger, mainExecutors, c.Int("workers"), formatOpts)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to create executor: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				tui.Start()
+
 				defer tui.Stop() // safety net for early returns / panics
 
 				ex.Start(exeCtx, s.WorkQueue, s.Results)
 
 				start := time.Now()
+
 				results := s.Run(runCtx)
+
 				duration := time.Since(start)
 
 				// Stop the TUI before printing the summary so the render loop
+
 				// cannot overwrite terminal output written by printTUISummary.
+
 				tui.Stop()
 
 				if err := s.SavePipelineState(afero.NewOsFs(), os.Args, runConfig, runID, statePath); err != nil {
@@ -1343,6 +2014,7 @@ func Run(isDebug *bool) *cli.Command {
 				}
 
 				errorsInTaskResults := make([]*scheduler.TaskExecutionResult, 0)
+
 				for _, res := range results {
 					if res.Error != nil {
 						errorsInTaskResults = append(errorsInTaskResults, res)
@@ -1350,29 +2022,44 @@ func Run(isDebug *bool) *cli.Command {
 				}
 
 				// Print summary to real terminal
+
 				printTUISummary(realTerminal, results, s, duration, foundPipeline.Name)
+
 				if len(errorsInTaskResults) > 0 {
 					printTUIErrors(realTerminal, errorsInTaskResults)
 				}
 
 				// Also print summary to piped stdout (for log file)
+
 				printExecutionSummary(results, s, duration, len(results))
+
 				if len(errorsInTaskResults) > 0 {
+
 					printErrorsInResults(errorsInTaskResults, s)
+
 					return cli.Exit("", 1)
+
 				}
+
 			} else {
+
 				// === Legacy mode (unchanged) ===
+
 				ex, err := executor.NewConcurrent(logger, mainExecutors, c.Int("workers"), formatOpts)
 				if err != nil {
+
 					errorPrinter.Printf("Failed to create executor: %v\n", err)
+
 					return cli.Exit("", 1)
+
 				}
 
 				ex.Start(exeCtx, s.WorkQueue, s.Results)
 
 				start := time.Now()
+
 				results := s.Run(runCtx)
+
 				duration := time.Since(start)
 
 				if err := s.SavePipelineState(afero.NewOsFs(), os.Args, runConfig, runID, statePath); err != nil {
@@ -1380,6 +2067,7 @@ func Run(isDebug *bool) *cli.Command {
 				}
 
 				errorsInTaskResults := make([]*scheduler.TaskExecutionResult, 0)
+
 				for _, res := range results {
 					if res.Error != nil {
 						errorsInTaskResults = append(errorsInTaskResults, res)
@@ -1387,115 +2075,178 @@ func Run(isDebug *bool) *cli.Command {
 				}
 
 				if len(errorsInTaskResults) > 0 {
+
 					if singleCheckID != "" {
 						printSingleCheckError(errorsInTaskResults[0])
 					} else {
 						if minimalLogs {
+
 							summaryPrinter.Printf("\n\nFailed %d tasks in %s\n", len(errorsInTaskResults), duration.Truncate(time.Millisecond).String())
+
 							printErrorsMinimal(errorsInTaskResults)
+
 						} else {
+
 							printExecutionSummary(results, s, duration, len(results))
+
 							printErrorsInResults(errorsInTaskResults, s)
+
 						}
 					}
+
 					return cli.Exit("", 1)
+
 				}
 
 				// Print single check success if running a single check
+
 				if singleCheckID != "" && len(results) > 0 {
+
 					printSingleCheckSuccess(results[0])
+
 					return nil
+
 				}
 
 				// Print execution summary (unless minimal-logs is enabled)
+
 				if minimalLogs {
 					summaryPrinter.Printf("\n\nExecuted %d tasks in %s\n", len(results), duration.Truncate(time.Millisecond).String())
 				} else {
 					printExecutionSummary(results, s, duration, len(results))
 				}
+
 			}
+
 			return nil
 		},
+
 		Before: telemetry.BeforeCommand,
-		After:  telemetry.AfterCommand,
+
+		After: telemetry.AfterCommand,
 	}
 }
 
 func ReadState(fs afero.Fs, statePath string, filter *Filter) (*scheduler.PipelineState, error) {
 	pipelineState, err := scheduler.ReadState(fs, statePath)
 	if err != nil {
+
 		errorPrinter.Printf("Failed to restore state: %v\n", err)
+
 		return nil, err
+
 	}
+
 	filter.IncludeTag = pipelineState.Parameters.Tag
+
 	filter.OnlyTaskTypes = pipelineState.Parameters.Only
+
 	filter.PushMetaData = pipelineState.Parameters.PushMetadata
+
 	filter.Selector = pipelineState.Parameters.Selector
+
 	filter.ExcludeTag = pipelineState.Parameters.ExcludeTag
+
 	return pipelineState, nil
 }
 
 func GetPipeline(ctx context.Context, inputPath string, runConfig *scheduler.RunConfig, log logger.Logger, opts ...pipeline.CreatePipelineOption) (*PipelineInfo, error) {
 	pipelinePath := inputPath
+
 	runningForAnAsset := isPathReferencingAsset(inputPath)
+
 	if runningForAnAsset && runConfig.Tag != "" {
+
 		errorPrinter.Printf("You cannot use the '--tag' flag when running a single asset.\n")
+
 		return nil, errors.New("you cannot use the '--tag' flag when running a single asset")
+
 	}
 
 	var err error
+
 	runDownstreamTasks := false
 
 	if runningForAnAsset {
+
 		pipelinePath, err = path.GetPipelineRootFromTask(inputPath, PipelineDefinitionFiles)
 		if err != nil {
+
 			errorPrinter.Printf("Failed to find the pipeline this task belongs to: '%s'\n", inputPath)
+
 			return &PipelineInfo{
-				RunningForAnAsset:  runningForAnAsset,
+				RunningForAnAsset: runningForAnAsset,
+
 				RunDownstreamTasks: runDownstreamTasks,
 			}, err
+
 		}
+
 	}
 
 	opts = append(opts, pipeline.WithMutate())
+
 	foundPipeline, err := DefaultPipelineBuilder.CreatePipelineFromPath(ctx, pipelinePath, opts...)
 	if err != nil {
+
 		errorPrinter.Println("Failed to build pipeline: ", err.Error())
+
 		errorPrinter.Println("\nHint: You need to run this command with a path to either the pipeline directory or the asset file itself directly.")
 
 		return &PipelineInfo{
-			Pipeline:           foundPipeline,
-			RunningForAnAsset:  runningForAnAsset,
+			Pipeline: foundPipeline,
+
+			RunningForAnAsset: runningForAnAsset,
+
 			RunDownstreamTasks: runDownstreamTasks,
 		}, err
+
 	}
 
 	return &PipelineInfo{
-		Pipeline:           foundPipeline,
-		RunningForAnAsset:  runningForAnAsset,
+		Pipeline: foundPipeline,
+
+		RunningForAnAsset: runningForAnAsset,
+
 		RunDownstreamTasks: runConfig.Downstream,
 	}, nil
 }
 
 func ParseDate(startDateStr, endDateStr string, logger logger.Logger) (time.Time, time.Time, error) {
 	startDate, err := date.ParseTime(startDateStr)
+
 	logger.Debug("given start date: ", startDate)
+
 	if err != nil {
+
 		errorPrinter.Printf("Please give a valid start date: bruin run --start-date <start date>)\n")
+
 		errorPrinter.Printf("A valid start date can be in the YYYY-MM-DD or YYYY-MM-DD HH:MM:SS formats. \n")
+
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02"))
+
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02 15:04:05"))
+
 		return time.Time{}, time.Time{}, err
+
 	}
 
 	endDate, err := date.ParseTime(endDateStr)
+
 	logger.Debug("given end date: ", endDate)
+
 	if err != nil {
+
 		errorPrinter.Printf("Please give a valid end date: bruin run --end-date <end date>)\n")
+
 		errorPrinter.Printf("A valid end date can be in the YYYY-MM-DD or YYYY-MM-DD HH:MM:SS formats. \n")
+
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02"))
+
 		errorPrinter.Printf("    e.g. %s  \n", time.Now().AddDate(0, 0, -1).Format("2006-01-02 15:04:05"))
+
 		return time.Time{}, time.Time{}, err
+
 	}
 
 	return startDate, endDate, nil
@@ -1503,33 +2254,47 @@ func ParseDate(startDateStr, endDateStr string, logger logger.Logger) (time.Time
 
 func DetermineStartDate(cliStartDate string, pipeline *pipeline.Pipeline, fullRefresh bool, logger logger.Logger) (time.Time, error) {
 	var startDate time.Time
+
 	var err error
 
 	switch {
+
 	case !fullRefresh:
+
 		startDate, err = date.ParseTime(cliStartDate)
 		if err != nil {
 			return time.Time{}, err
 		}
+
 		logger.Debug("Using CLI start_date: ", cliStartDate)
+
 	case pipeline == nil:
+
 		startDate, err = date.ParseTime(cliStartDate)
 		if err != nil {
 			return time.Time{}, err
 		}
+
 		logger.Debug("Using CLI start_date: ", cliStartDate)
+
 	case pipeline.StartDate == "":
+
 		startDate, err = date.ParseTime(cliStartDate)
 		if err != nil {
 			return time.Time{}, err
 		}
+
 		logger.Debug("Using CLI start_date: ", cliStartDate)
+
 	default:
+
 		startDate, err = date.ParseTime(pipeline.StartDate)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("invalid pipeline start_date '%s': %w", pipeline.StartDate, err)
 		}
+
 		logger.Debug("Using pipeline start_date: ", pipeline.StartDate)
+
 	}
 
 	return startDate, nil
@@ -1537,9 +2302,13 @@ func DetermineStartDate(cliStartDate string, pipeline *pipeline.Pipeline, fullRe
 
 func ValidateDateRange(startDate, endDate time.Time) error {
 	if startDate.After(endDate) {
+
 		errorPrinter.Printf("Start date cannot be after end date. Given start date: %s, end date: %s\n", startDate.Format("2006-01-02 15:04:05"), endDate.Format("2006-01-02 15:04:05"))
+
 		return fmt.Errorf("start date %s is after end date %s", startDate.Format("2006-01-02 15:04:05"), endDate.Format("2006-01-02 15:04:05"))
+
 	}
+
 	return nil
 }
 
@@ -1559,18 +2328,25 @@ func ValidateRunConfig(runConfig *scheduler.RunConfig, inputPath string, logger 
 func CheckLint(ctx context.Context, foundPipeline *pipeline.Pipeline, pipelinePath string, logger logger.Logger, validateOnlyAssetLevel bool) error {
 	rules, err := lint.GetRules(fs, &git.RepoFinder{}, true, nil, true)
 	if err != nil {
+
 		errorPrinter.Printf("An error occurred while linting the pipelines: %v\n", err)
+
 		return err
+
 	}
+
 	rules = append(rules, SeedAssetsValidator)
 
 	rules = lint.FilterRulesBySpeed(rules, true)
+
 	if validateOnlyAssetLevel {
 		rules = lint.FilterRulesByLevel(rules, lint.LevelAsset)
 	}
 
 	linter := lint.NewLinter(path.GetPipelinePaths, DefaultPipelineBuilder, rules, logger, nil)
+
 	res, err := linter.LintPipelines(ctx, []*pipeline.Pipeline{foundPipeline})
+
 	err = reportLintErrors(res, err, lint.Printer{RootCheckPath: pipelinePath}, "")
 	if err != nil {
 		return err
@@ -1580,103 +2356,187 @@ func CheckLint(ctx context.Context, foundPipeline *pipeline.Pipeline, pipelinePa
 }
 
 func printErrorsInResults(errorsInTaskResults []*scheduler.TaskExecutionResult, s *scheduler.Scheduler) { // nolint:unparam
+
 	data := make(map[string][]*scheduler.TaskExecutionResult, len(errorsInTaskResults))
+
 	for _, result := range errorsInTaskResults {
+
 		assetName := result.Instance.GetAsset().Name
+
 		data[assetName] = append(data[assetName], result)
+
 	}
 
 	fmt.Println()
+
 	tree := treeprint.NewWithRoot(color.New(color.FgRed).Sprintf("%d assets failed", len(data)))
+
 	for assetName, results := range data {
+
 		assetBranch := tree.AddBranch(color.New(color.FgYellow).Sprint(assetName))
 
 		for _, result := range results {
 			switch instance := result.Instance.(type) {
+
 			case *scheduler.ColumnCheckInstance:
+
 				assetBranch.AddNode(fmt.Sprintf("%s.%s - %s",
+
 					color.New(color.FgCyan).Sprint(instance.Column.Name),
+
 					color.New(color.FgMagenta).Sprint(instance.Check.Name),
+
 					color.New(color.FgRed).Sprintf("%s", result.Error)))
 
 			case *scheduler.CustomCheckInstance:
-				assetBranch.AddNode(fmt.Sprintf("%s %s - %s",
+
+				msg := fmt.Sprintf("%s %s - %s",
+
 					color.New(color.FgMagenta).Sprint(instance.Check.Name),
+
 					faint("custom check"),
-					color.New(color.FgRed).Sprintf("%s", result.Error)))
+
+					color.New(color.FgRed).Sprintf("%s", result.Error))
+
+				checkNode := assetBranch.AddBranch(msg)
+
+				if !instance.Check.SourceLocation.IsZero() {
+					checkNode.AddNode(faint("defined at:      " + instance.Check.SourceLocation.String()))
+				}
+
+				if !instance.Check.QueryLocation.IsZero() {
+					checkNode.AddNode(faint("query starts at: " + instance.Check.QueryLocation.String()))
+				}
 
 			default:
+
 				assetBranch.AddNode(color.New(color.FgRed).Sprintf("%s", result.Error))
+
 			}
 		}
+
 	}
+
 	fmt.Println()
+
 	fmt.Println(tree.String())
 }
 
 func printErrorsMinimal(errorsInTaskResults []*scheduler.TaskExecutionResult) {
 	for _, result := range errorsInTaskResults {
+
 		assetName := result.Instance.GetAsset().Name
+
 		fmt.Printf("\n  %s: %s\n", assetName, result.Error)
+
 	}
 }
 
 func printSingleCheckError(result *scheduler.TaskExecutionResult) {
 	fmt.Println("\nCheck Failed")
+
 	fmt.Println(strings.Repeat("-", 12))
 
 	checkErr, ok := result.Error.(*ansisql.CheckError) //nolint:errorlint
+
 	if ok {
+
 		fmt.Printf("Error: %s\n\n", checkErr.Message)
+
 		fmt.Printf("Result: %d (expected: %d)\n\n", checkErr.Result, checkErr.Expected)
+
 		fmt.Println("Query:")
+
 		fmt.Println(checkErr.Query + "\n")
+
 	} else {
 		fmt.Printf("Error: %s\n", result.Error)
+	}
+
+	if instance, ok := result.Instance.(*scheduler.CustomCheckInstance); ok {
+
+		if !instance.Check.SourceLocation.IsZero() {
+			fmt.Printf("Defined at:      %s\n", instance.Check.SourceLocation)
+		}
+
+		if !instance.Check.QueryLocation.IsZero() {
+			fmt.Printf("Query starts at: %s\n", instance.Check.QueryLocation)
+		}
+
 	}
 }
 
 func printSingleCheckSuccess(result *scheduler.TaskExecutionResult) {
 	fmt.Println("\nCheck Passed")
+
 	fmt.Println(strings.Repeat("-", 12))
 
 	switch instance := result.Instance.(type) {
+
 	case *scheduler.ColumnCheckInstance:
+
 		fmt.Printf("Check: %s.%s\n", instance.Column.Name, instance.Check.Name)
+
 		fmt.Printf("Asset: %s\n\n", instance.GetAsset().Name)
+
 		if instance.ExecutedQuery != "" {
+
 			fmt.Println("Query:")
+
 			fmt.Println(instance.ExecutedQuery)
+
 		}
+
 	case *scheduler.CustomCheckInstance:
+
 		fmt.Printf("Check: %s (custom)\n", instance.Check.Name)
+
 		fmt.Printf("Asset: %s\n\n", instance.GetAsset().Name)
+
 		if instance.ExecutedQuery != "" {
+
 			fmt.Println("Query:")
+
 			fmt.Println(instance.ExecutedQuery)
+
 		}
+
 	}
 }
 
 //nolint:maintidx
+
 func SetupExecutors(
 	s *scheduler.Scheduler,
+
 	conn config.ConnectionAndDetailsGetter,
+
 	startDate,
+
 	endDate,
+
 	executionDate time.Time,
+
 	pipelineName string,
+
 	runID string,
+
 	fullRefresh bool,
+
 	sensorMode string,
+
 	renderer *jinja.Renderer,
+
 	parser *sqlparser.SQLParser,
+
 	commitHash string,
 ) (map[pipeline.AssetType]executor.Config, error) {
 	mainExecutors := executor.DefaultExecutorsV2
 
 	// this is a heuristic we apply to find what might be the most common type of custom check in the pipeline
+
 	// this should go away once we incorporate URIs into the assets
+
 	estimateCustomCheckType := s.FindMajorityOfTypes(pipeline.AssetTypeBigqueryQuery)
 
 	seedOperator, err := ingestr.NewSeedOperator(conn, renderer)
@@ -1685,160 +2545,253 @@ func SetupExecutors(
 	}
 
 	jinjaVariables := jinja.PythonEnvVariables(&startDate, &endDate, &executionDate, pipelineName, runID, fullRefresh, commitHash)
+
 	if s.WillRunTaskOfType(pipeline.AssetTypePython) {
 		mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeMain] = python.NewLocalOperator(conn, jinjaVariables)
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeR) {
+
 		rOperator, err := r.NewLocalOperator(conn, jinjaVariables)
 		if err != nil {
 			return nil, err
 		}
+
 		mainExecutors[pipeline.AssetTypeR][scheduler.TaskInstanceTypeMain] = rOperator
+
 	}
 
 	wholeFileExtractor := &query.WholeFileExtractor{
-		Fs:       fs,
+		Fs: fs,
+
 		Renderer: renderer,
 	}
+
 	customCheckRunner := ansisql.NewCustomCheckOperator(conn, renderer)
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeBigqueryQuery) || estimateCustomCheckType == pipeline.AssetTypeBigqueryQuery || s.WillRunTaskOfType(pipeline.AssetTypeBigquerySeed) || s.WillRunTaskOfType(pipeline.AssetTypeBigqueryQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeBigqueryTableSensor) {
+
 		bqOperator := bigquery.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: bigquery.NewMaterializer(fullRefresh),
 		}, parser)
+
 		bqCheckRunner, err := bigquery.NewColumnCheckOperator(conn)
 		if err != nil {
 			return nil, err
 		}
 
 		metadataPushOperator := bigquery.NewMetadataPushOperator(conn)
+
 		bqQuerySensor := bigquery.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		bqTableSensor := bigquery.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeBigqueryQuery][scheduler.TaskInstanceTypeMain] = bqOperator
+
 		mainExecutors[pipeline.AssetTypeBigqueryQuery][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigqueryQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigqueryQuery][scheduler.TaskInstanceTypeMetadataPush] = metadataPushOperator
 
 		mainExecutors[pipeline.AssetTypeBigquerySource][scheduler.TaskInstanceTypeMetadataPush] = metadataPushOperator
+
 		mainExecutors[pipeline.AssetTypeBigquerySource][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigquerySource][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeBigqueryTableSensor][scheduler.TaskInstanceTypeMain] = bqTableSensor
+
 		mainExecutors[pipeline.AssetTypeBigqueryTableSensor][scheduler.TaskInstanceTypeMetadataPush] = metadataPushOperator
+
 		mainExecutors[pipeline.AssetTypeBigqueryTableSensor][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigqueryTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeBigqueryQuerySensor][scheduler.TaskInstanceTypeMain] = bqQuerySensor
+
 		mainExecutors[pipeline.AssetTypeBigqueryQuerySensor][scheduler.TaskInstanceTypeMetadataPush] = metadataPushOperator
+
 		mainExecutors[pipeline.AssetTypeBigqueryQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigqueryQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeBigquerySeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeBigquerySeed][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigquerySeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeBigquerySeed][scheduler.TaskInstanceTypeMetadataPush] = metadataPushOperator
+
 		// we set the Python runners to run the checks on BigQuery assuming that there won't be many usecases where a user has both BQ and Snowflake
+
 		if estimateCustomCheckType == pipeline.AssetTypeBigqueryQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = bqCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeMetadataPush] = metadataPushOperator
+
 		}
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypePostgresQuery) || estimateCustomCheckType == pipeline.AssetTypePostgresQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeRedshiftQuery) || estimateCustomCheckType == pipeline.AssetTypeRedshiftQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeRedshiftSeed) || s.WillRunTaskOfType(pipeline.AssetTypePostgresSeed) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypePostgresQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeRedshiftQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypePostgresTableSensor) || s.WillRunTaskOfType(pipeline.AssetTypeRedshiftTableSensor) {
+
 		pgCheckRunner := postgres.NewColumnCheckOperator(conn)
+
 		pgOperator := postgres.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: postgres.NewMaterializer(fullRefresh),
 		}, parser)
+
 		pgQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		pgTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
+
 		pgMetadataPushOperator := postgres.NewMetadataPushOperator(conn)
+
 		rsTableSensor := redshift.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeRedshiftQuery][scheduler.TaskInstanceTypeMain] = pgOperator
+
 		mainExecutors[pipeline.AssetTypeRedshiftQuery][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypeRedshiftQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypePostgresQuery][scheduler.TaskInstanceTypeMain] = pgOperator
+
 		mainExecutors[pipeline.AssetTypePostgresQuery][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresQuery][scheduler.TaskInstanceTypeMetadataPush] = pgMetadataPushOperator
 
 		mainExecutors[pipeline.AssetTypePostgresSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypePostgresSeed][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresSeed][scheduler.TaskInstanceTypeMetadataPush] = pgMetadataPushOperator
 
 		mainExecutors[pipeline.AssetTypeRedshiftSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeRedshiftSeed][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypeRedshiftSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypePostgresQuerySensor][scheduler.TaskInstanceTypeMain] = pgQuerySensor
+
 		mainExecutors[pipeline.AssetTypePostgresQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresQuerySensor][scheduler.TaskInstanceTypeMetadataPush] = pgMetadataPushOperator
 
 		mainExecutors[pipeline.AssetTypePostgresTableSensor][scheduler.TaskInstanceTypeMain] = pgTableSensor
+
 		mainExecutors[pipeline.AssetTypePostgresTableSensor][scheduler.TaskInstanceTypeMetadataPush] = pgMetadataPushOperator
+
 		mainExecutors[pipeline.AssetTypePostgresTableSensor][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypePostgresTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeRedshiftQuerySensor][scheduler.TaskInstanceTypeMain] = pgQuerySensor
+
 		mainExecutors[pipeline.AssetTypeRedshiftQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypeRedshiftQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeRedshiftTableSensor][scheduler.TaskInstanceTypeMain] = rsTableSensor
+
 		mainExecutors[pipeline.AssetTypeRedshiftTableSensor][scheduler.TaskInstanceTypeMetadataPush] = pgMetadataPushOperator
+
 		mainExecutors[pipeline.AssetTypeRedshiftTableSensor][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 		mainExecutors[pipeline.AssetTypeRedshiftTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		// we set the Python runners to run the checks on Snowflake assuming that there won't be many usecases where a user has both BQ and Snowflake
+
 		if estimateCustomCheckType == pipeline.AssetTypePostgresQuery || estimateCustomCheckType == pipeline.AssetTypeRedshiftQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = pgCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeTrinoQuery) || estimateCustomCheckType == pipeline.AssetTypeTrinoQuery || s.WillRunTaskOfType(pipeline.AssetTypeTrinoQuerySensor) {
+
 		trinoFileExtractor := &query.FileQuerySplitterExtractor{
-			Fs:       fs,
+			Fs: fs,
+
 			Renderer: renderer,
 		}
+
 		trinoOperator := trino.NewBasicOperator(conn, trinoFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: trino.NewMaterializer(fullRefresh),
 		}, parser)
+
 		trinoCheckRunner := athena.NewColumnCheckOperator(conn)
+
 		mainExecutors[pipeline.AssetTypeTrinoQuery][scheduler.TaskInstanceTypeMain] = trinoOperator
+
 		mainExecutors[pipeline.AssetTypeTrinoQuery][scheduler.TaskInstanceTypeColumnCheck] = trinoCheckRunner
+
 		mainExecutors[pipeline.AssetTypeTrinoQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		trinoQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		mainExecutors[pipeline.AssetTypeTrinoQuerySensor][scheduler.TaskInstanceTypeMain] = trinoQuerySensor
+
 		mainExecutors[pipeline.AssetTypeTrinoQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = trinoCheckRunner
+
 		mainExecutors[pipeline.AssetTypeTrinoQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 	}
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeOracleQuery) || s.WillRunTaskOfType(pipeline.AssetTypeOracleSource) || estimateCustomCheckType == pipeline.AssetTypeOracleQuery {
+
 		oracleCheckRunner := oracle.NewColumnCheckOperator(conn)
+
 		oracleOperator := oracle.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: oracle.NewMaterializer(fullRefresh),
 		}, parser)
+
 		oracleMetadataPushOperator := postgres.NewMetadataPushOperator(conn) // using Postgres Metadata Push for Oracle if suitable, or skipping it
 
 		mainExecutors[pipeline.AssetTypeOracleQuery][scheduler.TaskInstanceTypeMain] = oracleOperator
+
 		mainExecutors[pipeline.AssetTypeOracleQuery][scheduler.TaskInstanceTypeColumnCheck] = oracleCheckRunner
+
 		mainExecutors[pipeline.AssetTypeOracleQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeOracleQuery][scheduler.TaskInstanceTypeMetadataPush] = oracleMetadataPushOperator
 
 		mainExecutors[pipeline.AssetTypeOracleSource][scheduler.TaskInstanceTypeMain] = executor.NoOpOperator{}
+
 		mainExecutors[pipeline.AssetTypeOracleSource][scheduler.TaskInstanceTypeColumnCheck] = oracleCheckRunner
+
 		mainExecutors[pipeline.AssetTypeOracleSource][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeOracleSource][scheduler.TaskInstanceTypeMetadataPush] = oracleMetadataPushOperator
+
 	}
+
 	shouldInitiateSnowflake := s.WillRunTaskOfType(pipeline.AssetTypeSnowflakeQuery) || s.WillRunTaskOfType(pipeline.AssetTypeSnowflakeQuerySensor) || estimateCustomCheckType == pipeline.AssetTypeSnowflakeQuery || s.WillRunTaskOfType(pipeline.AssetTypeSnowflakeSeed) || s.WillRunTaskOfType(pipeline.AssetTypeSnowflakeTableSensor)
+
 	if shouldInitiateSnowflake {
+
 		sfOperator := snowflake.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: snowflake.NewMaterializer(fullRefresh),
 		}, parser)
@@ -1846,138 +2799,213 @@ func SetupExecutors(
 		sfCheckRunner := snowflake.NewColumnCheckOperator(conn)
 
 		sfQuerySensor := snowflake.NewQuerySensor(conn, wholeFileExtractor, 30)
+
 		sfTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		sfMetadataPushOperator := snowflake.NewMetadataPushOperator(conn)
 
 		mainExecutors[pipeline.AssetTypeSnowflakeQuery][scheduler.TaskInstanceTypeMain] = sfOperator
+
 		mainExecutors[pipeline.AssetTypeSnowflakeQuery][scheduler.TaskInstanceTypeColumnCheck] = sfCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeQuerySensor][scheduler.TaskInstanceTypeMain] = sfQuerySensor
+
 		mainExecutors[pipeline.AssetTypeSnowflakeQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = sfCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeQuery][scheduler.TaskInstanceTypeMetadataPush] = sfMetadataPushOperator
 
 		mainExecutors[pipeline.AssetTypeSnowflakeTableSensor][scheduler.TaskInstanceTypeMain] = sfTableSensor
+
 		mainExecutors[pipeline.AssetTypeSnowflakeTableSensor][scheduler.TaskInstanceTypeMetadataPush] = sfMetadataPushOperator
+
 		mainExecutors[pipeline.AssetTypeSnowflakeTableSensor][scheduler.TaskInstanceTypeColumnCheck] = sfCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeSnowflakeSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeSnowflakeSeed][scheduler.TaskInstanceTypeColumnCheck] = sfCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSnowflakeSeed][scheduler.TaskInstanceTypeMetadataPush] = sfMetadataPushOperator
 
 		// we set the Python runners to run the checks on Snowflake assuming that there won't be many usecases where a user has both BQ and Snowflake
+
 		if estimateCustomCheckType == pipeline.AssetTypeSnowflakeQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = sfCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeMetadataPush] = sfMetadataPushOperator
+
 		}
+
 	}
 
 	//nolint: dupl
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeMsSQLQuery) || estimateCustomCheckType == pipeline.AssetTypeMsSQLQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeSynapseQuery) || estimateCustomCheckType == pipeline.AssetTypeSynapseQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeMsSQLSeed) || s.WillRunTaskOfType(pipeline.AssetTypeSynapseSeed) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeMsSQLQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeSynapseQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeMsSQLTableSensor) || s.WillRunTaskOfType(pipeline.AssetTypeSynapseTableSensor) {
+
 		msOperator := mssql.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: mssql.NewMaterializer(fullRefresh),
 		}, parser)
+
 		synapseOperator := synapse.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializerList{
 			Mat: synapse.NewMaterializer(fullRefresh),
 		}, parser)
 
 		msCheckRunner := mssql.NewColumnCheckOperator(conn)
+
 		synapseCheckRunner := synapse.NewColumnCheckOperator(conn)
 
 		msQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		synapseQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
 
 		msTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
+
 		synapseTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeMsSQLQuery][scheduler.TaskInstanceTypeMain] = msOperator
+
 		mainExecutors[pipeline.AssetTypeMsSQLQuery][scheduler.TaskInstanceTypeColumnCheck] = msCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMsSQLQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeSynapseQuery][scheduler.TaskInstanceTypeMain] = synapseOperator
+
 		mainExecutors[pipeline.AssetTypeSynapseQuery][scheduler.TaskInstanceTypeColumnCheck] = synapseCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSynapseQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeMsSQLSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeMsSQLSeed][scheduler.TaskInstanceTypeColumnCheck] = msCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMsSQLSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeMsSQLQuerySensor][scheduler.TaskInstanceTypeMain] = msQuerySensor
+
 		mainExecutors[pipeline.AssetTypeMsSQLQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = msCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMsSQLQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeMsSQLTableSensor][scheduler.TaskInstanceTypeMain] = msTableSensor
+
 		mainExecutors[pipeline.AssetTypeMsSQLTableSensor][scheduler.TaskInstanceTypeColumnCheck] = msCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMsSQLTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeSynapseSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeSynapseSeed][scheduler.TaskInstanceTypeColumnCheck] = synapseCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSynapseSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeSynapseTableSensor][scheduler.TaskInstanceTypeMain] = synapseTableSensor
+
 		mainExecutors[pipeline.AssetTypeSynapseTableSensor][scheduler.TaskInstanceTypeColumnCheck] = synapseCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSynapseTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeSynapseSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeSynapseSeed][scheduler.TaskInstanceTypeColumnCheck] = synapseCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSynapseSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeSynapseQuerySensor][scheduler.TaskInstanceTypeMain] = synapseQuerySensor
+
 		mainExecutors[pipeline.AssetTypeSynapseQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = synapseCheckRunner
+
 		mainExecutors[pipeline.AssetTypeSynapseQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		// we set the Python runners to run the checks on MsSQL
+
 		if estimateCustomCheckType == pipeline.AssetTypeMsSQLQuery || estimateCustomCheckType == pipeline.AssetTypeSynapseQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = msCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeVerticaQuery) || estimateCustomCheckType == pipeline.AssetTypeVerticaQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeVerticaSeed) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeVerticaQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeVerticaTableSensor) {
+
 		verticaOperator := vertica.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: vertica.NewMaterializer(fullRefresh),
 		}, parser)
+
 		verticaCheckRunner := vertica.NewColumnCheckOperator(conn)
+
 		verticaQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		verticaTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeVerticaQuery][scheduler.TaskInstanceTypeMain] = verticaOperator
+
 		mainExecutors[pipeline.AssetTypeVerticaQuery][scheduler.TaskInstanceTypeColumnCheck] = verticaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeVerticaQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeVerticaSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeVerticaSeed][scheduler.TaskInstanceTypeColumnCheck] = verticaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeVerticaSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeVerticaQuerySensor][scheduler.TaskInstanceTypeMain] = verticaQuerySensor
+
 		mainExecutors[pipeline.AssetTypeVerticaQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = verticaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeVerticaQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeVerticaTableSensor][scheduler.TaskInstanceTypeMain] = verticaTableSensor
+
 		mainExecutors[pipeline.AssetTypeVerticaTableSensor][scheduler.TaskInstanceTypeColumnCheck] = verticaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeVerticaTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		if estimateCustomCheckType == pipeline.AssetTypeVerticaQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = verticaCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	//nolint: dupl
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeFabricQuery) || s.WillRunTaskOfType(pipeline.AssetTypeFabricQueryLegacy) ||
+
 		estimateCustomCheckType == pipeline.AssetTypeFabricQuery || estimateCustomCheckType == pipeline.AssetTypeFabricQueryLegacy ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeFabricSeed) || s.WillRunTaskOfType(pipeline.AssetTypeFabricSeedLegacy) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeFabricQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeFabricQuerySensorLegacy) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeFabricTableSensor) || s.WillRunTaskOfType(pipeline.AssetTypeFabricTableSensorLegacy) {
+
 		fabricOperator := fabric.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: fabric.NewMaterializer(fullRefresh),
 		}, parser)
@@ -1985,258 +3013,403 @@ func SetupExecutors(
 		fabricCheckRunner := fabric.NewColumnCheckOperator(conn)
 
 		fabricQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		fabricTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeFabricQuery][scheduler.TaskInstanceTypeMain] = fabricOperator
+
 		mainExecutors[pipeline.AssetTypeFabricQuery][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricQueryLegacy][scheduler.TaskInstanceTypeMain] = fabricOperator
+
 		mainExecutors[pipeline.AssetTypeFabricQueryLegacy][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricQueryLegacy][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeFabricSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeFabricSeed][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricSeedLegacy][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeFabricSeedLegacy][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricSeedLegacy][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeFabricQuerySensor][scheduler.TaskInstanceTypeMain] = fabricQuerySensor
+
 		mainExecutors[pipeline.AssetTypeFabricQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricQuerySensorLegacy][scheduler.TaskInstanceTypeMain] = fabricQuerySensor
+
 		mainExecutors[pipeline.AssetTypeFabricQuerySensorLegacy][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricQuerySensorLegacy][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeFabricTableSensor][scheduler.TaskInstanceTypeMain] = fabricTableSensor
+
 		mainExecutors[pipeline.AssetTypeFabricTableSensor][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricTableSensorLegacy][scheduler.TaskInstanceTypeMain] = fabricTableSensor
+
 		mainExecutors[pipeline.AssetTypeFabricTableSensorLegacy][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 		mainExecutors[pipeline.AssetTypeFabricTableSensorLegacy][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		if estimateCustomCheckType == pipeline.AssetTypeFabricQuery || estimateCustomCheckType == pipeline.AssetTypeFabricQueryLegacy {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = fabricCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	//nolint:dupl
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeDatabricksQuery) || estimateCustomCheckType == pipeline.AssetTypeDatabricksQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeDatabricksSeed) || s.WillRunTaskOfType(pipeline.AssetTypeDatabricksQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeDatabricksTableSensor) {
+
 		databricksOperator := databricks.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializerList{
 			Mat: databricks.NewMaterializer(fullRefresh),
 		}, parser)
+
 		databricksCheckRunner := databricks.NewColumnCheckOperator(conn)
+
 		databricksQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		databricksTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeDatabricksQuery][scheduler.TaskInstanceTypeMain] = databricksOperator
+
 		mainExecutors[pipeline.AssetTypeDatabricksQuery][scheduler.TaskInstanceTypeColumnCheck] = databricksCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDatabricksQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeDatabricksSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeDatabricksSeed][scheduler.TaskInstanceTypeColumnCheck] = databricksCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDatabricksSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeDatabricksQuerySensor][scheduler.TaskInstanceTypeMain] = databricksQuerySensor
+
 		mainExecutors[pipeline.AssetTypeDatabricksQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = databricksCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDatabricksQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeDatabricksTableSensor][scheduler.TaskInstanceTypeMain] = databricksTableSensor
+
 		mainExecutors[pipeline.AssetTypeDatabricksQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = databricksCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDatabricksQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		// we set the Python runners to run the checks on MsSQL
+
 		if estimateCustomCheckType == pipeline.AssetTypeDatabricksQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = databricksOperator
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeIngestr) || estimateCustomCheckType == pipeline.AssetTypeIngestr {
+
 		ingestrOperator, err := ingestr.NewBasicOperator(conn, renderer)
 		if err != nil {
 			return nil, err
 		}
+
 		ingestrCheckRunner := ingestr.NewColumnCheckOperator(&mainExecutors)
+
 		ingestrCustomCheckRunner := ingestr.NewCustomCheckOperator(&mainExecutors)
 
 		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeMain] = ingestrOperator
+
 		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeColumnCheck] = ingestrCheckRunner
+
 		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeCustomCheck] = ingestrCustomCheckRunner
+
 	}
 
 	//nolint:dupl
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeAthenaQuery) || estimateCustomCheckType == pipeline.AssetTypeAthenaQuery || s.WillRunTaskOfType(pipeline.AssetTypeAthenaSeed) {
+
 		athenaOperator := athena.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializerListWithLocation{
 			Mat: athena.NewMaterializer(fullRefresh),
 		}, parser)
+
 		athenaCheckRunner := athena.NewColumnCheckOperator(conn)
+
 		athenaTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeAthenaQuery][scheduler.TaskInstanceTypeMain] = athenaOperator
+
 		mainExecutors[pipeline.AssetTypeAthenaQuery][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeAthenaQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeAthenaSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeAthenaSeed][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeAthenaSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeAthenaTableSensor][scheduler.TaskInstanceTypeMain] = athenaTableSensor
+
 		mainExecutors[pipeline.AssetTypeAthenaTableSensor][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
+
 		mainExecutors[pipeline.AssetTypeAthenaTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		if estimateCustomCheckType == pipeline.AssetTypeAthenaQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	//nolint:dupl
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeDuckDBQuery) || estimateCustomCheckType == pipeline.AssetTypeDuckDBQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeDuckDBSeed) || s.WillRunTaskOfType(pipeline.AssetTypeDuckDBQuerySensor) {
+
 		duckDBOperator := duck.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: duck.NewMaterializer(fullRefresh),
 		}, parser)
+
 		duckDBCheckRunner := duck.NewColumnCheckOperator(conn)
+
 		duckDBQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
 
 		mainExecutors[pipeline.AssetTypeDuckDBQuery][scheduler.TaskInstanceTypeMain] = duckDBOperator
+
 		mainExecutors[pipeline.AssetTypeDuckDBQuery][scheduler.TaskInstanceTypeColumnCheck] = duckDBCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDuckDBQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeDuckDBSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeDuckDBSeed][scheduler.TaskInstanceTypeColumnCheck] = duckDBCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDuckDBSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeDuckDBQuerySensor][scheduler.TaskInstanceTypeMain] = duckDBQuerySensor
+
 		mainExecutors[pipeline.AssetTypeDuckDBQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = duckDBCheckRunner
+
 		mainExecutors[pipeline.AssetTypeDuckDBQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		if estimateCustomCheckType == pipeline.AssetTypeDuckDBQuery {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = duckDBCheckRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	//nolint:dupl
+
 	if s.WillRunTaskOfType(pipeline.AssetTypeClickHouse) || estimateCustomCheckType == pipeline.AssetTypeClickHouse ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeClickHouseSeed) || s.WillRunTaskOfType(pipeline.AssetTypeClickHouseQuerySensor) || s.WillRunTaskOfType(pipeline.AssetTypeClickHouseTableSensor) {
+
 		clickHouseOperator := clickhouse.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializerList{
 			Mat: clickhouse.NewMaterializer(fullRefresh),
 		}, parser)
+
 		checkRunner := clickhouse.NewColumnCheckOperator(conn)
+
 		clickHouseQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		clickHouseTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeClickHouse][scheduler.TaskInstanceTypeMain] = clickHouseOperator
+
 		mainExecutors[pipeline.AssetTypeClickHouse][scheduler.TaskInstanceTypeColumnCheck] = checkRunner
+
 		mainExecutors[pipeline.AssetTypeClickHouse][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeClickHouseSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeClickHouseSeed][scheduler.TaskInstanceTypeColumnCheck] = checkRunner
+
 		mainExecutors[pipeline.AssetTypeClickHouseSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeClickHouseQuerySensor][scheduler.TaskInstanceTypeMain] = clickHouseQuerySensor
+
 		mainExecutors[pipeline.AssetTypeClickHouseQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = checkRunner
+
 		mainExecutors[pipeline.AssetTypeClickHouseQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeClickHouseTableSensor][scheduler.TaskInstanceTypeMain] = clickHouseTableSensor
+
 		mainExecutors[pipeline.AssetTypeClickHouseTableSensor][scheduler.TaskInstanceTypeColumnCheck] = checkRunner
+
 		mainExecutors[pipeline.AssetTypeClickHouseTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		if estimateCustomCheckType == pipeline.AssetTypeClickHouse {
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = checkRunner
+
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 		}
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeTableauDatasource) {
+
 		tableauOperator := tableau.NewBasicOperator(conn)
+
 		mainExecutors[pipeline.AssetTypeTableauDatasource][scheduler.TaskInstanceTypeMain] = tableauOperator
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeTableauWorkbook) {
+
 		tableauOperator := tableau.NewBasicOperator(conn)
+
 		mainExecutors[pipeline.AssetTypeTableauWorkbook][scheduler.TaskInstanceTypeMain] = tableauOperator
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeTableau) {
+
 		tableauOperator := tableau.NewBasicOperator(conn)
+
 		mainExecutors[pipeline.AssetTypeTableau][scheduler.TaskInstanceTypeMain] = tableauOperator
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeQuicksightDataset) || s.WillRunTaskOfType(pipeline.AssetTypeQuicksightDashboard) {
+
 		qsOperator := qs.NewBasicOperator(conn)
+
 		mainExecutors[pipeline.AssetTypeQuicksightDataset][scheduler.TaskInstanceTypeMain] = qsOperator
+
 		mainExecutors[pipeline.AssetTypeQuicksightDashboard][scheduler.TaskInstanceTypeMain] = qsOperator
+
 	}
 
 	emrServerlessAssetTypes := []pipeline.AssetType{
 		pipeline.AssetTypeEMRServerlessSpark,
+
 		pipeline.AssetTypeEMRServerlessPyspark,
 	}
 
 	for _, typ := range emrServerlessAssetTypes {
 		if s.WillRunTaskOfType(typ) {
+
 			emrServerlessOperator, err := emr_serverless.NewBasicOperator(conn, jinjaVariables)
+
 			emrCheckRunner := emr_serverless.NewColumnCheckOperator(conn)
+
 			emrCustomCheckRunner := emr_serverless.NewCustomCheckOperator(conn, renderer)
+
 			if err != nil {
 				return nil, err
 			}
+
 			mainExecutors[typ][scheduler.TaskInstanceTypeMain] = emrServerlessOperator
+
 			mainExecutors[typ][scheduler.TaskInstanceTypeColumnCheck] = emrCheckRunner
+
 			mainExecutors[typ][scheduler.TaskInstanceTypeCustomCheck] = emrCustomCheckRunner
+
 		}
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeDataprocServerlessPyspark) {
+
 		dataprocServerlessOperator, err := dataprocserverless.NewBasicOperator(conn, jinjaVariables)
 		if err != nil {
 			return nil, err
 		}
+
 		mainExecutors[pipeline.AssetTypeDataprocServerlessPyspark][scheduler.TaskInstanceTypeMain] = dataprocServerlessOperator
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeS3KeySensor) {
+
 		s3KeySensor := s3.NewKeySensor(conn, sensorMode)
+
 		mainExecutors[pipeline.AssetTypeS3KeySensor][scheduler.TaskInstanceTypeMain] = s3KeySensor
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeMySQLQuery) ||
+
 		estimateCustomCheckType == pipeline.AssetTypeMySQLQuery ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeMySQLSeed) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeMySQLQuerySensor) ||
+
 		s.WillRunTaskOfType(pipeline.AssetTypeMySQLTableSensor) {
+
 		mysqlOperator := mysql.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializer{
 			Mat: mysql.NewMaterializer(fullRefresh),
 		}, parser)
+
 		mysqlCheckRunner := mysql.NewColumnCheckOperator(conn)
+
 		mysqlQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
+
 		mysqlTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
 
 		mainExecutors[pipeline.AssetTypeMySQLQuery][scheduler.TaskInstanceTypeMain] = mysqlOperator
+
 		mainExecutors[pipeline.AssetTypeMySQLQuery][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMySQLQuery][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeMySQLSeed][scheduler.TaskInstanceTypeMain] = seedOperator
+
 		mainExecutors[pipeline.AssetTypeMySQLSeed][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMySQLSeed][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeMySQLQuerySensor][scheduler.TaskInstanceTypeMain] = mysqlQuerySensor
+
 		mainExecutors[pipeline.AssetTypeMySQLQuerySensor][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMySQLQuerySensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		mainExecutors[pipeline.AssetTypeMySQLTableSensor][scheduler.TaskInstanceTypeMain] = mysqlTableSensor
+
 		mainExecutors[pipeline.AssetTypeMySQLTableSensor][scheduler.TaskInstanceTypeColumnCheck] = mysqlCheckRunner
+
 		mainExecutors[pipeline.AssetTypeMySQLTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
 	}
 
 	if s.WillRunTaskOfType(pipeline.AssetTypeAgentClaudeCode) {
+
 		claudeCodeOperator := claudecode.NewClaudeCodeOperator(renderer)
+
 		mainExecutors[pipeline.AssetTypeAgentClaudeCode][scheduler.TaskInstanceTypeMain] = claudeCodeOperator
+
 	}
 
 	return mainExecutors, nil
@@ -2244,6 +3417,7 @@ func SetupExecutors(
 
 func isPathReferencingAsset(p string) bool {
 	// Check if the path matches any of the pipeline definition file names
+
 	for _, pipelineDefinitionfile := range PipelineDefinitionFiles {
 		if strings.HasSuffix(p, pipelineDefinitionfile) {
 			return false
@@ -2251,6 +3425,7 @@ func isPathReferencingAsset(p string) bool {
 	}
 
 	// Return true only if it's not a directory
+
 	return !isDir(p)
 }
 
@@ -2265,40 +3440,54 @@ func isDir(path string) bool {
 
 type clearFileWriter struct {
 	file *os.File
-	m    sync.Mutex
+
+	m sync.Mutex
 }
 
 func (c *clearFileWriter) Write(p []byte) (int, error) {
 	c.m.Lock()
+
 	defer c.m.Unlock()
+
 	_, err := c.file.Write([]byte(Clean(string(p))))
+
 	return len(p), err
 }
 
 // generateLogFileName creates a log file name for multiple selected assets.
+
 // If the combined name would exceed filesystem limits (255 bytes), it uses a hash instead.
+
 func generateLogFileName(runID, pipelineName string, assets []*pipeline.Asset) string {
 	const maxFileNameLength = 196 // 200 - 4 for ".log" extension
 
 	assetNames := make([]string, len(assets))
+
 	for i, asset := range assets {
 		assetNames[i] = asset.Name
 	}
 
 	// Try the full name first
+
 	fullName := fmt.Sprintf("%s__%s__%s", runID, pipelineName, strings.Join(assetNames, "_"))
+
 	if len(fullName) <= maxFileNameLength {
 		return fullName
 	}
 
 	// If too long, use a hash of the asset names with a count indicator
+
 	hash := sha256.Sum256([]byte(strings.Join(assetNames, "_")))
+
 	shortHash := hex.EncodeToString(hash[:8]) // 16 hex chars
+
 	return fmt.Sprintf("%s__%s__%d_assets_%s", runID, pipelineName, len(assets), shortHash)
 }
 
 // logOutput sets up log file piping. terminalWriter controls where terminal output goes:
+
 // nil = os.Stdout (real terminal, legacy behavior), io.Discard = log file only (TUI mode).
+
 func logOutput(logPath string, terminalWriter io.Writer) (func(), error) {
 	err := os.MkdirAll(filepath.Dir(logPath), 0o755)
 	if err != nil {
@@ -2306,49 +3495,65 @@ func logOutput(logPath string, terminalWriter io.Writer) (func(), error) {
 	}
 
 	// open file read/write | create if not exist | clear file at open if exists
+
 	f, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open log file")
 	}
 
 	// save existing stdout | MultiWriter writes to saved stdout and file
+
 	if terminalWriter == nil {
 		terminalWriter = os.Stdout
 	}
+
 	mw := io.MultiWriter(terminalWriter, &clearFileWriter{f, sync.Mutex{}})
 
 	// get pipe reader and writer | writes to pipe writer come out pipe reader
+
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create log pipe")
 	}
 
 	// replace stdout,stderr with pipe writer | all writes to stdout, stderr will go through pipe instead (fmt.print, log)
+
 	os.Stdout = w
+
 	os.Stderr = w
 
 	// writes with log.Print should also write to mw
+
 	log.SetOutput(mw)
 
 	// create channel to control exit | will block until all copies are finished
+
 	exit := make(chan bool)
 
 	go func() {
 		// copy all reads from pipe to multiwriter, which writes to stdout and file
+
 		_, err := io.Copy(mw, r)
 		if err != nil {
 			panic(err)
 		}
+
 		// when r or w is closed copy will finish and true will be sent to channel
+
 		exit <- true
 	}()
 
 	// function to be deferred in main until program exits
+
 	return func() {
 		// close writer then block on exit channel | this will let mw finish writing before the program exits
+
 		_ = w.Close()
+
 		<-exit
+
 		// close file after all writes have finished
+
 		_ = f.Close()
 	}, nil
 }
@@ -2363,40 +3568,58 @@ func Clean(str string) string {
 
 func sendTelemetry(s *scheduler.Scheduler, c *cli.Command) {
 	assetStats := make(map[string]int)
+
 	for _, asset := range s.GetTaskInstancesByStatus(scheduler.Pending) {
+
 		_, ok := assetStats[string(asset.GetAsset().Type)]
+
 		if !ok {
 			assetStats[string(asset.GetAsset().Type)] = 0
 		}
+
 		assetStats[string(asset.GetAsset().Type)]++
+
 	}
 
 	telemetry.SendEventWithAssetStats("run_assets", assetStats, c)
 }
 
 type Filter struct {
-	IncludeTag         string   // Tag to include assets (from `--tag`)
-	OnlyTaskTypes      []string // Task types to include (from `--only`)
-	IncludeDownstream  bool     // Whether to include downstream tasks (from `--downstream`)
-	PushMetaData       bool
-	SingleTask         *pipeline.Asset   // Single asset (from running asset file directly)
-	SelectedAssets     []*pipeline.Asset // Multiple assets specified as positional arguments
-	ModifiedAssets     []*pipeline.Asset // Assets whose files have been modified vs default branch (from `--modified`)
-	Selector           string
-	ExcludeTag         string
+	IncludeTag string // Tag to include assets (from `--tag`)
+
+	OnlyTaskTypes []string // Task types to include (from `--only`)
+
+	IncludeDownstream bool // Whether to include downstream tasks (from `--downstream`)
+
+	PushMetaData bool
+
+	SingleTask *pipeline.Asset // Single asset (from running asset file directly)
+
+	SelectedAssets []*pipeline.Asset // Multiple assets specified as positional arguments
+
+	ModifiedAssets []*pipeline.Asset // Assets whose files have been modified vs default branch (from `--modified`)
+
+	Selector string
+
+	ExcludeTag string
+
 	selectedBySelector bool
-	singleCheckID      scheduler.CheckUniqueID // ID of the single check to run, if any
+
+	singleCheckID scheduler.CheckUniqueID // ID of the single check to run, if any
 }
 
 func SkipAllTasksIfSingleCheck(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *pipeline.Pipeline) error {
 	if f.singleCheckID.ID == "" {
 		return nil
 	}
+
 	s.MarkAll(scheduler.Skipped)
+
 	err := s.MarkCheckInstancesByID(f.singleCheckID.ID, f.singleCheckID.Asset, scheduler.Pending)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -2406,35 +3629,45 @@ func HandleModifiedAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 	}
 
 	// Cannot use with single asset mode
+
 	if f.SingleTask != nil {
 		return errors.New("cannot use --modified when running a single asset file directly")
 	}
 
 	// Cannot use with tags
+
 	if f.IncludeTag != "" {
 		return errors.New("cannot use --modified with --tag flag")
 	}
 
 	// Cannot use with selected assets
+
 	if len(f.SelectedAssets) > 0 {
 		return errors.New("cannot use --modified when specifying assets")
 	}
 
 	// Mark all as skipped first
+
 	s.MarkAll(scheduler.Skipped)
 
 	// Mark modified assets as pending
+
 	for _, asset := range f.ModifiedAssets {
 		s.MarkAsset(asset, scheduler.Pending, f.IncludeDownstream)
 	}
 
 	// Handle exclude-tag if specified
+
 	if f.ExcludeTag != "" {
+
 		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
+
 		if len(excludedAssets) == 0 {
 			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
 		}
+
 		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
+
 	}
 
 	return nil
@@ -2446,33 +3679,43 @@ func HandleMultipleAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 	}
 
 	// Cannot use with single asset mode
+
 	if f.SingleTask != nil {
 		return errors.New("cannot specify multiple assets when running a single asset file directly")
 	}
 
 	// Cannot use with tags
+
 	if f.IncludeTag != "" {
 		return errors.New("cannot specify assets with --tag flag")
 	}
 
 	// Mark all as skipped first
+
 	s.MarkAll(scheduler.Skipped)
 
 	// Mark selected assets as pending
+
 	for _, asset := range f.SelectedAssets {
 		s.MarkAsset(asset, scheduler.Pending, f.IncludeDownstream)
 	}
 
 	// Handle exclude-tag if specified
+
 	if f.ExcludeTag != "" {
+
 		if !f.IncludeDownstream && !f.selectedBySelector {
 			return errors.New("when specifying assets with --exclude-tag, you must also use --downstream flag")
 		}
+
 		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
+
 		if len(excludedAssets) == 0 {
 			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
 		}
+
 		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
+
 	}
 
 	return nil
@@ -2480,36 +3723,51 @@ func HandleMultipleAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 
 func HandleSingleTask(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *pipeline.Pipeline) error {
 	if f.SingleTask == nil {
+
 		// Allow downstream with selected assets or modified assets, but not for whole pipeline
+
 		if f.IncludeDownstream && len(f.SelectedAssets) == 0 && len(f.ModifiedAssets) == 0 {
 			return errors.New("cannot use the --downstream flag when running the whole pipeline")
 		}
+
 		return nil
+
 	}
 
 	// Cannot use with multiple assets
+
 	if len(f.SelectedAssets) > 0 {
 		return errors.New("cannot specify multiple assets when running a single asset file directly")
 	}
 
 	s.MarkAll(scheduler.Skipped)
+
 	found := s.MarkAsset(f.SingleTask, scheduler.Pending, f.IncludeDownstream)
+
 	if !found {
 		return fmt.Errorf("asset '%s' was not found among the pipeline's scheduled task instances; the asset name in the file may have been transformed differently during pipeline construction", f.SingleTask.Name)
 	}
+
 	if f.IncludeTag != "" {
 		return errors.New("you cannot use the '--tag' flag when running a single asset")
 	}
+
 	if f.ExcludeTag != "" {
+
 		if !f.IncludeDownstream {
 			return errors.New("when running a single asset with '--exclude-tag', you must also use the '--downstream' flag")
 		}
+
 		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
+
 		if len(excludedAssets) == 0 {
 			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
 		}
+
 		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
+
 	}
+
 	return nil
 }
 
@@ -2519,15 +3777,19 @@ func HandleIncludeTags(ctx context.Context, f *Filter, s *scheduler.Scheduler, p
 	}
 
 	// Cannot use with multiple assets
+
 	if len(f.SelectedAssets) > 0 {
 		return errors.New("cannot use --tag flag when specifying assets")
 	}
 
 	s.MarkAll(scheduler.Skipped)
+
 	includedAssets := p.GetAssetsByTag(f.IncludeTag)
+
 	if len(includedAssets) == 0 {
 		return fmt.Errorf("no assets found with include tag '%s'", f.IncludeTag)
 	}
+
 	s.MarkByTag(f.IncludeTag, scheduler.Pending, false)
 
 	return nil
@@ -2537,13 +3799,17 @@ func HandleExcludeTags(ctx context.Context, f *Filter, s *scheduler.Scheduler, p
 	if f.SingleTask != nil {
 		return nil
 	}
+
 	if f.ExcludeTag == "" {
 		return nil
 	}
+
 	excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
+
 	if len(excludedAssets) == 0 {
 		return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
 	}
+
 	s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
 
 	return nil
@@ -2553,7 +3819,9 @@ func FilterTaskTypes(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *
 	if f.PushMetaData {
 		p.MetadataPush.Global = true
 	}
+
 	if len(f.OnlyTaskTypes) > 0 {
+
 		for _, taskType := range f.OnlyTaskTypes {
 			if taskType != "main" && taskType != "checks" && taskType != "push-metadata" {
 				return fmt.Errorf("invalid value for '--only' flag: '%s', available values are 'main', 'checks', and 'push-metadata'", taskType)
@@ -2561,20 +3829,29 @@ func FilterTaskTypes(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *
 		}
 
 		runMain := slices.Contains(f.OnlyTaskTypes, "main")
+
 		runChecks := slices.Contains(f.OnlyTaskTypes, "checks")
+
 		runPushMetadata := slices.Contains(f.OnlyTaskTypes, "push-metadata")
 
 		if !runMain {
 			s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeMain, scheduler.Skipped)
 		}
+
 		if !runChecks {
+
 			s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeColumnCheck, scheduler.Skipped)
+
 			s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeCustomCheck, scheduler.Skipped)
+
 		}
+
 		if !runPushMetadata {
 			s.MarkPendingInstancesByType(scheduler.TaskInstanceTypeMetadataPush, scheduler.Skipped)
 		}
+
 	}
+
 	return nil
 }
 
@@ -2585,11 +3862,17 @@ func ApplyAllFilters(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *
 
 	funcs := []FilterMutator{
 		HandleModifiedAssets, // Check for modified assets first
+
 		HandleMultipleAssets, // Check for multiple assets
-		HandleSingleTask,     // Then single asset
-		HandleIncludeTags,    // Then tags
+
+		HandleSingleTask, // Then single asset
+
+		HandleIncludeTags, // Then tags
+
 		HandleExcludeTags,
+
 		FilterTaskTypes,
+
 		SkipAllTasksIfSingleCheck,
 	}
 
@@ -2598,6 +3881,7 @@ func ApplyAllFilters(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -2620,18 +3904,26 @@ func Validate(shouldvalidate bool, assetCounter assetCounter, lintChecker lintCh
 }
 
 // getPendingAssets extracts unique assets from pending task instances in the scheduler.
+
 func getPendingAssets(s *scheduler.Scheduler) []*pipeline.Asset {
 	pendingInstances := s.GetTaskInstancesByStatus(scheduler.Pending)
+
 	seen := make(map[string]bool)
+
 	assets := make([]*pipeline.Asset, 0)
 
 	for _, instance := range pendingInstances {
+
 		asset := instance.GetAsset()
+
 		if seen[asset.Name] {
 			continue
 		}
+
 		seen[asset.Name] = true
+
 		assets = append(assets, asset)
+
 	}
 
 	return assets
@@ -2643,20 +3935,27 @@ func ensurePythonCacheGitignore(fs afero.Fs, repoRoot string) error {
 			return fmt.Errorf("failed to add %s: %w", pattern, err)
 		}
 	}
+
 	return nil
 }
 
 // loadAssetsFromPaths loads assets from a list of paths or names.
+
 // It tries to find assets by path first, then by name if path lookup fails.
+
 // All assets must belong to the same pipeline.
+
 func loadAssetsFromPaths(assetPaths []string, p *pipeline.Pipeline, repoRoot, cwd string) ([]*pipeline.Asset, error) {
 	assets := make([]*pipeline.Asset, 0, len(assetPaths))
+
 	notFound := make([]string, 0)
 
 	// Get pipeline directory for path resolution
+
 	pipelineDir := filepath.Dir(p.DefinitionFile.Path)
 
 	for _, assetPath := range assetPaths {
+
 		if assetPath == "" {
 			continue
 		}
@@ -2664,65 +3963,97 @@ func loadAssetsFromPaths(assetPaths []string, p *pipeline.Pipeline, repoRoot, cw
 		var asset *pipeline.Asset
 
 		// Try multiple base paths for relative paths
+
 		basePaths := []string{cwd, repoRoot, pipelineDir}
 
 		// First, try as absolute path
+
 		if filepath.IsAbs(assetPath) {
+
 			absPath, err := filepath.Abs(assetPath)
+
 			if err == nil {
+
 				asset = p.GetAssetByPath(absPath)
+
 				if asset == nil {
 					asset = findAssetByExecutablePath(p, absPath)
 				}
+
 			}
+
 		}
 
 		// If not found, try relative to each base path
+
 		if asset == nil && !filepath.IsAbs(assetPath) {
 			for _, base := range basePaths {
+
 				relativePath := filepath.Join(base, assetPath)
+
 				absPath, err := filepath.Abs(relativePath)
+
 				if err == nil {
+
 					asset = p.GetAssetByPath(absPath)
+
 					if asset == nil {
 						asset = findAssetByExecutablePath(p, absPath)
 					}
+
 					if asset != nil {
 						break
 					}
+
 				}
+
 			}
 		}
 
 		// If still not found, try by asset name
+
 		if asset == nil {
 			// Try with the path as-is (might be just the name)
+
 			asset = p.GetAssetByName(assetPath)
 		}
 
 		// Try without file extension
+
 		if asset == nil {
+
 			nameWithoutExt := strings.TrimSuffix(filepath.Base(assetPath), filepath.Ext(assetPath))
+
 			asset = p.GetAssetByName(nameWithoutExt)
+
 		}
 
 		// Try case-insensitive name lookup
+
 		if asset == nil {
 			asset = p.GetAssetByNameCaseInsensitive(assetPath)
 		}
 
 		// Try case-insensitive without extension
+
 		if asset == nil {
+
 			nameWithoutExt := strings.TrimSuffix(filepath.Base(assetPath), filepath.Ext(assetPath))
+
 			asset = p.GetAssetByNameCaseInsensitive(nameWithoutExt)
+
 		}
 
 		if asset == nil {
+
 			notFound = append(notFound, assetPath)
+
 			continue
+
 		}
 
 		assets = append(assets, asset)
+
 	}
 
 	if len(notFound) > 0 {
@@ -2737,30 +4068,41 @@ func loadAssetsFromPaths(assetPaths []string, p *pipeline.Pipeline, repoRoot, cw
 }
 
 // findAssetsFromChangedFiles maps changed file paths (relative to repo root) to pipeline assets.
+
 func findAssetsFromChangedFiles(changedFiles []string, p *pipeline.Pipeline, repoRoot string) []*pipeline.Asset {
 	seen := make(map[string]bool)
+
 	var assets []*pipeline.Asset
 
 	for _, relPath := range changedFiles {
+
 		absPath := filepath.Join(repoRoot, relPath)
 
 		// Try matching by definition file path
+
 		asset := p.GetAssetByPath(absPath)
+
 		if asset == nil {
 			// Try matching by executable file path
+
 			asset = findAssetByExecutablePath(p, absPath)
 		}
 
 		if asset != nil && !seen[asset.Name] {
+
 			seen[asset.Name] = true
+
 			assets = append(assets, asset)
+
 		}
+
 	}
 
 	return assets
 }
 
 // findAssetByExecutablePath finds an asset by its executable file path.
+
 func findAssetByExecutablePath(p *pipeline.Pipeline, absPath string) *pipeline.Asset {
 	absPath, err := filepath.Abs(absPath)
 	if err != nil {

--- a/docs/quality/custom.md
+++ b/docs/quality/custom.md
@@ -137,3 +137,64 @@ GROUP BY 1
 
 > [!INFO]
 > Non-blocking checks are useful for long-running or expensive quality checks. It means the downstream assets will not be waiting for this quality check to finish.
+
+## Troubleshooting custom check failures
+
+When a custom check fails, Bruin prints the name of the failing check, its location in the original asset file, and the underlying database error.
+
+### Example output
+
+```
+  dataset.orders
+  └── duplicate check  custom check  result 2 doesn't match expected value 0
+      ├── defined at:      assets/orders.sql:8:5
+      └── query starts at: assets/orders.sql:9:5
+```
+
+When running a single check with `--single-check`, the output is:
+
+```
+Check Failed
+------------
+Error: result 2 doesn't match expected value 0
+
+Result: 2 (expected: 0)
+
+Query:
+SELECT COUNT(*) - COUNT(DISTINCT id) FROM dataset.orders
+
+Defined at:      assets/orders.sql:8:5
+Query starts at: assets/orders.sql:9:5
+```
+
+### Reading the locations
+
+| Field | Meaning |
+| ----- | ------- |
+| `defined at` | File, line, and column of the `- name:` entry for the failing check in the asset file. |
+| `query starts at` | File, line, and column of the `query:` key for that check. |
+
+Both locations refer to the **original asset file** — the `.sql` or `.yml` file you edit — not to the SQL that Bruin sends to the database.
+
+### Database error line numbers
+
+Database engines often report a location inside the SQL they received, for example:
+
+```
+Aggregations of aggregations are not allowed at [17:16]
+```
+
+That `[17:16]` refers to the **rendered SQL** Bruin sent to the database, which may differ from your source file because:
+
+- Bruin strips the `/* @bruin … @bruin */` metadata block before execution.
+- `count`-based checks are wrapped with `SELECT count(*) FROM (<your query>)`, adding extra lines.
+- Jinja templating expands macros and variables.
+
+Use `defined at` and `query starts at` to find the check in your file. Use the database location only to understand which part of the rendered SQL the engine rejected.
+
+### Supported asset types
+
+Source locations are captured for both asset types:
+
+- **SQL assets** (`.sql` files with a `/* @bruin … @bruin */` block) — line numbers are relative to the original `.sql` file, not the extracted YAML block.
+- **YAML assets** (`.yml` / `.yaml` asset files) — line numbers are the YAML file lines directly.

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -87,7 +88,7 @@ func isEmbeddedYamlComment(file afero.File, prefixes []string) bool {
 }
 
 func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
-	rows, commentRowEnd := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
+	rows, commentRowEnd, openingMarkerLine := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
 	if rows == "" {
 		return nil, &ParseError{"no embedded YAML found in the comments"}
 	}
@@ -100,6 +101,11 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	absFilePath, err := filepath.Abs(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get absolute path for file %s", filePath)
+	}
+
+	var root yaml.Node
+	if yamlErr := yaml.Unmarshal([]byte(rows), &root); yamlErr == nil {
+		annotateCustomCheckLocations(task, &root, absFilePath, openingMarkerLine)
 	}
 
 	scanner := bufio.NewScanner(file)
@@ -122,11 +128,12 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	return task, nil
 }
 
-func readUntilComments(file afero.File, prefixes, suffixes []string) (string, int) {
+func readUntilComments(file afero.File, prefixes, suffixes []string) (string, int, int) {
 	scanner := bufio.NewScanner(file)
 	defer func() { _, _ = file.Seek(0, io.SeekStart) }()
 	var rowsBuilder strings.Builder
 	rowCount := 0
+	openingMarkerLine := 0
 
 	seenPrefix := false
 
@@ -143,6 +150,7 @@ OUTER:
 				if !seenPrefix {
 					// First occurrence - this is the opening marker
 					seenPrefix = true
+					openingMarkerLine = rowCount
 					continue OUTER
 				}
 			}
@@ -160,7 +168,7 @@ OUTER:
 		rowsBuilder.WriteByte('\n')
 	}
 
-	return strings.TrimSpace(rowsBuilder.String()), rowCount
+	return strings.TrimSpace(rowsBuilder.String()), rowCount, openingMarkerLine
 }
 
 func singleLineCommentsToTask(scanner *bufio.Scanner, commentMarker, filePath string) (*Asset, error) {
@@ -414,7 +422,7 @@ func ValidateAssetYAML(fs afero.Fs, filePath string, defType TaskDefinitionType)
 			return nil
 		}
 
-		rows, _ := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
+		rows, _, _ := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
 		if rows == "" {
 			return nil
 		}

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -13,13 +13,17 @@ import (
 
 func mustRead(t *testing.T, file string) string {
 	content, err := afero.ReadFile(afero.NewOsFs(), file)
+
 	require.NoError(t, err)
+
 	return strings.ReplaceAll(strings.TrimSpace(string(content)), "\r\n", "\n")
 }
 
 func mustReadWithoutReplacement(t *testing.T, file string) string {
 	content, err := afero.ReadFile(afero.NewOsFs(), file)
+
 	require.NoError(t, err)
+
 	return strings.TrimSpace(string(content))
 }
 
@@ -27,6 +31,7 @@ func Test_createTaskFromFile(t *testing.T) {
 	t.Parallel()
 
 	falseValue := false
+
 	trueValue := true
 
 	type args struct {
@@ -34,345 +39,582 @@ func Test_createTaskFromFile(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		want    *pipeline.Asset
+		name string
+
+		args args
+
+		want *pipeline.Asset
+
 		wantErr bool
 	}{
 		{
 			name: "file does not exist",
+
 			args: args{
 				filePath: "testdata/comments/some-file-that-doesnt-exist.sql",
 			},
+
 			wantErr: true,
 		},
+
 		{
 			name: "existing file with no comments is skipped",
+
 			args: args{
 				filePath: "testdata/comments/nocomments.py",
 			},
+
 			wantErr: false,
 		},
+
 		{
 			name: "SQL file parsed",
+
 			args: args{
 				filePath: "testdata/comments/test.sql",
 			},
+
 			want: &pipeline.Asset{
-				ID:          "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
-				Name:        "some-sql-task",
+				ID: "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
+
+				Name: "some-sql-task",
+
 				Description: "some description goes here",
-				Type:        "bq.sql",
+
+				Type: "bq.sql",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "test.sql",
-					Path:    path.AbsPathForTests(t, "testdata/comments/test.sql"),
+					Name: "test.sql",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/test.sql"),
+
 					Content: "select *\nfrom foo;",
 				},
+
 				Parameters: map[string]string{
-					"param1":       "first-parameter",
-					"param2":       "second-parameter",
+					"param1": "first-parameter",
+
+					"param2": "second-parameter",
+
 					"s3_file_path": "s3://bucket/path",
 				},
+
 				Connection: "conn2",
-				Secrets:    []pipeline.SecretMapping{},
+
+				Secrets: []pipeline.SecretMapping{},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
 
 				Materialization: pipeline.Materialization{
-					Type:           pipeline.MaterializationTypeTable,
-					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
-					PartitionBy:    "dt",
+					Type: pipeline.MaterializationTypeTable,
+
+					Strategy: pipeline.MaterializationStrategyDeleteInsert,
+
+					PartitionBy: "dt",
+
 					IncrementalKey: "dt",
-					ClusterBy:      []string{"event_name"},
+
+					ClusterBy: []string{"event_name"},
 				},
+
 				Columns: []pipeline.Column{
 					{Name: "some_column", PrimaryKey: true, Checks: make([]pipeline.ColumnCheck, 0)},
+
 					{Name: "some_other_column", PrimaryKey: false, Checks: make([]pipeline.ColumnCheck, 0)},
 				},
+
 				CustomChecks: make([]pipeline.CustomCheck, 0),
 			},
 		},
+
 		{
 			name: "SQL file failed to parse",
+
 			args: args{
 				filePath: "testdata/comments/failparseprimarykey.sql",
 			},
+
 			wantErr: true,
 		},
+
 		{
 			name: "SQL file with embedded yaml content is parsed",
+
 			args: args{
 				filePath: "testdata/comments/embeddedyaml.sql",
 			},
+
 			want: &pipeline.Asset{
-				ID:          "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
-				Name:        "some-sql-task",
+				ID: "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
+
+				Name: "some-sql-task",
+
 				Description: "some description goes here",
-				Type:        "bq.sql",
+
+				Type: "bq.sql",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "embeddedyaml.sql",
-					Path:    path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+					Name: "embeddedyaml.sql",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+
 					Content: "select *\nfrom foo;",
 				},
+
 				Parameters: map[string]string{
-					"param1":       "first-parameter",
-					"param2":       "second-parameter",
+					"param1": "first-parameter",
+
+					"param2": "second-parameter",
+
 					"s3_file_path": "s3://bucket/path",
 				},
+
 				Connection: "conn1",
-				Secrets:    []pipeline.SecretMapping{},
+
+				Secrets: []pipeline.SecretMapping{},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
+
 				Materialization: pipeline.Materialization{
-					Type:           pipeline.MaterializationTypeTable,
-					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
-					PartitionBy:    "dt",
+					Type: pipeline.MaterializationTypeTable,
+
+					Strategy: pipeline.MaterializationStrategyDeleteInsert,
+
+					PartitionBy: "dt",
+
 					IncrementalKey: "dt",
-					ClusterBy:      []string{"event_name"},
+
+					ClusterBy: []string{"event_name"},
 				},
+
 				Columns: make([]pipeline.Column, 0),
+
 				CustomChecks: []pipeline.CustomCheck{
 					{
-						ID:    "480f365424205654f7108f2d0ddf6418faed97652bba106ba4080a967a50e5cf",
-						Name:  "check1",
+						ID: "480f365424205654f7108f2d0ddf6418faed97652bba106ba4080a967a50e5cf",
+
+						Name: "check1",
+
 						Query: "select * from table1",
+
 						Value: 16,
+
+						SourceLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+
+							Line: 27,
+
+							Column: 5,
+						},
+
+						QueryLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+
+							Line: 29,
+
+							Column: 5,
+						},
 					},
 				},
+
 				Hooks: pipeline.Hooks{
-					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Pre: []pipeline.Hook{{Query: "select 1"}},
+
 					Post: []pipeline.Hook{{Query: "select 2"}},
 				},
 			},
 		},
+
 		{
 			name: "Python file parsed",
+
 			args: args{
 				filePath: path.AbsPathForTests(t, "testdata/comments/test.py"), // giving an absolute path here tests the case of double-absolute paths
+
 			},
+
 			want: &pipeline.Asset{
-				ID:          "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
-				Name:        "some-python-task",
+				ID: "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
+
+				Name: "some-python-task",
+
 				Description: "some description goes here",
-				Type:        "bq.sql",
+
+				Type: "bq.sql",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "test.py",
-					Path:    path.AbsPathForTests(t, "testdata/comments/test.py"),
+					Name: "test.py",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/test.py"),
+
 					Content: "print('hello world')",
 				},
+
 				Parameters: map[string]string{
 					"param1": "first-parameter",
+
 					"param2": "second-parameter",
+
 					"param3": "third-parameter",
 				},
+
 				Connection: "conn1",
-				Image:      "python:3.11",
-				Instance:   "b1.nano",
-				Secrets:    []pipeline.SecretMapping{},
+
+				Image: "python:3.11",
+
+				Instance: "b1.nano",
+
+				Secrets: []pipeline.SecretMapping{},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
+
 				Columns: []pipeline.Column{
 					{
 						Name: "col1",
+
 						Type: "string",
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:       "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
-								Name:     "not_null",
+								ID: "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
+
+								Name: "not_null",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
+
 							{
-								ID:       "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
-								Name:     "positive",
+								ID: "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
+
+								Name: "positive",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
+
 							{
-								ID:       "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
-								Name:     "unique",
+								ID: "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
+
+								Name: "unique",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
 						},
 					},
+
 					{
 						Name: "col2",
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:       "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
-								Name:     "not_null",
+								ID: "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
+
+								Name: "not_null",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
+
 							{
-								ID:       "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
-								Name:     "unique",
+								ID: "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
+
+								Name: "unique",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
 						},
 					},
 				},
+
 				CustomChecks: make([]pipeline.CustomCheck, 0),
 			},
 		},
+
 		{
 			name: "Python file with comment block parsed",
+
 			args: args{
 				filePath: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
 			},
+
 			want: &pipeline.Asset{
-				ID:          "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
-				Name:        "some-python-task",
+				ID: "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
+
+				Name: "some-python-task",
+
 				Description: "some description goes here",
-				Type:        "python",
+
+				Type: "python",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "testblockcomments.py",
-					Path:    path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+					Name: "testblockcomments.py",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
 					Content: "print('hello world')",
 				},
+
 				Parameters: map[string]string{
 					"param1": "first-parameter",
+
 					"param2": "second-parameter",
+
 					"param3": "third-parameter",
 				},
-				Image:    "python:3.11",
+
+				Image: "python:3.11",
+
 				Instance: "b1.nano",
+
 				Secrets: []pipeline.SecretMapping{
 					{
-						SecretKey:   "secret1",
+						SecretKey: "secret1",
+
 						InjectedKey: "INJECTED_SECRET1",
 					},
+
 					{
-						SecretKey:   "secret2",
+						SecretKey: "secret2",
+
 						InjectedKey: "secret2",
 					},
 				},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
+
 				Columns: []pipeline.Column{
 					{
-						Name:      "col1",
-						Type:      "string",
+						Name: "col1",
+
+						Type: "string",
+
 						Upstreams: make([]*pipeline.UpstreamColumn, 0),
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:   "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
+								ID: "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
+
 								Name: "not_null",
 							},
+
 							{
-								ID:   "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
+								ID: "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
+
 								Name: "positive",
 							},
+
 							{
-								ID:   "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
+								ID: "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
+
 								Name: "unique",
 							},
 						},
 					},
+
 					{
-						Name:      "col2",
-						Type:      "string",
+						Name: "col2",
+
+						Type: "string",
+
 						Upstreams: make([]*pipeline.UpstreamColumn, 0),
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:   "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
+								ID: "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
+
 								Name: "not_null",
 							},
+
 							{
-								ID:       "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
-								Name:     "unique",
+								ID: "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
+
+								Name: "unique",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &falseValue},
 							},
 						},
 					},
 				},
+
 				CustomChecks: []pipeline.CustomCheck{
 					{
-						ID:       "a26c19e73c6b5cdee1b1bfe135a475979f360b9e7fdfc19a7fca1832d034adbc",
-						Name:     "check1",
-						Query:    "select 5",
-						Value:    16,
-						Blocking: pipeline.DefaultTrueBool{Value: &falseValue},
-					},
-					{
-						ID:    "cc1040bd694dcb5fae26300d2c0f721e4c4304cb16b9dce3b4ddcaa44498b940",
-						Name:  "check2",
+						ID: "a26c19e73c6b5cdee1b1bfe135a475979f360b9e7fdfc19a7fca1832d034adbc",
+
+						Name: "check1",
+
 						Query: "select 5",
+
 						Value: 16,
+
+						Blocking: pipeline.DefaultTrueBool{Value: &falseValue},
+
+						SourceLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 35,
+
+							Column: 7,
+						},
+
+						QueryLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 36,
+
+							Column: 7,
+						},
+					},
+
+					{
+						ID: "cc1040bd694dcb5fae26300d2c0f721e4c4304cb16b9dce3b4ddcaa44498b940",
+
+						Name: "check2",
+
+						Query: "select 5",
+
+						Value: 16,
+
+						SourceLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 40,
+
+							Column: 7,
+						},
+
+						QueryLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 41,
+
+							Column: 7,
+						},
 					},
 				},
+
 				Hooks: pipeline.Hooks{
-					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Pre: []pipeline.Hook{{Query: "select 1"}},
+
 					Post: []pipeline.Hook{{Query: "select 2"}},
 				},
 			},
 		},
+
 		{
 			name: "R file with comment block parsed",
+
 			args: args{
 				filePath: path.AbsPathForTests(t, "testdata/comments/test.r"),
 			},
+
 			want: &pipeline.Asset{
-				ID:          "aba30496cdc78a46e6e2e6da72985ac3e05aa83b87a01b3dc347166ffa634e5f",
-				Name:        "some-r-task",
+				ID: "aba30496cdc78a46e6e2e6da72985ac3e05aa83b87a01b3dc347166ffa634e5f",
+
+				Name: "some-r-task",
+
 				Description: "R task with multiline configuration",
-				Type:        "r",
+
+				Type: "r",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "test.r",
-					Path:    path.AbsPathForTests(t, "testdata/comments/test.r"),
+					Name: "test.r",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/test.r"),
+
 					Content: "cat(\"Hello from R!\\n\")\nprint(\"This is an R script\")",
 				},
+
 				Parameters: map[string]string{
 					"param1": "first-parameter",
+
 					"param2": "second-parameter",
+
 					"param3": "third-parameter",
 				},
-				Image:    "r:4.3",
+
+				Image: "r:4.3",
+
 				Instance: "b1.nano",
+
 				Secrets: []pipeline.SecretMapping{
 					{
-						SecretKey:   "secret1",
+						SecretKey: "secret1",
+
 						InjectedKey: "INJECTED_SECRET1",
 					},
+
 					{
-						SecretKey:   "secret2",
+						SecretKey: "secret2",
+
 						InjectedKey: "secret2",
 					},
 				},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
-				Columns:      make([]pipeline.Column, 0),
+
+				Columns: make([]pipeline.Column, 0),
+
 				CustomChecks: make([]pipeline.CustomCheck, 0),
+
 				Hooks: pipeline.Hooks{
-					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Pre: []pipeline.Hook{{Query: "select 1"}},
+
 					Post: []pipeline.Hook{{Query: "select 2"}},
 				},
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -387,6 +629,7 @@ func Test_createTaskFromFile(t *testing.T) {
 
 			if tt.want == nil {
 				assert.Nil(t, got)
+
 				return
 			}
 
@@ -402,6 +645,7 @@ func BenchmarkCreateTaskFromFileComments(b *testing.B) {
 
 	for range make([]struct{}, b.N) {
 		_, err := pipeline.CreateTaskFromFileComments(afero.NewOsFs())(file)
+
 		require.NoError(b, err)
 	}
 }

--- a/pkg/pipeline/custom_check_locations.go
+++ b/pkg/pipeline/custom_check_locations.go
@@ -1,0 +1,69 @@
+package pipeline
+
+import "gopkg.in/yaml.v3"
+
+// annotateCustomCheckLocations sets SourceLocation and QueryLocation on each custom check
+// by navigating the parsed yaml.Node tree.
+//
+// lineOffset is the number of file lines that precede the first line of the YAML block.
+// For a pure YAML asset file this is 0, so yaml.Node.Line maps directly to the file line.
+// For an embedded /* @bruin … @bruin */ block, lineOffset is the 1-based line number of
+// the opening marker so that yaml.Node.Line 1 maps to file line (lineOffset + 1).
+func annotateCustomCheckLocations(asset *Asset, root *yaml.Node, filePath string, lineOffset int) {
+	if len(asset.CustomChecks) == 0 {
+		return
+	}
+
+	// Navigate: Document → Mapping
+	doc := root
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return
+		}
+		doc = doc.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return
+	}
+
+	// Find the "custom_checks" key in the top-level mapping.
+	var checksSeqNode *yaml.Node
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		if doc.Content[i].Value == "custom_checks" {
+			checksSeqNode = doc.Content[i+1]
+			break
+		}
+	}
+	if checksSeqNode == nil || checksSeqNode.Kind != yaml.SequenceNode {
+		return
+	}
+
+	for i, checkNode := range checksSeqNode.Content {
+		if i >= len(asset.CustomChecks) {
+			break
+		}
+		if checkNode.Kind != yaml.MappingNode {
+			continue
+		}
+
+		// Set SourceLocation from the check item node position.
+		asset.CustomChecks[i].SourceLocation = &SourceLocation{
+			File:   filePath,
+			Line:   lineOffset + checkNode.Line,
+			Column: checkNode.Column,
+		}
+
+		// Find the "query" key inside the check's mapping.
+		for j := 0; j+1 < len(checkNode.Content); j += 2 {
+			if checkNode.Content[j].Value == "query" {
+				qk := checkNode.Content[j] // use the key node for the column reference
+				asset.CustomChecks[i].QueryLocation = &SourceLocation{
+					File:   filePath,
+					Line:   lineOffset + qk.Line,
+					Column: qk.Column,
+				}
+				break
+			}
+		}
+	}
+}

--- a/pkg/pipeline/custom_check_locations_test.go
+++ b/pkg/pipeline/custom_check_locations_test.go
@@ -1,0 +1,196 @@
+package pipeline_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/path"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCustomCheckLocations_SQLEmbeddedYAML verifies that parsing a SQL file with
+
+// an embedded /* @bruin … @bruin */ block annotates each custom check with its
+
+// exact source location within the original file.
+
+func TestCustomCheckLocations_SQLEmbeddedYAML(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+
+	creator := pipeline.CreateTaskFromFileComments(fs)
+
+	filePath := filepath.Join("testdata", "comments", "custom_checks_location.sql")
+
+	absPath := path.AbsPathForTests(t, filePath)
+
+	asset, err := creator(filePath)
+
+	require.NoError(t, err)
+
+	require.NotNil(t, asset)
+
+	require.Len(t, asset.CustomChecks, 2)
+
+	// check[0]: "row count"
+
+	c0 := asset.CustomChecks[0]
+
+	assert.Equal(t, "row count", c0.Name)
+
+	require.NotNil(t, c0.SourceLocation, "SourceLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.SourceLocation.File)
+
+	assert.Equal(t, 5, c0.SourceLocation.Line,
+
+		"'- name: row count' is at file line 5 (opening marker at line 1 + YAML line 4)")
+
+	assert.Equal(t, 5, c0.SourceLocation.Column)
+
+	require.NotNil(t, c0.QueryLocation, "QueryLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.QueryLocation.File)
+
+	assert.Equal(t, 6, c0.QueryLocation.Line,
+
+		"'query:' for check[0] is at file line 6 (opening marker at line 1 + YAML line 5)")
+
+	assert.Equal(t, 5, c0.QueryLocation.Column)
+
+	// check[1]: "null check"
+
+	c1 := asset.CustomChecks[1]
+
+	assert.Equal(t, "null check", c1.Name)
+
+	require.NotNil(t, c1.SourceLocation, "SourceLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.SourceLocation.File)
+
+	assert.Equal(t, 8, c1.SourceLocation.Line,
+
+		"'- name: null check' is at file line 8 (opening marker at line 1 + YAML line 7)")
+
+	assert.Equal(t, 5, c1.SourceLocation.Column)
+
+	require.NotNil(t, c1.QueryLocation, "QueryLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.QueryLocation.File)
+
+	assert.Equal(t, 9, c1.QueryLocation.Line,
+
+		"'query:' for check[1] is at file line 9 (opening marker at line 1 + YAML line 8)")
+
+	assert.Equal(t, 5, c1.QueryLocation.Column)
+}
+
+// TestCustomCheckLocations_YAMLAsset verifies that parsing a .yml asset file annotates
+
+// each custom check with its exact source location (lineOffset == 0 for pure YAML).
+
+func TestCustomCheckLocations_YAMLAsset(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+
+	creator := pipeline.CreateTaskFromYamlDefinition(fs)
+
+	filePath := filepath.Join("testdata", "yaml", "task-with-custom-check-location", "task.yml")
+
+	absPath := path.AbsPathForTests(t, filePath)
+
+	asset, err := creator(filePath)
+
+	require.NoError(t, err)
+
+	require.NotNil(t, asset)
+
+	require.Len(t, asset.CustomChecks, 2)
+
+	// check[0]: "row count"
+
+	c0 := asset.CustomChecks[0]
+
+	assert.Equal(t, "row count", c0.Name)
+
+	require.NotNil(t, c0.SourceLocation, "SourceLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.SourceLocation.File)
+
+	assert.Equal(t, 4, c0.SourceLocation.Line,
+
+		"'- name: row count' is at YAML line 4 (lineOffset==0 for pure YAML files)")
+
+	assert.Equal(t, 5, c0.SourceLocation.Column)
+
+	require.NotNil(t, c0.QueryLocation, "QueryLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.QueryLocation.File)
+
+	assert.Equal(t, 5, c0.QueryLocation.Line,
+
+		"'query:' for check[0] is at YAML line 5")
+
+	assert.Equal(t, 5, c0.QueryLocation.Column)
+
+	// check[1]: "null check"
+
+	c1 := asset.CustomChecks[1]
+
+	assert.Equal(t, "null check", c1.Name)
+
+	require.NotNil(t, c1.SourceLocation, "SourceLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.SourceLocation.File)
+
+	assert.Equal(t, 7, c1.SourceLocation.Line,
+
+		"'- name: null check' is at YAML line 7")
+
+	assert.Equal(t, 5, c1.SourceLocation.Column)
+
+	require.NotNil(t, c1.QueryLocation, "QueryLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.QueryLocation.File)
+
+	assert.Equal(t, 8, c1.QueryLocation.Line,
+
+		"'query:' for check[1] is at YAML line 8")
+
+	assert.Equal(t, 5, c1.QueryLocation.Column)
+}
+
+// TestCustomCheckLocations_NoChecks verifies that assets without custom checks
+
+// are handled gracefully.
+
+func TestCustomCheckLocations_NoChecks(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+
+	creator := pipeline.CreateTaskFromFileComments(fs)
+
+	// embeddedyaml.sql has custom_checks but the test validates it still parses cleanly
+
+	asset, err := creator(filepath.Join("testdata", "comments", "embeddedyaml.sql"))
+
+	require.NoError(t, err)
+
+	require.NotNil(t, asset)
+
+	// check that custom checks without source location still parse fine
+
+	for _, cc := range asset.CustomChecks {
+		if cc.SourceLocation != nil {
+			assert.NotEmpty(t, cc.SourceLocation.File)
+
+			assert.Positive(t, cc.SourceLocation.Line)
+		}
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -26,195 +26,362 @@ type RunConfig string
 
 const (
 	CommentTask TaskDefinitionType = "comment"
-	YamlTask    TaskDefinitionType = "yaml"
 
-	AssetTypeAgentClaudeCode           = AssetType("agent.claude_code")
-	AssetTypeAthenaQuery               = AssetType("athena.sql")
-	AssetTypeAthenaSeed                = AssetType("athena.seed")
-	AssetTypeAthenaSource              = AssetType("athena.source")
-	AssetTypeAthenaSQLSensor           = AssetType("athena.sensor.query")
-	AssetTypeAthenaTableSensor         = AssetType("athena.sensor.table")
-	AssetTypeBigqueryQuery             = AssetType("bq.sql")
-	AssetTypeBigqueryQuerySensor       = AssetType("bq.sensor.query")
-	AssetTypeBigquerySeed              = AssetType("bq.seed")
-	AssetTypeBigquerySource            = AssetType("bq.source")
-	AssetTypeBigqueryTableSensor       = AssetType("bq.sensor.table")
-	AssetTypeClickHouse                = AssetType("clickhouse.sql")
-	AssetTypeClickHouseQuerySensor     = AssetType("clickhouse.sensor.query")
-	AssetTypeClickHouseSeed            = AssetType("clickhouse.seed")
-	AssetTypeClickHouseSource          = AssetType("clickhouse.source")
-	AssetTypeClickHouseTableSensor     = AssetType("clickhouse.sensor.table")
-	AssetTypeDatabricksQuery           = AssetType("databricks.sql")
-	AssetTypeDatabricksQuerySensor     = AssetType("databricks.sensor.query")
-	AssetTypeDatabricksSeed            = AssetType("databricks.seed")
-	AssetTypeDatabricksSource          = AssetType("databricks.source")
-	AssetTypeDatabricksTableSensor     = AssetType("databricks.sensor.table")
+	YamlTask TaskDefinitionType = "yaml"
+
+	AssetTypeAgentClaudeCode = AssetType("agent.claude_code")
+
+	AssetTypeAthenaQuery = AssetType("athena.sql")
+
+	AssetTypeAthenaSeed = AssetType("athena.seed")
+
+	AssetTypeAthenaSource = AssetType("athena.source")
+
+	AssetTypeAthenaSQLSensor = AssetType("athena.sensor.query")
+
+	AssetTypeAthenaTableSensor = AssetType("athena.sensor.table")
+
+	AssetTypeBigqueryQuery = AssetType("bq.sql")
+
+	AssetTypeBigqueryQuerySensor = AssetType("bq.sensor.query")
+
+	AssetTypeBigquerySeed = AssetType("bq.seed")
+
+	AssetTypeBigquerySource = AssetType("bq.source")
+
+	AssetTypeBigqueryTableSensor = AssetType("bq.sensor.table")
+
+	AssetTypeClickHouse = AssetType("clickhouse.sql")
+
+	AssetTypeClickHouseQuerySensor = AssetType("clickhouse.sensor.query")
+
+	AssetTypeClickHouseSeed = AssetType("clickhouse.seed")
+
+	AssetTypeClickHouseSource = AssetType("clickhouse.source")
+
+	AssetTypeClickHouseTableSensor = AssetType("clickhouse.sensor.table")
+
+	AssetTypeDatabricksQuery = AssetType("databricks.sql")
+
+	AssetTypeDatabricksQuerySensor = AssetType("databricks.sensor.query")
+
+	AssetTypeDatabricksSeed = AssetType("databricks.seed")
+
+	AssetTypeDatabricksSource = AssetType("databricks.source")
+
+	AssetTypeDatabricksTableSensor = AssetType("databricks.sensor.table")
+
 	AssetTypeDataprocServerlessPyspark = AssetType("dataproc_serverless.pyspark")
-	AssetTypeDomo                      = AssetType("domo")
-	AssetTypeDuckDBQuery               = AssetType("duckdb.sql")
-	AssetTypeDuckDBQuerySensor         = AssetType("duckdb.sensor.query")
-	AssetTypeDuckDBSeed                = AssetType("duckdb.seed")
-	AssetTypeDuckDBSource              = AssetType("duckdb.source")
-	AssetTypeDynamoDB                  = AssetType("dynamodb")
-	AssetTypeElasticsearch             = AssetType("elasticsearch")
-	AssetTypeEmpty                     = AssetType("empty")
-	AssetTypeEMRServerlessPyspark      = AssetType("emr_serverless.pyspark")
-	AssetTypeEMRServerlessSpark        = AssetType("emr_serverless.spark")
-	AssetTypeGoodData                  = AssetType("gooddata")
-	AssetTypeGrafana                   = AssetType("grafana")
-	AssetTypeIngestr                   = AssetType("ingestr")
-	AssetTypeLooker                    = AssetType("looker")
-	AssetTypeLookerStudio              = AssetType("looker_studio")
-	AssetTypeMetabase                  = AssetType("metabase")
-	AssetTypeModeBI                    = AssetType("modebi")
-	AssetTypeMotherduckQuery           = AssetType("motherduck.sql")
-	AssetTypeMsSQLQuery                = AssetType("ms.sql")
-	AssetTypeMsSQLQuerySensor          = AssetType("ms.sensor.query")
-	AssetTypeMsSQLSeed                 = AssetType("ms.seed")
-	AssetTypeMsSQLSource               = AssetType("ms.source")
-	AssetTypeMsSQLTableSensor          = AssetType("ms.sensor.table")
-	AssetTypeFabricQuery               = AssetType("fabric.sql")
-	AssetTypeFabricQuerySensor         = AssetType("fabric.sensor.query")
-	AssetTypeFabricSeed                = AssetType("fabric.seed")
-	AssetTypeFabricTableSensor         = AssetType("fabric.sensor.table")
-	AssetTypeFabricQueryLegacy         = AssetType("fw.sql")
-	AssetTypeFabricQuerySensorLegacy   = AssetType("fw.sensor.query")
-	AssetTypeFabricSeedLegacy          = AssetType("fw.seed")
-	AssetTypeFabricTableSensorLegacy   = AssetType("fw.sensor.table")
-	AssetTypeMySQLQuery                = AssetType("my.sql")
-	AssetTypeMySQLQuerySensor          = AssetType("my.sensor.query")
-	AssetTypeMySQLSeed                 = AssetType("my.seed")
-	AssetTypeMySQLTableSensor          = AssetType("my.sensor.table")
-	AssetTypeOracleQuery               = AssetType("oracle.sql")
-	AssetTypeOracleSource              = AssetType("oracle.source")
-	AssetTypePostgresQuery             = AssetType("pg.sql")
-	AssetTypePostgresQuerySensor       = AssetType("pg.sensor.query")
-	AssetTypePostgresSeed              = AssetType("pg.seed")
-	AssetTypePostgresSource            = AssetType("pg.source")
-	AssetTypePostgresTableSensor       = AssetType("pg.sensor.table")
-	AssetTypePowerBI                   = AssetType("powerbi")
-	AssetTypePython                    = AssetType("python")
-	AssetTypeQlikSense                 = AssetType("qliksense")
-	AssetTypeQlikView                  = AssetType("qlikview")
-	AssetTypeQuicksight                = AssetType("quicksight")
-	AssetTypeQuicksightDashboard       = AssetType("quicksight.dashboard")
-	AssetTypeQuicksightDataset         = AssetType("quicksight.dataset")
-	AssetTypeR                         = AssetType("r")
-	AssetTypeRedash                    = AssetType("redash")
-	AssetTypeRedshiftQuery             = AssetType("rs.sql")
-	AssetTypeRedshiftQuerySensor       = AssetType("rs.sensor.query")
-	AssetTypeRedshiftSeed              = AssetType("rs.seed")
-	AssetTypeRedshiftSource            = AssetType("rs.source")
-	AssetTypeRedshiftTableSensor       = AssetType("rs.sensor.table")
-	AssetTypeS3KeySensor               = AssetType("s3.sensor.key_sensor")
-	AssetTypeSisense                   = AssetType("sisense")
-	AssetTypeSnowflakeQuery            = AssetType("sf.sql")
-	AssetTypeSnowflakeQuerySensor      = AssetType("sf.sensor.query")
-	AssetTypeSnowflakeSeed             = AssetType("sf.seed")
-	AssetTypeSnowflakeSource           = AssetType("sf.source")
-	AssetTypeSnowflakeTableSensor      = AssetType("sf.sensor.table")
-	AssetTypeSuperset                  = AssetType("superset")
-	AssetTypeSynapseQuery              = AssetType("synapse.sql")
-	AssetTypeSynapseQuerySensor        = AssetType("synapse.sensor.query")
-	AssetTypeSynapseSeed               = AssetType("synapse.seed")
-	AssetTypeSynapseSource             = AssetType("synapse.source")
-	AssetTypeSynapseTableSensor        = AssetType("synapse.sensor.table")
-	AssetTypeTableau                   = AssetType("tableau")
-	AssetTypeTableauDashboard          = AssetType("tableau.dashboard")
-	AssetTypeTableauDatasource         = AssetType("tableau.datasource")
-	AssetTypeTableauWorkbook           = AssetType("tableau.workbook")
-	AssetTypeTableauWorksheet          = AssetType("tableau.worksheet")
-	AssetTypeTrinoQuery                = AssetType("trino.sql")
-	AssetTypeTrinoQuerySensor          = AssetType("trino.sensor.query")
-	AssetTypeVerticaQuery              = AssetType("vertica.sql")
-	AssetTypeVerticaQuerySensor        = AssetType("vertica.sensor.query")
-	AssetTypeVerticaSeed               = AssetType("vertica.seed")
-	AssetTypeVerticaSource             = AssetType("vertica.source")
-	AssetTypeVerticaTableSensor        = AssetType("vertica.sensor.table")
-	RunConfigApplyIntervalModifiers    = RunConfig("apply-interval-modifiers")
-	RunConfigEndDate                   = RunConfig("end-date")
-	RunConfigFullRefresh               = RunConfig("full-refresh")
-	RunConfigQueryAnnotations          = RunConfig("query-annotations")
-	RunConfigRunID                     = RunConfig("run-id")
-	RunConfigStartDate                 = RunConfig("start-date")
-	RunConfigExecutionDate             = RunConfig("execution-date")
+
+	AssetTypeDomo = AssetType("domo")
+
+	AssetTypeDuckDBQuery = AssetType("duckdb.sql")
+
+	AssetTypeDuckDBQuerySensor = AssetType("duckdb.sensor.query")
+
+	AssetTypeDuckDBSeed = AssetType("duckdb.seed")
+
+	AssetTypeDuckDBSource = AssetType("duckdb.source")
+
+	AssetTypeDynamoDB = AssetType("dynamodb")
+
+	AssetTypeElasticsearch = AssetType("elasticsearch")
+
+	AssetTypeEmpty = AssetType("empty")
+
+	AssetTypeEMRServerlessPyspark = AssetType("emr_serverless.pyspark")
+
+	AssetTypeEMRServerlessSpark = AssetType("emr_serverless.spark")
+
+	AssetTypeGoodData = AssetType("gooddata")
+
+	AssetTypeGrafana = AssetType("grafana")
+
+	AssetTypeIngestr = AssetType("ingestr")
+
+	AssetTypeLooker = AssetType("looker")
+
+	AssetTypeLookerStudio = AssetType("looker_studio")
+
+	AssetTypeMetabase = AssetType("metabase")
+
+	AssetTypeModeBI = AssetType("modebi")
+
+	AssetTypeMotherduckQuery = AssetType("motherduck.sql")
+
+	AssetTypeMsSQLQuery = AssetType("ms.sql")
+
+	AssetTypeMsSQLQuerySensor = AssetType("ms.sensor.query")
+
+	AssetTypeMsSQLSeed = AssetType("ms.seed")
+
+	AssetTypeMsSQLSource = AssetType("ms.source")
+
+	AssetTypeMsSQLTableSensor = AssetType("ms.sensor.table")
+
+	AssetTypeFabricQuery = AssetType("fabric.sql")
+
+	AssetTypeFabricQuerySensor = AssetType("fabric.sensor.query")
+
+	AssetTypeFabricSeed = AssetType("fabric.seed")
+
+	AssetTypeFabricTableSensor = AssetType("fabric.sensor.table")
+
+	AssetTypeFabricQueryLegacy = AssetType("fw.sql")
+
+	AssetTypeFabricQuerySensorLegacy = AssetType("fw.sensor.query")
+
+	AssetTypeFabricSeedLegacy = AssetType("fw.seed")
+
+	AssetTypeFabricTableSensorLegacy = AssetType("fw.sensor.table")
+
+	AssetTypeMySQLQuery = AssetType("my.sql")
+
+	AssetTypeMySQLQuerySensor = AssetType("my.sensor.query")
+
+	AssetTypeMySQLSeed = AssetType("my.seed")
+
+	AssetTypeMySQLTableSensor = AssetType("my.sensor.table")
+
+	AssetTypeOracleQuery = AssetType("oracle.sql")
+
+	AssetTypeOracleSource = AssetType("oracle.source")
+
+	AssetTypePostgresQuery = AssetType("pg.sql")
+
+	AssetTypePostgresQuerySensor = AssetType("pg.sensor.query")
+
+	AssetTypePostgresSeed = AssetType("pg.seed")
+
+	AssetTypePostgresSource = AssetType("pg.source")
+
+	AssetTypePostgresTableSensor = AssetType("pg.sensor.table")
+
+	AssetTypePowerBI = AssetType("powerbi")
+
+	AssetTypePython = AssetType("python")
+
+	AssetTypeQlikSense = AssetType("qliksense")
+
+	AssetTypeQlikView = AssetType("qlikview")
+
+	AssetTypeQuicksight = AssetType("quicksight")
+
+	AssetTypeQuicksightDashboard = AssetType("quicksight.dashboard")
+
+	AssetTypeQuicksightDataset = AssetType("quicksight.dataset")
+
+	AssetTypeR = AssetType("r")
+
+	AssetTypeRedash = AssetType("redash")
+
+	AssetTypeRedshiftQuery = AssetType("rs.sql")
+
+	AssetTypeRedshiftQuerySensor = AssetType("rs.sensor.query")
+
+	AssetTypeRedshiftSeed = AssetType("rs.seed")
+
+	AssetTypeRedshiftSource = AssetType("rs.source")
+
+	AssetTypeRedshiftTableSensor = AssetType("rs.sensor.table")
+
+	AssetTypeS3KeySensor = AssetType("s3.sensor.key_sensor")
+
+	AssetTypeSisense = AssetType("sisense")
+
+	AssetTypeSnowflakeQuery = AssetType("sf.sql")
+
+	AssetTypeSnowflakeQuerySensor = AssetType("sf.sensor.query")
+
+	AssetTypeSnowflakeSeed = AssetType("sf.seed")
+
+	AssetTypeSnowflakeSource = AssetType("sf.source")
+
+	AssetTypeSnowflakeTableSensor = AssetType("sf.sensor.table")
+
+	AssetTypeSuperset = AssetType("superset")
+
+	AssetTypeSynapseQuery = AssetType("synapse.sql")
+
+	AssetTypeSynapseQuerySensor = AssetType("synapse.sensor.query")
+
+	AssetTypeSynapseSeed = AssetType("synapse.seed")
+
+	AssetTypeSynapseSource = AssetType("synapse.source")
+
+	AssetTypeSynapseTableSensor = AssetType("synapse.sensor.table")
+
+	AssetTypeTableau = AssetType("tableau")
+
+	AssetTypeTableauDashboard = AssetType("tableau.dashboard")
+
+	AssetTypeTableauDatasource = AssetType("tableau.datasource")
+
+	AssetTypeTableauWorkbook = AssetType("tableau.workbook")
+
+	AssetTypeTableauWorksheet = AssetType("tableau.worksheet")
+
+	AssetTypeTrinoQuery = AssetType("trino.sql")
+
+	AssetTypeTrinoQuerySensor = AssetType("trino.sensor.query")
+
+	AssetTypeVerticaQuery = AssetType("vertica.sql")
+
+	AssetTypeVerticaQuerySensor = AssetType("vertica.sensor.query")
+
+	AssetTypeVerticaSeed = AssetType("vertica.seed")
+
+	AssetTypeVerticaSource = AssetType("vertica.source")
+
+	AssetTypeVerticaTableSensor = AssetType("vertica.sensor.table")
+
+	RunConfigApplyIntervalModifiers = RunConfig("apply-interval-modifiers")
+
+	RunConfigEndDate = RunConfig("end-date")
+
+	RunConfigFullRefresh = RunConfig("full-refresh")
+
+	RunConfigQueryAnnotations = RunConfig("query-annotations")
+
+	RunConfigRunID = RunConfig("run-id")
+
+	RunConfigStartDate = RunConfig("start-date")
+
+	RunConfigExecutionDate = RunConfig("execution-date")
 )
 
 var defaultMapping = map[string]string{
-	"aws":                   "aws-default",
-	"athena":                "athena-default",
-	"gcp":                   "gcp-default",
+
+	"aws": "aws-default",
+
+	"athena": "athena-default",
+
+	"gcp": "gcp-default",
+
 	"google_cloud_platform": "gcp-default",
-	"snowflake":             "snowflake-default",
-	"postgres":              "postgres-default",
-	"redshift":              "redshift-default",
-	"mssql":                 "mssql-default",
-	"databricks":            "databricks-default",
-	"synapse":               "synapse-default",
-	"fabric":                "fabric-default",
-	"mongo":                 "mongo-default",
-	"mysql":                 "mysql-default",
-	"notion":                "notion-default",
-	"hana":                  "hana-default",
-	"shopify":               "shopify-default",
-	"gorgias":               "gorgias-default",
-	"facebookads":           "facebookads-default",
-	"klaviyo":               "klaviyo-default",
-	"adjust":                "adjust-default",
-	"stripe":                "stripe-default",
-	"appsflyer":             "appsflyer-default",
-	"kafka":                 "kafka-default",
-	"duckdb":                "duckdb-default",
-	"clickhouse":            "clickhouse-default",
-	"hubspot":               "hubspot-default",
-	"google_sheets":         "google-sheets-default",
-	"chess":                 "chess-default",
-	"airtable":              "airtable-default",
-	"zendesk":               "zendesk-default",
-	"s3":                    "s3-default",
-	"slack":                 "slack-default",
-	"asana":                 "asana-default",
-	"dynamodb":              "dynamodb-default",
-	"googleads":             "googleads-default",
-	"tiktokads":             "tiktokads-default",
-	"appstore":              "appstore-default",
-	"gcs":                   "gcs-default",
-	"emr_serverless":        "emr_serverless-default",
-	"dataproc_serverless":   "dataproc_serverless-default",
-	"trino":                 "trino-default",
-	"oracle":                "oracle-default",
-	"googleanalytics":       "googleanalytics-default",
-	"applovin":              "applovin-default",
-	"salesforce":            "salesforce-default",
-	"solidgate":             "solidgate-default",
-	"smartsheet":            "smartsheet-default",
-	"sftp":                  "sftp-default",
-	"motherduck":            "motherduck-default",
-	"elasticsearch":         "elasticsearch-default",
-	"vertica":               "vertica-default",
+
+	"snowflake": "snowflake-default",
+
+	"postgres": "postgres-default",
+
+	"redshift": "redshift-default",
+
+	"mssql": "mssql-default",
+
+	"databricks": "databricks-default",
+
+	"synapse": "synapse-default",
+
+	"fabric": "fabric-default",
+
+	"mongo": "mongo-default",
+
+	"mysql": "mysql-default",
+
+	"notion": "notion-default",
+
+	"hana": "hana-default",
+
+	"shopify": "shopify-default",
+
+	"gorgias": "gorgias-default",
+
+	"facebookads": "facebookads-default",
+
+	"klaviyo": "klaviyo-default",
+
+	"adjust": "adjust-default",
+
+	"stripe": "stripe-default",
+
+	"appsflyer": "appsflyer-default",
+
+	"kafka": "kafka-default",
+
+	"duckdb": "duckdb-default",
+
+	"clickhouse": "clickhouse-default",
+
+	"hubspot": "hubspot-default",
+
+	"google_sheets": "google-sheets-default",
+
+	"chess": "chess-default",
+
+	"airtable": "airtable-default",
+
+	"zendesk": "zendesk-default",
+
+	"s3": "s3-default",
+
+	"slack": "slack-default",
+
+	"asana": "asana-default",
+
+	"dynamodb": "dynamodb-default",
+
+	"googleads": "googleads-default",
+
+	"tiktokads": "tiktokads-default",
+
+	"appstore": "appstore-default",
+
+	"gcs": "gcs-default",
+
+	"emr_serverless": "emr_serverless-default",
+
+	"dataproc_serverless": "dataproc_serverless-default",
+
+	"trino": "trino-default",
+
+	"oracle": "oracle-default",
+
+	"googleanalytics": "googleanalytics-default",
+
+	"applovin": "applovin-default",
+
+	"salesforce": "salesforce-default",
+
+	"solidgate": "solidgate-default",
+
+	"smartsheet": "smartsheet-default",
+
+	"sftp": "sftp-default",
+
+	"motherduck": "motherduck-default",
+
+	"elasticsearch": "elasticsearch-default",
+
+	"vertica": "vertica-default",
 }
 
 var SupportedFileSuffixes = []string{"asset.yml", "asset.yaml", ".sql", ".py", ".r", "task.yml", "task.yaml"}
 
 type (
-	Schedule           string
+	Schedule string
+
 	TaskDefinitionType string
 )
 
 type ExecutableFile struct {
-	Name    string `json:"name"`
-	Path    string `json:"path"`
+	Name string `json:"name"`
+
+	Path string `json:"path"`
+
 	Content string `json:"content"`
 }
 
 type TaskDefinitionFile struct {
-	Name string             `json:"name"`
-	Path string             `json:"path"`
+	Name string `json:"name"`
+
+	Path string `json:"path"`
+
 	Type TaskDefinitionType `json:"type"`
 }
 
 type DefinitionFile struct {
 	Name string `json:"name"`
+
 	Path string `json:"path"`
 }
 
@@ -223,13 +390,17 @@ type TaskSchedule struct {
 }
 
 type Notifications struct {
-	Slack   []SlackNotification   `yaml:"slack" json:"slack" mapstructure:"slack"`
+	Slack []SlackNotification `yaml:"slack" json:"slack" mapstructure:"slack"`
+
 	MSTeams []MSTeamsNotification `yaml:"ms_teams" json:"ms_teams" mapstructure:"ms_teams"`
+
 	Discord []DiscordNotification `yaml:"discord" json:"discord" mapstructure:"discord"`
+
 	Webhook []WebhookNotification `yaml:"webhook" json:"webhook" mapstructure:"webhook"`
 }
 
 type DefaultTrueBool struct { //nolint:recvcheck
+
 	Value *bool
 }
 
@@ -239,11 +410,13 @@ func (b *DefaultTrueBool) UnmarshalJSON(data []byte) error {
 	}
 
 	var v bool
+
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
 	b.Value = &v
+
 	return nil
 }
 
@@ -261,10 +434,13 @@ func (b DefaultTrueBool) MarshalJSON() ([]byte, error) {
 
 func (b *DefaultTrueBool) UnmarshalYAML(value *yaml.Node) error {
 	var multi *bool
+
 	err := value.Decode(&multi)
+
 	if err != nil {
 		return err
 	}
+
 	b.Value = multi
 
 	return nil
@@ -288,49 +464,61 @@ func (b DefaultTrueBool) MarshalYAML() (interface{}, error) {
 
 type NotificationCommon struct {
 	Success DefaultTrueBool `yaml:"success" json:"success" mapstructure:"success"`
+
 	Failure DefaultTrueBool `yaml:"failure" json:"failure" mapstructure:"failure"`
 }
 
 type SlackNotification struct {
-	Channel            string `json:"channel"`
+	Channel string `json:"channel"`
+
 	NotificationCommon `yaml:",inline" json:",inline" mapstructure:",inline"`
 }
 
 type MSTeamsNotification struct {
-	Connection         string `yaml:"connection" json:"connection" mapstructure:"connection"`
+	Connection string `yaml:"connection" json:"connection" mapstructure:"connection"`
+
 	NotificationCommon `yaml:",inline" json:",inline" mapstructure:",inline"`
 }
 
 type DiscordNotification struct {
-	Connection         string `yaml:"connection" json:"connection" mapstructure:"connection"`
+	Connection string `yaml:"connection" json:"connection" mapstructure:"connection"`
+
 	NotificationCommon `yaml:",inline" json:",inline" mapstructure:",inline"`
 }
 
 type WebhookNotification struct {
-	Connection         string `yaml:"connection" json:"connection" mapstructure:"connection"`
+	Connection string `yaml:"connection" json:"connection" mapstructure:"connection"`
+
 	NotificationCommon `yaml:",inline" json:",inline" mapstructure:",inline"`
 }
 
 func (n Notifications) MarshalJSON() ([]byte, error) {
 	slack := make([]SlackNotification, 0, len(n.Slack))
+
 	MSTeams := make([]MSTeamsNotification, 0, len(n.MSTeams))
+
 	discord := make([]DiscordNotification, 0, len(n.Discord))
+
 	webhook := make([]WebhookNotification, 0, len(n.Webhook))
+
 	for _, s := range n.Slack {
 		if !reflect.ValueOf(s).IsZero() {
 			slack = append(slack, s)
 		}
 	}
+
 	for _, s := range n.MSTeams {
 		if !reflect.ValueOf(s).IsZero() {
 			MSTeams = append(MSTeams, s)
 		}
 	}
+
 	for _, s := range n.Discord {
 		if !reflect.ValueOf(s).IsZero() {
 			discord = append(discord, s)
 		}
 	}
+
 	for _, s := range n.Webhook {
 		if !reflect.ValueOf(s).IsZero() {
 			webhook = append(webhook, s)
@@ -338,14 +526,21 @@ func (n Notifications) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(struct {
-		Slack   []SlackNotification   `json:"slack"`
+		Slack []SlackNotification `json:"slack"`
+
 		MSTeams []MSTeamsNotification `json:"ms_teams"`
+
 		Discord []DiscordNotification `json:"discord"`
+
 		Webhook []WebhookNotification `json:"webhook"`
 	}{
-		Slack:   slack,
+
+		Slack: slack,
+
 		MSTeams: MSTeams,
+
 		Discord: discord,
+
 		Webhook: webhook,
 	})
 }
@@ -355,49 +550,77 @@ type (
 )
 
 const (
-	MaterializationTypeNone  MaterializationType = ""
-	MaterializationTypeView  MaterializationType = "view"
+	MaterializationTypeNone MaterializationType = ""
+
+	MaterializationTypeView MaterializationType = "view"
+
 	MaterializationTypeTable MaterializationType = "table"
 )
 
 type (
-	MaterializationStrategy        string
+	MaterializationStrategy string
+
 	MaterializationTimeGranularity string
 )
 
 const (
-	MaterializationStrategyNone             MaterializationStrategy        = ""
-	MaterializationStrategyCreateReplace    MaterializationStrategy        = "create+replace"
-	MaterializationStrategyDeleteInsert     MaterializationStrategy        = "delete+insert"
-	MaterializationStrategyTruncateInsert   MaterializationStrategy        = "truncate+insert"
-	MaterializationStrategyAppend           MaterializationStrategy        = "append"
-	MaterializationStrategyMerge            MaterializationStrategy        = "merge"
-	MaterializationStrategyTimeInterval     MaterializationStrategy        = "time_interval"
-	MaterializationStrategyDDL              MaterializationStrategy        = "ddl"
-	MaterializationTimeGranularityDate      MaterializationTimeGranularity = "date"
+	MaterializationStrategyNone MaterializationStrategy = ""
+
+	MaterializationStrategyCreateReplace MaterializationStrategy = "create+replace"
+
+	MaterializationStrategyDeleteInsert MaterializationStrategy = "delete+insert"
+
+	MaterializationStrategyTruncateInsert MaterializationStrategy = "truncate+insert"
+
+	MaterializationStrategyAppend MaterializationStrategy = "append"
+
+	MaterializationStrategyMerge MaterializationStrategy = "merge"
+
+	MaterializationStrategyTimeInterval MaterializationStrategy = "time_interval"
+
+	MaterializationStrategyDDL MaterializationStrategy = "ddl"
+
+	MaterializationTimeGranularityDate MaterializationTimeGranularity = "date"
+
 	MaterializationTimeGranularityTimestamp MaterializationTimeGranularity = "timestamp"
-	MaterializationStrategySCD2ByTime       MaterializationStrategy        = "scd2_by_time"
-	MaterializationStrategySCD2ByColumn     MaterializationStrategy        = "scd2_by_column"
+
+	MaterializationStrategySCD2ByTime MaterializationStrategy = "scd2_by_time"
+
+	MaterializationStrategySCD2ByColumn MaterializationStrategy = "scd2_by_column"
 )
 
 var AllAvailableMaterializationStrategies = []MaterializationStrategy{
+
 	MaterializationStrategyCreateReplace,
+
 	MaterializationStrategyDeleteInsert,
+
 	MaterializationStrategyTruncateInsert,
+
 	MaterializationStrategyAppend,
+
 	MaterializationStrategyMerge,
+
 	MaterializationStrategyTimeInterval,
+
 	MaterializationStrategyDDL,
+
 	MaterializationStrategySCD2ByTime,
+
 	MaterializationStrategySCD2ByColumn,
 }
 
 type Materialization struct {
-	Type            MaterializationType            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
-	Strategy        MaterializationStrategy        `json:"strategy" yaml:"strategy,omitempty" mapstructure:"strategy"`
-	PartitionBy     string                         `json:"partition_by" yaml:"partition_by,omitempty" mapstructure:"partition_by"`
-	ClusterBy       []string                       `json:"cluster_by" yaml:"cluster_by,omitempty" mapstructure:"cluster_by"`
-	IncrementalKey  string                         `json:"incremental_key" yaml:"incremental_key,omitempty" mapstructure:"incremental_key"`
+	Type MaterializationType `json:"type" yaml:"type,omitempty" mapstructure:"type"`
+
+	Strategy MaterializationStrategy `json:"strategy" yaml:"strategy,omitempty" mapstructure:"strategy"`
+
+	PartitionBy string `json:"partition_by" yaml:"partition_by,omitempty" mapstructure:"partition_by"`
+
+	ClusterBy []string `json:"cluster_by" yaml:"cluster_by,omitempty" mapstructure:"cluster_by"`
+
+	IncrementalKey string `json:"incremental_key" yaml:"incremental_key,omitempty" mapstructure:"incremental_key"`
+
 	TimeGranularity MaterializationTimeGranularity `json:"time_granularity" yaml:"time_granularity,omitempty" mapstructure:"time_granularity"`
 }
 
@@ -407,20 +630,27 @@ func (m Materialization) MarshalJSON() ([]byte, error) {
 	}
 
 	type Alias Materialization
+
 	return json.Marshal(&struct {
 		*Alias
 	}{
+
 		Alias: (*Alias)(&m),
 	})
 }
 
 type ColumnCheckValue struct {
-	IntArray    *[]int    `json:"int_array"`
-	Int         *int      `json:"int"`
-	Float       *float64  `json:"float"`
+	IntArray *[]int `json:"int_array"`
+
+	Int *int `json:"int"`
+
+	Float *float64 `json:"float"`
+
 	StringArray *[]string `json:"string_array"`
-	String      *string   `json:"string"`
-	Bool        *bool     `json:"bool"`
+
+	String *string `json:"string"`
+
+	Bool *bool `json:"bool"`
 }
 
 func (ccv *ColumnCheckValue) MarshalJSON() ([]byte, error) {
@@ -429,18 +659,23 @@ func (ccv *ColumnCheckValue) MarshalJSON() ([]byte, error) {
 	if actual.IntArray != nil {
 		return json.Marshal(actual.IntArray)
 	}
+
 	if actual.Int != nil {
 		return json.Marshal(actual.Int)
 	}
+
 	if actual.Float != nil {
 		return json.Marshal(actual.Float)
 	}
+
 	if actual.StringArray != nil {
 		return json.Marshal(actual.StringArray)
 	}
+
 	if actual.String != nil {
 		return json.Marshal(actual.String)
 	}
+
 	if actual.Bool != nil {
 		return json.Marshal(actual.Bool)
 	}
@@ -452,26 +687,33 @@ func (ccv ColumnCheckValue) MarshalYAML() (interface{}, error) {
 	if ccv.IntArray != nil {
 		return ccv.IntArray, nil
 	}
+
 	if ccv.Int != nil {
 		return ccv.Int, nil
 	}
+
 	if ccv.Float != nil {
 		return ccv.Float, nil
 	}
+
 	if ccv.StringArray != nil {
 		return ccv.StringArray, nil
 	}
+
 	if ccv.String != nil {
 		return ccv.String, nil
 	}
+
 	if ccv.Bool != nil {
 		return ccv.Bool, nil
 	}
+
 	return nil, nil
 }
 
 func (ccv *ColumnCheckValue) UnmarshalJSON(data []byte) error {
 	var temp interface{}
+
 	if err := json.Unmarshal(data, &temp); err != nil {
 		return err
 	}
@@ -484,32 +726,45 @@ func (ccv *ColumnCheckValue) UnmarshalJSON(data []byte) error {
 	case []interface{}:
 
 		var intSlice []int
+
 		if err := json.Unmarshal(data, &intSlice); err == nil {
 			ccv.IntArray = &intSlice
+
 			return nil
 		}
 
 		var stringSlice []string
+
 		if err := json.Unmarshal(data, &stringSlice); err == nil {
 			ccv.StringArray = &stringSlice
+
 			return nil
 		}
 
 		return fmt.Errorf("unable to parse JSON structure %v into ColumnCheckValue", v)
+
 	case float64:
 
 		if v == float64(int(v)) {
 			i := int(v)
+
 			ccv.Int = &i
+
 			return nil
 		}
 
 		ccv.Float = &v
+
 	case string:
+
 		ccv.String = &v
+
 	case bool:
+
 		ccv.Bool = &v
+
 	default:
+
 		return fmt.Errorf("unexpected type %T", v)
 	}
 
@@ -519,23 +774,30 @@ func (ccv *ColumnCheckValue) UnmarshalJSON(data []byte) error {
 func (ccv *ColumnCheckValue) ToString() string {
 	if ccv.IntArray != nil {
 		ints := make([]string, 0, len(*ccv.IntArray))
+
 		for _, i := range *ccv.IntArray {
 			ints = append(ints, strconv.Itoa(i))
 		}
+
 		return fmt.Sprintf("[%s]", strings.Join(ints, ", "))
 	}
+
 	if ccv.Int != nil {
 		return strconv.Itoa(*ccv.Int)
 	}
+
 	if ccv.Float != nil {
 		return fmt.Sprintf("%f", *ccv.Float)
 	}
+
 	if ccv.StringArray != nil {
 		return strings.Join(*ccv.StringArray, ", ")
 	}
+
 	if ccv.String != nil {
 		return *ccv.String
 	}
+
 	if ccv.Bool != nil {
 		return strconv.FormatBool(*ccv.Bool)
 	}
@@ -544,50 +806,76 @@ func (ccv *ColumnCheckValue) ToString() string {
 }
 
 type ColumnCheck struct {
-	ID            string           `json:"id" yaml:"-" mapstructure:"-"`
-	Name          string           `json:"name" yaml:"name,omitempty" mapstructure:"name"`
-	Value         ColumnCheckValue `json:"value" yaml:"value,omitempty" mapstructure:"value"`
-	Blocking      DefaultTrueBool  `json:"blocking" yaml:"blocking,omitempty" mapstructure:"blocking"`
-	Description   string           `json:"description" yaml:"description,omitempty" mapstructure:"description"`
-	Notifications *Notifications   `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+	ID string `json:"id" yaml:"-" mapstructure:"-"`
+
+	Name string `json:"name" yaml:"name,omitempty" mapstructure:"name"`
+
+	Value ColumnCheckValue `json:"value" yaml:"value,omitempty" mapstructure:"value"`
+
+	Blocking DefaultTrueBool `json:"blocking" yaml:"blocking,omitempty" mapstructure:"blocking"`
+
+	Description string `json:"description" yaml:"description,omitempty" mapstructure:"description"`
+
+	Notifications *Notifications `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
 }
 
 func NewColumnCheck(assetName, columnName, name string, value ColumnCheckValue, blocking *bool, description string) ColumnCheck {
 	return ColumnCheck{
-		ID:          hash(fmt.Sprintf("%s-%s-%s", assetName, columnName, name)),
-		Name:        strings.TrimSpace(name),
-		Value:       value,
-		Blocking:    DefaultTrueBool{Value: blocking},
+
+		ID: hash(fmt.Sprintf("%s-%s-%s", assetName, columnName, name)),
+
+		Name: strings.TrimSpace(name),
+
+		Value: value,
+
+		Blocking: DefaultTrueBool{Value: blocking},
+
 		Description: description,
 	}
 }
 
 type EntityAttribute struct {
-	Entity    string `json:"entity"`
+	Entity string `json:"entity"`
+
 	Attribute string `json:"attribute"`
 }
 
 type UpstreamColumn struct {
 	Column string `json:"column" yaml:"column,omitempty" mapstructure:"column"`
-	Table  string `json:"table" yaml:"table,omitempty" mapstructure:"table"`
+
+	Table string `json:"table" yaml:"table,omitempty" mapstructure:"table"`
 }
 
 type Column struct {
-	EntityAttribute *EntityAttribute  `json:"entity_attribute" yaml:"-" mapstructure:"-"`
-	Name            string            `json:"name" yaml:"name,omitempty" mapstructure:"name"`
-	Type            string            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
-	Description     string            `json:"description" yaml:"description,omitempty" mapstructure:"description"`
-	Tags            EmptyStringArray  `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
-	PrimaryKey      bool              `json:"primary_key" yaml:"primary_key,omitempty" mapstructure:"primary_key"`
-	UpdateOnMerge   bool              `json:"update_on_merge" yaml:"update_on_merge,omitempty" mapstructure:"update_on_merge"`
-	MergeSQL        string            `json:"merge_sql" yaml:"merge_sql,omitempty" mapstructure:"merge_sql"`
-	Nullable        DefaultTrueBool   `json:"nullable" yaml:"nullable,omitempty" mapstructure:"nullable"`
-	Owner           string            `json:"owner" yaml:"owner,omitempty" mapstructure:"owner"`
-	Domains         EmptyStringArray  `json:"domains" yaml:"domains,omitempty" mapstructure:"domains"`
-	Meta            EmptyStringMap    `json:"meta" yaml:"meta,omitempty" mapstructure:"meta"`
-	Extends         string            `json:"-" yaml:"extends,omitempty" mapstructure:"extends"`
-	Checks          []ColumnCheck     `json:"checks" yaml:"checks,omitempty" mapstructure:"checks"`
-	Upstreams       []*UpstreamColumn `json:"upstreams" yaml:"-" mapstructure:"-"`
+	EntityAttribute *EntityAttribute `json:"entity_attribute" yaml:"-" mapstructure:"-"`
+
+	Name string `json:"name" yaml:"name,omitempty" mapstructure:"name"`
+
+	Type string `json:"type" yaml:"type,omitempty" mapstructure:"type"`
+
+	Description string `json:"description" yaml:"description,omitempty" mapstructure:"description"`
+
+	Tags EmptyStringArray `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
+
+	PrimaryKey bool `json:"primary_key" yaml:"primary_key,omitempty" mapstructure:"primary_key"`
+
+	UpdateOnMerge bool `json:"update_on_merge" yaml:"update_on_merge,omitempty" mapstructure:"update_on_merge"`
+
+	MergeSQL string `json:"merge_sql" yaml:"merge_sql,omitempty" mapstructure:"merge_sql"`
+
+	Nullable DefaultTrueBool `json:"nullable" yaml:"nullable,omitempty" mapstructure:"nullable"`
+
+	Owner string `json:"owner" yaml:"owner,omitempty" mapstructure:"owner"`
+
+	Domains EmptyStringArray `json:"domains" yaml:"domains,omitempty" mapstructure:"domains"`
+
+	Meta EmptyStringMap `json:"meta" yaml:"meta,omitempty" mapstructure:"meta"`
+
+	Extends string `json:"-" yaml:"extends,omitempty" mapstructure:"extends"`
+
+	Checks []ColumnCheck `json:"checks" yaml:"checks,omitempty" mapstructure:"checks"`
+
+	Upstreams []*UpstreamColumn `json:"upstreams" yaml:"-" mapstructure:"-"`
 }
 
 func (c *Column) HasCheck(check string) bool {
@@ -603,107 +891,200 @@ func (c *Column) HasCheck(check string) bool {
 type AssetType string
 
 var AssetTypeConnectionMapping = map[AssetType]string{
-	AssetTypeBigqueryQuery:       "google_cloud_platform",
+
+	AssetTypeBigqueryQuery: "google_cloud_platform",
+
 	AssetTypeBigqueryTableSensor: "google_cloud_platform",
-	AssetTypeBigquerySeed:        "google_cloud_platform",
-	AssetTypeBigquerySource:      "google_cloud_platform",
+
+	AssetTypeBigquerySeed: "google_cloud_platform",
+
+	AssetTypeBigquerySource: "google_cloud_platform",
+
 	AssetTypeBigqueryQuerySensor: "google_cloud_platform",
 
-	AssetTypeSnowflakeQuery:            "snowflake",
-	AssetTypeSnowflakeQuerySensor:      "snowflake",
-	AssetTypeSnowflakeTableSensor:      "snowflake",
-	AssetTypeSnowflakeSeed:             "snowflake",
-	AssetTypeSnowflakeSource:           "snowflake",
-	AssetTypePostgresQuery:             "postgres",
-	AssetTypePostgresSeed:              "postgres",
-	AssetTypePostgresQuerySensor:       "postgres",
-	AssetTypePostgresTableSensor:       "postgres",
-	AssetTypePostgresSource:            "postgres",
-	AssetTypeMySQLQuery:                "mysql",
-	AssetTypeMySQLSeed:                 "mysql",
-	AssetTypeMySQLQuerySensor:          "mysql",
-	AssetTypeMySQLTableSensor:          "mysql",
-	AssetTypeRedshiftQuery:             "redshift",
-	AssetTypeRedshiftSeed:              "redshift",
-	AssetTypeRedshiftQuerySensor:       "redshift",
-	AssetTypeRedshiftSource:            "redshift",
-	AssetTypeRedshiftTableSensor:       "redshift",
-	AssetTypeMsSQLQuery:                "mssql",
-	AssetTypeMsSQLSeed:                 "mssql",
-	AssetTypeMsSQLQuerySensor:          "mssql",
-	AssetTypeMsSQLTableSensor:          "mssql",
-	AssetTypeMsSQLSource:               "mssql",
-	AssetTypeFabricQuery:               "fabric",
-	AssetTypeFabricSeed:                "fabric",
-	AssetTypeFabricQuerySensor:         "fabric",
-	AssetTypeFabricTableSensor:         "fabric",
-	AssetTypeFabricQueryLegacy:         "fabric",
-	AssetTypeFabricSeedLegacy:          "fabric",
-	AssetTypeFabricQuerySensorLegacy:   "fabric",
-	AssetTypeFabricTableSensorLegacy:   "fabric",
-	AssetTypeDatabricksQuery:           "databricks",
-	AssetTypeDatabricksSeed:            "databricks",
-	AssetTypeDatabricksQuerySensor:     "databricks",
-	AssetTypeDatabricksSource:          "databricks",
-	AssetTypeDatabricksTableSensor:     "databricks",
-	AssetTypeSynapseQuery:              "synapse",
-	AssetTypeSynapseSeed:               "synapse",
-	AssetTypeSynapseQuerySensor:        "synapse",
-	AssetTypeSynapseSource:             "synapse",
-	AssetTypeAthenaQuery:               "athena",
-	AssetTypeAthenaSeed:                "athena",
-	AssetTypeAthenaSQLSensor:           "athena",
-	AssetTypeAthenaTableSensor:         "athena",
-	AssetTypeAthenaSource:              "athena",
-	AssetTypeDuckDBQuery:               "duckdb",
-	AssetTypeDuckDBSeed:                "duckdb",
-	AssetTypeDuckDBQuerySensor:         "duckdb",
-	AssetTypeDuckDBSource:              "duckdb",
-	AssetTypeMotherduckQuery:           "motherduck",
-	AssetTypeClickHouse:                "clickhouse",
-	AssetTypeClickHouseSeed:            "clickhouse",
-	AssetTypeClickHouseQuerySensor:     "clickhouse",
-	AssetTypeClickHouseTableSensor:     "clickhouse",
-	AssetTypeClickHouseSource:          "clickhouse",
-	AssetTypeEMRServerlessSpark:        "emr_serverless",
-	AssetTypeEMRServerlessPyspark:      "emr_serverless",
+	AssetTypeSnowflakeQuery: "snowflake",
+
+	AssetTypeSnowflakeQuerySensor: "snowflake",
+
+	AssetTypeSnowflakeTableSensor: "snowflake",
+
+	AssetTypeSnowflakeSeed: "snowflake",
+
+	AssetTypeSnowflakeSource: "snowflake",
+
+	AssetTypePostgresQuery: "postgres",
+
+	AssetTypePostgresSeed: "postgres",
+
+	AssetTypePostgresQuerySensor: "postgres",
+
+	AssetTypePostgresTableSensor: "postgres",
+
+	AssetTypePostgresSource: "postgres",
+
+	AssetTypeMySQLQuery: "mysql",
+
+	AssetTypeMySQLSeed: "mysql",
+
+	AssetTypeMySQLQuerySensor: "mysql",
+
+	AssetTypeMySQLTableSensor: "mysql",
+
+	AssetTypeRedshiftQuery: "redshift",
+
+	AssetTypeRedshiftSeed: "redshift",
+
+	AssetTypeRedshiftQuerySensor: "redshift",
+
+	AssetTypeRedshiftSource: "redshift",
+
+	AssetTypeRedshiftTableSensor: "redshift",
+
+	AssetTypeMsSQLQuery: "mssql",
+
+	AssetTypeMsSQLSeed: "mssql",
+
+	AssetTypeMsSQLQuerySensor: "mssql",
+
+	AssetTypeMsSQLTableSensor: "mssql",
+
+	AssetTypeMsSQLSource: "mssql",
+
+	AssetTypeFabricQuery: "fabric",
+
+	AssetTypeFabricSeed: "fabric",
+
+	AssetTypeFabricQuerySensor: "fabric",
+
+	AssetTypeFabricTableSensor: "fabric",
+
+	AssetTypeFabricQueryLegacy: "fabric",
+
+	AssetTypeFabricSeedLegacy: "fabric",
+
+	AssetTypeFabricQuerySensorLegacy: "fabric",
+
+	AssetTypeFabricTableSensorLegacy: "fabric",
+
+	AssetTypeDatabricksQuery: "databricks",
+
+	AssetTypeDatabricksSeed: "databricks",
+
+	AssetTypeDatabricksQuerySensor: "databricks",
+
+	AssetTypeDatabricksSource: "databricks",
+
+	AssetTypeDatabricksTableSensor: "databricks",
+
+	AssetTypeSynapseQuery: "synapse",
+
+	AssetTypeSynapseSeed: "synapse",
+
+	AssetTypeSynapseQuerySensor: "synapse",
+
+	AssetTypeSynapseSource: "synapse",
+
+	AssetTypeAthenaQuery: "athena",
+
+	AssetTypeAthenaSeed: "athena",
+
+	AssetTypeAthenaSQLSensor: "athena",
+
+	AssetTypeAthenaTableSensor: "athena",
+
+	AssetTypeAthenaSource: "athena",
+
+	AssetTypeDuckDBQuery: "duckdb",
+
+	AssetTypeDuckDBSeed: "duckdb",
+
+	AssetTypeDuckDBQuerySensor: "duckdb",
+
+	AssetTypeDuckDBSource: "duckdb",
+
+	AssetTypeMotherduckQuery: "motherduck",
+
+	AssetTypeClickHouse: "clickhouse",
+
+	AssetTypeClickHouseSeed: "clickhouse",
+
+	AssetTypeClickHouseQuerySensor: "clickhouse",
+
+	AssetTypeClickHouseTableSensor: "clickhouse",
+
+	AssetTypeClickHouseSource: "clickhouse",
+
+	AssetTypeEMRServerlessSpark: "emr_serverless",
+
+	AssetTypeEMRServerlessPyspark: "emr_serverless",
+
 	AssetTypeDataprocServerlessPyspark: "dataproc_serverless",
-	AssetTypeTrinoQuery:                "trino",
-	AssetTypeTrinoQuerySensor:          "trino",
-	AssetTypeOracleQuery:               "oracle",
-	AssetTypeOracleSource:              "oracle",
-	AssetTypeS3KeySensor:               "aws",
-	AssetTypeDynamoDB:                  "dynamodb",
-	AssetTypeElasticsearch:             "elasticsearch",
-	AssetTypeVerticaQuery:              "vertica",
-	AssetTypeVerticaSeed:               "vertica",
-	AssetTypeVerticaQuerySensor:        "vertica",
-	AssetTypeVerticaTableSensor:        "vertica",
-	AssetTypeVerticaSource:             "vertica",
-	AssetTypeQuicksightDataset:         "quicksight",
-	AssetTypeQuicksightDashboard:       "quicksight",
+
+	AssetTypeTrinoQuery: "trino",
+
+	AssetTypeTrinoQuerySensor: "trino",
+
+	AssetTypeOracleQuery: "oracle",
+
+	AssetTypeOracleSource: "oracle",
+
+	AssetTypeS3KeySensor: "aws",
+
+	AssetTypeDynamoDB: "dynamodb",
+
+	AssetTypeElasticsearch: "elasticsearch",
+
+	AssetTypeVerticaQuery: "vertica",
+
+	AssetTypeVerticaSeed: "vertica",
+
+	AssetTypeVerticaQuerySensor: "vertica",
+
+	AssetTypeVerticaTableSensor: "vertica",
+
+	AssetTypeVerticaSource: "vertica",
+
+	AssetTypeQuicksightDataset: "quicksight",
+
+	AssetTypeQuicksightDashboard: "quicksight",
 }
 
 var IngestrTypeConnectionMapping = map[string]AssetType{
-	"athena":        AssetTypeAthenaQuery,
-	"bigquery":      AssetTypeBigqueryQuery,
-	"snowflake":     AssetTypeSnowflakeQuery,
-	"postgres":      AssetTypePostgresQuery,
-	"redshift":      AssetTypeRedshiftQuery,
-	"mssql":         AssetTypeMsSQLQuery,
-	"databricks":    AssetTypeDatabricksQuery,
-	"synapse":       AssetTypeSynapseQuery,
-	"duckdb":        AssetTypeDuckDBQuery,
-	"clickhouse":    AssetTypeClickHouse,
-	"oracle":        AssetTypeOracleQuery,
-	"motherduck":    AssetTypeMotherduckQuery,
-	"dynamodb":      AssetTypeDynamoDB,
+
+	"athena": AssetTypeAthenaQuery,
+
+	"bigquery": AssetTypeBigqueryQuery,
+
+	"snowflake": AssetTypeSnowflakeQuery,
+
+	"postgres": AssetTypePostgresQuery,
+
+	"redshift": AssetTypeRedshiftQuery,
+
+	"mssql": AssetTypeMsSQLQuery,
+
+	"databricks": AssetTypeDatabricksQuery,
+
+	"synapse": AssetTypeSynapseQuery,
+
+	"duckdb": AssetTypeDuckDBQuery,
+
+	"clickhouse": AssetTypeClickHouse,
+
+	"oracle": AssetTypeOracleQuery,
+
+	"motherduck": AssetTypeMotherduckQuery,
+
+	"dynamodb": AssetTypeDynamoDB,
+
 	"elasticsearch": AssetTypeElasticsearch,
-	"vertica":       AssetTypeVerticaQuery,
+
+	"vertica": AssetTypeVerticaQuery,
 }
 
 type SecretMapping struct {
-	SecretKey   string `json:"secret_key"`
+	SecretKey string `json:"secret_key"`
+
 	InjectedKey string `json:"injected_key"`
 }
 
@@ -713,51 +1094,74 @@ func (s SecretMapping) MarshalYAML() (interface{}, error) {
 	}
 
 	type Alias struct {
-		Key      string `yaml:"key"`
+		Key string `yaml:"key"`
+
 		InjectAs string `yaml:"inject_as"`
 	}
 
 	return Alias{
-		Key:      s.SecretKey,
+
+		Key: s.SecretKey,
+
 		InjectAs: s.InjectedKey,
 	}, nil
 }
 
 type CustomCheck struct {
-	ID            string          `json:"id" yaml:"-" mapstructure:"-"`
-	Name          string          `json:"name" yaml:"name" mapstructure:"name"`
-	Description   string          `json:"description" yaml:"description,omitempty" mapstructure:"description"`
-	Value         int64           `json:"value" yaml:"value" mapstructure:"value"`
-	Count         *int64          `json:"count,omitempty" yaml:"count,omitempty" mapstructure:"count"`
-	Blocking      DefaultTrueBool `json:"blocking" yaml:"blocking,omitempty" mapstructure:"blocking"`
-	Query         string          `json:"query" yaml:"query" mapstructure:"query"`
-	Notifications *Notifications  `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+	ID string `json:"id" yaml:"-" mapstructure:"-"`
+
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	Description string `json:"description" yaml:"description,omitempty" mapstructure:"description"`
+
+	Value int64 `json:"value" yaml:"value" mapstructure:"value"`
+
+	Count *int64 `json:"count,omitempty" yaml:"count,omitempty" mapstructure:"count"`
+
+	Blocking DefaultTrueBool `json:"blocking" yaml:"blocking,omitempty" mapstructure:"blocking"`
+
+	Query string `json:"query" yaml:"query" mapstructure:"query"`
+
+	Notifications *Notifications `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+
+	SourceLocation *SourceLocation `json:"-" yaml:"-" mapstructure:"-"`
+
+	QueryLocation *SourceLocation `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 type DependsColumn struct {
-	Name  string `json:"name" yaml:"name" mapstructure:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
 	Usage string `json:"usage" yaml:"usage" mapstructure:"usage"`
 }
 
 type Upstream struct {
-	Type     string          `json:"type" yaml:"type" mapstructure:"type"`
-	Value    string          `json:"value" yaml:"value" mapstructure:"value"`
-	Metadata EmptyStringMap  `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata"`
-	Columns  []DependsColumn `json:"columns" yaml:"columns,omitempty" mapstructure:"columns"`
-	Mode     UpstreamMode    `json:"mode" yaml:"mode,omitempty" mapstructure:"mode"`
+	Type string `json:"type" yaml:"type" mapstructure:"type"`
+
+	Value string `json:"value" yaml:"value" mapstructure:"value"`
+
+	Metadata EmptyStringMap `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata"`
+
+	Columns []DependsColumn `json:"columns" yaml:"columns,omitempty" mapstructure:"columns"`
+
+	Mode UpstreamMode `json:"mode" yaml:"mode,omitempty" mapstructure:"mode"`
 }
 
 func (u Upstream) MarshalYAML() (interface{}, error) {
 	isAsset := u.Type == "" || u.Type == "asset"
+
 	if u.Mode == UpstreamModeFull && isAsset {
 		return u.Value, nil
 	}
 
 	val := map[string]any{}
+
 	id := "uri"
+
 	if isAsset {
 		id = "asset"
 	}
+
 	val[id] = u.Value
 
 	if u.Mode == UpstreamModeSymbolic {
@@ -777,6 +1181,7 @@ func (s SnowflakeConfig) MarshalJSON() ([]byte, error) {
 	}
 
 	type Alias SnowflakeConfig
+
 	return json.Marshal(Alias(s))
 }
 
@@ -790,49 +1195,88 @@ func (s AthenaConfig) MarshalJSON() ([]byte, error) {
 	}
 
 	type Alias AthenaConfig
+
 	return json.Marshal(Alias(s))
 }
 
 // Asset is the in-memory representation of one asset within a pipeline. When
-// adding a new exported string-valued field, extend renderAssetStrings in
-// pkg/pipeline/variant.go so variant materialization renders it. Asset bodies
-// (ExecutableFile.Content) are intentionally left for run-time Jinja and are
-// excluded from the visitor — see the allowlist in TestVariantVisitorCoversStringFields.
-type Asset struct { //nolint:recvcheck
-	ID                string             `json:"id" yaml:"-" mapstructure:"-"`
-	URI               string             `json:"uri" yaml:"uri,omitempty" mapstructure:"uri"`
-	Name              string             `json:"name" yaml:"name,omitempty" mapstructure:"name"`
-	Type              AssetType          `json:"type" yaml:"type,omitempty" mapstructure:"type"`
-	Description       string             `json:"description" yaml:"description,omitempty" mapstructure:"description"`
-	StartDate         string             `json:"start_date" yaml:"start_date,omitempty" mapstructure:"start_date"`
-	Connection        string             `json:"connection" yaml:"connection,omitempty" mapstructure:"connection"`
-	Tags              EmptyStringArray   `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
-	Domains           EmptyStringArray   `json:"domains" yaml:"domains,omitempty" mapstructure:"domains"`
-	Meta              EmptyStringMap     `json:"meta" yaml:"meta,omitempty" mapstructure:"meta"`
-	Materialization   Materialization    `json:"materialization" yaml:"materialization,omitempty" mapstructure:"materialization"`
-	Upstreams         []Upstream         `json:"upstreams" yaml:"depends,omitempty" mapstructure:"depends"`
-	Image             string             `json:"image" yaml:"image,omitempty" mapstructure:"image"`
-	Instance          string             `json:"instance" yaml:"instance,omitempty" mapstructure:"instance"`
-	Owner             string             `json:"owner" yaml:"owner,omitempty" mapstructure:"owner"`
-	Tier              int                `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
-	ExecutableFile    ExecutableFile     `json:"executable_file" yaml:"-" mapstructure:"-"`
-	DefinitionFile    TaskDefinitionFile `json:"definition_file" yaml:"-" mapstructure:"-"`
-	Parameters        EmptyStringMap     `json:"parameters" yaml:"parameters,omitempty" mapstructure:"parameters"`
-	Secrets           []SecretMapping    `json:"secrets" yaml:"secrets,omitempty" mapstructure:"secrets"`
-	Extends           []string           `json:"extends" yaml:"extends,omitempty" mapstructure:"extends"`
-	Columns           []Column           `json:"columns" yaml:"columns,omitempty" mapstructure:"columns"`
-	CustomChecks      []CustomCheck      `json:"custom_checks" yaml:"custom_checks,omitempty" mapstructure:"custom_checks"`
-	Hooks             Hooks              `json:"hooks,omitempty" yaml:"hooks,omitempty" mapstructure:"hooks"`
-	Metadata          EmptyStringMap     `json:"metadata" yaml:"metadata,omitempty" mapstructure:"metadata"`
-	Snowflake         SnowflakeConfig    `json:"snowflake" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
-	Athena            AthenaConfig       `json:"athena" yaml:"athena,omitempty" mapstructure:"athena"`
-	IntervalModifiers IntervalModifiers  `json:"interval_modifiers" yaml:"interval_modifiers,omitempty" mapstructure:"interval_modifiers"`
-	RerunCooldown     *int               `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
-	RetriesDelay      *int               `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
-	RefreshRestricted *bool              `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
-	Notifications     *Notifications     `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
 
-	upstream   []*Asset
+// adding a new exported string-valued field, extend renderAssetStrings in
+
+// pkg/pipeline/variant.go so variant materialization renders it. Asset bodies
+
+// (ExecutableFile.Content) are intentionally left for run-time Jinja and are
+
+// excluded from the visitor — see the allowlist in TestVariantVisitorCoversStringFields.
+
+type Asset struct { //nolint:recvcheck
+
+	ID string `json:"id" yaml:"-" mapstructure:"-"`
+
+	URI string `json:"uri" yaml:"uri,omitempty" mapstructure:"uri"`
+
+	Name string `json:"name" yaml:"name,omitempty" mapstructure:"name"`
+
+	Type AssetType `json:"type" yaml:"type,omitempty" mapstructure:"type"`
+
+	Description string `json:"description" yaml:"description,omitempty" mapstructure:"description"`
+
+	StartDate string `json:"start_date" yaml:"start_date,omitempty" mapstructure:"start_date"`
+
+	Connection string `json:"connection" yaml:"connection,omitempty" mapstructure:"connection"`
+
+	Tags EmptyStringArray `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
+
+	Domains EmptyStringArray `json:"domains" yaml:"domains,omitempty" mapstructure:"domains"`
+
+	Meta EmptyStringMap `json:"meta" yaml:"meta,omitempty" mapstructure:"meta"`
+
+	Materialization Materialization `json:"materialization" yaml:"materialization,omitempty" mapstructure:"materialization"`
+
+	Upstreams []Upstream `json:"upstreams" yaml:"depends,omitempty" mapstructure:"depends"`
+
+	Image string `json:"image" yaml:"image,omitempty" mapstructure:"image"`
+
+	Instance string `json:"instance" yaml:"instance,omitempty" mapstructure:"instance"`
+
+	Owner string `json:"owner" yaml:"owner,omitempty" mapstructure:"owner"`
+
+	Tier int `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
+
+	ExecutableFile ExecutableFile `json:"executable_file" yaml:"-" mapstructure:"-"`
+
+	DefinitionFile TaskDefinitionFile `json:"definition_file" yaml:"-" mapstructure:"-"`
+
+	Parameters EmptyStringMap `json:"parameters" yaml:"parameters,omitempty" mapstructure:"parameters"`
+
+	Secrets []SecretMapping `json:"secrets" yaml:"secrets,omitempty" mapstructure:"secrets"`
+
+	Extends []string `json:"extends" yaml:"extends,omitempty" mapstructure:"extends"`
+
+	Columns []Column `json:"columns" yaml:"columns,omitempty" mapstructure:"columns"`
+
+	CustomChecks []CustomCheck `json:"custom_checks" yaml:"custom_checks,omitempty" mapstructure:"custom_checks"`
+
+	Hooks Hooks `json:"hooks,omitempty" yaml:"hooks,omitempty" mapstructure:"hooks"`
+
+	Metadata EmptyStringMap `json:"metadata" yaml:"metadata,omitempty" mapstructure:"metadata"`
+
+	Snowflake SnowflakeConfig `json:"snowflake" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
+
+	Athena AthenaConfig `json:"athena" yaml:"athena,omitempty" mapstructure:"athena"`
+
+	IntervalModifiers IntervalModifiers `json:"interval_modifiers" yaml:"interval_modifiers,omitempty" mapstructure:"interval_modifiers"`
+
+	RerunCooldown *int `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
+
+	RetriesDelay *int `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
+
+	RefreshRestricted *bool `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
+
+	Notifications *Notifications `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+
+	upstream []*Asset
+
 	downstream []*Asset
 }
 
@@ -841,7 +1285,8 @@ type Hook struct {
 }
 
 type Hooks struct {
-	Pre  []Hook `json:"pre,omitempty" yaml:"pre,omitempty" mapstructure:"pre"`
+	Pre []Hook `json:"pre,omitempty" yaml:"pre,omitempty" mapstructure:"pre"`
+
 	Post []Hook `json:"post,omitempty" yaml:"post,omitempty" mapstructure:"post"`
 }
 
@@ -849,17 +1294,25 @@ func (h Hooks) IsZero() bool {
 	return len(h.Pre) == 0 && len(h.Post) == 0
 }
 
-//nolint:recvcheck
-type TimeModifier struct {
-	Months       int    `json:"months" yaml:"months,omitempty" mapstructure:"months"`
-	Days         int    `json:"days" yaml:"days,omitempty" mapstructure:"days"`
-	Hours        int    `json:"hours" yaml:"hours,omitempty" mapstructure:"hours"`
-	Minutes      int    `json:"minutes" yaml:"minutes,omitempty" mapstructure:"minutes"`
-	Seconds      int    `json:"seconds" yaml:"seconds,omitempty" mapstructure:"seconds"`
-	Milliseconds int    `json:"milliseconds" yaml:"milliseconds,omitempty" mapstructure:"milliseconds"`
-	Nanoseconds  int    `json:"nanoseconds" yaml:"nanoseconds,omitempty" mapstructure:"nanoseconds"`
-	CronPeriods  int    `json:"cron_periods" yaml:"cron_periods,omitempty" mapstructure:"cron_periods"`
-	Template     string `json:"template" yaml:"template,omitempty" mapstructure:"template"`
+type TimeModifier struct { //nolint:recvcheck
+
+	Months int `json:"months" yaml:"months,omitempty" mapstructure:"months"`
+
+	Days int `json:"days" yaml:"days,omitempty" mapstructure:"days"`
+
+	Hours int `json:"hours" yaml:"hours,omitempty" mapstructure:"hours"`
+
+	Minutes int `json:"minutes" yaml:"minutes,omitempty" mapstructure:"minutes"`
+
+	Seconds int `json:"seconds" yaml:"seconds,omitempty" mapstructure:"seconds"`
+
+	Milliseconds int `json:"milliseconds" yaml:"milliseconds,omitempty" mapstructure:"milliseconds"`
+
+	Nanoseconds int `json:"nanoseconds" yaml:"nanoseconds,omitempty" mapstructure:"nanoseconds"`
+
+	CronPeriods int `json:"cron_periods" yaml:"cron_periods,omitempty" mapstructure:"cron_periods"`
+
+	Template string `json:"template" yaml:"template,omitempty" mapstructure:"template"`
 }
 
 func (t *TimeModifier) UnmarshalYAML(value *yaml.Node) error {
@@ -868,13 +1321,16 @@ func (t *TimeModifier) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	modifier := value.Value
+
 	if len(modifier) < 2 {
 		return fmt.Errorf("invalid time modifier format: %s", modifier)
 	}
 
 	// Check if it's a Jinja template
+
 	if strings.Contains(modifier, "{{") || strings.Contains(modifier, "{%") {
 		t.Template = modifier
+
 		return nil
 	}
 
@@ -883,19 +1339,26 @@ func (t *TimeModifier) UnmarshalYAML(value *yaml.Node) error {
 
 func (t *TimeModifier) parseTimeModifier(modifier string) error {
 	// Check for two-character suffixes first (ms, ns)
+
 	if len(modifier) >= 3 {
 		twoCharSuffix := modifier[len(modifier)-2:]
+
 		if twoCharSuffix == "ms" || twoCharSuffix == "ns" {
 			numeric := modifier[:len(modifier)-2]
+
 			num, err := strconv.Atoi(numeric)
+
 			if err != nil {
 				return fmt.Errorf("invalid numeric portion %q in interval %q: %w", numeric, modifier, err)
 			}
 
 			switch twoCharSuffix {
 			case "ms":
+
 				t.Milliseconds = num
+
 			case "ns":
+
 				t.Nanoseconds = num
 			}
 
@@ -904,25 +1367,38 @@ func (t *TimeModifier) parseTimeModifier(modifier string) error {
 	}
 
 	suffix := modifier[len(modifier)-1]
+
 	numeric := modifier[:len(modifier)-1]
 
 	num, err := strconv.Atoi(numeric)
+
 	if err != nil {
 		return fmt.Errorf("invalid numeric portion %q in interval %q: %w", numeric, modifier, err)
 	}
 
 	switch suffix {
 	case 'h':
+
 		t.Hours = num
+
 	case 'm':
+
 		t.Minutes = num
+
 	case 's':
+
 		t.Seconds = num
+
 	case 'd':
+
 		t.Days = num
+
 	case 'M':
+
 		t.Months = num
+
 	default:
+
 		return fmt.Errorf("unknown interval suffix %q in %q; must be h, m, s, d, M, ms, or ns", string(suffix), modifier)
 	}
 
@@ -930,6 +1406,7 @@ func (t *TimeModifier) parseTimeModifier(modifier string) error {
 }
 
 // RendererInterface is used to avoid circular dependencies.
+
 type RendererInterface interface {
 	Render(template string) (string, error)
 }
@@ -940,12 +1417,15 @@ func (t TimeModifier) ResolveTemplateToNew(renderer RendererInterface) (TimeModi
 	}
 
 	rendered, err := renderer.Render(t.Template)
+
 	if err != nil {
 		return t, fmt.Errorf("failed to render interval modifier template: %w", err)
 	}
 
 	newModifier := TimeModifier{}
+
 	rendered = strings.TrimSpace(rendered)
+
 	if err := newModifier.parseTimeModifier(rendered); err != nil {
 		return t, fmt.Errorf("failed to parse rendered template result '%s': %w", rendered, err)
 	}
@@ -959,12 +1439,14 @@ func (t TimeModifier) MarshalJSON() ([]byte, error) {
 	}
 
 	type Alias TimeModifier
+
 	return json.Marshal(Alias(t))
 }
 
 type IntervalModifiers struct {
 	Start TimeModifier `json:"start" yaml:"start,omitempty" mapstructure:"start"`
-	End   TimeModifier `json:"end" yaml:"end,omitempty" mapstructure:"end"`
+
+	End TimeModifier `json:"end" yaml:"end,omitempty" mapstructure:"end"`
 }
 
 func (im IntervalModifiers) MarshalJSON() ([]byte, error) {
@@ -973,6 +1455,7 @@ func (im IntervalModifiers) MarshalJSON() ([]byte, error) {
 	}
 
 	type Alias IntervalModifiers
+
 	return json.Marshal(Alias(im))
 }
 
@@ -986,9 +1469,12 @@ func (a *Asset) AddUpstream(asset *Asset) {
 	}
 
 	a.Upstreams = append(a.Upstreams, Upstream{
-		Type:  "asset",
+
+		Type: "asset",
+
 		Value: asset.Name,
-		Mode:  UpstreamModeFull,
+
+		Mode: UpstreamModeFull,
 	})
 }
 
@@ -998,6 +1484,7 @@ func (a *Asset) PrefixSchema(prefix string) {
 	}
 
 	nameParts := strings.Split(a.Name, ".")
+
 	if len(nameParts) == 2 {
 		a.Name = prefix + nameParts[0] + "." + nameParts[1]
 	}
@@ -1014,6 +1501,7 @@ func (a *Asset) PrefixUpstreams(prefix string) {
 		}
 
 		nameParts := strings.Split(u.Value, ".")
+
 		if len(nameParts) == 2 {
 			a.Upstreams[i].Value = prefix + nameParts[0] + "." + nameParts[1]
 		}
@@ -1021,13 +1509,18 @@ func (a *Asset) PrefixUpstreams(prefix string) {
 }
 
 // removeRedundanciesBeforePersisting aims to remove unnecessary configuration from the asset.
+
 // This is particularly useful when we save a formatted version of the asset itself.
+
 func (a *Asset) removeRedundanciesBeforePersisting() {
 	a.clearDuplicateUpstreams()
+
 	a.clearDuplicateTags()
+
 	a.removeExtraSpacesAtLineEndingsInTextContent()
 
 	// python assets don't require a type anymore
+
 	if a.Type == AssetTypePython && strings.HasSuffix(a.ExecutableFile.Path, ".py") {
 		a.Type = ""
 	}
@@ -1039,13 +1532,18 @@ func deduplicateTags(tags EmptyStringArray) EmptyStringArray {
 	}
 
 	seen := make(map[string]bool, len(tags))
+
 	unique := make(EmptyStringArray, 0, len(tags))
+
 	for _, tag := range tags {
 		lower := strings.ToLower(tag)
+
 		if seen[lower] {
 			continue
 		}
+
 		seen[lower] = true
+
 		unique = append(unique, tag)
 	}
 
@@ -1054,29 +1552,37 @@ func deduplicateTags(tags EmptyStringArray) EmptyStringArray {
 
 func (a *Asset) clearDuplicateTags() {
 	a.Tags = deduplicateTags(a.Tags)
+
 	for i := range a.Columns {
 		a.Columns[i].Tags = deduplicateTags(a.Columns[i].Tags)
 	}
 }
 
 // clearDuplicateUpstreams removes duplicate upstream dependencies from the asset.
+
 func (a *Asset) clearDuplicateUpstreams() {
 	if a.Upstreams == nil {
 		return
 	}
 
 	seenUpstreams := make(map[string]bool, len(a.Upstreams))
+
 	uniqueUpstreams := make([]*Upstream, 0, len(a.Upstreams))
+
 	for _, u := range a.Upstreams {
 		key := fmt.Sprintf("%s-%s", u.Type, u.Value)
+
 		if _, ok := seenUpstreams[key]; ok {
 			continue
 		}
+
 		seenUpstreams[key] = true
+
 		uniqueUpstreams = append(uniqueUpstreams, &u)
 	}
 
 	a.Upstreams = make([]Upstream, len(uniqueUpstreams))
+
 	for i, val := range uniqueUpstreams {
 		a.Upstreams[i] = *val
 	}
@@ -1084,10 +1590,12 @@ func (a *Asset) clearDuplicateUpstreams() {
 
 func ClearSpacesAtLineEndings(content string) string {
 	lines := strings.Split(content, "\n")
+
 	for i, l := range lines {
 		for strings.HasSuffix(l, " ") {
 			l = strings.TrimSuffix(l, " ")
 		}
+
 		lines[i] = l
 	}
 
@@ -1095,16 +1603,27 @@ func ClearSpacesAtLineEndings(content string) string {
 }
 
 // removeExtraSpacesAtLineEndingsInTextContent clears text content from various strings that might be multi-line.
+
 //
+
 // You might be thinking "why the hell would anyone want to do that?", but hear me out.
+
 //
+
 // Basically, when marshalling a string to YAML, the go-yaml library will have two ways of representing strings:
+
 //   - if the string contains no lines that end with a space, it'll convert them to multi-line yaml, which is good.
+
 //   - however, if there's a space at the end of any line within that multi-line string, then the lib will instead convert
+
 //     the content to be a single-line string with escaped "\n" characters, which breaks all the existing multi-line documentation.
+
 //
+
 // This was the only solution I could think of to not break multi-line strings, happy to hear better ideas that would make the existing tests pass.
+
 // I am also open to performance improvements here, as I think this is a suboptimal implementation.
+
 func (a *Asset) removeExtraSpacesAtLineEndingsInTextContent() {
 	if a.Description != "" && strings.Contains(a.Description, "\n") {
 		a.Description = ClearSpacesAtLineEndings(a.Description)
@@ -1113,13 +1632,17 @@ func (a *Asset) removeExtraSpacesAtLineEndingsInTextContent() {
 	for i := range a.Columns {
 		a.Columns[i].Description = ClearSpacesAtLineEndings(a.Columns[i].Description)
 	}
+
 	for i := range a.CustomChecks {
 		a.CustomChecks[i].Description = ClearSpacesAtLineEndings(a.CustomChecks[i].Description)
+
 		a.CustomChecks[i].Query = ClearSpacesAtLineEndings(a.CustomChecks[i].Query)
 	}
+
 	for i := range a.Hooks.Pre {
 		a.Hooks.Pre[i].Query = ClearSpacesAtLineEndings(a.Hooks.Pre[i].Query)
 	}
+
 	for i := range a.Hooks.Post {
 		a.Hooks.Post[i].Query = ClearSpacesAtLineEndings(a.Hooks.Post[i].Query)
 	}
@@ -1134,6 +1657,7 @@ func (a *Asset) GetFullUpstream() []*Asset {
 
 	for _, asset := range a.upstream {
 		upstream = append(upstream, asset)
+
 		upstream = append(upstream, asset.GetFullUpstream()...)
 	}
 
@@ -1153,6 +1677,7 @@ func (a *Asset) GetFullDownstream() []*Asset {
 
 	for _, asset := range a.downstream {
 		downstream = append(downstream, asset)
+
 		downstream = append(downstream, asset.GetFullDownstream()...)
 	}
 
@@ -1161,29 +1686,35 @@ func (a *Asset) GetFullDownstream() []*Asset {
 
 func (a *Asset) ColumnNames() []string {
 	columns := make([]string, len(a.Columns))
+
 	for i, c := range a.Columns {
 		columns[i] = c.Name
 	}
+
 	return columns
 }
 
 func (a *Asset) ColumnNamesWithUpdateOnMerge() []string {
 	columns := make([]string, 0)
+
 	for _, c := range a.Columns {
 		if c.UpdateOnMerge {
 			columns = append(columns, c.Name)
 		}
 	}
+
 	return columns
 }
 
 func (a *Asset) ColumnNamesWithPrimaryKey() []string {
 	columns := make([]string, 0)
+
 	for _, c := range a.Columns {
 		if c.PrimaryKey {
 			columns = append(columns, c.Name)
 		}
 	}
+
 	return columns
 }
 
@@ -1199,16 +1730,19 @@ func (a *Asset) GetColumnWithName(name string) *Column {
 
 func (a *Asset) CheckCount() int {
 	checkCount := 0
+
 	for _, c := range a.Columns {
 		checkCount += len(c.Checks)
 	}
 
 	checkCount += len(a.CustomChecks)
+
 	return checkCount
 }
 
 func (a *Asset) EnrichFromEntityAttributes(entities []*glossary.Entity) error {
 	entityMap := make(map[string]*glossary.Entity, len(entities))
+
 	for _, e := range entities {
 		entityMap[e.Name] = e
 	}
@@ -1221,11 +1755,13 @@ func (a *Asset) EnrichFromEntityAttributes(entities []*glossary.Entity) error {
 		entity := c.EntityAttribute.Entity
 
 		e, ok := entityMap[entity]
+
 		if !ok {
 			return errors.Errorf("entity '%s' not found", entity)
 		}
 
 		attr, ok := e.Attributes[c.EntityAttribute.Attribute]
+
 		if !ok {
 			return errors.Errorf("attribute '%s' not found in entity '%s'", c.EntityAttribute.Attribute, entity)
 		}
@@ -1248,30 +1784,39 @@ func (a *Asset) EnrichFromEntityAttributes(entities []*glossary.Entity) error {
 
 func (a *Asset) GetNameIfItWasSetFromItsPath(foundPipeline *Pipeline) (string, error) {
 	var err error
+
 	var baseFolder string
+
 	relativePath := a.DefinitionFile.Path
+
 	if filepath.IsAbs(a.DefinitionFile.Path) {
 		if foundPipeline != nil {
 			pipelinePath := foundPipeline.DefinitionFile.Path
+
 			baseFolder = filepath.Join(filepath.Dir(pipelinePath), "assets")
 		} else {
 			pipelinePath, err := path.GetPipelineRootFromTask(a.DefinitionFile.Path, []string{"pipeline.yml", "pipeline.yaml"})
+
 			if err != nil {
 				return "", err
 			}
+
 			baseFolder = filepath.Join(pipelinePath, "assets")
 		}
 
 		relativePath, err = filepath.Rel(baseFolder, a.DefinitionFile.Path)
+
 		if err != nil {
 			return "", err
 		}
 	}
 
 	parts := strings.Split(relativePath, string(filepath.Separator))
+
 	for i, part := range parts {
 		if part == "assets" {
 			parts = parts[i+1:]
+
 			break
 		}
 	}
@@ -1280,10 +1825,15 @@ func (a *Asset) GetNameIfItWasSetFromItsPath(foundPipeline *Pipeline) (string, e
 
 	switch {
 	case strings.HasSuffix(name, ".asset.yml"):
+
 		name = strings.TrimSuffix(name, ".asset.yml")
+
 	case strings.HasSuffix(name, ".asset.yaml"):
+
 		name = strings.TrimSuffix(name, ".asset.yaml")
+
 	default:
+
 		name = strings.TrimSuffix(name, filepath.Ext(name))
 	}
 
@@ -1292,20 +1842,26 @@ func (a *Asset) GetNameIfItWasSetFromItsPath(foundPipeline *Pipeline) (string, e
 
 func (a Asset) Persist(fs afero.Fs, pipeline ...*Pipeline) error {
 	// Save original values
+
 	originalParams := a.Parameters
 
 	// Remove parameters that match pipeline defaults
+
 	// pipeline is optional - if provided and has defaults, filter them out
+
 	if len(pipeline) > 0 && pipeline[0] != nil && pipeline[0].DefaultValues != nil && len(pipeline[0].DefaultValues.Parameters) > 0 {
 		filteredParams := EmptyStringMap{}
+
 		for key, value := range a.Parameters {
 			// Only keep parameters that are NOT in defaults or have different values
+
 			if defaultValue, existsInDefaults := pipeline[0].DefaultValues.Parameters[key]; !existsInDefaults || defaultValue != value {
 				filteredParams[key] = value
 			}
 		}
 
 		// If no parameters remain, set to nil instead of empty map
+
 		if len(filteredParams) == 0 {
 			a.Parameters = nil
 		} else {
@@ -1314,9 +1870,11 @@ func (a Asset) Persist(fs afero.Fs, pipeline ...*Pipeline) error {
 	}
 
 	// Reuse the logic from PersistWithoutWriting
+
 	content, err := a.FormatContent()
 
 	// Restore original values (even if formatting failed)
+
 	a.Parameters = originalParams
 
 	if err != nil {
@@ -1324,7 +1882,9 @@ func (a Asset) Persist(fs afero.Fs, pipeline ...*Pipeline) error {
 	}
 
 	// Write the generated content to the file
+
 	filePath := a.ExecutableFile.Path
+
 	return afero.WriteFile(fs, filePath, content, 0o644)
 }
 
@@ -1336,10 +1896,13 @@ func (a *Asset) FormatContent() ([]byte, error) {
 	a.removeRedundanciesBeforePersisting()
 
 	buf := bytes.NewBuffer(nil)
+
 	enc := yaml.NewEncoder(buf)
+
 	enc.SetIndent(2)
 
 	err := enc.Encode(a)
+
 	if err != nil {
 		return nil, err
 	}
@@ -1347,27 +1910,35 @@ func (a *Asset) FormatContent() ([]byte, error) {
 	yamlConfig := buf.Bytes()
 
 	keysToAddSpace := []string{"custom_checks", "depends", "columns", "materialization", "secrets", "parameters", "hooks"}
+
 	for _, key := range keysToAddSpace {
 		yamlConfig = bytes.ReplaceAll(yamlConfig, []byte("\n"+key+":"), []byte("\n\n"+key+":"))
 	}
 
 	beginning := ""
+
 	end := ""
+
 	executableContent := ""
 
 	if strings.HasSuffix(a.ExecutableFile.Path, ".sql") {
 		beginning = "/* " + configMarkerString + "\n\n"
+
 		end = "\n" + configMarkerString + " */" + "\n\n"
+
 		executableContent = a.ExecutableFile.Content
 	}
 
 	if strings.HasSuffix(a.ExecutableFile.Path, ".py") {
 		beginning = `"""` + configMarkerString + "\n\n"
+
 		end = "\n" + configMarkerString + `"""` + "\n\n"
+
 		executableContent = a.ExecutableFile.Content
 	}
 
 	stringVersion := beginning + string(yamlConfig) + end + executableContent
+
 	if !strings.HasSuffix(stringVersion, "\n") {
 		stringVersion += "\n"
 	}
@@ -1377,13 +1948,17 @@ func (a *Asset) FormatContent() ([]byte, error) {
 
 func (p *Pipeline) Persist(fs afero.Fs) error {
 	// Generate the YAML content for the pipeline
+
 	content, err := p.FormatContent()
+
 	if err != nil {
 		return errors.Wrap(err, "failed to generate content for persistence")
 	}
 
 	// Write the generated content to the file
+
 	filePath := p.DefinitionFile.Path
+
 	return afero.WriteFile(fs, filePath, content, 0o644)
 }
 
@@ -1393,10 +1968,13 @@ func (p *Pipeline) FormatContent() ([]byte, error) {
 	}
 
 	buf := bytes.NewBuffer(nil)
+
 	enc := yaml.NewEncoder(buf)
+
 	enc.SetIndent(2)
 
 	err := enc.Encode(p)
+
 	if err != nil {
 		return nil, err
 	}
@@ -1404,11 +1982,13 @@ func (p *Pipeline) FormatContent() ([]byte, error) {
 	yamlConfig := buf.Bytes()
 
 	keysToAddSpace := []string{"assets", "notifications", "default_connections", "variables"}
+
 	for _, key := range keysToAddSpace {
 		yamlConfig = bytes.ReplaceAll(yamlConfig, []byte("\n"+key+":"), []byte("\n\n"+key+":"))
 	}
 
 	stringVersion := string(yamlConfig)
+
 	if !strings.HasSuffix(stringVersion, "\n") {
 		stringVersion += "\n"
 	}
@@ -1418,15 +1998,19 @@ func (p *Pipeline) FormatContent() ([]byte, error) {
 
 func uniqueAssets(assets []*Asset) []*Asset {
 	seenValues := make(map[string]bool, len(assets))
+
 	unique := make([]*Asset, 0, len(assets))
+
 	for _, value := range assets {
 		if seenValues[value.Name] {
 			continue
 		}
 
 		seenValues[value.Name] = true
+
 		unique = append(unique, value)
 	}
+
 	return unique
 }
 
@@ -1446,6 +2030,7 @@ func (b *EmptyStringMap) UnmarshalJSON(data []byte) error {
 	}
 
 	var v map[string]string
+
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
@@ -1455,6 +2040,7 @@ func (b *EmptyStringMap) UnmarshalJSON(data []byte) error {
 	}
 
 	*b = v
+
 	return nil
 }
 
@@ -1474,23 +2060,29 @@ func (a *EmptyStringArray) UnmarshalJSON(data []byte) error {
 	}
 
 	var v []string
+
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
 
 	if len(v) == 0 {
 		*a = nil
+
 		return nil
 	}
 
 	*a = v
+
 	return nil
 }
 
 func PipelineFromPath(filePath string, fs afero.Fs) (*Pipeline, error) {
 	yamlError := new(path.YamlParseError)
+
 	var pl Pipeline
+
 	err := path.ReadYaml(fs, filePath, &pl)
+
 	if err != nil && errors.As(err, &yamlError) {
 		return nil, &ParseError{Msg: "error parsing bruin pipeline definition :" + err.Error()}
 	}
@@ -1500,13 +2092,17 @@ func PipelineFromPath(filePath string, fs afero.Fs) (*Pipeline, error) {
 	}
 
 	pl.Assets = make([]*Asset, 0)
+
 	pl.DefinitionFile.Name = filepath.Base(filePath)
+
 	pl.DefinitionFile.Path = filePath
 
 	pipelineDir := filepath.Dir(filePath)
+
 	pl.MacrosPath = filepath.Join(pipelineDir, "macros")
 
 	pl.Macros, err = LoadMacrosFromPath(pl.MacrosPath, fs)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing macros")
 	}
@@ -1516,22 +2112,28 @@ func PipelineFromPath(filePath string, fs afero.Fs) (*Pipeline, error) {
 
 func LoadMacrosFromPath(macrosPath string, fs afero.Fs) ([]Macro, error) {
 	// Check if the path exists and is a directory
+
 	info, err := fs.Stat(macrosPath)
+
 	if err != nil || !info.IsDir() {
 		return []Macro{}, nil //nolint:nilerr
 	}
 
 	macros := []Macro{}
+
 	files, err := path.GetAllFilesRecursive(macrosPath, []string{".sql"})
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read macros folder file at '%s'", macrosPath)
 	}
 
 	for _, file := range files {
 		content, err := afero.ReadFile(fs, file)
+
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read macro file at '%s'", file)
 		}
+
 		macros = append(macros, Macro(string(content)))
 	}
 
@@ -1539,7 +2141,8 @@ func LoadMacrosFromPath(macrosPath string, fs afero.Fs) ([]Macro, error) {
 }
 
 type MetadataPush struct {
-	Global   bool `json:"-"`
+	Global bool `json:"-"`
+
 	BigQuery bool `json:"bigquery" yaml:"bigquery" mapstructure:"bigquery"`
 }
 
@@ -1550,54 +2153,92 @@ func (mp *MetadataPush) HasAnyEnabled() bool {
 type Macro string
 
 // Pipeline is the in-memory representation of a pipeline.yml plus its loaded
+
 // assets. When adding a new exported field that may legitimately contain Jinja
+
 // (`{{ var.X }}`) — typically string-valued metadata fields — extend the
+
 // renderPipelineStrings visitor in pkg/pipeline/variant.go so variant
+
 // materialization picks it up. The TestVariantVisitorCoversStringFields test
+
 // guards against silently regressing this.
+
 type Pipeline struct {
-	LegacyID           string                 `json:"legacy_id" yaml:"id,omitempty" mapstructure:"id"`
-	Name               string                 `json:"name" yaml:"name,omitempty" mapstructure:"name"`
-	Tags               EmptyStringArray       `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
-	Domains            EmptyStringArray       `json:"domains" yaml:"domains,omitempty" mapstructure:"domains"`
-	Meta               EmptyStringMap         `json:"meta" yaml:"meta,omitempty" mapstructure:"meta"`
-	Owner              string                 `json:"owner" yaml:"owner,omitempty" mapstructure:"owner"`
-	Schedule           Schedule               `json:"schedule" yaml:"schedule,omitempty" mapstructure:"schedule"`
-	StartDate          string                 `json:"start_date" yaml:"start_date,omitempty" mapstructure:"start_date"`
-	DefinitionFile     DefinitionFile         `json:"definition_file" yaml:"-"`
-	DefaultConnections EmptyStringMap         `json:"default_connections" yaml:"default_connections,omitempty" mapstructure:"default_connections"`
-	Assets             []*Asset               `json:"assets" yaml:"assets,omitempty"`
-	Notifications      Notifications          `json:"notifications" yaml:"notifications,omitempty" mapstructure:"notifications"`
-	Catchup            bool                   `json:"catchup" yaml:"catchup,omitempty" mapstructure:"catchup"`
-	CatchupMode        string                 `json:"catchup_mode" yaml:"catchup_mode,omitempty" mapstructure:"catchup_mode"`
-	MetadataPush       MetadataPush           `json:"metadata_push" yaml:"metadata_push,omitempty" mapstructure:"metadata_push"`
-	Retries            int                    `json:"retries" yaml:"retries,omitempty" mapstructure:"retries"`
-	RetriesDelay       *int                   `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
-	Concurrency        int                    `json:"concurrency" yaml:"concurrency,omitempty" mapstructure:"concurrency"`
-	MaxActiveSteps     *int                   `json:"max_active_steps" yaml:"max_active_steps,omitempty" mapstructure:"max_active_steps"`
-	DefaultValues      *DefaultValues         `json:"default,omitempty" yaml:"default,omitempty" mapstructure:"default,omitempty"`
-	Commit             string                 `json:"commit" yaml:"commit,omitempty"`
-	Snapshot           string                 `json:"snapshot" yaml:"snapshot,omitempty"`
-	Agent              bool                   `json:"agent" yaml:"agent,omitempty" mapstructure:"agent"`
-	Variables          Variables              `json:"variables" yaml:"variables,omitempty" mapstructure:"variables"`
-	Variants           VariantSet             `json:"variants,omitempty" yaml:"variants,omitempty" mapstructure:"variants"`
-	TasksByType        map[AssetType][]*Asset `json:"-" yaml:"-"`
-	tasksByName        map[string]*Asset      `yaml:"-"`
-	MacrosPath         string                 `json:"-" yaml:"-"`
-	Macros             []Macro                `json:"macros" yaml:"macros,omitempty" mapstructure:"macros"`
+	LegacyID string `json:"legacy_id" yaml:"id,omitempty" mapstructure:"id"`
+
+	Name string `json:"name" yaml:"name,omitempty" mapstructure:"name"`
+
+	Tags EmptyStringArray `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
+
+	Domains EmptyStringArray `json:"domains" yaml:"domains,omitempty" mapstructure:"domains"`
+
+	Meta EmptyStringMap `json:"meta" yaml:"meta,omitempty" mapstructure:"meta"`
+
+	Owner string `json:"owner" yaml:"owner,omitempty" mapstructure:"owner"`
+
+	Schedule Schedule `json:"schedule" yaml:"schedule,omitempty" mapstructure:"schedule"`
+
+	StartDate string `json:"start_date" yaml:"start_date,omitempty" mapstructure:"start_date"`
+
+	DefinitionFile DefinitionFile `json:"definition_file" yaml:"-"`
+
+	DefaultConnections EmptyStringMap `json:"default_connections" yaml:"default_connections,omitempty" mapstructure:"default_connections"`
+
+	Assets []*Asset `json:"assets" yaml:"assets,omitempty"`
+
+	Notifications Notifications `json:"notifications" yaml:"notifications,omitempty" mapstructure:"notifications"`
+
+	Catchup bool `json:"catchup" yaml:"catchup,omitempty" mapstructure:"catchup"`
+
+	CatchupMode string `json:"catchup_mode" yaml:"catchup_mode,omitempty" mapstructure:"catchup_mode"`
+
+	MetadataPush MetadataPush `json:"metadata_push" yaml:"metadata_push,omitempty" mapstructure:"metadata_push"`
+
+	Retries int `json:"retries" yaml:"retries,omitempty" mapstructure:"retries"`
+
+	RetriesDelay *int `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
+
+	Concurrency int `json:"concurrency" yaml:"concurrency,omitempty" mapstructure:"concurrency"`
+
+	MaxActiveSteps *int `json:"max_active_steps" yaml:"max_active_steps,omitempty" mapstructure:"max_active_steps"`
+
+	DefaultValues *DefaultValues `json:"default,omitempty" yaml:"default,omitempty" mapstructure:"default,omitempty"`
+
+	Commit string `json:"commit" yaml:"commit,omitempty"`
+
+	Snapshot string `json:"snapshot" yaml:"snapshot,omitempty"`
+
+	Agent bool `json:"agent" yaml:"agent,omitempty" mapstructure:"agent"`
+
+	Variables Variables `json:"variables" yaml:"variables,omitempty" mapstructure:"variables"`
+
+	Variants VariantSet `json:"variants,omitempty" yaml:"variants,omitempty" mapstructure:"variants"`
+
+	TasksByType map[AssetType][]*Asset `json:"-" yaml:"-"`
+
+	tasksByName map[string]*Asset `yaml:"-"`
+
+	MacrosPath string `json:"-" yaml:"-"`
+
+	Macros []Macro `json:"macros" yaml:"macros,omitempty" mapstructure:"macros"`
 }
 
 func validateCatchupMode(mode string) error {
 	switch mode {
 	case "", "active", "all":
+
 		return nil
+
 	default:
+
 		return fmt.Errorf("invalid catchup_mode %q, must be one of: 'active', 'all'", mode)
 	}
 }
 
 func (p *Pipeline) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type pipelineAlias Pipeline
+
 	aux := (*pipelineAlias)(p)
 
 	if err := unmarshal(aux); err != nil {
@@ -1621,6 +2262,7 @@ func (p *Pipeline) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (p *Pipeline) UnmarshalJSON(data []byte) error {
 	type pipelineAlias Pipeline
+
 	aux := (*pipelineAlias)(p)
 
 	if err := json.Unmarshal(data, aux); err != nil {
@@ -1643,68 +2285,96 @@ func (p *Pipeline) UnmarshalJSON(data []byte) error {
 }
 
 type DefaultValues struct {
-	Type              string            `json:"type" yaml:"type" mapstructure:"type"`
-	Parameters        map[string]string `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
-	Secrets           []secretMapping   `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
-	Hooks             Hooks             `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
+	Type string `json:"type" yaml:"type" mapstructure:"type"`
+
+	Parameters map[string]string `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
+
+	Secrets []secretMapping `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
+
+	Hooks Hooks `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
+
 	IntervalModifiers IntervalModifiers `json:"interval_modifiers" yaml:"interval_modifiers" mapstructure:"interval_modifiers"`
-	RerunCooldown     *int              `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
+
+	RerunCooldown *int `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 }
 
 func (p *Pipeline) GetCompatibilityHash() string {
 	parts := make([]string, 0, len(p.Assets)+1)
+
 	parts = append(parts, p.Name)
+
 	for _, asset := range p.Assets {
 		var assetBuilder strings.Builder
+
 		fmt.Fprintf(&assetBuilder, ":%s{", asset.Name)
+
 		for _, upstream := range asset.Upstreams {
 			fmt.Fprintf(&assetBuilder, ":%s:%s:", upstream.Value, upstream.Type)
 		}
+
 		assetBuilder.WriteByte('}')
+
 		parts = append(parts, assetBuilder.String())
 	}
+
 	parts = append(parts, ":")
+
 	hash := sha256.New()
+
 	hash.Write([]byte(strings.Join(parts, "")))
+
 	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func (p *Pipeline) GetAllConnectionNamesForAsset(asset *Asset) ([]string, error) {
 	assetType := asset.Type
+
 	if assetType == AssetTypePython { //nolint
+
 		secretKeys := make([]string, 0, len(asset.Secrets))
+
 		for _, secret := range asset.Secrets {
 			secretKeys = append(secretKeys, secret.SecretKey)
 		}
+
 		return secretKeys, nil
 	} else if assetType == AssetTypeIngestr {
 		ingestrSource, ok := asset.Parameters["source_connection"]
+
 		if !ok {
 			return []string{}, errors.Errorf("No source connection in asset")
 		}
 
 		ingestrDestination, ok := asset.Parameters["destination_connection"]
+
 		if ok {
 			return []string{ingestrDestination, ingestrSource}, nil
 		}
 
 		// if destination connection not specified, we infer from destination type
+
 		assetType, ok = IngestrTypeConnectionMapping[asset.Parameters["destination"]]
+
 		if !ok {
 			return []string{}, errors.Errorf("connection type could not be inferred for destination '%s', please specify a `connection` key in the asset", asset.Parameters["destination"])
 		}
 
 		mapping, ok := AssetTypeConnectionMapping[assetType]
+
 		if !ok {
 			return []string{}, errors.Errorf("No connection mapping found for asset type:'%s' (%s)", assetType, asset.Name)
 		}
+
 		conn, ok := p.DefaultConnections[mapping]
+
 		if ok {
 			ingestrDestination = conn
+
 			return []string{ingestrDestination, ingestrSource}, nil
 		}
 
 		ingestrDestination, ok = defaultMapping[mapping]
+
 		if ok {
 			return []string{ingestrDestination, ingestrSource}, nil
 		}
@@ -1712,6 +2382,7 @@ func (p *Pipeline) GetAllConnectionNamesForAsset(asset *Asset) ([]string, error)
 		return []string{}, errors.Errorf("No default connection for type: '%s'", assetType)
 	} else {
 		conn, err := p.GetConnectionNameForAsset(asset)
+
 		if err != nil {
 			return []string{}, err
 		}
@@ -1726,25 +2397,35 @@ func (p *Pipeline) GetConnectionNameForAsset(asset *Asset) (string, error) {
 	}
 
 	assetType := asset.Type
+
 	var ok bool
+
 	switch assetType {
 	case AssetTypeIngestr:
+
 		assetType, ok = IngestrTypeConnectionMapping[asset.Parameters["destination"]]
+
 		if !ok {
 			return "", errors.Errorf("connection type could not be inferred for destination '%s', please specify a `connection` key in the asset", asset.Parameters["destination"])
 		}
+
 	case AssetTypePython, AssetTypeEmpty:
+
 		assetType = p.GetMajorityAssetTypesFromSQLAssets(AssetTypeBigqueryQuery)
+
 	default:
+
 		// For all other asset types, use the asset type directly for connection mapping lookup.
 	}
 
 	mapping, ok := AssetTypeConnectionMapping[assetType]
+
 	if !ok {
 		return "", errors.Errorf("no connection mapping found for asset type '%s'", assetType)
 	}
 
 	conn, ok := p.DefaultConnections[mapping]
+
 	if ok {
 		return conn, nil
 	}
@@ -1759,7 +2440,9 @@ func (p *Pipeline) GetConnectionNameForAsset(asset *Asset) (string, error) {
 }
 
 // WipeContentOfAssets removes the content of the executable files of all assets in the pipeline.
+
 // This is useful when we want to serialize the pipeline to JSON and we don't want to include the content of the assets.
+
 func (p *Pipeline) WipeContentOfAssets() {
 	for _, asset := range p.Assets {
 		asset.ExecutableFile.Content = ""
@@ -1768,23 +2451,38 @@ func (p *Pipeline) WipeContentOfAssets() {
 
 func (p *Pipeline) GetMajorityAssetTypesFromSQLAssets(defaultIfNone AssetType) AssetType {
 	taskTypeCounts := map[AssetType]int{
-		AssetTypeBigqueryQuery:     0,
-		AssetTypeSnowflakeQuery:    0,
-		AssetTypePostgresQuery:     0,
-		AssetTypeMsSQLQuery:        0,
-		AssetTypeVerticaQuery:      0,
-		AssetTypeDatabricksQuery:   0,
-		AssetTypeRedshiftQuery:     0,
-		AssetTypeSynapseQuery:      0,
-		AssetTypeFabricQuery:       0,
+
+		AssetTypeBigqueryQuery: 0,
+
+		AssetTypeSnowflakeQuery: 0,
+
+		AssetTypePostgresQuery: 0,
+
+		AssetTypeMsSQLQuery: 0,
+
+		AssetTypeVerticaQuery: 0,
+
+		AssetTypeDatabricksQuery: 0,
+
+		AssetTypeRedshiftQuery: 0,
+
+		AssetTypeSynapseQuery: 0,
+
+		AssetTypeFabricQuery: 0,
+
 		AssetTypeFabricQueryLegacy: 0,
-		AssetTypeAthenaQuery:       0,
-		AssetTypeDuckDBQuery:       0,
+
+		AssetTypeAthenaQuery: 0,
+
+		AssetTypeDuckDBQuery: 0,
 	}
+
 	maxTasks := 0
+
 	maxTaskType := defaultIfNone
 
 	searchTypeMap := make(map[AssetType]bool)
+
 	for t := range taskTypeCounts {
 		searchTypeMap[t] = true
 	}
@@ -1794,11 +2492,13 @@ func (p *Pipeline) GetMajorityAssetTypesFromSQLAssets(defaultIfNone AssetType) A
 
 		if assetType == AssetTypeIngestr {
 			ingestrDestination, ok := asset.Parameters["destination"]
+
 			if !ok {
 				continue
 			}
 
 			assetType, ok = IngestrTypeConnectionMapping[ingestrDestination]
+
 			if !ok {
 				continue
 			}
@@ -1816,6 +2516,7 @@ func (p *Pipeline) GetMajorityAssetTypesFromSQLAssets(defaultIfNone AssetType) A
 
 		if taskTypeCounts[assetType] > maxTasks {
 			maxTasks = taskTypeCounts[assetType]
+
 			maxTaskType = assetType
 		} else if taskTypeCounts[assetType] == maxTasks {
 			maxTaskType = defaultIfNone
@@ -1829,6 +2530,7 @@ func (p *Pipeline) RelativeAssetPath(t *Asset) string {
 	absolutePipelineRoot := filepath.Dir(p.DefinitionFile.Path)
 
 	pipelineDirectory, err := filepath.Rel(absolutePipelineRoot, t.DefinitionFile.Path)
+
 	if err != nil {
 		return absolutePipelineRoot
 	}
@@ -1838,6 +2540,7 @@ func (p *Pipeline) RelativeAssetPath(t *Asset) string {
 
 func (p *Pipeline) HasAssetType(taskType AssetType) bool {
 	_, ok := p.TasksByType[taskType]
+
 	return ok
 }
 
@@ -1847,6 +2550,7 @@ func (p *Pipeline) ensureTaskNameMapIsFilled() {
 	}
 
 	p.tasksByName = make(map[string]*Asset)
+
 	for _, asset := range p.Assets {
 		p.tasksByName[asset.Name] = asset
 	}
@@ -1854,6 +2558,7 @@ func (p *Pipeline) ensureTaskNameMapIsFilled() {
 
 func (p *Pipeline) GetAssetByPath(assetPath string) *Asset {
 	assetPath, err := filepath.Abs(assetPath)
+
 	if err != nil {
 		return nil
 	}
@@ -1881,6 +2586,7 @@ func (p *Pipeline) GetAssetByName(assetName string) *Asset {
 	p.ensureTaskNameMapIsFilled()
 
 	asset, ok := p.tasksByName[assetName]
+
 	if !ok {
 		return nil
 	}
@@ -1890,6 +2596,7 @@ func (p *Pipeline) GetAssetByName(assetName string) *Asset {
 
 func (p *Pipeline) GetAssetsByTag(tag string) []*Asset {
 	assets := make([]*Asset, 0)
+
 	for _, asset := range p.Assets {
 		for _, t := range asset.Tags {
 			if t == tag {
@@ -1904,10 +2611,13 @@ func (p *Pipeline) GetAssetsByTag(tag string) []*Asset {
 type TaskCreator func(path string) (*Asset, error)
 
 type BuilderConfig struct {
-	PipelineFileName    []string
-	TasksDirectoryName  string
+	PipelineFileName []string
+
+	TasksDirectoryName string
+
 	TasksDirectoryNames []string
-	TasksFileSuffixes   []string
+
+	TasksFileSuffixes []string
 }
 
 type glossaryReader interface {
@@ -1919,13 +2629,19 @@ type AssetMutator func(ctx context.Context, asset *Asset, foundPipeline *Pipelin
 type PipelineMutator func(ctx context.Context, pipeline *Pipeline) (*Pipeline, error)
 
 type Builder struct {
-	config             BuilderConfig
-	yamlTaskCreator    TaskCreator
+	config BuilderConfig
+
+	yamlTaskCreator TaskCreator
+
 	commentTaskCreator TaskCreator
-	fs                 afero.Fs
-	assetMutators      []AssetMutator
-	pipelineMutators   []PipelineMutator
-	variantRenderer    VariantRendererFactory
+
+	fs afero.Fs
+
+	assetMutators []AssetMutator
+
+	pipelineMutators []PipelineMutator
+
+	variantRenderer VariantRendererFactory
 
 	GlossaryReader glossaryReader
 }
@@ -1935,10 +2651,15 @@ func (b *Builder) SetGlossaryReader(reader glossaryReader) {
 }
 
 // SetVariantRenderer wires a renderer factory used by WithVariant /
+
 // CreatePipelinesFromPath. The factory receives the effective variable values
+
 // (after merging the variant's overrides) plus the variant name and returns a
+
 // per-render function. Callers wire this once at builder construction; if it's
+
 // unset, attempting to materialize a variant returns a clear error.
+
 func (b *Builder) SetVariantRenderer(f VariantRendererFactory) {
 	b.variantRenderer = f
 }
@@ -1961,22 +2682,33 @@ func (e ParseError) Error() string {
 
 func NewBuilder(config BuilderConfig, yamlTaskCreator TaskCreator, commentTaskCreator TaskCreator, fs afero.Fs, gr glossaryReader) *Builder {
 	b := &Builder{
-		config:             config,
-		yamlTaskCreator:    yamlTaskCreator,
+
+		config: config,
+
+		yamlTaskCreator: yamlTaskCreator,
+
 		commentTaskCreator: commentTaskCreator,
-		fs:                 fs,
-		GlossaryReader:     gr,
+
+		fs: fs,
+
+		GlossaryReader: gr,
 	}
 
 	b.assetMutators = []AssetMutator{
+
 		b.fillGlossaryStuff,
+
 		b.SetupDefaultsFromPipeline,
+
 		b.InjectConnectionAsSecret,
+
 		b.translateRetryConfig,
+
 		b.SetNameFromPath,
 	}
 
 	b.pipelineMutators = []PipelineMutator{
+
 		b.translatePipelineRetryConfig,
 	}
 
@@ -1989,24 +2721,31 @@ func matchPipelineFileName(filePath string, validFileNames []string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
 func resolvePipelineFilePath(basePath string, validFileNames []string, fs afero.Fs) (string, error) {
 	for _, fileName := range validFileNames {
 		candidatePath := filepath.Join(basePath, fileName)
+
 		if exists, _ := afero.Exists(fs, candidatePath); exists {
 			return candidatePath, nil
 		}
 	}
+
 	return "", fmt.Errorf("no pipeline file found in '%s'. Supported files: %v", basePath, validFileNames)
 }
 
 type createPipelineConfig struct {
 	parseGitMetadata bool
-	isMutate         bool
-	onlyPipeline     bool
-	variantName      string
+
+	isMutate bool
+
+	onlyPipeline bool
+
+	variantName string
+
 	skipVariantCheck bool
 }
 
@@ -2031,8 +2770,11 @@ func WithOnlyPipeline() CreatePipelineOption {
 }
 
 // WithVariant materializes the named variant during pipeline construction.
+
 // The Builder must have a renderer set via SetVariantRenderer; otherwise the
+
 // call errors. Passing an empty name is equivalent to omitting the option.
+
 func WithVariant(name string) CreatePipelineOption {
 	return func(o *createPipelineConfig) {
 		o.variantName = name
@@ -2040,9 +2782,13 @@ func WithVariant(name string) CreatePipelineOption {
 }
 
 // withSkipVariantCheck is an internal option used by CreatePipelinesFromPath
+
 // to probe a path for variants without triggering the "variant required" guard.
+
 // Not exported because external callers should use WithOnlyPipeline (which also
+
 // skips the check) for the same effect.
+
 func withSkipVariantCheck() CreatePipelineOption {
 	return func(o *createPipelineConfig) {
 		o.skipVariantCheck = true
@@ -2051,60 +2797,80 @@ func withSkipVariantCheck() CreatePipelineOption {
 
 func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline string, opts ...CreatePipelineOption) (*Pipeline, error) {
 	config := createPipelineConfig{}
+
 	for _, opt := range opts {
 		opt(&config)
 	}
 
 	pipelineFilePath := pathToPipeline
+
 	if !matchPipelineFileName(pipelineFilePath, b.config.PipelineFileName) {
 		resolvedPath, err := resolvePipelineFilePath(pathToPipeline, b.config.PipelineFileName, b.fs)
+
 		if err != nil {
 			return nil, err
 		}
+
 		pipelineFilePath = resolvedPath
 	} else {
 		pathToPipeline = filepath.Dir(pipelineFilePath)
 	}
+
 	pipeline, err := PipelineFromPath(pipelineFilePath, b.fs)
+
 	if err != nil {
 		return nil, err
 	}
 
 	// this is needed until we migrate all the pipelines to use the new naming convention
+
 	if pipeline.Name == "" {
 		pipeline.Name = pipeline.LegacyID
 	}
+
 	pipeline.TasksByType = make(map[AssetType][]*Asset)
+
 	pipeline.tasksByName = make(map[string]*Asset)
 
 	if config.parseGitMetadata {
 		pipeline.Commit, err = git.CurrentCommit(pathToPipeline)
+
 		if err != nil {
 			return nil, fmt.Errorf("error parsing commit: %w", err)
 		}
 	}
 
 	absPipelineFilePath, err := filepath.Abs(pipelineFilePath)
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting absolute path for pipeline file at '%s'", pipelineFilePath)
 	}
 
 	pipeline.DefinitionFile = DefinitionFile{
+
 		Name: filepath.Base(pipelineFilePath),
+
 		Path: absPipelineFilePath,
 	}
 
 	// Variant guard: when the pipeline declares variants, callers MUST pick
+
 	// one (via WithVariant) or use CreatePipelinesFromPath. WithOnlyPipeline
+
 	// is exempted because it explicitly asks for the un-materialized template
+
 	// view (used by `bruin internal list-variants` and the plural builder's
+
 	// own probe step).
+
 	if !config.onlyPipeline && !config.skipVariantCheck && len(pipeline.Variants) > 0 && config.variantName == "" {
 		return nil, fmt.Errorf("pipeline %q declares variants %v; pass WithVariant(name) or use CreatePipelinesFromPath", pipeline.Name, pipeline.Variants.Names())
 	}
 
 	// Apply the variant's variable overrides BEFORE asset construction so any
+
 	// asset-level mutator (e.g. parameter rendering) sees variant values.
+
 	if config.variantName != "" && len(pipeline.Variants) > 0 {
 		if err := pipeline.ApplyVariantVariables(config.variantName); err != nil {
 			return nil, err
@@ -2113,6 +2879,7 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 
 	if config.isMutate {
 		pipeline, err = b.MutatePipeline(ctx, pipeline)
+
 		if err != nil {
 			return nil, err
 		}
@@ -2123,9 +2890,12 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 	}
 
 	taskFiles := make([]string, 0)
+
 	for _, tasksDirectoryName := range b.config.TasksDirectoryNames {
 		tasksPath := filepath.Join(pathToPipeline, tasksDirectoryName)
+
 		files, err := path.GetAllFilesRecursive(tasksPath, SupportedFileSuffixes)
+
 		if err != nil {
 			continue
 		}
@@ -2135,6 +2905,7 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 
 	for _, file := range taskFiles {
 		task, err := b.CreateAssetFromFile(file, pipeline)
+
 		if err != nil {
 			return nil, err
 		}
@@ -2145,12 +2916,14 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 
 		if config.isMutate {
 			task, err = b.MutateAsset(ctx, task, pipeline)
+
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		task.upstream = make([]*Asset, 0)
+
 		task.downstream = make([]*Asset, 0)
 
 		pipeline.Assets = append(pipeline.Assets, task)
@@ -2160,11 +2933,15 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 		}
 
 		pipeline.TasksByType[task.Type] = append(pipeline.TasksByType[task.Type], task)
+
 		pipeline.tasksByName[task.Name] = task
 	}
+
 	var entities []*glossary.Entity
+
 	if b.GlossaryReader != nil {
 		entities, err = b.GlossaryReader.GetEntities(pathToPipeline)
+
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting entities")
 		}
@@ -2179,17 +2956,21 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 			if upstream.Type != "asset" {
 				continue
 			}
+
 			u, ok := pipeline.tasksByName[upstream.Value]
+
 			if !ok {
 				continue
 			}
 
 			asset.AddUpstream(u)
+
 			u.AddDownstream(asset)
 		}
 
 		if len(entities) > 0 {
 			err := asset.EnrichFromEntityAttributes(entities)
+
 			if err != nil {
 				return nil, errors.Wrap(err, "error enriching asset from entity attributes")
 			}
@@ -2197,14 +2978,20 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 	}
 
 	// Final step for variant pipelines: render identity/structure string fields
+
 	// (asset names, dependencies, schedule, …) so the materialized pipeline has
+
 	// stable values. Variables.Merge ran earlier; the asset *Asset pointer graph
+
 	// stays valid because rendering only mutates values, not pointers.
+
 	if config.variantName != "" && len(pipeline.Variants) > 0 {
 		if b.variantRenderer == nil {
 			return nil, fmt.Errorf("WithVariant(%q) requires a renderer; call Builder.SetVariantRenderer", config.variantName)
 		}
+
 		variantName := config.variantName
+
 		if err := pipeline.RenderTemplatedFields(func(vars map[string]any) RenderFunc {
 			return b.variantRenderer(vars, variantName)
 		}); err != nil {
@@ -2216,49 +3003,70 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 }
 
 // CreatePipelinesFromPath returns one *Pipeline per declared variant when the
+
 // pipeline at pathToPipeline is a variant pipeline, or a single-element slice
+
 // otherwise. Each returned Pipeline is fully materialized (variant variables
+
 // merged, identity fields rendered, assets loaded) and ready for downstream use.
+
 //
+
 // This is the entry point external services (e.g. asset-service) should prefer:
+
 // it makes the variant fan-out invisible to callers that don't care.
+
 func (b *Builder) CreatePipelinesFromPath(ctx context.Context, pathToPipeline string, opts ...CreatePipelineOption) ([]*Pipeline, error) {
 	cfg := createPipelineConfig{}
+
 	for _, o := range opts {
 		o(&cfg)
 	}
 
 	// Honour an explicit WithVariant by delegating to the singular form.
+
 	if cfg.variantName != "" {
 		pl, err := b.CreatePipelineFromPath(ctx, pathToPipeline, opts...)
+
 		if err != nil {
 			return nil, err
 		}
+
 		return []*Pipeline{pl}, nil
 	}
 
 	// Probe the un-materialized form to discover declared variants without
+
 	// loading assets.
+
 	probe, err := b.CreatePipelineFromPath(ctx, pathToPipeline, append(opts, WithOnlyPipeline(), withSkipVariantCheck())...)
+
 	if err != nil {
 		return nil, err
 	}
+
 	if len(probe.Variants) == 0 {
 		pl, err := b.CreatePipelineFromPath(ctx, pathToPipeline, opts...)
+
 		if err != nil {
 			return nil, err
 		}
+
 		return []*Pipeline{pl}, nil
 	}
 
 	out := make([]*Pipeline, 0, len(probe.Variants))
+
 	for _, name := range probe.Variants.Names() {
 		pl, err := b.CreatePipelineFromPath(ctx, pathToPipeline, append(opts, WithVariant(name))...)
+
 		if err != nil {
 			return nil, fmt.Errorf("variant %q: %w", name, err)
 		}
+
 		out = append(out, pl)
 	}
+
 	return out, nil
 }
 
@@ -2268,19 +3076,23 @@ func fileHasSuffix(arr []string, str string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
 func (b *Builder) CreateAssetFromFile(filePath string, foundPipeline *Pipeline) (*Asset, error) {
 	isSeparateDefinitionFile := false
+
 	creator := b.commentTaskCreator
 
 	if fileHasSuffix(b.config.TasksFileSuffixes, filePath) {
 		creator = b.yamlTaskCreator
+
 		isSeparateDefinitionFile = true
 	}
 
 	task, err := creator(filePath)
+
 	if err != nil {
 		if errors.As(err, &ParseError{}) {
 			return nil, err
@@ -2294,23 +3106,31 @@ func (b *Builder) CreateAssetFromFile(filePath string, foundPipeline *Pipeline) 
 	}
 
 	// if the definition comes from a Python file the asset is always a Python asset, so force it
+
 	// at least that's the hypothesis for now
+
 	if strings.HasSuffix(task.ExecutableFile.Path, ".py") && task.Type == "" {
 		task.Type = AssetTypePython
 	}
 
 	// if the definition comes from an R file the asset is always an R asset
+
 	if strings.HasSuffix(task.ExecutableFile.Path, ".r") && task.Type == "" {
 		task.Type = AssetTypeR
 	}
 
 	absPath, absErr := filepath.Abs(filePath)
+
 	if absErr != nil {
 		absPath = filePath
 	}
+
 	task.DefinitionFile.Name = filepath.Base(absPath)
+
 	task.DefinitionFile.Path = absPath
+
 	task.DefinitionFile.Type = CommentTask
+
 	if isSeparateDefinitionFile {
 		task.DefinitionFile.Type = YamlTask
 	}
@@ -2321,7 +3141,9 @@ func (b *Builder) CreateAssetFromFile(filePath string, foundPipeline *Pipeline) 
 func (b *Builder) MutateAsset(ctx context.Context, task *Asset, foundPipeline *Pipeline) (*Asset, error) {
 	for _, mutator := range b.assetMutators {
 		var err error
+
 		task, err = mutator(ctx, task, foundPipeline)
+
 		if err != nil {
 			return nil, err
 		}
@@ -2333,7 +3155,9 @@ func (b *Builder) MutateAsset(ctx context.Context, task *Asset, foundPipeline *P
 func (b *Builder) MutatePipeline(ctx context.Context, pipeline *Pipeline) (*Pipeline, error) {
 	for _, mutator := range b.pipelineMutators {
 		var err error
+
 		pipeline, err = mutator(ctx, pipeline)
+
 		if err != nil {
 			return nil, err
 		}
@@ -2348,11 +3172,13 @@ func (b *Builder) translatePipelineRetryConfig(ctx context.Context, pipeline *Pi
 	}
 
 	// Translate pipeline default rerun_cooldown to retries_delay
+
 	if pipeline.DefaultValues != nil && pipeline.DefaultValues.RerunCooldown != nil {
 		if *pipeline.DefaultValues.RerunCooldown > 0 {
 			pipeline.RetriesDelay = pipeline.DefaultValues.RerunCooldown
 		} else if *pipeline.DefaultValues.RerunCooldown == -1 {
 			zero := 0
+
 			pipeline.RetriesDelay = &zero
 		}
 	}
@@ -2378,6 +3204,7 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 	}
 
 	// merge parameters from the default values to asset parameters
+
 	if len(asset.Parameters) == 0 {
 		asset.Parameters = EmptyStringMap{}
 	}
@@ -2387,26 +3214,35 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 			asset.Parameters[key] = value
 		}
 	}
+
 	// merge secrets from the default values to asset secrets
+
 	existingSecrets := make(map[string]bool)
+
 	for _, secret := range asset.Secrets {
 		existingSecrets[secret.SecretKey] = true
 	}
+
 	for _, secret := range foundPipeline.DefaultValues.Secrets {
 		secretMap := SecretMapping(secret)
+
 		if !existingSecrets[secretMap.SecretKey] {
 			asset.Secrets = append(asset.Secrets, secretMap)
 		}
 	}
+
 	if (asset.IntervalModifiers.Start == TimeModifier{}) {
 		asset.IntervalModifiers.Start = foundPipeline.DefaultValues.IntervalModifiers.Start
 	}
+
 	if (asset.IntervalModifiers.End == TimeModifier{}) {
 		asset.IntervalModifiers.End = foundPipeline.DefaultValues.IntervalModifiers.End
 	}
+
 	if len(asset.Hooks.Pre) == 0 {
 		asset.Hooks.Pre = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Pre...)
 	}
+
 	if len(asset.Hooks.Post) == 0 {
 		asset.Hooks.Post = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Post...)
 	}
@@ -2426,7 +3262,9 @@ func (b *Builder) InjectConnectionAsSecret(ctx context.Context, asset *Asset, fo
 	}
 
 	asset.Secrets = append(asset.Secrets, SecretMapping{
-		SecretKey:   asset.Connection,
+
+		SecretKey: asset.Connection,
+
 		InjectedKey: asset.Connection,
 	})
 
@@ -2439,15 +3277,18 @@ func (b *Builder) translateRetryConfig(ctx context.Context, asset *Asset, foundP
 	}
 
 	// Translate asset-level rerun_cooldown to retries_delay
+
 	if asset.RerunCooldown != nil {
 		if *asset.RerunCooldown > 0 {
 			asset.RetriesDelay = asset.RerunCooldown
 		} else if *asset.RerunCooldown == -1 {
 			zero := 0
+
 			asset.RetriesDelay = &zero
 		}
 	} else if foundPipeline != nil && foundPipeline.DefaultValues != nil && foundPipeline.DefaultValues.RerunCooldown != nil && *foundPipeline.DefaultValues.RerunCooldown > 0 {
 		// Inherit from pipeline default if asset has no specific retry config
+
 		asset.RetriesDelay = foundPipeline.DefaultValues.RerunCooldown
 	}
 
@@ -2468,30 +3309,40 @@ func (b *Builder) fillGlossaryStuff(ctx context.Context, asset *Asset, foundPipe
 	}
 
 	entities, err := b.GlossaryReader.GetEntities(foundPipeline.DefinitionFile.Path)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting entities")
 	}
 
 	cache := make(map[string][]Column)
+
 	cacheEntityColumns := make(map[string]bool)
+
 	for _, column := range asset.Columns {
 		cacheEntityColumns[column.Extends] = true
 	}
 
 	for _, entity := range entities {
 		attributeNames := make([]string, 0, len(entity.Attributes))
+
 		for attrName := range entity.Attributes {
 			attributeNames = append(attributeNames, attrName)
 		}
+
 		sort.Strings(attributeNames)
 
 		cache[entity.Name] = make([]Column, 0)
+
 		for _, attrName := range attributeNames {
 			attribute := entity.Attributes[attrName]
+
 			if _, ok := cacheEntityColumns[fmt.Sprintf("%s.%s", entity.Name, attribute.Name)]; !ok {
 				cache[entity.Name] = append(cache[entity.Name], Column{
+
 					EntityAttribute: &EntityAttribute{
-						Entity:    entity.Name,
+
+						Entity: entity.Name,
+
 						Attribute: attribute.Name,
 					},
 				})
@@ -2508,21 +3359,36 @@ func (b *Builder) fillGlossaryStuff(ctx context.Context, asset *Asset, foundPipe
 
 func (a *Asset) IsSQLAsset() bool {
 	sqlAssetTypes := map[AssetType]bool{
-		AssetTypeBigqueryQuery:     true,
-		AssetTypeSnowflakeQuery:    true,
-		AssetTypePostgresQuery:     true,
-		AssetTypeRedshiftQuery:     true,
-		AssetTypeMsSQLQuery:        true,
-		AssetTypeVerticaQuery:      true,
-		AssetTypeDatabricksQuery:   true,
-		AssetTypeSynapseQuery:      true,
-		AssetTypeFabricQuery:       true,
+
+		AssetTypeBigqueryQuery: true,
+
+		AssetTypeSnowflakeQuery: true,
+
+		AssetTypePostgresQuery: true,
+
+		AssetTypeRedshiftQuery: true,
+
+		AssetTypeMsSQLQuery: true,
+
+		AssetTypeVerticaQuery: true,
+
+		AssetTypeDatabricksQuery: true,
+
+		AssetTypeSynapseQuery: true,
+
+		AssetTypeFabricQuery: true,
+
 		AssetTypeFabricQueryLegacy: true,
-		AssetTypeAthenaQuery:       true,
-		AssetTypeDuckDBQuery:       true,
-		AssetTypeClickHouse:        true,
-		AssetTypeTrinoQuery:        true,
-		AssetTypeOracleQuery:       true,
+
+		AssetTypeAthenaQuery: true,
+
+		AssetTypeDuckDBQuery: true,
+
+		AssetTypeClickHouse: true,
+
+		AssetTypeTrinoQuery: true,
+
+		AssetTypeOracleQuery: true,
 	}
 
 	return sqlAssetTypes[a.Type]
@@ -2530,9 +3396,12 @@ func (a *Asset) IsSQLAsset() bool {
 
 func (b *Builder) SetAssetColumnFromGlossary(asset *Asset, pathToPipeline string) error {
 	var entities []*glossary.Entity
+
 	var err error
+
 	if b.GlossaryReader != nil {
 		entities, err = b.GlossaryReader.GetEntities(pathToPipeline)
+
 		if err != nil {
 			return errors.Wrap(err, "error getting entities")
 		}
@@ -2540,10 +3409,12 @@ func (b *Builder) SetAssetColumnFromGlossary(asset *Asset, pathToPipeline string
 
 	if len(entities) > 0 {
 		err := asset.EnrichFromEntityAttributes(entities)
+
 		if err != nil {
 			return errors.Wrap(err, "error enriching asset from entity attributes")
 		}
 	}
+
 	return nil
 }
 
@@ -2562,6 +3433,7 @@ func (b *Builder) SetNameFromPath(ctx context.Context, asset *Asset, foundPipeli
 	if foundPipeline == nil {
 		return asset, nil
 	}
+
 	if asset == nil {
 		return asset, nil
 	}
@@ -2571,12 +3443,15 @@ func (b *Builder) SetNameFromPath(ctx context.Context, asset *Asset, foundPipeli
 	}
 
 	name, err := asset.GetNameIfItWasSetFromItsPath(foundPipeline)
+
 	if err != nil {
 		return asset, errors.Wrap(err, "error getting asset name")
 	}
 
 	asset.Name = name
+
 	asset.ID = hash(name)
+
 	return asset, nil
 }
 
@@ -2586,35 +3461,60 @@ func (t TimeModifier) MarshalYAML() (interface{}, error) {
 	}
 
 	// Helper to check if only one field is set (excluding the specified one)
+
 	allZeroExcept := func(exceptDays, exceptMonths, exceptHours, exceptMinutes, exceptSeconds, exceptMilliseconds, exceptNanoseconds bool) bool {
 		return (exceptDays || t.Days == 0) &&
+
 			(exceptMonths || t.Months == 0) &&
+
 			(exceptHours || t.Hours == 0) &&
+
 			(exceptMinutes || t.Minutes == 0) &&
+
 			(exceptSeconds || t.Seconds == 0) &&
+
 			(exceptMilliseconds || t.Milliseconds == 0) &&
+
 			(exceptNanoseconds || t.Nanoseconds == 0) &&
+
 			t.CronPeriods == 0
 	}
 
 	switch {
 	case t.Days != 0 && allZeroExcept(true, false, false, false, false, false, false):
+
 		return fmt.Sprintf("%dd", t.Days), nil
+
 	case t.Months != 0 && allZeroExcept(false, true, false, false, false, false, false):
+
 		return fmt.Sprintf("%dM", t.Months), nil
+
 	case t.Hours != 0 && allZeroExcept(false, false, true, false, false, false, false):
+
 		return fmt.Sprintf("%dh", t.Hours), nil
+
 	case t.Minutes != 0 && allZeroExcept(false, false, false, true, false, false, false):
+
 		return fmt.Sprintf("%dm", t.Minutes), nil
+
 	case t.Seconds != 0 && allZeroExcept(false, false, false, false, true, false, false):
+
 		return fmt.Sprintf("%ds", t.Seconds), nil
+
 	case t.Milliseconds != 0 && allZeroExcept(false, false, false, false, false, true, false):
+
 		return fmt.Sprintf("%dms", t.Milliseconds), nil
+
 	case t.Nanoseconds != 0 && allZeroExcept(false, false, false, false, false, false, true):
+
 		return fmt.Sprintf("%dns", t.Nanoseconds), nil
+
 	default:
+
 		// fallback to struct/object form
+
 		type Alias TimeModifier
+
 		return Alias(t), nil
 	}
 }

--- a/pkg/pipeline/source_location.go
+++ b/pkg/pipeline/source_location.go
@@ -1,0 +1,26 @@
+package pipeline
+
+import "fmt"
+
+// SourceLocation describes the position of a code element within a source file.
+type SourceLocation struct {
+	File   string `json:"file,omitempty"   yaml:"-" mapstructure:"-"`
+	Line   int    `json:"line,omitempty"   yaml:"-" mapstructure:"-"`
+	Column int    `json:"column,omitempty" yaml:"-" mapstructure:"-"`
+}
+
+// IsZero reports whether the location carries no meaningful position.
+func (l *SourceLocation) IsZero() bool {
+	return l == nil || l.Line <= 0
+}
+
+// String formats the location as "file:line:col".
+func (l *SourceLocation) String() string {
+	if l.IsZero() {
+		return ""
+	}
+	if l.Column > 0 {
+		return fmt.Sprintf("%s:%d:%d", l.File, l.Line, l.Column)
+	}
+	return fmt.Sprintf("%s:%d", l.File, l.Line)
+}

--- a/pkg/pipeline/testdata/comments/custom_checks_location.sql
+++ b/pkg/pipeline/testdata/comments/custom_checks_location.sql
@@ -1,0 +1,13 @@
+/* @bruin
+name: test.location_checks
+type: bq.sql
+custom_checks:
+  - name: row count
+    query: |
+      SELECT COUNT(*) FROM my_table
+  - name: null check
+    query: |
+      SELECT COUNT(*) FROM my_table WHERE id IS NULL
+@bruin */
+
+SELECT 1;

--- a/pkg/pipeline/testdata/yaml/task-with-custom-check-location/task.yml
+++ b/pkg/pipeline/testdata/yaml/task-with-custom-check-location/task.yml
@@ -1,0 +1,9 @@
+name: test.yaml_location_checks
+type: bq.sql
+custom_checks:
+  - name: row count
+    query: |
+      SELECT COUNT(*) FROM my_table
+  - name: null check
+    query: |
+      SELECT COUNT(*) FROM my_table WHERE id IS NULL

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -14,30 +14,41 @@ import (
 )
 
 var ValidQualityChecks = map[string]bool{
-	"not_null":        true,
-	"unique":          true,
-	"positive":        true,
-	"min":             true,
-	"max":             true,
+	"not_null": true,
+
+	"unique": true,
+
+	"positive": true,
+
+	"min": true,
+
+	"max": true,
+
 	"accepted_values": true,
-	"negative":        true,
-	"non_negative":    true,
-	"pattern":         true,
+
+	"negative": true,
+
+	"non_negative": true,
+
+	"pattern": true,
 }
 
 func mustBeStringArray(fieldName string, value *yaml.Node) ([]string, error) {
 	var multi []string
+
 	err := value.Decode(&multi)
 	if err != nil {
 		return nil, &ParseError{Msg: "`" + fieldName + "` field must be an array of strings"}
 	}
+
 	return multi, nil
 }
 
 type columns []upstreamColumn
 
 type upstreamColumn struct {
-	Name  string
+	Name string
+
 	Usage string
 }
 
@@ -47,14 +58,18 @@ type UpstreamMode int
 
 const (
 	UpstreamModeFull UpstreamMode = iota
+
 	UpstreamModeSymbolic
 )
 
 func (m *UpstreamMode) IsValid() bool {
 	switch *m {
 	case UpstreamModeFull, UpstreamModeSymbolic:
+
 		return true
+
 	default:
+
 		return false
 	}
 }
@@ -62,10 +77,15 @@ func (m *UpstreamMode) IsValid() bool {
 func (m *UpstreamMode) String() string {
 	switch *m {
 	case UpstreamModeFull:
+
 		return "full"
+
 	case UpstreamModeSymbolic:
+
 		return "symbolic"
+
 	default:
+
 		return "full" // default to full mode for safety
 	}
 }
@@ -76,50 +96,74 @@ func (m *UpstreamMode) MarshalJSON() ([]byte, error) {
 
 func (m *UpstreamMode) UnmarshalJSON(data []byte) error {
 	var s string
+
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
+
 	*m = MarshalUpstreamMode(s)
+
 	return nil
 }
 
 func MarshalUpstreamMode(s string) UpstreamMode {
 	switch strings.ToLower(s) {
 	case "full":
+
 		return UpstreamModeFull
+
 	case "symbolic":
+
 		return UpstreamModeSymbolic
+
 	default:
+
 		return UpstreamModeFull // default to full mode for safety
 	}
 }
 
 type upstream struct {
-	Value   string       `yaml:"value"`
-	Type    string       `yaml:"type"`
-	Mode    UpstreamMode `yaml:"mode"`
-	Columns columns      `yaml:"columns"`
+	Value string `yaml:"value"`
+
+	Type string `yaml:"type"`
+
+	Mode UpstreamMode `yaml:"mode"`
+
+	Columns columns `yaml:"columns"`
 }
 
 func (a *depends) UnmarshalYAML(value *yaml.Node) error {
 	switch value.Kind {
 	case yaml.SequenceNode:
+
 		var multi []upstream
+
 		if err := value.Decode(&multi); err != nil {
 			return &ParseError{Msg: "Malformed `depends` items"}
 		}
+
 		*a = multi
+
 		return nil
+
 	case yaml.ScalarNode, yaml.MappingNode:
+
 		var single upstream
+
 		if err := value.Decode(&single); err != nil {
 			return &ParseError{Msg: "Malformed `depends` items"}
 		}
+
 		*a = []upstream{single}
+
 		return nil
+
 	case yaml.DocumentNode, yaml.AliasNode:
+
 		return &ParseError{Msg: "Malformed `depends` items"}
+
 	default:
+
 		return &ParseError{Msg: "Malformed `depends` items"}
 	}
 }
@@ -127,51 +171,69 @@ func (a *depends) UnmarshalYAML(value *yaml.Node) error {
 func (u *upstream) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind == yaml.ScalarNode {
 		*u = upstream{Value: value.Value, Type: "asset", Columns: columns(nil), Mode: UpstreamModeFull}
+
 		return nil
 	}
 
 	var us map[string]any
+
 	err := value.Decode(&us)
 	if err != nil {
 		return &ParseError{Msg: "Malformed `depends` field"}
 	}
 
 	uri, foundURI := us["uri"]
+
 	asset, foundAsset := us["asset"]
+
 	cols, foundColumns := us["columns"]
+
 	colsStruct := columns(nil)
 
 	mode, foundMode := us["mode"]
+
 	upstreamMode := UpstreamModeFull
+
 	if foundMode {
 		upstreamMode = MarshalUpstreamMode(mode.(string))
 	}
 
 	if foundColumns {
 		colsSlice, ok := cols.([]any)
+
 		if !ok {
 			return &ParseError{Msg: "`columns` is malformed"}
 		}
 
 		for _, col := range colsSlice {
 			colString, ok := col.(string)
+
 			if ok {
 				colsStruct = append(colsStruct, upstreamColumn{Name: colString, Usage: ""})
+
 				continue
 			}
+
 			colMap, ok := col.(map[string]any)
+
 			if !ok {
 				return &ParseError{Msg: "'columns' is malformed"}
 			}
+
 			name, ok := colMap["name"]
+
 			if !ok {
 				return &ParseError{Msg: "Missing 'name' in column"}
 			}
+
 			nameString, ok := name.(string)
+
 			if !ok {
 				return &ParseError{Msg: "Malformed 'name' in column"}
 			}
+
 			usage, ok := colMap["usage"]
+
 			if !ok {
 				usage = ""
 			}
@@ -182,19 +244,25 @@ func (u *upstream) UnmarshalYAML(value *yaml.Node) error {
 
 	if foundURI && !foundAsset {
 		uriString, ok := uri.(string)
+
 		if !ok {
 			return &ParseError{Msg: "`uri` field must be a string"}
 		}
+
 		*u = upstream{Value: uriString, Type: "uri", Columns: colsStruct, Mode: upstreamMode}
+
 		return nil
 	}
 
 	if foundAsset && !foundURI {
 		assetString, ok := asset.(string)
+
 		if !ok {
 			return &ParseError{Msg: "`uri` field must be a string"}
 		}
+
 		*u = upstream{Value: assetString, Type: "asset", Columns: colsStruct, Mode: upstreamMode}
+
 		return nil
 	}
 
@@ -205,30 +273,43 @@ type clusterBy []string
 
 func (a *clusterBy) UnmarshalYAML(value *yaml.Node) error {
 	multi, err := mustBeStringArray("cluster_by", value)
+
 	*a = multi
+
 	return err
 }
 
 type materialization struct {
-	Type            string    `yaml:"type"`
-	Strategy        string    `yaml:"strategy"`
-	PartitionBy     string    `yaml:"partition_by"`
-	ClusterBy       clusterBy `yaml:"cluster_by"`
-	IncrementalKey  string    `yaml:"incremental_key"`
-	TimeGranularity string    `yaml:"time_granularity,omitempty"`
+	Type string `yaml:"type"`
+
+	Strategy string `yaml:"strategy"`
+
+	PartitionBy string `yaml:"partition_by"`
+
+	ClusterBy clusterBy `yaml:"cluster_by"`
+
+	IncrementalKey string `yaml:"incremental_key"`
+
+	TimeGranularity string `yaml:"time_granularity,omitempty"`
 }
 
 type columnCheckValue struct {
-	IntArray    *[]int
-	Int         *int
-	Float       *float64
+	IntArray *[]int
+
+	Int *int
+
+	Float *float64
+
 	StringArray *[]string
-	String      *string
-	Bool        *bool
+
+	String *string
+
+	Bool *bool
 }
 
 func (a *columnCheckValue) UnmarshalYAML(value *yaml.Node) error {
 	var val interface{}
+
 	err := value.Decode(&val)
 	if err != nil {
 		return err
@@ -236,29 +317,44 @@ func (a *columnCheckValue) UnmarshalYAML(value *yaml.Node) error {
 
 	switch v := val.(type) {
 	case []interface{}:
+
 		var multiInt []int
+
 		err := value.Decode(&multiInt)
+
 		if err == nil {
 			*a = columnCheckValue{IntArray: &multiInt}
+
 			return nil
 		}
 
 		var multi []string
+
 		err = value.Decode(&multi)
 		if err != nil {
 			return &ParseError{Msg: err.Error()}
 		}
 
 		*a = columnCheckValue{StringArray: &multi}
+
 	case string:
+
 		*a = columnCheckValue{String: &v}
+
 	case int:
+
 		*a = columnCheckValue{Int: &v}
+
 	case float64:
+
 		*a = columnCheckValue{Float: &v}
+
 	case bool:
+
 		*a = columnCheckValue{Bool: &v}
+
 	default:
+
 		return &ParseError{Msg: fmt.Sprintf("unexpected type %T", v)}
 	}
 
@@ -266,47 +362,72 @@ func (a *columnCheckValue) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type columnCheck struct {
-	Name          string           `yaml:"name"`
-	Value         columnCheckValue `yaml:"value"`
-	Blocking      *bool            `yaml:"blocking"`
-	Description   string           `yaml:"description,omitempty"`
-	Notifications Notifications    `yaml:"notifications"`
+	Name string `yaml:"name"`
+
+	Value columnCheckValue `yaml:"value"`
+
+	Blocking *bool `yaml:"blocking"`
+
+	Description string `yaml:"description,omitempty"`
+
+	Notifications Notifications `yaml:"notifications"`
 }
 
 type columnUpstream struct {
 	Column string `yaml:"column"`
-	Table  string `yaml:"table"`
+
+	Table string `yaml:"table"`
 }
 
 type column struct {
-	Extends       string            `yaml:"extends"`
-	Name          string            `yaml:"name"`
-	Type          string            `yaml:"type"`
-	Description   string            `yaml:"description"`
-	Tests         []columnCheck     `yaml:"checks"`
-	PrimaryKey    bool              `yaml:"primary_key"`
-	UpdateOnMerge bool              `yaml:"update_on_merge"`
-	MergeSQL      string            `yaml:"merge_sql"`
-	Nullable      *bool             `yaml:"nullable"`
-	Upstreams     []columnUpstream  `yaml:"upstreams"`
-	Tags          []string          `yaml:"tags"`
-	Domains       []string          `yaml:"domains"`
-	Meta          map[string]string `yaml:"meta"`
-	Owner         string            `yaml:"owner"`
+	Extends string `yaml:"extends"`
+
+	Name string `yaml:"name"`
+
+	Type string `yaml:"type"`
+
+	Description string `yaml:"description"`
+
+	Tests []columnCheck `yaml:"checks"`
+
+	PrimaryKey bool `yaml:"primary_key"`
+
+	UpdateOnMerge bool `yaml:"update_on_merge"`
+
+	MergeSQL string `yaml:"merge_sql"`
+
+	Nullable *bool `yaml:"nullable"`
+
+	Upstreams []columnUpstream `yaml:"upstreams"`
+
+	Tags []string `yaml:"tags"`
+
+	Domains []string `yaml:"domains"`
+
+	Meta map[string]string `yaml:"meta"`
+
+	Owner string `yaml:"owner"`
 }
 
 type secretMapping struct {
-	SecretKey   string `yaml:"key"`
+	SecretKey string `yaml:"key"`
+
 	InjectedKey string `yaml:"inject_as"`
 }
 
 type customCheck struct {
-	Name          string        `yaml:"name"`
-	Description   string        `yaml:"description"`
-	Query         string        `yaml:"query"`
-	Value         int64         `yaml:"value"`
-	Count         *int64        `yaml:"count"`
-	Blocking      *bool         `yaml:"blocking"`
+	Name string `yaml:"name"`
+
+	Description string `yaml:"description"`
+
+	Query string `yaml:"query"`
+
+	Value int64 `yaml:"value"`
+
+	Count *int64 `yaml:"count"`
+
+	Blocking *bool `yaml:"blocking"`
+
 	Notifications Notifications `yaml:"notifications"`
 }
 
@@ -322,38 +443,66 @@ func notificationsOrNil(n Notifications) *Notifications {
 	if len(n.Slack) == 0 && len(n.MSTeams) == 0 && len(n.Discord) == 0 && len(n.Webhook) == 0 {
 		return nil
 	}
+
 	return &n
 }
 
 type taskDefinition struct {
-	Name              string            `yaml:"name"`
-	URI               string            `yaml:"uri"`
-	Description       string            `yaml:"description"`
-	Type              string            `yaml:"type"`
-	RunFile           string            `yaml:"run"`
-	Depends           depends           `yaml:"depends"`
-	Parameters        map[string]string `yaml:"parameters"`
-	Connections       map[string]string `yaml:"connections"`
-	Secrets           []secretMapping   `yaml:"secrets"`
-	Connection        string            `yaml:"connection"`
-	Image             string            `yaml:"image"`
-	Instance          string            `yaml:"instance"`
-	Materialization   materialization   `yaml:"materialization"`
-	Owner             string            `yaml:"owner"`
-	StartDate         string            `yaml:"start_date"`
-	Extends           []string          `yaml:"extends"`
-	Columns           []column          `yaml:"columns"`
-	CustomChecks      []customCheck     `yaml:"custom_checks"`
-	Hooks             Hooks             `yaml:"hooks"`
-	Tags              []string          `yaml:"tags"`
-	Snowflake         snowflake         `yaml:"snowflake"`
-	Athena            athena            `yaml:"athena"`
+	Name string `yaml:"name"`
+
+	URI string `yaml:"uri"`
+
+	Description string `yaml:"description"`
+
+	Type string `yaml:"type"`
+
+	RunFile string `yaml:"run"`
+
+	Depends depends `yaml:"depends"`
+
+	Parameters map[string]string `yaml:"parameters"`
+
+	Connections map[string]string `yaml:"connections"`
+
+	Secrets []secretMapping `yaml:"secrets"`
+
+	Connection string `yaml:"connection"`
+
+	Image string `yaml:"image"`
+
+	Instance string `yaml:"instance"`
+
+	Materialization materialization `yaml:"materialization"`
+
+	Owner string `yaml:"owner"`
+
+	StartDate string `yaml:"start_date"`
+
+	Extends []string `yaml:"extends"`
+
+	Columns []column `yaml:"columns"`
+
+	CustomChecks []customCheck `yaml:"custom_checks"`
+
+	Hooks Hooks `yaml:"hooks"`
+
+	Tags []string `yaml:"tags"`
+
+	Snowflake snowflake `yaml:"snowflake"`
+
+	Athena athena `yaml:"athena"`
+
 	IntervalModifiers IntervalModifiers `yaml:"interval_modifiers"`
-	Domains           []string          `yaml:"domains"`
-	Meta              map[string]string `yaml:"meta"`
-	RerunCooldown     *int              `yaml:"rerun_cooldown"`
-	RefreshRestricted *bool             `yaml:"refresh_restricted,omitempty"`
-	Notifications     Notifications     `yaml:"notifications"`
+
+	Domains []string `yaml:"domains"`
+
+	Meta map[string]string `yaml:"meta"`
+
+	RerunCooldown *int `yaml:"rerun_cooldown"`
+
+	RefreshRestricted *bool `yaml:"refresh_restricted,omitempty"`
+
+	Notifications Notifications `yaml:"notifications"`
 }
 
 func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
@@ -364,11 +513,15 @@ func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
 		}
 
 		yamlError := new(path.YamlParseError)
+
 		var definition taskDefinition
+
 		err = path.ReadYaml(fs, filePath, &definition)
+
 		if err != nil && errors.As(err, &yamlError) {
 			return nil, &ParseError{Msg: err.Error()}
 		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -383,27 +536,40 @@ func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
 			return nil, err
 		}
 
+		var root yaml.Node
+
+		if yamlErr := yaml.Unmarshal(buf, &root); yamlErr == nil {
+			annotateCustomCheckLocations(task, &root, filePath, 0)
+		}
+
 		executableFile := ExecutableFile{
-			Name:    filepath.Base(filePath),
-			Path:    filePath,
+			Name: filepath.Base(filePath),
+
+			Path: filePath,
+
 			Content: string(buf),
 		}
+
 		if definition.RunFile != "" {
 			relativeRunFilePath := filepath.Join(filepath.Dir(filePath), definition.RunFile)
+
 			absRunFile, err := filepath.Abs(relativeRunFilePath)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to resolve the absolute run file path: %s", definition.RunFile)
 			}
 
 			executableFile.Name = filepath.Base(definition.RunFile)
+
 			executableFile.Path = absRunFile
 
 			content, err := afero.ReadFile(fs, absRunFile)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to read the run file: %s", absRunFile)
 			}
+
 			executableFile.Content = string(content)
 		}
+
 		task.ExecutableFile = executableFile
 
 		return task, nil
@@ -412,21 +578,28 @@ func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
 
 func ConvertYamlToTask(content []byte) (*Asset, error) {
 	var definition taskDefinition
+
 	err := path.ConvertYamlToObject(content, &definition)
 	if err != nil {
 		return nil, err
 	}
 
 	mat := Materialization{
-		Type:            MaterializationType(strings.ToLower(definition.Materialization.Type)),
-		Strategy:        MaterializationStrategy(strings.ToLower(definition.Materialization.Strategy)),
-		ClusterBy:       definition.Materialization.ClusterBy,
-		PartitionBy:     definition.Materialization.PartitionBy,
-		IncrementalKey:  definition.Materialization.IncrementalKey,
+		Type: MaterializationType(strings.ToLower(definition.Materialization.Type)),
+
+		Strategy: MaterializationStrategy(strings.ToLower(definition.Materialization.Strategy)),
+
+		ClusterBy: definition.Materialization.ClusterBy,
+
+		PartitionBy: definition.Materialization.PartitionBy,
+
+		IncrementalKey: definition.Materialization.IncrementalKey,
+
 		TimeGranularity: MaterializationTimeGranularity(strings.ToLower(definition.Materialization.TimeGranularity)),
 	}
 
 	columns := make([]Column, len(definition.Columns))
+
 	for index, column := range definition.Columns {
 		tests := make([]ColumnCheck, 0, len(column.Tests))
 
@@ -444,53 +617,76 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 			seenTests[test.Name] = true
 
 			check := NewColumnCheck(definition.Name, column.Name, test.Name, ColumnCheckValue(test.Value), test.Blocking, test.Description)
+
 			check.Notifications = notificationsOrNil(test.Notifications)
+
 			tests = append(tests, check)
 		}
 
 		var entityDefinition *EntityAttribute
+
 		if column.Extends != "" {
 			fromBits := strings.Split(column.Extends, ".")
+
 			if len(fromBits) != 2 {
 				return nil, &ParseError{Msg: "'from' field must be in the format `entity.attribute`"}
 			}
 
 			entityDefinition = &EntityAttribute{
-				Entity:    strings.TrimSpace(fromBits[0]),
+				Entity: strings.TrimSpace(fromBits[0]),
+
 				Attribute: strings.TrimSpace(fromBits[1]),
 			}
 		}
 
 		upstreamColumns := make([]*UpstreamColumn, len(column.Upstreams))
+
 		for index, upstream := range column.Upstreams {
 			upstreamColumns[index] = &UpstreamColumn{
 				Column: upstream.Column,
-				Table:  upstream.Table,
+
+				Table: upstream.Table,
 			}
 		}
 
 		columns[index] = Column{
-			Name:            column.Name,
-			Type:            strings.TrimSpace(column.Type),
-			Description:     column.Description,
-			Checks:          tests,
-			PrimaryKey:      column.PrimaryKey,
-			UpdateOnMerge:   column.UpdateOnMerge,
-			MergeSQL:        column.MergeSQL,
-			Nullable:        DefaultTrueBool{Value: column.Nullable},
+			Name: column.Name,
+
+			Type: strings.TrimSpace(column.Type),
+
+			Description: column.Description,
+
+			Checks: tests,
+
+			PrimaryKey: column.PrimaryKey,
+
+			UpdateOnMerge: column.UpdateOnMerge,
+
+			MergeSQL: column.MergeSQL,
+
+			Nullable: DefaultTrueBool{Value: column.Nullable},
+
 			EntityAttribute: entityDefinition,
-			Extends:         column.Extends,
-			Upstreams:       upstreamColumns,
-			Tags:            column.Tags,
-			Domains:         column.Domains,
-			Meta:            column.Meta,
-			Owner:           column.Owner,
+
+			Extends: column.Extends,
+
+			Upstreams: upstreamColumns,
+
+			Tags: column.Tags,
+
+			Domains: column.Domains,
+
+			Meta: column.Meta,
+
+			Owner: column.Owner,
 		}
 	}
 
 	upstreams := make([]Upstream, len(definition.Depends))
+
 	for index, dep := range definition.Depends {
 		cols := make([]DependsColumn, 0)
+
 		for _, col := range dep.Columns {
 			cols = append(cols, DependsColumn(col))
 		}
@@ -500,60 +696,99 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 		}
 
 		upstreams[index] = Upstream{
-			Value:   dep.Value,
-			Type:    dep.Type,
-			Mode:    dep.Mode,
+			Value: dep.Value,
+
+			Type: dep.Type,
+
+			Mode: dep.Mode,
+
 			Columns: cols,
 		}
 	}
 
 	task := Asset{
-		ID:                hash(definition.Name),
-		URI:               definition.URI,
-		Name:              definition.Name,
-		Description:       definition.Description,
-		Type:              AssetType(definition.Type),
-		Parameters:        definition.Parameters,
-		Connection:        definition.Connection,
-		Secrets:           make([]SecretMapping, len(definition.Secrets)),
-		Upstreams:         upstreams,
-		ExecutableFile:    ExecutableFile{},
-		Materialization:   mat,
-		Image:             definition.Image,
-		Instance:          definition.Instance,
-		Owner:             definition.Owner,
-		StartDate:         definition.StartDate,
-		Tags:              definition.Tags,
-		Extends:           definition.Extends,
-		Columns:           columns,
-		CustomChecks:      make([]CustomCheck, len(definition.CustomChecks)),
-		Hooks:             definition.Hooks,
-		Snowflake:         SnowflakeConfig{Warehouse: definition.Snowflake.Warehouse},
-		Athena:            AthenaConfig{Location: definition.Athena.QueryResultsPath},
+		ID: hash(definition.Name),
+
+		URI: definition.URI,
+
+		Name: definition.Name,
+
+		Description: definition.Description,
+
+		Type: AssetType(definition.Type),
+
+		Parameters: definition.Parameters,
+
+		Connection: definition.Connection,
+
+		Secrets: make([]SecretMapping, len(definition.Secrets)),
+
+		Upstreams: upstreams,
+
+		ExecutableFile: ExecutableFile{},
+
+		Materialization: mat,
+
+		Image: definition.Image,
+
+		Instance: definition.Instance,
+
+		Owner: definition.Owner,
+
+		StartDate: definition.StartDate,
+
+		Tags: definition.Tags,
+
+		Extends: definition.Extends,
+
+		Columns: columns,
+
+		CustomChecks: make([]CustomCheck, len(definition.CustomChecks)),
+
+		Hooks: definition.Hooks,
+
+		Snowflake: SnowflakeConfig{Warehouse: definition.Snowflake.Warehouse},
+
+		Athena: AthenaConfig{Location: definition.Athena.QueryResultsPath},
+
 		IntervalModifiers: definition.IntervalModifiers,
-		Domains:           definition.Domains,
-		Meta:              definition.Meta,
-		RerunCooldown:     definition.RerunCooldown,
+
+		Domains: definition.Domains,
+
+		Meta: definition.Meta,
+
+		RerunCooldown: definition.RerunCooldown,
+
 		RefreshRestricted: definition.RefreshRestricted,
-		Notifications:     notificationsOrNil(definition.Notifications),
+
+		Notifications: notificationsOrNil(definition.Notifications),
 	}
 
 	for index, check := range definition.CustomChecks {
 		// set the ID as the hash of the name
+
 		task.CustomChecks[index] = CustomCheck{
-			ID:            hash(fmt.Sprintf("%s-%s", task.Name, check.Name)),
-			Name:          check.Name,
-			Description:   check.Description,
-			Query:         check.Query,
-			Value:         check.Value,
-			Count:         check.Count,
-			Blocking:      DefaultTrueBool{Value: check.Blocking},
+			ID: hash(fmt.Sprintf("%s-%s", task.Name, check.Name)),
+
+			Name: check.Name,
+
+			Description: check.Description,
+
+			Query: check.Query,
+
+			Value: check.Value,
+
+			Count: check.Count,
+
+			Blocking: DefaultTrueBool{Value: check.Blocking},
+
 			Notifications: notificationsOrNil(check.Notifications),
 		}
 	}
 
 	for index, m := range definition.Secrets {
 		mapping := SecretMapping(m)
+
 		if mapping.InjectedKey == "" {
 			mapping.InjectedKey = mapping.SecretKey
 		}


### PR DESCRIPTION
## Problem

When a custom check fails, Bruin prints the error from the database engine, which may include a position like `[17:16]`. That position refers to the compiled query inside the database — it has no relation to the user's asset file. The user has no way to know *which check* failed or *where in their file* it is defined.

Reported by Neda: the requested improvement was to show line numbers that correspond to the YAML definition in the Bruin asset file.

## Solution

Track the source file position of every custom check at parse time and surface it in the CLI output when a check fails.

### Changes

**`pkg/pipeline/source_location.go`** (new)  
Introduces a `SourceLocation` struct (`File`, `Line`, `Column`) with `IsZero()` and `String()` helpers, used to represent a position within a source file.

**`pkg/pipeline/custom_check_locations.go`** (new)  
`annotateCustomCheckLocations` walks the parsed `yaml.Node` tree after a successful asset parse and stamps each `CustomCheck` with:
- `SourceLocation` — the line/column of the `- name:` entry in the original file
- `QueryLocation` — the line/column of the `query:` key in the original file

A `lineOffset` parameter handles the difference between pure YAML assets (offset 0) and SQL assets with embedded `/* @bruin … @bruin */` blocks (offset = line number of the opening marker).

**`pkg/pipeline/pipeline.go`**  
Added `SourceLocation` and `QueryLocation` fields to `CustomCheck`. Both are tagged `json:"-" yaml:"-" mapstructure:"-"` so they are invisible to serialisation and YAML parsing — parse-time annotation only.

**`pkg/pipeline/yaml.go`**  
After `ConvertYamlToTask`, re-parses the raw YAML bytes into a `yaml.Node` and calls `annotateCustomCheckLocations` with `lineOffset=0`.

**`pkg/pipeline/comment.go`**  
`readUntilComments` now returns the line number of the opening `/* @bruin` marker. `commentedYamlToTask` re-parses the extracted YAML bytes into a `yaml.Node` and calls `annotateCustomCheckLocations` with that line as the offset, so node positions are correctly mapped back to the original `.sql` / `.py` file.

**`cmd/run.go`**  
When a `CustomCheckInstance` fails, the error output now includes: