### PR TITLE
add stripe to gong-enabled sources

### DIFF
--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -819,6 +819,7 @@ var gongSources = map[string]bool{
 	"posthog":      true,
 	"rabbitmq":     true,
 	"smartsheet":   true,
+	"stripe":       true,
 	"surveymonkey": true,
 }
 


### PR DESCRIPTION
## Summary
- Add `stripe` to the `gongSources` map so Stripe ingestion auto-enables gong (`use_gong=true`), matching the other sources in that list.

## Test plan
- [ ] Run a Stripe ingestion asset and verify it routes through gong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)