### PR TITLE
emit-both-variant-and-var

### DIFF
--- a/cmd/const.go
+++ b/cmd/const.go
@@ -112,6 +112,13 @@ func variableOverridesMutator(variables []string) pipeline.PipelineMutator {
 				overrides[key] = value
 			}
 		}
+		if p.SelectedVariant != "" {
+			if variantOverrides, ok := p.Variants[p.SelectedVariant]; ok {
+				for key := range variantOverrides {
+					delete(overrides, key)
+				}
+			}
+		}
 		err := p.Variables.Merge(overrides)
 		if err != nil {
 			return nil, fmt.Errorf("invalid variable overrides: %w", err)

--- a/cmd/const_test.go
+++ b/cmd/const_test.go
@@ -73,3 +73,84 @@ func TestRenderAssetHooks_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "error rendering hooks for asset schema.asset")
 }
+
+func TestVariableOverridesMutator_VariantWinsOnOverlap(t *testing.T) {
+	t.Parallel()
+
+	newPipeline := func() *pipeline.Pipeline {
+		return &pipeline.Pipeline{
+			Variables: pipeline.Variables{
+				"client":        {"type": "string", "default": "alpha"},
+				"region":        {"type": "string", "default": "us"},
+				"forecast_days": {"type": "integer", "default": int64(7)},
+				"min_signups":   {"type": "integer", "default": int64(0)},
+			},
+			Variants: pipeline.VariantSet{
+				"client_alpha": {
+					"client":        "alpha",
+					"region":        "us",
+					"forecast_days": int64(7),
+				},
+			},
+			SelectedVariant: "client_alpha",
+		}
+	}
+
+	t.Run("overlapping --var key is dropped, variant value preserved", func(t *testing.T) {
+		t.Parallel()
+		p := newPipeline()
+
+		mutator := variableOverridesMutator([]string{
+			`{"forecast_days": 14}`, // overlaps with variant, must be ignored
+			`{"min_signups": 5}`,    // no overlap, must apply
+		})
+		out, err := mutator(t.Context(), p)
+		require.NoError(t, err)
+
+		vals := out.Variables.Value()
+		assert.Equal(t, int64(7), vals["forecast_days"], "variant value should win over --var")
+		assert.Equal(t, int64(5), vals["min_signups"], "non-overlapping --var should still apply")
+	})
+
+	t.Run("no variant selected: all --var overrides apply", func(t *testing.T) {
+		t.Parallel()
+		p := newPipeline()
+		p.SelectedVariant = ""
+
+		mutator := variableOverridesMutator([]string{
+			`{"forecast_days": 14, "min_signups": 5}`,
+		})
+		out, err := mutator(t.Context(), p)
+		require.NoError(t, err)
+
+		vals := out.Variables.Value()
+		assert.Equal(t, int64(14), vals["forecast_days"])
+		assert.Equal(t, int64(5), vals["min_signups"])
+	})
+
+	t.Run("--var overlapping every variant key is fully suppressed", func(t *testing.T) {
+		t.Parallel()
+		p := newPipeline()
+
+		mutator := variableOverridesMutator([]string{
+			`{"client": "manual", "region": "zz", "forecast_days": 99}`,
+		})
+		out, err := mutator(t.Context(), p)
+		require.NoError(t, err)
+
+		vals := out.Variables.Value()
+		assert.Equal(t, "alpha", vals["client"])
+		assert.Equal(t, "us", vals["region"])
+		assert.Equal(t, int64(7), vals["forecast_days"])
+	})
+
+	t.Run("unknown --var key still errors", func(t *testing.T) {
+		t.Parallel()
+		p := newPipeline()
+
+		mutator := variableOverridesMutator([]string{`{"nope": 1}`})
+		_, err := mutator(t.Context(), p)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `no such variable "nope"`)
+	})
+}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -117,10 +117,6 @@ func Lint(isDebug *bool) *cli.Command {
 
 			variantName := c.String("variant")
 			vars := c.StringSlice("var")
-			if variantName != "" && len(vars) > 0 {
-				printError(errors.New("--var and --variant cannot be used together"), c.String("output"), "Invalid flags")
-				return cli.Exit("", 1)
-			}
 			if len(vars) > 0 {
 				DefaultPipelineBuilder.AddPipelineMutator(variableOverridesMutator(vars))
 			}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -87,10 +87,6 @@ func Render() *cli.Command {
 
 			variantName := c.String("variant")
 			vars := c.StringSlice("var")
-			if variantName != "" && len(vars) > 0 {
-				printError(errors.New("--var and --variant cannot be used together"), c.String("output"), "Invalid flags")
-				return cli.Exit("", 1)
-			}
 			if len(vars) > 0 {
 				DefaultPipelineBuilder.AddPipelineMutator(variableOverridesMutator(vars))
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -761,10 +761,6 @@ func Run(isDebug *bool) *cli.Command {
 
 			variantName := c.String("variant")
 			vars := c.StringSlice("var")
-			if variantName != "" && len(vars) > 0 {
-				printError(errors.New("--var and --variant cannot be used together"), c.String("output"), "Invalid flags")
-				return cli.Exit("", 1)
-			}
 			if len(vars) > 0 {
 				DefaultPipelineBuilder.AddPipelineMutator(variableOverridesMutator(vars))
 			}
@@ -809,6 +805,8 @@ func Run(isDebug *bool) *cli.Command {
 					printError(fmt.Errorf("pipeline %q does not declare any variants but --variant=%q was provided", preview.Pipeline.Name, variantName), c.String("output"), "Variant not supported")
 					return cli.Exit("", 1)
 				}
+				// --var may co-exist with --variant. When both target the same
+				// variable, the variant's value wins (see variableOverridesMutator).
 				// Materialize the preview pipeline too, so downstream code that
 				// reads preview.Pipeline.Name (e.g. the state path) sees the
 				// rendered name.


### PR DESCRIPTION
Bruin now lets --variant and --var co-exist on the same bruin run (or bruin render). When you pass --variant client_alpha, bruin first materializes the pipeline with that variant's overrides applied on top of the declared variable defaults. Then it processes --var flags: for each key=value you passed, bruin checks whether that key is already pinned by the active variant. If yes, the --var is silently dropped and the variant's value is kept. If no, the --var is merged in and overrides the variable's default. In short, the precedence is variant > --var > default.