### PR TITLE
fix: hoist DECLAREs to top of hook-wrapped SQL

### DIFF
--- a/pkg/pipeline/hooks.go
+++ b/pkg/pipeline/hooks.go
@@ -160,7 +160,7 @@ func hasDeclarePrefix(s string) bool {
 	if len(s) < len(kw) {
 		return false
 	}
-	for i := 0; i < len(kw); i++ {
+	for i := range len(kw) {
 		c := s[i]
 		if c >= 'A' && c <= 'Z' {
 			c += 'a' - 'A'

--- a/pkg/pipeline/hooks.go
+++ b/pkg/pipeline/hooks.go
@@ -2,14 +2,19 @@ package pipeline
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+// declarePrefixRegex matches a leading DECLARE keyword (case-insensitive) after any
+// leading whitespace and SQL line/block comments have been stripped.
+var declarePrefixRegex = regexp.MustCompile(`(?i)^declare\b`)
 
 func WrapHooks(query string, hooks Hooks) string {
 	preParts := formatHookQueries(hooks.Pre)
 	postParts := formatHookQueries(hooks.Post)
 	if len(preParts) == 0 && len(postParts) == 0 {
-		return query
+		return hoistDeclares(query)
 	}
 
 	parts := make([]string, 0, len(preParts)+1+len(postParts))
@@ -20,21 +25,21 @@ func WrapHooks(query string, hooks Hooks) string {
 	}
 
 	parts = append(parts, postParts...)
-	return strings.Join(parts, "\n")
+	return hoistDeclares(strings.Join(parts, "\n"))
 }
 
 func wrapHookQueriesList(queries []string, hooks Hooks) []string {
 	pre := formatHookQueries(hooks.Pre)
 	post := formatHookQueries(hooks.Post)
 	if len(pre) == 0 && len(post) == 0 {
-		return queries
+		return hoistDeclaresList(queries)
 	}
 
 	combined := make([]string, 0, len(pre)+len(queries)+len(post))
 	combined = append(combined, pre...)
 	combined = append(combined, queries...)
 	combined = append(combined, post...)
-	return combined
+	return hoistDeclaresList(combined)
 }
 
 func formatHookQueries(hooks []Hook) []string {
@@ -56,6 +61,113 @@ func formatStatement(query string) string {
 		return trimmed
 	}
 	return trimmed + ";"
+}
+
+// hoistDeclares moves any DECLARE statements within a multi-statement SQL script
+// to the top, preserving the relative order of DECLAREs and the relative order
+// of remaining statements. Some SQL dialects (notably BigQuery) require all
+// DECLARE statements to appear at the very start of a script or block; when
+// asset hooks contain non-DECLARE statements like SET or IF, a materialization's
+// own DECLARE can otherwise end up past the start of the script.
+//
+// Returns the input unchanged when no DECLARE statements are present, when only
+// a single statement exists, or when reordering would have no effect.
+func hoistDeclares(sql string) string {
+	if !containsDeclare(sql) {
+		return sql
+	}
+
+	parts := strings.Split(sql, ";")
+	declares := make([]string, 0, len(parts))
+	rest := make([]string, 0, len(parts))
+	hadDeclare := false
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		if isDeclareStatement(trimmed) {
+			declares = append(declares, trimmed)
+			hadDeclare = true
+		} else {
+			rest = append(rest, trimmed)
+		}
+	}
+
+	if !hadDeclare {
+		return sql
+	}
+
+	reordered := append(declares, rest...) //nolint:gocritic // intentional concat into a fresh slice
+	return strings.Join(reordered, ";\n") + ";"
+}
+
+// hoistDeclaresList reorders a list of pre-split SQL statements so DECLAREs
+// appear first, preserving relative order within each group. Mirrors hoistDeclares
+// for list-based materializers.
+func hoistDeclaresList(queries []string) []string {
+	hasDeclare := false
+	for _, q := range queries {
+		if isDeclareStatement(q) {
+			hasDeclare = true
+			break
+		}
+	}
+	if !hasDeclare {
+		return queries
+	}
+
+	declares := make([]string, 0, len(queries))
+	rest := make([]string, 0, len(queries))
+	for _, q := range queries {
+		if isDeclareStatement(q) {
+			declares = append(declares, q)
+		} else {
+			rest = append(rest, q)
+		}
+	}
+	return append(declares, rest...)
+}
+
+// containsDeclare is a fast pre-check that avoids splitting the script when
+// no DECLARE keyword is present at all.
+func containsDeclare(sql string) bool {
+	lower := strings.ToLower(sql)
+	return strings.Contains(lower, "declare")
+}
+
+// isDeclareStatement reports whether the given statement (without trailing ';')
+// begins with a DECLARE keyword once leading whitespace and SQL comments are
+// stripped.
+func isDeclareStatement(stmt string) bool {
+	trimmed := stripLeadingCommentsAndWhitespace(stmt)
+	return declarePrefixRegex.MatchString(trimmed)
+}
+
+// stripLeadingCommentsAndWhitespace removes leading whitespace and SQL line
+// (`-- ...`) and block (`/* ... */`) comments, returning the remainder. It
+// stops at the first non-comment, non-whitespace character.
+func stripLeadingCommentsAndWhitespace(s string) string {
+	for {
+		s = strings.TrimLeft(s, " \t\r\n")
+		switch {
+		case strings.HasPrefix(s, "--"):
+			if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+				s = s[idx+1:]
+			} else {
+				return ""
+			}
+		case strings.HasPrefix(s, "/*"):
+			if idx := strings.Index(s, "*/"); idx >= 0 {
+				s = s[idx+2:]
+			} else {
+				return ""
+			}
+		default:
+			return s
+		}
+	}
 }
 
 // ResolveHookTemplatesToNew renders hook query templates with the provided renderer and returns a new hooks value.

--- a/pkg/pipeline/hooks.go
+++ b/pkg/pipeline/hooks.go
@@ -71,36 +71,140 @@ func formatStatement(query string) string {
 // own DECLARE can otherwise end up past the start of the script.
 //
 // Returns the input unchanged when no DECLARE statements are present, when only
-// a single statement exists, or when reordering would have no effect.
+// a single statement exists, when reordering would have no effect, or when the
+// SQL contains a string literal that would be corrupted by a naive ';' split.
 func hoistDeclares(sql string) string {
-	if !containsDeclare(sql) {
+	// Cheap pre-check: only ASCII upper/lower forms of "declare" matter as a
+	// keyword, and a top-level DECLARE must appear at a statement boundary
+	// (start of script or after a ';'). Anything else means we can return the
+	// input untouched without splitting.
+	if !mayContainDeclareStatement(sql) {
 		return sql
 	}
 
 	parts := strings.Split(sql, ";")
 	declares := make([]string, 0, len(parts))
 	rest := make([]string, 0, len(parts))
-	hadDeclare := false
+	sawNonDeclare := false
+	needsReorder := false
 
 	for _, part := range parts {
 		trimmed := strings.TrimSpace(part)
 		if trimmed == "" {
 			continue
 		}
+		// If splitting on ';' produced a fragment with an unbalanced quote, a
+		// string literal contained a semicolon and we cannot safely reorder.
+		// Return the input unchanged rather than risk corrupting the SQL.
+		if hasUnbalancedQuote(trimmed) {
+			return sql
+		}
 		if isDeclareStatement(trimmed) {
 			declares = append(declares, trimmed)
-			hadDeclare = true
+			if sawNonDeclare {
+				needsReorder = true
+			}
 		} else {
 			rest = append(rest, trimmed)
+			sawNonDeclare = true
 		}
 	}
 
-	if !hadDeclare {
+	// If every DECLARE is already ahead of every non-DECLARE, return the input
+	// unchanged so we don't normalize separators or whitespace unnecessarily.
+	if !needsReorder {
 		return sql
 	}
 
 	reordered := append(declares, rest...) //nolint:gocritic // intentional concat into a fresh slice
 	return strings.Join(reordered, ";\n") + ";"
+}
+
+// mayContainDeclareStatement is a fast pre-check: it scans the input once,
+// skipping over single- and double-quoted string literals, and returns true
+// only when the keyword "declare" appears outside of any string literal.
+// This avoids the cost of the full split/classify pass for queries that only
+// mention "declare" inside a quoted string (e.g. SELECT 'declare bankruptcy').
+func mayContainDeclareStatement(sql string) bool {
+	for i := 0; i < len(sql); i++ {
+		c := sql[i]
+		switch c {
+		case '\'', '"':
+			// Skip past the matching closing quote (treating doubled quotes as
+			// escapes). If unterminated, fall through to the end of the input.
+			quote := c
+			i++
+			for i < len(sql) {
+				if sql[i] == quote {
+					if i+1 < len(sql) && sql[i+1] == quote {
+						i += 2
+						continue
+					}
+					break
+				}
+				i++
+			}
+		case 'd', 'D':
+			if hasDeclarePrefix(sql[i:]) && (i == 0 || !isIdentChar(sql[i-1])) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasDeclarePrefix reports whether s begins with the keyword "declare" followed
+// by a non-identifier character (i.e. a word boundary), case-insensitive.
+func hasDeclarePrefix(s string) bool {
+	const kw = "declare"
+	if len(s) < len(kw) {
+		return false
+	}
+	for i := 0; i < len(kw); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != kw[i] {
+			return false
+		}
+	}
+	if len(s) == len(kw) {
+		return true
+	}
+	return !isIdentChar(s[len(kw)])
+}
+
+func isIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_'
+}
+
+// hasUnbalancedQuote reports whether a SQL fragment contains an odd number of
+// single or double quote characters, ignoring `”` / `""` escapes. Used as a
+// guard so hoistDeclares bails out when a naive `;` split has cut through a
+// string literal.
+func hasUnbalancedQuote(s string) bool {
+	single, double := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\'':
+			if i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				continue
+			}
+			single++
+		case '"':
+			if i+1 < len(s) && s[i+1] == '"' {
+				i++
+				continue
+			}
+			double++
+		}
+	}
+	return single%2 != 0 || double%2 != 0
 }
 
 // hoistDeclaresList reorders a list of pre-split SQL statements so DECLAREs
@@ -128,13 +232,6 @@ func hoistDeclaresList(queries []string) []string {
 		}
 	}
 	return append(declares, rest...)
-}
-
-// containsDeclare is a fast pre-check that avoids splitting the script when
-// no DECLARE keyword is present at all.
-func containsDeclare(sql string) bool {
-	lower := strings.ToLower(sql)
-	return strings.Contains(lower, "declare")
 }
 
 // isDeclareStatement reports whether the given statement (without trailing ';')

--- a/pkg/pipeline/hooks_test.go
+++ b/pkg/pipeline/hooks_test.go
@@ -164,6 +164,16 @@ func TestHoistDeclares(t *testing.T) {
 			want: "DECLARE x INT64;\nSELECT 1;",
 		},
 		{
+			name: "already-ordered declares preserve original separators",
+			in:   "DECLARE x INT64; SELECT 1;",
+			want: "DECLARE x INT64; SELECT 1;",
+		},
+		{
+			name: "multiple already-ordered declares preserve original formatting",
+			in:   "DECLARE x INT64;DECLARE y STRING;\n\nSELECT 1;",
+			want: "DECLARE x INT64;DECLARE y STRING;\n\nSELECT 1;",
+		},
+		{
 			name: "declare after non-declare gets hoisted",
 			in:   "SET x = 1;\nDECLARE y INT64;\nSELECT 1;",
 			want: "DECLARE y INT64;\nSET x = 1;\nSELECT 1;",
@@ -192,6 +202,31 @@ func TestHoistDeclares(t *testing.T) {
 			name: "empty parts are dropped",
 			in:   "SET x = 1;;\nDECLARE y INT64;",
 			want: "DECLARE y INT64;\nSET x = 1;",
+		},
+		{
+			name: "semicolon inside single-quoted literal is left untouched",
+			in:   "SET separator = ';';\nDECLARE y INT64;",
+			want: "SET separator = ';';\nDECLARE y INT64;",
+		},
+		{
+			name: "declare keyword inside string literal does not trigger reordering",
+			in:   "SELECT 'declare bankruptcy' AS msg;",
+			want: "SELECT 'declare bankruptcy' AS msg;",
+		},
+		{
+			name: "declare as a column alias does not trigger reordering",
+			in:   "SELECT 1 AS declare;",
+			want: "SELECT 1 AS declare;",
+		},
+		{
+			name: "semicolon inside double-quoted literal is left untouched",
+			in:   "SET label = \"a;b\";\nDECLARE y INT64;",
+			want: "SET label = \"a;b\";\nDECLARE y INT64;",
+		},
+		{
+			name: "escaped quote inside literal does not trip the guard",
+			in:   "SET msg = 'it''s fine';\nDECLARE y INT64;",
+			want: "DECLARE y INT64;\nSET msg = 'it''s fine';",
 		},
 	}
 

--- a/pkg/pipeline/hooks_test.go
+++ b/pkg/pipeline/hooks_test.go
@@ -76,6 +76,166 @@ func TestWrapHooks_TrimsAndSkipsEmpty(t *testing.T) {
 	}
 }
 
+func TestWrapHooks_HoistsDeclares(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		hooks Hooks
+		want  string
+	}{
+		{
+			name: "materialization DECLARE bubbles past pre-hook SET",
+			query: "DECLARE distinct_keys array<STRING>;\n" +
+				"BEGIN TRANSACTION;\n" +
+				"SELECT 1;\n" +
+				"COMMIT TRANSACTION",
+			hooks: Hooks{
+				Pre: []Hook{
+					{Query: "DECLARE my_var DATE"},
+					{Query: "SET my_var = DATE('2026-01-01')"},
+				},
+			},
+			want: "DECLARE my_var DATE;\n" +
+				"DECLARE distinct_keys array<STRING>;\n" +
+				"SET my_var = DATE('2026-01-01');\n" +
+				"BEGIN TRANSACTION;\n" +
+				"SELECT 1;\n" +
+				"COMMIT TRANSACTION;",
+		},
+		{
+			name:  "lowercase declare also hoisted",
+			query: "select 1",
+			hooks: Hooks{
+				Pre: []Hook{
+					{Query: "set x = 1"},
+					{Query: "declare y int64"},
+				},
+			},
+			want: "declare y int64;\n" +
+				"set x = 1;\n" +
+				"select 1;",
+		},
+		{
+			name:  "declare preceded by line comment is still detected",
+			query: "select 1",
+			hooks: Hooks{
+				Pre: []Hook{
+					{Query: "SET x = 1"},
+					{Query: "-- setup\nDECLARE y INT64"},
+				},
+			},
+			want: "-- setup\nDECLARE y INT64;\n" +
+				"SET x = 1;\n" +
+				"select 1;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, WrapHooks(tt.query, tt.hooks))
+		})
+	}
+}
+
+func TestHoistDeclares(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no declare is a no-op",
+			in:   "SELECT 1;\nSELECT 2;",
+			want: "SELECT 1;\nSELECT 2;",
+		},
+		{
+			name: "single statement is a no-op",
+			in:   "SELECT 1",
+			want: "SELECT 1",
+		},
+		{
+			name: "leading declare is a no-op",
+			in:   "DECLARE x INT64;\nSELECT 1;",
+			want: "DECLARE x INT64;\nSELECT 1;",
+		},
+		{
+			name: "declare after non-declare gets hoisted",
+			in:   "SET x = 1;\nDECLARE y INT64;\nSELECT 1;",
+			want: "DECLARE y INT64;\nSET x = 1;\nSELECT 1;",
+		},
+		{
+			name: "multiple declares preserve relative order",
+			in:   "SET x = 1;\nDECLARE y INT64;\nSET z = 2;\nDECLARE w STRING;",
+			want: "DECLARE y INT64;\nDECLARE w STRING;\nSET x = 1;\nSET z = 2;",
+		},
+		{
+			name: "case-insensitive detection",
+			in:   "set x = 1;\ndeclare y int64",
+			want: "declare y int64;\nset x = 1;",
+		},
+		{
+			name: "leading comment before declare is tolerated",
+			in:   "SET x = 1;\n-- a comment\nDECLARE y INT64",
+			want: "-- a comment\nDECLARE y INT64;\nSET x = 1;",
+		},
+		{
+			name: "block comment before declare is tolerated",
+			in:   "SET x = 1;\n/* block */ DECLARE y INT64",
+			want: "/* block */ DECLARE y INT64;\nSET x = 1;",
+		},
+		{
+			name: "empty parts are dropped",
+			in:   "SET x = 1;;\nDECLARE y INT64;",
+			want: "DECLARE y INT64;\nSET x = 1;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hoistDeclares(tt.in))
+		})
+	}
+}
+
+func TestHoistDeclaresList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "no declare is a no-op",
+			in:   []string{"SELECT 1", "SELECT 2"},
+			want: []string{"SELECT 1", "SELECT 2"},
+		},
+		{
+			name: "declare after non-declare gets hoisted",
+			in:   []string{"SET x = 1", "DECLARE y INT64", "SELECT 1"},
+			want: []string{"DECLARE y INT64", "SET x = 1", "SELECT 1"},
+		},
+		{
+			name: "case-insensitive",
+			in:   []string{"set x = 1", "declare y int64"},
+			want: []string{"declare y int64", "set x = 1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hoistDeclaresList(tt.in))
+		})
+	}
+}
+
 func TestWrapHookQueriesList(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- BigQuery requires all `DECLARE` statements at the start of a script. With `delete+insert` materialization, Bruin emits its own `DECLARE distinct_keys_...` after pre-hook output — any pre-hook containing a non-DECLARE statement (`SET`, `IF`, `BEGIN`) pushes Bruin's `DECLARE` past the start of the script and BigQuery rejects the run with `Variable declarations are allowed only at the start of a block or script`.
- `WrapHooks` and `wrapHookQueriesList` now post-process the combined SQL to hoist DECLAREs to the top, preserving the relative order of both DECLAREs and the remaining statements.
- No-op when no DECLARE is present, so dialects without DECLARE syntax (DuckDB, MySQL, PG) keep their existing output byte-for-byte.

## Reproduction (before)

`bruin render` of an asset with `delete+insert` + a pre-hook containing `SET`:

```sql
DECLARE my_var DATE;
SET my_var = DATE('2026-01-01');
DECLARE distinct_keys_xxx array<STRING>;   -- ❌ no longer at start
BEGIN TRANSACTION;
...
```

## After fix

```sql
DECLARE my_var DATE;
DECLARE distinct_keys_xxx array<STRING>;   -- ✅ both at top
SET my_var = DATE('2026-01-01');
BEGIN TRANSACTION;
...
```

## Detection

- Split combined SQL on `;`, classify each statement
- Strip leading whitespace + `--` line and `/* */` block comments
- Match case-insensitive `^DECLARE\b`
- Statements with DECLARE move to the top in original order; rest follow in original order

## Test plan

- [x] Added `TestHoistDeclares`, `TestHoistDeclaresList`, `TestWrapHooks_HoistsDeclares` covering: no-op, single DECLARE hoist, multiple DECLAREs, case-insensitive, leading line/block comments, empty parts.
- [x] All existing `pkg/pipeline` tests pass (no behavior change when no DECLARE present).
- [x] `pkg/bigquery` and `pkg/duckdb` tests pass.
- [x] `make test` clean.
- [x] Manual `bruin render` verification on a BigQuery asset (DECLAREs now at top) and a DuckDB asset (output unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)