### PR TITLE
Add clarifying comment for build-time variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ var (
 	version      = "dev"
 	commit       = ""
 	telemetryKey string
-)
+) // Build-time variables injected via ldflags
 
 func init() { //nolint:gochecknoinits
 	// Disable the Snowflake driver's platform detection which runs in a background goroutine on import.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A small test change that adds a clarifying inline comment to the build-time variables in `main.go`.

## Changes
- Added comment `// Build-time variables injected via ldflags` to the var block containing `version`, `commit`, and `telemetryKey`

This is a minor documentation improvement to make it clearer that these variables are populated at build time.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1778587984927599?thread_ts=1778587984.927599&cid=C094932THFW)

<div><a href="https://cursor.com/agents/bc-0cf78c7d-49e4-5671-8608-395f7b26044b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cf78c7d-49e4-5671-8608-395f7b26044b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

