### PR TITLE
fix(checks): display source file location when a custom check fails

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1600,10 +1600,17 @@ func printErrorsInResults(errorsInTaskResults []*scheduler.TaskExecutionResult, 
 					color.New(color.FgRed).Sprintf("%s", result.Error)))
 
 			case *scheduler.CustomCheckInstance:
-				assetBranch.AddNode(fmt.Sprintf("%s %s - %s",
+				msg := fmt.Sprintf("%s %s - %s",
 					color.New(color.FgMagenta).Sprint(instance.Check.Name),
 					faint("custom check"),
-					color.New(color.FgRed).Sprintf("%s", result.Error)))
+					color.New(color.FgRed).Sprintf("%s", result.Error))
+				checkNode := assetBranch.AddBranch(msg)
+				if !instance.Check.SourceLocation.IsZero() {
+					checkNode.AddNode(faint("defined at:      " + instance.Check.SourceLocation.String()))
+				}
+				if !instance.Check.QueryLocation.IsZero() {
+					checkNode.AddNode(faint("query starts at: " + instance.Check.QueryLocation.String()))
+				}
 
 			default:
 				assetBranch.AddNode(color.New(color.FgRed).Sprintf("%s", result.Error))
@@ -1633,6 +1640,15 @@ func printSingleCheckError(result *scheduler.TaskExecutionResult) {
 		fmt.Println(checkErr.Query + "\n")
 	} else {
 		fmt.Printf("Error: %s\n", result.Error)
+	}
+
+	if instance, ok := result.Instance.(*scheduler.CustomCheckInstance); ok {
+		if !instance.Check.SourceLocation.IsZero() {
+			fmt.Printf("Defined at:      %s\n", instance.Check.SourceLocation)
+		}
+		if !instance.Check.QueryLocation.IsZero() {
+			fmt.Printf("Query starts at: %s\n", instance.Check.QueryLocation)
+		}
 	}
 }
 

--- a/docs/quality/custom.md
+++ b/docs/quality/custom.md
@@ -137,3 +137,64 @@ GROUP BY 1
 
 > [!INFO]
 > Non-blocking checks are useful for long-running or expensive quality checks. It means the downstream assets will not be waiting for this quality check to finish.
+
+## Troubleshooting custom check failures
+
+When a custom check fails, Bruin prints the name of the failing check, its location in the original asset file, and the underlying database error.
+
+### Example output
+
+```
+  dataset.orders
+  └── duplicate check  custom check  result 2 doesn't match expected value 0
+      ├── defined at:      assets/orders.sql:8:5
+      └── query starts at: assets/orders.sql:9:5
+```
+
+When running a single check with `--single-check`, the output is:
+
+```
+Check Failed
+------------
+Error: result 2 doesn't match expected value 0
+
+Result: 2 (expected: 0)
+
+Query:
+SELECT COUNT(*) - COUNT(DISTINCT id) FROM dataset.orders
+
+Defined at:      assets/orders.sql:8:5
+Query starts at: assets/orders.sql:9:5
+```
+
+### Reading the locations
+
+| Field | Meaning |
+| ----- | ------- |
+| `defined at` | File, line, and column of the `- name:` entry for the failing check in the asset file. |
+| `query starts at` | File, line, and column of the `query:` key for that check. |
+
+Both locations refer to the **original asset file** — the `.sql` or `.yml` file you edit — not to the SQL that Bruin sends to the database.
+
+### Database error line numbers
+
+Database engines often report a location inside the SQL they received, for example:
+
+```
+Aggregations of aggregations are not allowed at [17:16]
+```
+
+That `[17:16]` refers to the **rendered SQL** Bruin sent to the database, which may differ from your source file because:
+
+- Bruin strips the `/* @bruin … @bruin */` metadata block before execution.
+- `count`-based checks are wrapped with `SELECT count(*) FROM (<your query>)`, adding extra lines.
+- Jinja templating expands macros and variables.
+
+Use `defined at` and `query starts at` to find the check in your file. Use the database location only to understand which part of the rendered SQL the engine rejected.
+
+### Supported asset types
+
+Source locations are captured for both asset types:
+
+- **SQL assets** (`.sql` files with a `/* @bruin … @bruin */` block) — line numbers are relative to the original `.sql` file, not the extracted YAML block.
+- **YAML assets** (`.yml` / `.yaml` asset files) — line numbers are the YAML file lines directly.

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -955,7 +955,12 @@ func TestIndividualTasks(t *testing.T) {
 				Env:     []string{},
 				Expected: e2e.Output{
 					ExitCode: 1,
-					Contains: []string{"custom check 'row_count' has returned 4 instead of the expected 7"},
+					Contains: []string{
+						"custom check 'row_count' has returned 4 instead of the expected 7",
+						"defined at:",
+						"query starts at:",
+						"products.sql",
+					},
 				},
 				Asserts: []func(*e2e.Task) error{
 					e2e.AssertByExitCode,

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -87,7 +88,7 @@ func isEmbeddedYamlComment(file afero.File, prefixes []string) bool {
 }
 
 func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
-	rows, commentRowEnd := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
+	rows, commentRowEnd, openingMarkerLine := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
 	if rows == "" {
 		return nil, &ParseError{"no embedded YAML found in the comments"}
 	}
@@ -100,6 +101,11 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	absFilePath, err := filepath.Abs(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get absolute path for file %s", filePath)
+	}
+
+	var root yaml.Node
+	if yamlErr := yaml.Unmarshal([]byte(rows), &root); yamlErr == nil {
+		annotateCustomCheckLocations(task, &root, absFilePath, openingMarkerLine)
 	}
 
 	scanner := bufio.NewScanner(file)
@@ -122,11 +128,12 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	return task, nil
 }
 
-func readUntilComments(file afero.File, prefixes, suffixes []string) (string, int) {
+func readUntilComments(file afero.File, prefixes, suffixes []string) (string, int, int) {
 	scanner := bufio.NewScanner(file)
 	defer func() { _, _ = file.Seek(0, io.SeekStart) }()
 	var rowsBuilder strings.Builder
 	rowCount := 0
+	openingMarkerLine := 0
 
 	seenPrefix := false
 
@@ -143,6 +150,7 @@ OUTER:
 				if !seenPrefix {
 					// First occurrence - this is the opening marker
 					seenPrefix = true
+					openingMarkerLine = rowCount
 					continue OUTER
 				}
 			}
@@ -160,7 +168,7 @@ OUTER:
 		rowsBuilder.WriteByte('\n')
 	}
 
-	return strings.TrimSpace(rowsBuilder.String()), rowCount
+	return strings.TrimSpace(rowsBuilder.String()), rowCount, openingMarkerLine
 }
 
 func singleLineCommentsToTask(scanner *bufio.Scanner, commentMarker, filePath string) (*Asset, error) {
@@ -414,7 +422,7 @@ func ValidateAssetYAML(fs afero.Fs, filePath string, defType TaskDefinitionType)
 			return nil
 		}
 
-		rows, _ := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
+		rows, _, _ := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
 		if rows == "" {
 			return nil
 		}

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -13,13 +13,17 @@ import (
 
 func mustRead(t *testing.T, file string) string {
 	content, err := afero.ReadFile(afero.NewOsFs(), file)
+
 	require.NoError(t, err)
+
 	return strings.ReplaceAll(strings.TrimSpace(string(content)), "\r\n", "\n")
 }
 
 func mustReadWithoutReplacement(t *testing.T, file string) string {
 	content, err := afero.ReadFile(afero.NewOsFs(), file)
+
 	require.NoError(t, err)
+
 	return strings.TrimSpace(string(content))
 }
 
@@ -27,6 +31,7 @@ func Test_createTaskFromFile(t *testing.T) {
 	t.Parallel()
 
 	falseValue := false
+
 	trueValue := true
 
 	type args struct {
@@ -34,345 +39,582 @@ func Test_createTaskFromFile(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		want    *pipeline.Asset
+		name string
+
+		args args
+
+		want *pipeline.Asset
+
 		wantErr bool
 	}{
 		{
 			name: "file does not exist",
+
 			args: args{
 				filePath: "testdata/comments/some-file-that-doesnt-exist.sql",
 			},
+
 			wantErr: true,
 		},
+
 		{
 			name: "existing file with no comments is skipped",
+
 			args: args{
 				filePath: "testdata/comments/nocomments.py",
 			},
+
 			wantErr: false,
 		},
+
 		{
 			name: "SQL file parsed",
+
 			args: args{
 				filePath: "testdata/comments/test.sql",
 			},
+
 			want: &pipeline.Asset{
-				ID:          "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
-				Name:        "some-sql-task",
+				ID: "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
+
+				Name: "some-sql-task",
+
 				Description: "some description goes here",
-				Type:        "bq.sql",
+
+				Type: "bq.sql",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "test.sql",
-					Path:    path.AbsPathForTests(t, "testdata/comments/test.sql"),
+					Name: "test.sql",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/test.sql"),
+
 					Content: "select *\nfrom foo;",
 				},
+
 				Parameters: map[string]string{
-					"param1":       "first-parameter",
-					"param2":       "second-parameter",
+					"param1": "first-parameter",
+
+					"param2": "second-parameter",
+
 					"s3_file_path": "s3://bucket/path",
 				},
+
 				Connection: "conn2",
-				Secrets:    []pipeline.SecretMapping{},
+
+				Secrets: []pipeline.SecretMapping{},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
 
 				Materialization: pipeline.Materialization{
-					Type:           pipeline.MaterializationTypeTable,
-					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
-					PartitionBy:    "dt",
+					Type: pipeline.MaterializationTypeTable,
+
+					Strategy: pipeline.MaterializationStrategyDeleteInsert,
+
+					PartitionBy: "dt",
+
 					IncrementalKey: "dt",
-					ClusterBy:      []string{"event_name"},
+
+					ClusterBy: []string{"event_name"},
 				},
+
 				Columns: []pipeline.Column{
 					{Name: "some_column", PrimaryKey: true, Checks: make([]pipeline.ColumnCheck, 0)},
+
 					{Name: "some_other_column", PrimaryKey: false, Checks: make([]pipeline.ColumnCheck, 0)},
 				},
+
 				CustomChecks: make([]pipeline.CustomCheck, 0),
 			},
 		},
+
 		{
 			name: "SQL file failed to parse",
+
 			args: args{
 				filePath: "testdata/comments/failparseprimarykey.sql",
 			},
+
 			wantErr: true,
 		},
+
 		{
 			name: "SQL file with embedded yaml content is parsed",
+
 			args: args{
 				filePath: "testdata/comments/embeddedyaml.sql",
 			},
+
 			want: &pipeline.Asset{
-				ID:          "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
-				Name:        "some-sql-task",
+				ID: "5812ba61bb0f08ce192bf074c9de21c19355e08cd52e75d008bbff59e5729e5b",
+
+				Name: "some-sql-task",
+
 				Description: "some description goes here",
-				Type:        "bq.sql",
+
+				Type: "bq.sql",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "embeddedyaml.sql",
-					Path:    path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+					Name: "embeddedyaml.sql",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+
 					Content: "select *\nfrom foo;",
 				},
+
 				Parameters: map[string]string{
-					"param1":       "first-parameter",
-					"param2":       "second-parameter",
+					"param1": "first-parameter",
+
+					"param2": "second-parameter",
+
 					"s3_file_path": "s3://bucket/path",
 				},
+
 				Connection: "conn1",
-				Secrets:    []pipeline.SecretMapping{},
+
+				Secrets: []pipeline.SecretMapping{},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
+
 				Materialization: pipeline.Materialization{
-					Type:           pipeline.MaterializationTypeTable,
-					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
-					PartitionBy:    "dt",
+					Type: pipeline.MaterializationTypeTable,
+
+					Strategy: pipeline.MaterializationStrategyDeleteInsert,
+
+					PartitionBy: "dt",
+
 					IncrementalKey: "dt",
-					ClusterBy:      []string{"event_name"},
+
+					ClusterBy: []string{"event_name"},
 				},
+
 				Columns: make([]pipeline.Column, 0),
+
 				CustomChecks: []pipeline.CustomCheck{
 					{
-						ID:    "480f365424205654f7108f2d0ddf6418faed97652bba106ba4080a967a50e5cf",
-						Name:  "check1",
+						ID: "480f365424205654f7108f2d0ddf6418faed97652bba106ba4080a967a50e5cf",
+
+						Name: "check1",
+
 						Query: "select * from table1",
+
 						Value: 16,
+
+						SourceLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+
+							Line: 27,
+
+							Column: 5,
+						},
+
+						QueryLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
+
+							Line: 29,
+
+							Column: 5,
+						},
 					},
 				},
+
 				Hooks: pipeline.Hooks{
-					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Pre: []pipeline.Hook{{Query: "select 1"}},
+
 					Post: []pipeline.Hook{{Query: "select 2"}},
 				},
 			},
 		},
+
 		{
 			name: "Python file parsed",
+
 			args: args{
 				filePath: path.AbsPathForTests(t, "testdata/comments/test.py"), // giving an absolute path here tests the case of double-absolute paths
+
 			},
+
 			want: &pipeline.Asset{
-				ID:          "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
-				Name:        "some-python-task",
+				ID: "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
+
+				Name: "some-python-task",
+
 				Description: "some description goes here",
-				Type:        "bq.sql",
+
+				Type: "bq.sql",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "test.py",
-					Path:    path.AbsPathForTests(t, "testdata/comments/test.py"),
+					Name: "test.py",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/test.py"),
+
 					Content: "print('hello world')",
 				},
+
 				Parameters: map[string]string{
 					"param1": "first-parameter",
+
 					"param2": "second-parameter",
+
 					"param3": "third-parameter",
 				},
+
 				Connection: "conn1",
-				Image:      "python:3.11",
-				Instance:   "b1.nano",
-				Secrets:    []pipeline.SecretMapping{},
+
+				Image: "python:3.11",
+
+				Instance: "b1.nano",
+
+				Secrets: []pipeline.SecretMapping{},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
+
 				Columns: []pipeline.Column{
 					{
 						Name: "col1",
+
 						Type: "string",
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:       "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
-								Name:     "not_null",
+								ID: "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
+
+								Name: "not_null",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
+
 							{
-								ID:       "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
-								Name:     "positive",
+								ID: "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
+
+								Name: "positive",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
+
 							{
-								ID:       "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
-								Name:     "unique",
+								ID: "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
+
+								Name: "unique",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
 						},
 					},
+
 					{
 						Name: "col2",
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:       "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
-								Name:     "not_null",
+								ID: "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
+
+								Name: "not_null",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
+
 							{
-								ID:       "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
-								Name:     "unique",
+								ID: "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
+
+								Name: "unique",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &trueValue},
 							},
 						},
 					},
 				},
+
 				CustomChecks: make([]pipeline.CustomCheck, 0),
 			},
 		},
+
 		{
 			name: "Python file with comment block parsed",
+
 			args: args{
 				filePath: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
 			},
+
 			want: &pipeline.Asset{
-				ID:          "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
-				Name:        "some-python-task",
+				ID: "21f2fa1b09d584a6b4fe30cd82b4540b769fd777da7c547353386e2930291ef9",
+
+				Name: "some-python-task",
+
 				Description: "some description goes here",
-				Type:        "python",
+
+				Type: "python",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "testblockcomments.py",
-					Path:    path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+					Name: "testblockcomments.py",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
 					Content: "print('hello world')",
 				},
+
 				Parameters: map[string]string{
 					"param1": "first-parameter",
+
 					"param2": "second-parameter",
+
 					"param3": "third-parameter",
 				},
-				Image:    "python:3.11",
+
+				Image: "python:3.11",
+
 				Instance: "b1.nano",
+
 				Secrets: []pipeline.SecretMapping{
 					{
-						SecretKey:   "secret1",
+						SecretKey: "secret1",
+
 						InjectedKey: "INJECTED_SECRET1",
 					},
+
 					{
-						SecretKey:   "secret2",
+						SecretKey: "secret2",
+
 						InjectedKey: "secret2",
 					},
 				},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task4", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task5", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
+
 				Columns: []pipeline.Column{
 					{
-						Name:      "col1",
-						Type:      "string",
+						Name: "col1",
+
+						Type: "string",
+
 						Upstreams: make([]*pipeline.UpstreamColumn, 0),
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:   "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
+								ID: "08745666ad3e043ceb0321ed502e9a2d20248d62b2ee7dd1c600fc5c944af238",
+
 								Name: "not_null",
 							},
+
 							{
-								ID:   "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
+								ID: "29f700e6438c361ab038fcb611a71dab5a6949f3942b75c52402dce7a17cf698",
+
 								Name: "positive",
 							},
+
 							{
-								ID:   "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
+								ID: "6660a3e1f845f9046ff2cda9ef8ae9357c4008c43724ebaf834186e5c2bd7a35",
+
 								Name: "unique",
 							},
 						},
 					},
+
 					{
-						Name:      "col2",
-						Type:      "string",
+						Name: "col2",
+
+						Type: "string",
+
 						Upstreams: make([]*pipeline.UpstreamColumn, 0),
+
 						Checks: []pipeline.ColumnCheck{
 							{
-								ID:   "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
+								ID: "7870f9ce39b0d29451a41e2d8240c02713ce80647db886fe5e5cc69227dd86d3",
+
 								Name: "not_null",
 							},
+
 							{
-								ID:       "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
-								Name:     "unique",
+								ID: "68e80e2b513c908c9c1d3aac2f96bd535f43f2c62a78c6744dee8ae767e60e5d",
+
+								Name: "unique",
+
 								Blocking: pipeline.DefaultTrueBool{Value: &falseValue},
 							},
 						},
 					},
 				},
+
 				CustomChecks: []pipeline.CustomCheck{
 					{
-						ID:       "a26c19e73c6b5cdee1b1bfe135a475979f360b9e7fdfc19a7fca1832d034adbc",
-						Name:     "check1",
-						Query:    "select 5",
-						Value:    16,
-						Blocking: pipeline.DefaultTrueBool{Value: &falseValue},
-					},
-					{
-						ID:    "cc1040bd694dcb5fae26300d2c0f721e4c4304cb16b9dce3b4ddcaa44498b940",
-						Name:  "check2",
+						ID: "a26c19e73c6b5cdee1b1bfe135a475979f360b9e7fdfc19a7fca1832d034adbc",
+
+						Name: "check1",
+
 						Query: "select 5",
+
 						Value: 16,
+
+						Blocking: pipeline.DefaultTrueBool{Value: &falseValue},
+
+						SourceLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 35,
+
+							Column: 7,
+						},
+
+						QueryLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 36,
+
+							Column: 7,
+						},
+					},
+
+					{
+						ID: "cc1040bd694dcb5fae26300d2c0f721e4c4304cb16b9dce3b4ddcaa44498b940",
+
+						Name: "check2",
+
+						Query: "select 5",
+
+						Value: 16,
+
+						SourceLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 40,
+
+							Column: 7,
+						},
+
+						QueryLocation: &pipeline.SourceLocation{
+							File: path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
+
+							Line: 41,
+
+							Column: 7,
+						},
 					},
 				},
+
 				Hooks: pipeline.Hooks{
-					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Pre: []pipeline.Hook{{Query: "select 1"}},
+
 					Post: []pipeline.Hook{{Query: "select 2"}},
 				},
 			},
 		},
+
 		{
 			name: "R file with comment block parsed",
+
 			args: args{
 				filePath: path.AbsPathForTests(t, "testdata/comments/test.r"),
 			},
+
 			want: &pipeline.Asset{
-				ID:          "aba30496cdc78a46e6e2e6da72985ac3e05aa83b87a01b3dc347166ffa634e5f",
-				Name:        "some-r-task",
+				ID: "aba30496cdc78a46e6e2e6da72985ac3e05aa83b87a01b3dc347166ffa634e5f",
+
+				Name: "some-r-task",
+
 				Description: "R task with multiline configuration",
-				Type:        "r",
+
+				Type: "r",
+
 				ExecutableFile: pipeline.ExecutableFile{
-					Name:    "test.r",
-					Path:    path.AbsPathForTests(t, "testdata/comments/test.r"),
+					Name: "test.r",
+
+					Path: path.AbsPathForTests(t, "testdata/comments/test.r"),
+
 					Content: "cat(\"Hello from R!\\n\")\nprint(\"This is an R script\")",
 				},
+
 				Parameters: map[string]string{
 					"param1": "first-parameter",
+
 					"param2": "second-parameter",
+
 					"param3": "third-parameter",
 				},
-				Image:    "r:4.3",
+
+				Image: "r:4.3",
+
 				Instance: "b1.nano",
+
 				Secrets: []pipeline.SecretMapping{
 					{
-						SecretKey:   "secret1",
+						SecretKey: "secret1",
+
 						InjectedKey: "INJECTED_SECRET1",
 					},
+
 					{
-						SecretKey:   "secret2",
+						SecretKey: "secret2",
+
 						InjectedKey: "secret2",
 					},
 				},
+
 				Upstreams: []pipeline.Upstream{
 					{Value: "task1", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task2", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
+
 					{Value: "task3", Type: "asset", Columns: make([]pipeline.DependsColumn, 0), Mode: pipeline.UpstreamModeFull},
 				},
-				Columns:      make([]pipeline.Column, 0),
+
+				Columns: make([]pipeline.Column, 0),
+
 				CustomChecks: make([]pipeline.CustomCheck, 0),
+
 				Hooks: pipeline.Hooks{
-					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Pre: []pipeline.Hook{{Query: "select 1"}},
+
 					Post: []pipeline.Hook{{Query: "select 2"}},
 				},
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -387,6 +629,7 @@ func Test_createTaskFromFile(t *testing.T) {
 
 			if tt.want == nil {
 				assert.Nil(t, got)
+
 				return
 			}
 
@@ -402,6 +645,7 @@ func BenchmarkCreateTaskFromFileComments(b *testing.B) {
 
 	for range make([]struct{}, b.N) {
 		_, err := pipeline.CreateTaskFromFileComments(afero.NewOsFs())(file)
+
 		require.NoError(b, err)
 	}
 }

--- a/pkg/pipeline/custom_check_locations.go
+++ b/pkg/pipeline/custom_check_locations.go
@@ -1,0 +1,69 @@
+package pipeline
+
+import "gopkg.in/yaml.v3"
+
+// annotateCustomCheckLocations sets SourceLocation and QueryLocation on each custom check
+// by navigating the parsed yaml.Node tree.
+//
+// lineOffset is the number of file lines that precede the first line of the YAML block.
+// For a pure YAML asset file this is 0, so yaml.Node.Line maps directly to the file line.
+// For an embedded /* @bruin … @bruin */ block, lineOffset is the 1-based line number of
+// the opening marker so that yaml.Node.Line 1 maps to file line (lineOffset + 1).
+func annotateCustomCheckLocations(asset *Asset, root *yaml.Node, filePath string, lineOffset int) {
+	if len(asset.CustomChecks) == 0 {
+		return
+	}
+
+	// Navigate: Document → Mapping
+	doc := root
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return
+		}
+		doc = doc.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return
+	}
+
+	// Find the "custom_checks" key in the top-level mapping.
+	var checksSeqNode *yaml.Node
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		if doc.Content[i].Value == "custom_checks" {
+			checksSeqNode = doc.Content[i+1]
+			break
+		}
+	}
+	if checksSeqNode == nil || checksSeqNode.Kind != yaml.SequenceNode {
+		return
+	}
+
+	for i, checkNode := range checksSeqNode.Content {
+		if i >= len(asset.CustomChecks) {
+			break
+		}
+		if checkNode.Kind != yaml.MappingNode {
+			continue
+		}
+
+		// Set SourceLocation from the check item node position.
+		asset.CustomChecks[i].SourceLocation = &SourceLocation{
+			File:   filePath,
+			Line:   lineOffset + checkNode.Line,
+			Column: checkNode.Column,
+		}
+
+		// Find the "query" key inside the check's mapping.
+		for j := 0; j+1 < len(checkNode.Content); j += 2 {
+			if checkNode.Content[j].Value == "query" {
+				qk := checkNode.Content[j] // use the key node for the column reference
+				asset.CustomChecks[i].QueryLocation = &SourceLocation{
+					File:   filePath,
+					Line:   lineOffset + qk.Line,
+					Column: qk.Column,
+				}
+				break
+			}
+		}
+	}
+}

--- a/pkg/pipeline/custom_check_locations.go
+++ b/pkg/pipeline/custom_check_locations.go
@@ -38,16 +38,19 @@ func annotateCustomCheckLocations(asset *Asset, root *yaml.Node, filePath string
 		return
 	}
 
-	for i, checkNode := range checksSeqNode.Content {
-		if i >= len(asset.CustomChecks) {
+	ccIdx := 0
+	for _, checkNode := range checksSeqNode.Content {
+		if ccIdx >= len(asset.CustomChecks) {
 			break
 		}
 		if checkNode.Kind != yaml.MappingNode {
+			// Skip non-mapping nodes without advancing the CustomChecks index
+			// so all subsequent checks are stamped correctly.
 			continue
 		}
 
 		// Set SourceLocation from the check item node position.
-		asset.CustomChecks[i].SourceLocation = &SourceLocation{
+		asset.CustomChecks[ccIdx].SourceLocation = &SourceLocation{
 			File:   filePath,
 			Line:   lineOffset + checkNode.Line,
 			Column: checkNode.Column,
@@ -57,7 +60,7 @@ func annotateCustomCheckLocations(asset *Asset, root *yaml.Node, filePath string
 		for j := 0; j+1 < len(checkNode.Content); j += 2 {
 			if checkNode.Content[j].Value == "query" {
 				qk := checkNode.Content[j] // use the key node for the column reference
-				asset.CustomChecks[i].QueryLocation = &SourceLocation{
+				asset.CustomChecks[ccIdx].QueryLocation = &SourceLocation{
 					File:   filePath,
 					Line:   lineOffset + qk.Line,
 					Column: qk.Column,
@@ -65,5 +68,6 @@ func annotateCustomCheckLocations(asset *Asset, root *yaml.Node, filePath string
 				break
 			}
 		}
+		ccIdx++
 	}
 }

--- a/pkg/pipeline/custom_check_locations_internal_test.go
+++ b/pkg/pipeline/custom_check_locations_internal_test.go
@@ -1,0 +1,70 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestAnnotateCustomCheckLocations_SkipsNonMappingNodes verifies the fix for the
+// index mis-alignment bug: when a non-mapping node (e.g. a scalar) appears in the
+// custom_checks sequence, annotateCustomCheckLocations must skip it without
+// advancing the CustomChecks index, so the subsequent checks are still annotated
+// with the correct positions.
+func TestAnnotateCustomCheckLocations_SkipsNonMappingNodes(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal YAML document with two valid mapping nodes and a scalar
+	// interspersed between them:
+	//
+	//   custom_checks:
+	//     - name: check_one       <- mapping node (index 0 in Content)
+	//       query: select 1
+	//     - "stray scalar"        <- scalar node  (index 1 in Content, must be skipped)
+	//     - name: check_two       <- mapping node (index 2 in Content)
+	//       query: select 2
+	//
+	// Without the ccIdx fix the second mapping node (check_two) would be annotated
+	// as CustomChecks[2], but there are only 2 checks so that slot doesn't exist —
+	// and CustomChecks[1] would remain un-annotated.
+	const src = `custom_checks:
+  - name: check_one
+    query: select 1
+  - "stray scalar"
+  - name: check_two
+    query: select 2
+`
+	// Parse into a yaml.Node tree.
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &root))
+
+	// The asset has exactly 2 custom checks (the scalar is not a check).
+	asset := &Asset{
+		CustomChecks: []CustomCheck{
+			{Name: "check_one"},
+			{Name: "check_two"},
+		},
+	}
+
+	annotateCustomCheckLocations(asset, &root, "fake.yml", 0)
+
+	// check_one (first mapping) must be annotated.
+	require.NotNil(t, asset.CustomChecks[0].SourceLocation,
+		"check_one must have a SourceLocation")
+	assert.Equal(t, "fake.yml", asset.CustomChecks[0].SourceLocation.File)
+
+	// check_two (third YAML node, second mapping) must also be annotated.
+	// Before the fix, this would be nil because ccIdx would have been incremented
+	// for the scalar node, leaving CustomChecks[1] never reached.
+	require.NotNil(t, asset.CustomChecks[1].SourceLocation,
+		"check_two must have a SourceLocation — ccIdx must not advance for non-mapping nodes")
+	assert.Equal(t, "fake.yml", asset.CustomChecks[1].SourceLocation.File)
+
+	// Both query locations must be set too.
+	require.NotNil(t, asset.CustomChecks[0].QueryLocation,
+		"check_one must have a QueryLocation")
+	require.NotNil(t, asset.CustomChecks[1].QueryLocation,
+		"check_two must have a QueryLocation")
+}

--- a/pkg/pipeline/custom_check_locations_test.go
+++ b/pkg/pipeline/custom_check_locations_test.go
@@ -1,0 +1,196 @@
+package pipeline_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/path"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCustomCheckLocations_SQLEmbeddedYAML verifies that parsing a SQL file with
+
+// an embedded /* @bruin … @bruin */ block annotates each custom check with its
+
+// exact source location within the original file.
+
+func TestCustomCheckLocations_SQLEmbeddedYAML(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+
+	creator := pipeline.CreateTaskFromFileComments(fs)
+
+	filePath := filepath.Join("testdata", "comments", "custom_checks_location.sql")
+
+	absPath := path.AbsPathForTests(t, filePath)
+
+	asset, err := creator(filePath)
+
+	require.NoError(t, err)
+
+	require.NotNil(t, asset)
+
+	require.Len(t, asset.CustomChecks, 2)
+
+	// check[0]: "row count"
+
+	c0 := asset.CustomChecks[0]
+
+	assert.Equal(t, "row count", c0.Name)
+
+	require.NotNil(t, c0.SourceLocation, "SourceLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.SourceLocation.File)
+
+	assert.Equal(t, 5, c0.SourceLocation.Line,
+
+		"'- name: row count' is at file line 5 (opening marker at line 1 + YAML line 4)")
+
+	assert.Equal(t, 5, c0.SourceLocation.Column)
+
+	require.NotNil(t, c0.QueryLocation, "QueryLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.QueryLocation.File)
+
+	assert.Equal(t, 6, c0.QueryLocation.Line,
+
+		"'query:' for check[0] is at file line 6 (opening marker at line 1 + YAML line 5)")
+
+	assert.Equal(t, 5, c0.QueryLocation.Column)
+
+	// check[1]: "null check"
+
+	c1 := asset.CustomChecks[1]
+
+	assert.Equal(t, "null check", c1.Name)
+
+	require.NotNil(t, c1.SourceLocation, "SourceLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.SourceLocation.File)
+
+	assert.Equal(t, 8, c1.SourceLocation.Line,
+
+		"'- name: null check' is at file line 8 (opening marker at line 1 + YAML line 7)")
+
+	assert.Equal(t, 5, c1.SourceLocation.Column)
+
+	require.NotNil(t, c1.QueryLocation, "QueryLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.QueryLocation.File)
+
+	assert.Equal(t, 9, c1.QueryLocation.Line,
+
+		"'query:' for check[1] is at file line 9 (opening marker at line 1 + YAML line 8)")
+
+	assert.Equal(t, 5, c1.QueryLocation.Column)
+}
+
+// TestCustomCheckLocations_YAMLAsset verifies that parsing a .yml asset file annotates
+
+// each custom check with its exact source location (lineOffset == 0 for pure YAML).
+
+func TestCustomCheckLocations_YAMLAsset(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+
+	creator := pipeline.CreateTaskFromYamlDefinition(fs)
+
+	filePath := filepath.Join("testdata", "yaml", "task-with-custom-check-location", "task.yml")
+
+	absPath := path.AbsPathForTests(t, filePath)
+
+	asset, err := creator(filePath)
+
+	require.NoError(t, err)
+
+	require.NotNil(t, asset)
+
+	require.Len(t, asset.CustomChecks, 2)
+
+	// check[0]: "row count"
+
+	c0 := asset.CustomChecks[0]
+
+	assert.Equal(t, "row count", c0.Name)
+
+	require.NotNil(t, c0.SourceLocation, "SourceLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.SourceLocation.File)
+
+	assert.Equal(t, 4, c0.SourceLocation.Line,
+
+		"'- name: row count' is at YAML line 4 (lineOffset==0 for pure YAML files)")
+
+	assert.Equal(t, 5, c0.SourceLocation.Column)
+
+	require.NotNil(t, c0.QueryLocation, "QueryLocation must be set for check[0]")
+
+	assert.Equal(t, absPath, c0.QueryLocation.File)
+
+	assert.Equal(t, 5, c0.QueryLocation.Line,
+
+		"'query:' for check[0] is at YAML line 5")
+
+	assert.Equal(t, 5, c0.QueryLocation.Column)
+
+	// check[1]: "null check"
+
+	c1 := asset.CustomChecks[1]
+
+	assert.Equal(t, "null check", c1.Name)
+
+	require.NotNil(t, c1.SourceLocation, "SourceLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.SourceLocation.File)
+
+	assert.Equal(t, 7, c1.SourceLocation.Line,
+
+		"'- name: null check' is at YAML line 7")
+
+	assert.Equal(t, 5, c1.SourceLocation.Column)
+
+	require.NotNil(t, c1.QueryLocation, "QueryLocation must be set for check[1]")
+
+	assert.Equal(t, absPath, c1.QueryLocation.File)
+
+	assert.Equal(t, 8, c1.QueryLocation.Line,
+
+		"'query:' for check[1] is at YAML line 8")
+
+	assert.Equal(t, 5, c1.QueryLocation.Column)
+}
+
+// TestCustomCheckLocations_NoChecks verifies that assets without custom checks
+
+// are handled gracefully.
+
+func TestCustomCheckLocations_NoChecks(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewOsFs()
+
+	creator := pipeline.CreateTaskFromFileComments(fs)
+
+	// embeddedyaml.sql has custom_checks but the test validates it still parses cleanly
+
+	asset, err := creator(filepath.Join("testdata", "comments", "embeddedyaml.sql"))
+
+	require.NoError(t, err)
+
+	require.NotNil(t, asset)
+
+	// check that custom checks without source location still parse fine
+
+	for _, cc := range asset.CustomChecks {
+		if cc.SourceLocation != nil {
+			assert.NotEmpty(t, cc.SourceLocation.File)
+
+			assert.Positive(t, cc.SourceLocation.Line)
+		}
+	}
+}

--- a/pkg/pipeline/custom_check_locations_test.go
+++ b/pkg/pipeline/custom_check_locations_test.go
@@ -167,30 +167,26 @@ func TestCustomCheckLocations_YAMLAsset(t *testing.T) {
 
 // TestCustomCheckLocations_NoChecks verifies that assets without custom checks
 
-// are handled gracefully.
+// are handled gracefully — the early-return path in annotateCustomCheckLocations
+
+// must not panic and the returned asset must have an empty CustomChecks slice.
 
 func TestCustomCheckLocations_NoChecks(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewOsFs()
 
-	creator := pipeline.CreateTaskFromFileComments(fs)
+	creator := pipeline.CreateTaskFromYamlDefinition(fs)
 
-	// embeddedyaml.sql has custom_checks but the test validates it still parses cleanly
+	// task-with-no-runfile has no custom_checks section at all, which exercises
 
-	asset, err := creator(filepath.Join("testdata", "comments", "embeddedyaml.sql"))
+	// the len(asset.CustomChecks) == 0 early-return in annotateCustomCheckLocations.
+
+	asset, err := creator(filepath.Join("testdata", "yaml", "task-with-no-runfile", "task.yml"))
 
 	require.NoError(t, err)
 
 	require.NotNil(t, asset)
 
-	// check that custom checks without source location still parse fine
-
-	for _, cc := range asset.CustomChecks {
-		if cc.SourceLocation != nil {
-			assert.NotEmpty(t, cc.SourceLocation.File)
-
-			assert.Positive(t, cc.SourceLocation.Line)
-		}
-	}
+	assert.Empty(t, asset.CustomChecks, "expected no custom checks for this asset")
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -732,6 +732,8 @@ type CustomCheck struct {
 	Blocking      DefaultTrueBool `json:"blocking" yaml:"blocking,omitempty" mapstructure:"blocking"`
 	Query         string          `json:"query" yaml:"query" mapstructure:"query"`
 	Notifications *Notifications  `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+	SourceLocation *SourceLocation `json:"-" yaml:"-" mapstructure:"-"`
+	QueryLocation  *SourceLocation `json:"-" yaml:"-" mapstructure:"-"`
 }
 
 type DependsColumn struct {
@@ -850,7 +852,7 @@ func (h Hooks) IsZero() bool {
 }
 
 //nolint:recvcheck
-type TimeModifier struct {
+type TimeModifier struct { //nolint:recvcheck
 	Months       int    `json:"months" yaml:"months,omitempty" mapstructure:"months"`
 	Days         int    `json:"days" yaml:"days,omitempty" mapstructure:"days"`
 	Hours        int    `json:"hours" yaml:"hours,omitempty" mapstructure:"hours"`

--- a/pkg/pipeline/source_location.go
+++ b/pkg/pipeline/source_location.go
@@ -1,0 +1,26 @@
+package pipeline
+
+import "fmt"
+
+// SourceLocation describes the position of a code element within a source file.
+type SourceLocation struct {
+	File   string `json:"file,omitempty"   yaml:"-" mapstructure:"-"`
+	Line   int    `json:"line,omitempty"   yaml:"-" mapstructure:"-"`
+	Column int    `json:"column,omitempty" yaml:"-" mapstructure:"-"`
+}
+
+// IsZero reports whether the location carries no meaningful position.
+func (l *SourceLocation) IsZero() bool {
+	return l == nil || l.Line <= 0
+}
+
+// String formats the location as "file:line:col".
+func (l *SourceLocation) String() string {
+	if l.IsZero() {
+		return ""
+	}
+	if l.Column > 0 {
+		return fmt.Sprintf("%s:%d:%d", l.File, l.Line, l.Column)
+	}
+	return fmt.Sprintf("%s:%d", l.File, l.Line)
+}

--- a/pkg/pipeline/testdata/comments/custom_checks_location.sql
+++ b/pkg/pipeline/testdata/comments/custom_checks_location.sql
@@ -1,0 +1,13 @@
+/* @bruin
+name: test.location_checks
+type: bq.sql
+custom_checks:
+  - name: row count
+    query: |
+      SELECT COUNT(*) FROM my_table
+  - name: null check
+    query: |
+      SELECT COUNT(*) FROM my_table WHERE id IS NULL
+@bruin */
+
+SELECT 1;

--- a/pkg/pipeline/testdata/yaml/task-with-custom-check-location/task.yml
+++ b/pkg/pipeline/testdata/yaml/task-with-custom-check-location/task.yml
@@ -1,0 +1,9 @@
+name: test.yaml_location_checks
+type: bq.sql
+custom_checks:
+  - name: row count
+    query: |
+      SELECT COUNT(*) FROM my_table
+  - name: null check
+    query: |
+      SELECT COUNT(*) FROM my_table WHERE id IS NULL

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -383,6 +383,11 @@ func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
 			return nil, err
 		}
 
+		var root yaml.Node
+		if yamlErr := yaml.Unmarshal(buf, &root); yamlErr == nil {
+			annotateCustomCheckLocations(task, &root, filePath, 0)
+		}
+
 		executableFile := ExecutableFile{
 			Name:    filepath.Base(filePath),
 			Path:    filePath,


### PR DESCRIPTION
## Problem

When a custom check fails, Bruin prints the error from the database engine, which may include a position like `[17:16]`. That position refers to the compiled query inside the database — it has no relation to the user's asset file. The user has no way to know *which check* failed or *where in their file* it is defined.

Reported by Neda: the requested improvement was to show line numbers that correspond to the YAML definition in the Bruin asset file.

## Solution

Track the source file position of every custom check at parse time and surface it in the CLI output when a check fails.

### Changes

**`pkg/pipeline/source_location.go`** (new)
Introduces a `SourceLocation` struct (`File`, `Line`, `Column`) with `IsZero()` and `String()` helpers, used to represent a position within a source file.

**`pkg/pipeline/custom_check_locations.go`** (new)
`annotateCustomCheckLocations` walks the parsed `yaml.Node` tree after a successful asset parse and stamps each `CustomCheck` with:
- `SourceLocation` — the line/column of the `- name:` entry in the original file
- `QueryLocation` — the line/column of the `query:` key in the original file

A `lineOffset` parameter handles the difference between pure YAML assets (offset 0) and SQL assets with embedded `/* @bruin ... @bruin */` blocks (offset = line number of the opening marker).

**`pkg/pipeline/pipeline.go`**
Added `SourceLocation` and `QueryLocation` fields to `CustomCheck`. Both are tagged `json:"-" yaml:"-" mapstructure:"-"` so they are invisible to serialisation and YAML parsing — parse-time annotation only.

**`pkg/pipeline/yaml.go`**
After `ConvertYamlToTask`, re-parses the raw YAML bytes into a `yaml.Node` and calls `annotateCustomCheckLocations` with `lineOffset=0`.

**`pkg/pipeline/comment.go`**
`readUntilComments` now returns the line number of the opening `/* @bruin` marker. `commentedYamlToTask` re-parses the extracted YAML bytes into a `yaml.Node` and calls `annotateCustomCheckLocations` with that line as the offset, so node positions are correctly mapped back to the original `.sql` / `.py` file.

**`cmd/run.go`**
When a `CustomCheckInstance` fails, the error output now includes:
- `defined at:` — file and line where the check is declared
- `query starts at:` — file and line where the check's query begins

Both lines are omitted when location data is unavailable (e.g. assets parsed before this change).

**`docs/quality/custom.md`**
Added a Troubleshooting section showing the new output format.

### Tests

- `pkg/pipeline/custom_check_locations_test.go` (new): covers SQL-embedded YAML, pure YAML assets, and assets with no custom checks.
- `pkg/pipeline/comment_test.go`: updated to assert `SourceLocation` and `QueryLocation` are populated with the correct values.

## Example output
1 assets failed
└── my_pipeline/my_asset
└── row_count_check custom check - expected at least 1 row, got 0
├── defined at: assets/my_asset.sql:14:5
└── query starts at: assets/my_asset.sql:15:9