### PR TITLE
Allow multiple exclude tags

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2440,7 +2440,8 @@ func HandleModifiedAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 	}
 
 	// Handle exclude-tag if specified
-	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	excludeTags, missingExcludeTags := existingExcludeTags(f.excludeTags(), p)
+	warnMissingExcludeTags(missingExcludeTags)
 	for _, tag := range excludeTags {
 		s.MarkByTag(tag, scheduler.Skipped, false)
 	}
@@ -2472,14 +2473,17 @@ func HandleMultipleAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 	}
 
 	// Handle exclude-tag if specified
-	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	excludeTags, missingExcludeTags := existingExcludeTags(f.excludeTags(), p)
 	if len(excludeTags) > 0 {
 		if !f.IncludeDownstream && !f.selectedBySelector {
 			return errors.New("when specifying assets with --exclude-tag, you must also use --downstream flag")
 		}
+		warnMissingExcludeTags(missingExcludeTags)
 		for _, tag := range excludeTags {
 			s.MarkByTag(tag, scheduler.Skipped, false)
 		}
+	} else {
+		warnMissingExcludeTags(missingExcludeTags)
 	}
 
 	return nil
@@ -2507,14 +2511,17 @@ func HandleSingleTask(ctx context.Context, f *Filter, s *scheduler.Scheduler, p 
 	if f.IncludeTag != "" {
 		return errors.New("you cannot use the '--tag' flag when running a single asset")
 	}
-	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	excludeTags, missingExcludeTags := existingExcludeTags(f.excludeTags(), p)
 	if len(excludeTags) > 0 {
 		if !f.IncludeDownstream {
 			return errors.New("when running a single asset with '--exclude-tag', you must also use the '--downstream' flag")
 		}
+		warnMissingExcludeTags(missingExcludeTags)
 		for _, tag := range excludeTags {
 			s.MarkByTag(tag, scheduler.Skipped, false)
 		}
+	} else {
+		warnMissingExcludeTags(missingExcludeTags)
 	}
 	return nil
 }
@@ -2543,7 +2550,8 @@ func HandleExcludeTags(ctx context.Context, f *Filter, s *scheduler.Scheduler, p
 	if f.SingleTask != nil || len(f.SelectedAssets) > 0 || len(f.ModifiedAssets) > 0 {
 		return nil
 	}
-	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	excludeTags, missingExcludeTags := existingExcludeTags(f.excludeTags(), p)
+	warnMissingExcludeTags(missingExcludeTags)
 	for _, tag := range excludeTags {
 		s.MarkByTag(tag, scheduler.Skipped, false)
 	}
@@ -2573,17 +2581,24 @@ func (f *Filter) excludeTags() []string {
 	return unique
 }
 
-func existingExcludeTags(tags []string, p *pipeline.Pipeline) []string {
+func existingExcludeTags(tags []string, p *pipeline.Pipeline) ([]string, []string) {
 	existing := make([]string, 0, len(tags))
+	missing := make([]string, 0, len(tags))
 	for _, tag := range tags {
 		excludedAssets := p.GetAssetsByTag(tag)
 		if len(excludedAssets) > 0 {
 			existing = append(existing, tag)
 			continue
 		}
+		missing = append(missing, tag)
+	}
+	return existing, missing
+}
+
+func warnMissingExcludeTags(tags []string) {
+	for _, tag := range tags {
 		warningPrinter.Printf("Warning: no assets found with exclude tag '%s'; continuing without excluding any assets.\n", tag)
 	}
-	return existing
 }
 
 func FilterTaskTypes(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *pipeline.Pipeline) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -566,10 +566,10 @@ func Run(isDebug *bool) *cli.Command {
 				Name:  "single-check",
 				Usage: "runs a single column or custom check by ID",
 			},
-			&cli.StringFlag{
+			&cli.StringSliceFlag{
 				Name:    "exclude-tag",
 				Aliases: []string{"x"},
-				Usage:   "exclude the assets with given tag",
+				Usage:   "exclude assets with the given tag. Can be used multiple times",
 			},
 			&cli.StringSliceFlag{
 				Name:        "only",
@@ -710,7 +710,7 @@ func Run(isDebug *bool) *cli.Command {
 				FullRefresh:            fullRefresh,
 				Selector:               c.String("selector"),
 				Tag:                    c.String("tag"),
-				ExcludeTag:             c.String("exclude-tag"),
+				ExcludeTags:            c.StringSlice("exclude-tag"),
 				Only:                   c.StringSlice("only"),
 				Output:                 c.String("output"),
 				ExpUseWingetForUv:      c.Bool("exp-use-winget-for-uv"),
@@ -863,7 +863,7 @@ func Run(isDebug *bool) *cli.Command {
 				SingleTask:        task,
 				SelectedAssets:    selectedAssets,
 				Selector:          runConfig.Selector,
-				ExcludeTag:        runConfig.ExcludeTag,
+				ExcludeTags:       runConfig.ExcludeTags,
 				singleCheckID: scheduler.CheckUniqueID{
 					ID:    singleCheckID,
 					Asset: task,
@@ -1441,6 +1441,7 @@ func ReadState(fs afero.Fs, statePath string, filter *Filter) (*scheduler.Pipeli
 	filter.PushMetaData = pipelineState.Parameters.PushMetadata
 	filter.Selector = pipelineState.Parameters.Selector
 	filter.ExcludeTag = pipelineState.Parameters.ExcludeTag
+	filter.ExcludeTags = pipelineState.Parameters.ExcludeTags
 	return pipelineState, nil
 }
 
@@ -2393,6 +2394,7 @@ type Filter struct {
 	ModifiedAssets     []*pipeline.Asset // Assets whose files have been modified vs default branch (from `--modified`)
 	Selector           string
 	ExcludeTag         string
+	ExcludeTags        []string
 	selectedBySelector bool
 	singleCheckID      scheduler.CheckUniqueID // ID of the single check to run, if any
 }
@@ -2438,12 +2440,9 @@ func HandleModifiedAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 	}
 
 	// Handle exclude-tag if specified
-	if f.ExcludeTag != "" {
-		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
-		if len(excludedAssets) == 0 {
-			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
-		}
-		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
+	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	for _, tag := range excludeTags {
+		s.MarkByTag(tag, scheduler.Skipped, false)
 	}
 
 	return nil
@@ -2473,15 +2472,14 @@ func HandleMultipleAssets(ctx context.Context, f *Filter, s *scheduler.Scheduler
 	}
 
 	// Handle exclude-tag if specified
-	if f.ExcludeTag != "" {
+	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	if len(excludeTags) > 0 {
 		if !f.IncludeDownstream && !f.selectedBySelector {
 			return errors.New("when specifying assets with --exclude-tag, you must also use --downstream flag")
 		}
-		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
-		if len(excludedAssets) == 0 {
-			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
+		for _, tag := range excludeTags {
+			s.MarkByTag(tag, scheduler.Skipped, false)
 		}
-		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
 	}
 
 	return nil
@@ -2509,15 +2507,14 @@ func HandleSingleTask(ctx context.Context, f *Filter, s *scheduler.Scheduler, p 
 	if f.IncludeTag != "" {
 		return errors.New("you cannot use the '--tag' flag when running a single asset")
 	}
-	if f.ExcludeTag != "" {
+	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	if len(excludeTags) > 0 {
 		if !f.IncludeDownstream {
 			return errors.New("when running a single asset with '--exclude-tag', you must also use the '--downstream' flag")
 		}
-		excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
-		if len(excludedAssets) == 0 {
-			return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
+		for _, tag := range excludeTags {
+			s.MarkByTag(tag, scheduler.Skipped, false)
 		}
-		s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
 	}
 	return nil
 }
@@ -2543,19 +2540,50 @@ func HandleIncludeTags(ctx context.Context, f *Filter, s *scheduler.Scheduler, p
 }
 
 func HandleExcludeTags(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *pipeline.Pipeline) error {
-	if f.SingleTask != nil {
+	if f.SingleTask != nil || len(f.SelectedAssets) > 0 || len(f.ModifiedAssets) > 0 {
 		return nil
 	}
-	if f.ExcludeTag == "" {
-		return nil
+	excludeTags := existingExcludeTags(f.excludeTags(), p)
+	for _, tag := range excludeTags {
+		s.MarkByTag(tag, scheduler.Skipped, false)
 	}
-	excludedAssets := p.GetAssetsByTag(f.ExcludeTag)
-	if len(excludedAssets) == 0 {
-		return fmt.Errorf("no assets found with exclude tag '%s'", f.ExcludeTag)
-	}
-	s.MarkByTag(f.ExcludeTag, scheduler.Skipped, false)
 
 	return nil
+}
+
+func (f *Filter) excludeTags() []string {
+	tags := make([]string, 0, len(f.ExcludeTags)+1)
+	if f.ExcludeTag != "" {
+		tags = append(tags, f.ExcludeTag)
+	}
+	tags = append(tags, f.ExcludeTags...)
+
+	seen := make(map[string]struct{}, len(tags))
+	unique := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if tag == "" {
+			continue
+		}
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		seen[tag] = struct{}{}
+		unique = append(unique, tag)
+	}
+	return unique
+}
+
+func existingExcludeTags(tags []string, p *pipeline.Pipeline) []string {
+	existing := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		excludedAssets := p.GetAssetsByTag(tag)
+		if len(excludedAssets) > 0 {
+			existing = append(existing, tag)
+			continue
+		}
+		warningPrinter.Printf("Warning: no assets found with exclude tag '%s'; continuing without excluding any assets.\n", tag)
+	}
+	return existing
 }
 
 func FilterTaskTypes(ctx context.Context, f *Filter, s *scheduler.Scheduler, p *pipeline.Pipeline) error {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -741,6 +741,27 @@ func TestApplyFilters(t *testing.T) { //nolint
 			expectError:     true,
 			expectedError:   "when running a single asset with '--exclude-tag', you must also use the '--downstream' flag",
 		},
+		{
+			name: "Single Task with missing exclude-tag warns and continues",
+			pipeline: &pipeline.Pipeline{
+				Name: "TestPipeline",
+				Assets: []*pipeline.Asset{
+					task0,
+					task1,
+					task2,
+					task3,
+					task4,
+					task5,
+				},
+				MetadataPush: pipeline.MetadataPush{Global: false, BigQuery: false},
+			},
+			filter: &Filter{
+				SingleTask: task4,
+				ExcludeTag: "non-existent-tag",
+			},
+			expectedPending: []string{"Task4"},
+			expectError:     false,
+		},
 
 		{
 			name: "Full pipeline with exclude-tag",
@@ -764,7 +785,7 @@ func TestApplyFilters(t *testing.T) { //nolint
 		},
 
 		{
-			name: "Full pipeline with exclude-tag",
+			name: "Full pipeline with missing exclude-tag warns and continues",
 			pipeline: &pipeline.Pipeline{
 				Name: "TestPipeline",
 				Assets: []*pipeline.Asset{
@@ -780,9 +801,28 @@ func TestApplyFilters(t *testing.T) { //nolint
 			filter: &Filter{
 				ExcludeTag: "non-existent-tag",
 			},
-			expectedPending: []string{},
-			expectError:     true,
-			expectedError:   "no assets found with exclude tag 'non-existent-tag'",
+			expectedPending: []string{"Task0", "Task0:Column0:Check0", "Task0:custom-check:customcheck0", "Task1", "Task2", "Task3", "Task4", "Task5"},
+			expectError:     false,
+		},
+		{
+			name: "Full pipeline with multiple exclude tags",
+			pipeline: &pipeline.Pipeline{
+				Name: "TestPipeline",
+				Assets: []*pipeline.Asset{
+					task0,
+					task1,
+					task2,
+					task3,
+					task4,
+					task5,
+				},
+				MetadataPush: pipeline.MetadataPush{Global: false, BigQuery: false},
+			},
+			filter: &Filter{
+				ExcludeTags: []string{"tag1", "tag2"},
+			},
+			expectedPending: []string{"Task3"},
+			expectError:     false,
 		},
 		{
 			name: "Exclude Tag and the downstreams",
@@ -855,7 +895,7 @@ func TestApplyFilters(t *testing.T) { //nolint
 		},
 
 		{
-			name: "Exclude and Include Tag (exclude tag non existent)",
+			name: "Exclude and Include Tag with missing exclude tag warns and continues",
 			pipeline: &pipeline.Pipeline{
 				Name: "TestPipeline",
 				Assets: []*pipeline.Asset{
@@ -872,9 +912,29 @@ func TestApplyFilters(t *testing.T) { //nolint
 				IncludeTag:        "tag1",
 				IncludeDownstream: false,
 			},
-			expectedPending: []string{},
-			expectError:     true,
-			expectedError:   "no assets found with exclude tag 'non-existent-tag'",
+			expectedPending: []string{"Task4", "Task5", "Task8"},
+			expectError:     false,
+		},
+		{
+			name: "Exclude and Include Tag with multiple exclude tags",
+			pipeline: &pipeline.Pipeline{
+				Name: "TestPipeline",
+				Assets: []*pipeline.Asset{
+					task4,
+					task5,
+					task6,
+					task7,
+					task8,
+				},
+				MetadataPush: pipeline.MetadataPush{Global: false, BigQuery: false},
+			},
+			filter: &Filter{
+				ExcludeTags:       []string{"tag3", "exclude"},
+				IncludeTag:        "tag1",
+				IncludeDownstream: false,
+			},
+			expectedPending: []string{"Task5"},
+			expectError:     false,
 		},
 
 		{
@@ -1402,6 +1462,25 @@ func TestReadState(t *testing.T) {
 				OnlyTaskTypes: []string{"task-type"},
 				PushMetaData:  true,
 				ExcludeTag:    "exclude-tag",
+			},
+			runConfig:         &scheduler.RunConfig{},
+			expectedRunConfig: &scheduler.RunConfig{},
+		},
+		{
+			name:      "State With Multiple Exclude Tags",
+			statePath: "/logs/run",
+			stateContent: `{
+				"parameters": {
+					"tag": "test-tag",
+					"excludeTags": ["exclude-tag", "skip-tag"]
+				}
+			}`,
+			expectedError: false,
+			filter:        &Filter{},
+			expectedFilter: &Filter{
+				IncludeTag:   "test-tag",
+				ExcludeTags:  []string{"exclude-tag", "skip-tag"},
+				PushMetaData: false,
 			},
 			runConfig:         &scheduler.RunConfig{},
 			expectedRunConfig: &scheduler.RunConfig{},
@@ -2136,6 +2215,26 @@ func TestHandleModifiedAssets(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			name: "Modified assets with multiple exclude tags",
+			pipeline: &pipeline.Pipeline{
+				Name: "TestPipeline",
+				Assets: []*pipeline.Asset{
+					{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery, Tags: []string{"exclude"}},
+					{Name: "Task2", Type: pipeline.AssetTypePython, Tags: []string{"skip"}, Upstreams: []pipeline.Upstream{{Type: "asset", Value: "Task1"}}},
+					{Name: "Task3", Type: pipeline.AssetTypeBigqueryQuery, Upstreams: []pipeline.Upstream{{Type: "asset", Value: "Task2"}}},
+				},
+			},
+			filter: &Filter{
+				ModifiedAssets: []*pipeline.Asset{
+					{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery, Tags: []string{"exclude"}},
+				},
+				ExcludeTags:       []string{"exclude", "skip", "missing"},
+				IncludeDownstream: true,
+			},
+			expectedPending: []string{"Task3"},
+			expectError:     false,
+		},
+		{
 			name: "Empty modified assets is no-op",
 			pipeline: &pipeline.Pipeline{
 				Name: "TestPipeline",
@@ -2373,6 +2472,24 @@ func TestHandleMultipleAssets(t *testing.T) {
 			expectedError:   "when specifying assets with --exclude-tag, you must also use --downstream flag",
 		},
 		{
+			name: "Selected assets with missing exclude tag warns and continues without downstream",
+			pipeline: &pipeline.Pipeline{
+				Name: "TestPipeline",
+				Assets: []*pipeline.Asset{
+					{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery},
+					{Name: "Task2", Type: pipeline.AssetTypePython},
+				},
+			},
+			filter: &Filter{
+				SelectedAssets: []*pipeline.Asset{
+					{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery},
+				},
+				ExcludeTags: []string{"missing"},
+			},
+			expectedPending: []string{"Task1"},
+			expectError:     false,
+		},
+		{
 			name: "Selected assets with exclude tag and downstream",
 			pipeline: &pipeline.Pipeline{
 				Name: "TestPipeline",
@@ -2390,6 +2507,26 @@ func TestHandleMultipleAssets(t *testing.T) {
 				IncludeDownstream: true,
 			},
 			expectedPending: []string{"Task2", "Task3"},
+			expectError:     false,
+		},
+		{
+			name: "Selected assets with multiple exclude tags and downstream",
+			pipeline: &pipeline.Pipeline{
+				Name: "TestPipeline",
+				Assets: []*pipeline.Asset{
+					{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery, Tags: []string{"exclude"}},
+					{Name: "Task2", Type: pipeline.AssetTypePython, Tags: []string{"skip"}, Upstreams: []pipeline.Upstream{{Type: "asset", Value: "Task1"}}},
+					{Name: "Task3", Type: pipeline.AssetTypeBigqueryQuery, Upstreams: []pipeline.Upstream{{Type: "asset", Value: "Task2"}}},
+				},
+			},
+			filter: &Filter{
+				SelectedAssets: []*pipeline.Asset{
+					{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery, Tags: []string{"exclude"}},
+				},
+				ExcludeTags:       []string{"exclude", "skip"},
+				IncludeDownstream: true,
+			},
+			expectedPending: []string{"Task3"},
 			expectError:     false,
 		},
 	}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3002,3 +3002,20 @@ func TestApplyAllFilters_SelectorAllowsExcludeTagWithoutDownstream(t *testing.T)
 	}
 	assert.Equal(t, []string{"stg_orders", "int_orders", "fct_orders"}, names)
 }
+
+func TestExistingExcludeTagsSeparatesMissingTags(t *testing.T) {
+	t.Parallel()
+
+	p := &pipeline.Pipeline{
+		Name: "TestPipeline",
+		Assets: []*pipeline.Asset{
+			{Name: "Task1", Type: pipeline.AssetTypeBigqueryQuery, Tags: []string{"exclude"}},
+			{Name: "Task2", Type: pipeline.AssetTypePython, Tags: []string{"skip"}},
+		},
+	}
+
+	existing, missing := existingExcludeTags([]string{"exclude", "missing", "skip"}, p)
+
+	assert.Equal(t, []string{"exclude", "skip"}, existing)
+	assert.Equal(t, []string{"missing"}, missing)
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -137,7 +137,8 @@ type RunConfig struct {
 	FullRefresh            bool     `json:"fullRefresh"`
 	Selector               string   `json:"selector"`
 	Tag                    string   `json:"tag"`
-	ExcludeTag             string   `json:"excludeTag"`
+	ExcludeTag             string   `json:"excludeTag,omitempty"`
+	ExcludeTags            []string `json:"excludeTags,omitempty"`
 	Only                   []string `json:"only"`
 	Output                 string   `json:"output"`
 	ExpUseWingetForUv      bool     `json:"expUseWingetForUv"`


### PR DESCRIPTION
This makes `bruin run --exclude-tag` repeatable and skips all matching tags. Missing exclude tags now warn and continue instead of failing the run. Saved run state keeps reading legacy `excludeTag` while storing the new `excludeTags` array. Validated with `make format` and `make test`.