### PR TITLE
feat(executor): log periodic still-running messages for long tasks

### DIFF
--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -133,9 +133,12 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 
 		// Periodically log "still running" for long-running tasks
 		var stopTicker chan struct{}
+		var tickerWg sync.WaitGroup
 		if !w.formatOpts.TUIMode && !w.formatOpts.MinimalLogs {
 			stopTicker = make(chan struct{})
+			tickerWg.Add(1)
 			go func() {
+				defer tickerWg.Done()
 				ticker := time.NewTicker(10 * time.Second)
 				defer ticker.Stop()
 				for {
@@ -181,6 +184,7 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 
 		if stopTicker != nil {
 			close(stopTicker)
+			tickerWg.Wait()
 		}
 
 		duration := time.Since(start)

--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -131,6 +131,36 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 
 		start := time.Now()
 
+		// Periodically log "still running" for long-running tasks
+		var stopTicker chan struct{}
+		if !w.formatOpts.TUIMode && !w.formatOpts.MinimalLogs {
+			stopTicker = make(chan struct{})
+			go func() {
+				ticker := time.NewTicker(10 * time.Second)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ticker.C:
+						elapsed := time.Since(start).Truncate(time.Second)
+						w.printLock.Lock()
+						stillRunningPrinter := w.printer
+						if !w.formatOpts.NoColor {
+							stillRunningPrinter = color.New(color.Faint)
+						}
+						if w.formatOpts.DoNotLogTimestamp {
+							fmt.Printf("%s\n", stillRunningPrinter.Sprintf("Still running: %s (%s)", task.GetHumanID(), elapsed))
+						} else {
+							ts := whitePrinter("[%s]", time.Now().Format(timeFormat))
+							fmt.Printf("%s %s\n", ts, stillRunningPrinter.Sprintf("Still running: %s (%s)", task.GetHumanID(), elapsed))
+						}
+						w.printLock.Unlock()
+					case <-stopTicker:
+						return
+					}
+				}
+			}()
+		}
+
 		// In TUI mode, redirect worker output to log-only writer
 		outputWriter := io.Writer(os.Stdout)
 		if w.formatOpts.TUIMode && w.formatOpts.LogOnlyWriter != nil {
@@ -148,6 +178,10 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 		executionCtx := context.WithValue(ctx, KeyPrinter, printer)
 		executionCtx = context.WithValue(executionCtx, ContextLogger, w.logger)
 		err := w.executor.RunSingleTask(executionCtx, task)
+
+		if stopTicker != nil {
+			close(stopTicker)
+		}
 
 		duration := time.Since(start)
 


### PR DESCRIPTION
## Summary
- Adds a periodic "Still running: \<id\> (\<elapsed\>)" log every 10 seconds for assets/checks that take a long time to execute
- Uses the same faint color and timestamp style as the existing Running/Finished log lines
- Respects TUI mode, MinimalLogs, NoColor, and DoNotLogTimestamp settings

## Test plan
- [x] `make test` passes
- [x] `make format` passes
- [ ] Verify with a long-running asset that the "Still running" messages appear every ~10s
- [ ] Verify no extra logs appear for fast assets (< 10s)
- [ ] Verify TUI mode and MinimalLogs suppress the heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)