### PR TITLE
docs(stripe): add payment_record table

### DIFF
--- a/docs/ingestion/stripe.md
+++ b/docs/ingestion/stripe.md
@@ -65,7 +65,7 @@ parameters:
 | payment_link | id | created | merge | Contains information about payment links created for collecting payments. |
 | payment_method | id | created | merge | Stores payment method information such as cards, bank accounts, and other payment instruments. |
 | payment_method_domain | id | created | merge | Represents domains verified for payment method collection. |
-| payment_record | id | created | merge | Contains detailed payment records, including amount breakdowns, card issuer (bank), BIN, brand, and last4 for each payment. Retrieved per PaymentIntent in the requested window; intents without an associated record (e.g., orchestration not enabled) are skipped. |
+| payment_record | id | created | merge | Contains detailed payment records, including amount breakdowns, card issuer (bank), BIN, brand, and last4 for each payment. |
 | payout | id | created | merge | Records payouts made from Stripe accounts to bank accounts or debit cards. |
 | plan | id | created | merge | Contains subscription plan information including pricing and billing intervals. |
 | price | id | created | merge | Contains pricing information for products, including currency, amount, and billing intervals. |

--- a/docs/ingestion/stripe.md
+++ b/docs/ingestion/stripe.md
@@ -65,6 +65,7 @@ parameters:
 | payment_link | id | created | merge | Contains information about payment links created for collecting payments. |
 | payment_method | id | created | merge | Stores payment method information such as cards, bank accounts, and other payment instruments. |
 | payment_method_domain | id | created | merge | Represents domains verified for payment method collection. |
+| payment_record | id | created | merge | Contains detailed payment records, including amount breakdowns, card issuer (bank), BIN, brand, and last4 for each payment. Retrieved per PaymentIntent in the requested window; intents without an associated record (e.g., orchestration not enabled) are skipped. |
 | payout | id | created | merge | Records payouts made from Stripe accounts to bank accounts or debit cards. |
 | plan | id | created | merge | Contains subscription plan information including pricing and billing intervals. |
 | price | id | created | merge | Contains pricing information for products, including currency, amount, and billing intervals. |


### PR DESCRIPTION
## Summary
- Documents the new \`payment_record\` Stripe ingestion table
- Same row format as every other Stripe table: PK \`id\`, inc key \`created\`, strategy \`merge\`
- Description notes that records are retrieved per PaymentIntent in the window, and intents without an associated record (orchestration off, etc.) are skipped

Pairs with the gong implementation PR and the matching ingestr docs PR.

## Test plan
- [x] Markdown table formatting matches surrounding rows
- [x] Position is alphabetical (between \`payment_method_domain\` and \`payout\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)