### PR TITLE
[codex] Add Gong bootstrap seed template

### DIFF
--- a/templates/bootstrap/.bruin.yml
+++ b/templates/bootstrap/.bruin.yml
@@ -5,6 +5,8 @@ environments:
       duckdb:
         - name: "duckdb-default"
           path: "duckdb.db"
+        - name: "duckdb-gong"
+          path: "duckdb_gong.db"
       chess:
         - name: "chess-default"
           players:

--- a/templates/bootstrap/assets/bootstrap_gong.asset.yml
+++ b/templates/bootstrap/assets/bootstrap_gong.asset.yml
@@ -1,6 +1,7 @@
-name: public.bootstrap
+name: public.bootstrap_gong
 type: duckdb.seed
 connection: duckdb-default
 
 parameters:
     path: seed.csv
+    use_gong: "true"

--- a/templates/bootstrap/pipeline.yml
+++ b/templates/bootstrap/pipeline.yml
@@ -6,3 +6,5 @@ environments:
       duckdb:
         - name: "duckdb-default"
           path: "/tmp/duckdb.db"
+        - name: "duckdb-gong"
+          path: "/tmp/duckdb_gong.db"


### PR DESCRIPTION
## Summary
- add a second DuckDB connection for Gong bootstrap output
- add a Gong-enabled bootstrap seed asset
- pin the existing bootstrap seed asset to the default DuckDB connection

## Validation
- make format
- make test