### PR TITLE
Auto-sweep orphan arrow temp files on materialization start

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -30,6 +30,41 @@ var (
 	ingestrInstalledPackages = make(map[string]bool)
 )
 
+const (
+	tempArrowFilePrefix   = "asset_data_"
+	tempArrowScriptPrefix = "bruin-arrow-"
+	orphanTempFileMaxAge  = time.Hour
+)
+
+// sweepOrphanArrowTempFiles removes leftover arrow data and wrapper script
+// files from previous Python materialization runs that crashed before defers
+// could fire (e.g. SIGKILL/OOM). Files newer than orphanTempFileMaxAge are
+// skipped to avoid touching files belonging to a concurrently running bruin.
+func sweepOrphanArrowTempFiles() {
+	tmpDir := os.TempDir()
+	patterns := []string{
+		filepath.Join(tmpDir, tempArrowFilePrefix+"*.arrow"),
+		filepath.Join(tmpDir, tempArrowScriptPrefix+"*.py"),
+	}
+	cutoff := time.Now().Add(-orphanTempFileMaxAge)
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, f := range matches {
+			info, err := os.Stat(f)
+			if err != nil {
+				continue
+			}
+			if info.ModTime().After(cutoff) {
+				continue
+			}
+			_ = os.Remove(f)
+		}
+	}
+}
+
 var AvailablePythonVersions = map[string]bool{
 	"3.8":  true,
 	"3.9":  true,
@@ -389,12 +424,14 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		return errors.New("only table materialization is supported for Python assets")
 	}
 
-	arrowFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("asset_data_%d.arrow", time.Now().UnixNano()))
+	sweepOrphanArrowTempFiles()
+
+	arrowFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s%d.arrow", tempArrowFilePrefix, time.Now().UnixNano()))
 	defer func(name string) {
 		_ = os.Remove(name)
 	}(arrowFilePath)
 
-	tempPyScript, err := os.CreateTemp("", "bruin-arrow-*.py")
+	tempPyScript, err := os.CreateTemp("", tempArrowScriptPrefix+"*.py")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/pkg/python/uv_orphan_sweep_test.go
+++ b/pkg/python/uv_orphan_sweep_test.go
@@ -12,6 +12,8 @@ import (
 func TestSweepOrphanArrowTempFiles(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("TMPDIR", tmp)
+	t.Setenv("TMP", tmp)
+	t.Setenv("TEMP", tmp)
 
 	oldArrow := filepath.Join(tmp, tempArrowFilePrefix+"old.arrow")
 	oldScript := filepath.Join(tmp, tempArrowScriptPrefix+"old.py")

--- a/pkg/python/uv_orphan_sweep_test.go
+++ b/pkg/python/uv_orphan_sweep_test.go
@@ -1,0 +1,38 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSweepOrphanArrowTempFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	oldArrow := filepath.Join(tmp, tempArrowFilePrefix+"old.arrow")
+	oldScript := filepath.Join(tmp, tempArrowScriptPrefix+"old.py")
+	freshArrow := filepath.Join(tmp, tempArrowFilePrefix+"fresh.arrow")
+	freshScript := filepath.Join(tmp, tempArrowScriptPrefix+"fresh.py")
+	unrelated := filepath.Join(tmp, "unrelated.arrow")
+
+	for _, p := range []string{oldArrow, oldScript, freshArrow, freshScript, unrelated} {
+		require.NoError(t, os.WriteFile(p, []byte("x"), 0o600))
+	}
+
+	pastMtime := time.Now().Add(-2 * orphanTempFileMaxAge)
+	require.NoError(t, os.Chtimes(oldArrow, pastMtime, pastMtime))
+	require.NoError(t, os.Chtimes(oldScript, pastMtime, pastMtime))
+	require.NoError(t, os.Chtimes(unrelated, pastMtime, pastMtime))
+
+	sweepOrphanArrowTempFiles()
+
+	require.NoFileExists(t, oldArrow, "old arrow file should be swept")
+	require.NoFileExists(t, oldScript, "old script file should be swept")
+	require.FileExists(t, freshArrow, "recent arrow file must be preserved")
+	require.FileExists(t, freshScript, "recent script file must be preserved")
+	require.FileExists(t, unrelated, "files not matching the prefix must be preserved")
+}


### PR DESCRIPTION
## Summary

When a Python materialization is killed via `SIGKILL` (OOM kill, `kill -9`, container OOM, hardware fault), Go's deferred cleanup in `runWithMaterialization` never runs, leaving behind:

- `asset_data_<timestamp>.arrow` — the data file (can be multiple GB)
- `bruin-arrow-<id>.py` — the wrapper script

These files accumulate silently in `$TMPDIR` and can fill the disk over time. One user reported a 5 GB ghost file from a single crash.

This PR adds an automatic sweep at the **start of every Python materialization run** that removes orphan files matching the bruin prefixes. Files newer than 1 hour are skipped to avoid touching in-flight files belonging to a concurrently running bruin process.

## Why this approach (vs. the earlier `bruin clean` proposal)

An earlier draft (#1877, now closed) attached the cleanup to `bruin clean` — but that requires the user to remember to run a manual command, and the original feedback explicitly asked for **automatic** cleanup of failed processes.

Putting the sweep at the start of `runWithMaterialization` gives us:

- **Automatic**: every Python materialization run cleans up after the previous crash, no manual command required.
- **Scoped**: only triggers on the code path that actually creates these files. Unrelated commands (`bruin lint`, `bruin render`, ingestr-only runs, etc.) are unaffected.
- **No new flags or surface area**: nothing visible to the user beyond the disk usage going away.

## Implementation

`pkg/python/uv.go`:
- Extract temp file prefixes into private constants (`tempArrowFilePrefix`, `tempArrowScriptPrefix`) so the writer and the sweeper stay in sync.
- Add `sweepOrphanArrowTempFiles()` — globs `$TMPDIR` for matching files, skips anything newer than `orphanTempFileMaxAge` (1 hour), removes the rest. Errors are silently ignored (best-effort cleanup; the file will be retried on the next run).
- Call the sweeper at the start of `runWithMaterialization`, before the new run's own temp files are created. The current process is safe — its files don't exist yet.

`pkg/python/uv_orphan_sweep_test.go`:
- Unit test that creates fixtures (old arrow, old script, fresh arrow, fresh script, unrelated file), backdates the "old" ones via `os.Chtimes`, runs the sweep, and asserts that only the old prefix-matching files were removed.

## Manual reproduction & verification

Reproduced the bug end-to-end against a local DuckDB pipeline (`../chess-test`):

**1. Reproduced on `main`** — confirmed the orphan problem exists.

Created a slow-materialization Python asset (`time.sleep(120)` before returning rows). On `main`:

```bash
./bin/bruin run bruin/chess/assets/slow_materialize.py &
# wait until "[slow_materialize] sleeping 120s" appears in output
pkill -9 -f "bin/bruin run"
ls $TMPDIR | grep -E "(asset_data_|bruin-arrow-)"
# -> bruin-arrow-61952875.py  (orphan, defer never ran)
```

**2. Verified the fix on this branch.**

Backdated the orphan file by 2 hours via `touch -t`, switched to this branch, rebuilt, and started a new materialization:

```bash
ls -la $TMPDIR | grep -E "(asset_data_|bruin-arrow-)"
# -rw-r--r-- ... 12:25 asset_data_1778232215004241000.arrow   <- fresh orphan from earlier kill
# -rw------- ... 10:25 bruin-arrow-61952875.py                <- backdated orphan

./bin/bruin run bruin/chess/assets/slow_materialize.py &
# wait until python sleeps...

ls -la $TMPDIR | grep -E "(asset_data_|bruin-arrow-)"
# -rw-r--r-- ... 12:25 asset_data_1778232215004241000.arrow   <- KEPT (fresh, <1h old)
# -rw------- ... 12:26 bruin-arrow-2659869328.py              <- the running run's own script
# bruin-arrow-61952875.py is GONE                              <- swept (>1h old)
```

The new run completed successfully (`exit 0`, ~3 minutes), and its own temp files were cleaned by the existing defers.

| State | `main` | `fix/auto-cleanup-orphan-temp-files` |
|---|---|---|
| Run 1 (SIGKILL during sleep) | orphan left behind | orphan left behind (defer still can't run on SIGKILL) |
| Run 2 (subsequent materialization) | orphan still there | **orphan auto-removed at start of run** |

## Test plan
- [x] Unit test (`TestSweepOrphanArrowTempFiles`) covers: old file removed, fresh file kept, non-matching file kept
- [x] `make test` passes locally
- [x] Manual SIGKILL reproduction on `main` confirms the bug
- [x] Manual reproduction on this branch confirms the fix
- [x] Verified the sweep does not delete files newer than 1 hour (protects concurrent runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)