### PR TITLE
Add full refresh restriction config

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -193,6 +193,15 @@ func Render() *cli.Command {
 				}
 			}
 
+			cm, err := loadRenderConfig(fs, inputPath, c.String("config-file"), false)
+			if err != nil {
+				printError(err, c.String("output"), "Failed to load the config file:")
+				return cli.Exit("", 1)
+			}
+			if cm != nil {
+				applyEnvironmentRefreshRestrictionToAsset(cm.SelectedEnvironment, asset)
+			}
+
 			resultsLocation := "s3://{destination-bucket}"
 			if asset.Type == pipeline.AssetTypeAthenaQuery {
 				connName, err := pl.GetConnectionNameForAsset(asset)
@@ -201,20 +210,13 @@ func Render() *cli.Command {
 					return cli.Exit("", 1)
 				}
 
-				configFilePath := c.String("config-file")
-				if configFilePath == "" {
-					repoRoot, err := git.FindRepoFromPath(inputPath)
+				if cm == nil {
+					cm, err = loadRenderConfig(fs, inputPath, c.String("config-file"), true)
 					if err != nil {
-						printError(err, c.String("output"), "Failed to find the git repository root:")
+						printError(err, c.String("output"), "Failed to load the config file:")
 						return cli.Exit("", 1)
 					}
-					configFilePath = path2.Join(repoRoot.Path, ".bruin.yml")
-				}
-
-				cm, err := config.LoadOrCreate(afero.NewOsFs(), configFilePath)
-				if err != nil {
-					printError(err, c.String("output"), fmt.Sprintf("Failed to load the config file at '%s':", configFilePath))
-					return cli.Exit("", 1)
+					applyEnvironmentRefreshRestrictionToAsset(cm.SelectedEnvironment, asset)
 				}
 
 				for _, conn := range cm.SelectedEnvironment.Connections.AthenaConnection {
@@ -291,6 +293,41 @@ func Render() *cli.Command {
 			return r.Run(pl, asset, modifierInfo)
 		},
 	}
+}
+
+func loadRenderConfig(renderFS afero.Fs, inputPath, configuredConfigFilePath string, createIfMissing bool) (*config.Config, error) {
+	configFilePath := configuredConfigFilePath
+	if configFilePath == "" {
+		repoRoot, err := git.FindRepoFromPath(inputPath)
+		if err != nil {
+			switch {
+			case os.Getenv("BRUIN_CONFIG_FILE_CONTENT") != "":
+				configFilePath = ".bruin.yml"
+			case createIfMissing:
+				return nil, err
+			default:
+				return nil, nil
+			}
+		} else {
+			configFilePath = path2.Join(repoRoot.Path, ".bruin.yml")
+		}
+	}
+
+	if createIfMissing {
+		return config.LoadOrCreate(renderFS, configFilePath)
+	}
+
+	if configuredConfigFilePath == "" && os.Getenv("BRUIN_CONFIG_FILE_CONTENT") == "" {
+		exists, err := afero.Exists(renderFS, configFilePath)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+	}
+
+	return config.LoadFromFileOrEnv(renderFS, configFilePath)
 }
 
 type queryExtractor interface {

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -503,6 +504,34 @@ func TestRenderCommand_Run_QuerySensors(t *testing.T) { //nolint:paralleltest
 			writer.AssertExpectations(t)
 		})
 	}
+}
+
+func TestLoadRenderConfig_AppliesFullRefreshRestriction(t *testing.T) {
+	t.Parallel()
+
+	renderFS := afero.NewMemMapFs()
+	configPath := "/repo/.bruin.yml"
+	err := afero.WriteFile(renderFS, configPath, []byte(`default_environment: prod
+environments:
+  prod:
+    config:
+      full_refresh_restricted: true
+    connections:
+      duckdb:
+        - name: duckdb-default
+          path: duckdb.db
+`), 0o644)
+	require.NoError(t, err)
+
+	cm, err := loadRenderConfig(renderFS, "/repo/pipeline/assets/asset.sql", configPath, false)
+	require.NoError(t, err)
+	require.NotNil(t, cm)
+
+	asset := &pipeline.Asset{Name: "asset"}
+	applyEnvironmentRefreshRestrictionToAsset(cm.SelectedEnvironment, asset)
+
+	require.NotNil(t, asset.RefreshRestricted)
+	assert.True(t, *asset.RefreshRestricted)
 }
 
 func TestIsQuerySensorAsset(t *testing.T) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -904,6 +904,8 @@ func Run(isDebug *bool) *cli.Command {
 			if err != nil {
 				return err
 			}
+			applyEnvironmentRefreshRestriction(cm.SelectedEnvironment, pipelineInfo.Pipeline)
+			applyEnvironmentRefreshRestrictionToAsset(cm.SelectedEnvironment, task)
 
 			// Auto-enable gong for CDC mode assets
 			if !runConfig.UseGong {
@@ -2651,6 +2653,25 @@ func ensurePythonCacheGitignore(fs afero.Fs, repoRoot string) error {
 		}
 	}
 	return nil
+}
+
+func applyEnvironmentRefreshRestriction(env *config.Environment, p *pipeline.Pipeline) {
+	if p == nil {
+		return
+	}
+
+	for _, asset := range p.Assets {
+		applyEnvironmentRefreshRestrictionToAsset(env, asset)
+	}
+}
+
+func applyEnvironmentRefreshRestrictionToAsset(env *config.Environment, asset *pipeline.Asset) {
+	if env == nil || env.Config == nil || !env.Config.RefreshRestricted || asset == nil {
+		return
+	}
+
+	refreshRestricted := true
+	asset.RefreshRestricted = &refreshRestricted
 }
 
 // loadAssetsFromPaths loads assets from a list of paths or names.

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/logger"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/scheduler"
@@ -2789,6 +2790,46 @@ func TestDetermineStartDate_AllowsFutureDates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyEnvironmentRefreshRestriction(t *testing.T) {
+	t.Parallel()
+
+	explicitFalse := false
+	p := &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{Name: "asset-without-setting"},
+			{Name: "asset-with-explicit-false", RefreshRestricted: &explicitFalse},
+		},
+	}
+	env := &config.Environment{
+		Config: &config.EnvironmentConfig{RefreshRestricted: true},
+	}
+
+	applyEnvironmentRefreshRestriction(env, p)
+
+	for _, asset := range p.Assets {
+		require.NotNil(t, asset.RefreshRestricted)
+		assert.True(t, *asset.RefreshRestricted)
+	}
+}
+
+func TestApplyEnvironmentRefreshRestriction_NoConfig(t *testing.T) {
+	t.Parallel()
+
+	explicitFalse := false
+	p := &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{Name: "asset-without-setting"},
+			{Name: "asset-with-explicit-false", RefreshRestricted: &explicitFalse},
+		},
+	}
+
+	applyEnvironmentRefreshRestriction(&config.Environment{}, p)
+
+	assert.Nil(t, p.Assets[0].RefreshRestricted)
+	require.NotNil(t, p.Assets[1].RefreshRestricted)
+	assert.False(t, *p.Assets[1].RefreshRestricted)
 }
 
 func TestApplyAllFilters_SelectorAllowsExcludeTagWithoutDownstream(t *testing.T) {

--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -117,7 +117,7 @@ select 2 as one
 
 The result will be a table `dashboard.hello_bq` with the result of the query.
 
-## Full Refresh and `refresh_restricted`
+## Full Refresh and `full_refresh_restricted`
 
 When running assets with the `--full-refresh` flag, Bruin will drop and recreate tables to ensure a clean state. However, there are cases where you may want to protect certain tables from being dropped during a full refresh, such as:
 
@@ -125,7 +125,7 @@ When running assets with the `--full-refresh` flag, Bruin will drop and recreate
 - Tables that take a long time to rebuild
 - Critical production tables that should never be accidentally dropped
 
-You can use the `refresh_restricted` flag to prevent an asset from being dropped during a full refresh:
+You can use the `full_refresh_restricted` flag to prevent an asset from being dropped during a full refresh:
 
 ```bruin-sql
 /* @bruin
@@ -136,7 +136,7 @@ type: bq.sql
 materialization:
     type: table
 
-refresh_restricted: true
+full_refresh_restricted: true
 
 @bruin */
 
@@ -145,8 +145,21 @@ select * from important_data
 
 **Behavior:**
 
-- `refresh_restricted: true` - Table will NOT be dropped during full refresh. The asset will use its normal materialization strategy instead.
-- `refresh_restricted: false` or not set - Table will be dropped and recreated during full refresh (default behavior).
+- `full_refresh_restricted: true` - Table will NOT be dropped during full refresh. The asset will use its normal materialization strategy instead.
+- `full_refresh_restricted: false` or not set - Table will be dropped and recreated during full refresh (default behavior).
+
+The older asset-level `refresh_restricted` field is still supported as an alias.
+
+You can also apply the same protection to every asset in an environment from `.bruin.yml`:
+
+```yaml
+environments:
+  production:
+    config:
+      full_refresh_restricted: true
+    connections:
+      # ...
+```
 
 This is useful when you want to run `bruin run --full-refresh` on your entire pipeline but protect specific critical tables from being dropped.
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -214,7 +214,7 @@ bruin run --full-refresh
 ```
 
 > [!TIP]
-> You can protect specific assets from being dropped during full refresh by setting `refresh_restricted: true` in the asset definition. See [Materialization](../assets/materialization.md#full-refresh-and-refresh_restricted) for more details.
+> You can protect assets from being dropped during full refresh by setting `full_refresh_restricted: true` in an asset definition, or for an entire environment under `.bruin.yml` `config.full_refresh_restricted`. Asset-level `refresh_restricted` is still supported as an alias. See [Materialization](../assets/materialization.md#full-refresh-and-full_refresh_restricted) for more details.
 
 Run with default query annotations:
 

--- a/docs/secrets/bruinyml.md
+++ b/docs/secrets/bruinyml.md
@@ -13,6 +13,8 @@ default_environment: <environment_name>
 environments:
   <environment_name>:
     schema_prefix: <optional_prefix>
+    config:
+      full_refresh_restricted: true
     connections:
       <connection_type>:
         - name: "<connection_name>"
@@ -59,6 +61,7 @@ Each environment contains:
 |-------|------|----------|-------------|
 | `connections` | object | Yes | Connection definitions grouped by type. |
 | `schema_prefix` | string | No | Prefix added to schema names (useful for dev/staging environments). |
+| `config.full_refresh_restricted` | boolean | No | Prevents `--full-refresh` from dropping and recreating tables for all assets in this environment. |
 
 ## Environment Variables
 

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -211,8 +211,13 @@ func (c *Connections) buildConnectionKeyMap() {
 }
 
 type Environment struct {
-	Connections  *Connections `yaml:"connections" json:"connections" mapstructure:"connections"`
-	SchemaPrefix string       `yaml:"schema_prefix,omitempty" json:"schema_prefix" mapstructure:"schema_prefix"`
+	Connections  *Connections       `yaml:"connections" json:"connections" mapstructure:"connections"`
+	SchemaPrefix string             `yaml:"schema_prefix,omitempty" json:"schema_prefix" mapstructure:"schema_prefix"`
+	Config       *EnvironmentConfig `yaml:"config,omitempty" json:"config,omitempty" mapstructure:"config"`
+}
+
+type EnvironmentConfig struct {
+	RefreshRestricted bool `yaml:"full_refresh_restricted,omitempty" json:"full_refresh_restricted,omitempty" mapstructure:"full_refresh_restricted"`
 }
 
 type EnvContextKey string

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -2448,6 +2448,26 @@ environments:
 	}
 }
 
+func TestLoadFromFileOrEnv_EnvironmentConfig(t *testing.T) {
+	t.Setenv("BRUIN_CONFIG_FILE_CONTENT", `default_environment: prod
+environments:
+  prod:
+    config:
+      full_refresh_restricted: true
+    connections:
+      duckdb:
+        - name: duckdb-default
+          path: duckdb.db`)
+
+	fs := afero.NewReadOnlyFs(afero.NewOsFs())
+	got, err := LoadFromFileOrEnv(fs, "testdata/nonexistent.yml")
+	require.NoError(t, err)
+
+	require.NotNil(t, got.SelectedEnvironment.Config)
+	assert.True(t, got.SelectedEnvironment.Config.RefreshRestricted)
+	assert.True(t, got.Environments["prod"].Config.RefreshRestricted)
+}
+
 func TestSnowflakeConnection_MarshalYAML_PrivateKey(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -270,6 +270,14 @@ func commentRowsToTask(commentRows []string) (*Asset, error) {
 			task.RerunCooldown = &rerunCooldown
 
 			continue
+		case "refresh_restricted", "full_refresh_restricted":
+			refreshRestricted, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse %s value '%s'", key, value)
+			}
+			task.RefreshRestricted = &refreshRestricted
+
+			continue
 		case "secrets":
 			values := strings.Split(value, ",")
 			for _, v := range values {

--- a/pkg/pipeline/materializer.go
+++ b/pkg/pipeline/materializer.go
@@ -30,7 +30,7 @@ func (m *Materializer) Render(asset *Asset, query string) (string, error) {
 	if m.FullRefresh && mat.Type == MaterializationTypeTable {
 		// Only override to CreateReplace if strategy is not explicitly set to DDL
 		// This strategy should never be overridden, even with full refresh
-		// Also respect refresh_restricted flag - if true, don't drop/recreate the table
+		// Also respect full refresh restriction - if true, don't drop/recreate the table
 		if mat.Strategy != MaterializationStrategyDDL && (asset.RefreshRestricted == nil || !*asset.RefreshRestricted) {
 			strategy = MaterializationStrategyCreateReplace
 		}

--- a/pkg/pipeline/materializer_test.go
+++ b/pkg/pipeline/materializer_test.go
@@ -7,15 +7,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func TestMaterializer_Render(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		matMap      AssetMaterializationMap
-		fullRefresh bool
-		query       string
-		expected    string
+		name              string
+		matMap            AssetMaterializationMap
+		fullRefresh       bool
+		refreshRestricted *bool
+		query             string
+		expected          string
 	}{
 		{
 			name: "no full refresh, remove comments",
@@ -43,6 +48,23 @@ func TestMaterializer_Render(t *testing.T) {
 			query:       "SELECT * FROM table",
 			expected:    "SELECT 1;SELECT * FROM table",
 		},
+		{
+			name: "full refresh respects refresh restricted",
+			matMap: AssetMaterializationMap{
+				MaterializationTypeTable: {
+					MaterializationStrategyMerge: func(task *Asset, query string) (string, error) {
+						return "MERGE;" + query, nil
+					},
+					MaterializationStrategyCreateReplace: func(task *Asset, query string) (string, error) {
+						return "CREATE OR REPLACE;" + query, nil
+					},
+				},
+			},
+			fullRefresh:       true,
+			refreshRestricted: boolPtr(true),
+			query:             "SELECT * FROM table",
+			expected:          "MERGE;SELECT * FROM table",
+		},
 	}
 
 	for _, tt := range tests {
@@ -59,6 +81,7 @@ func TestMaterializer_Render(t *testing.T) {
 					Type:     MaterializationTypeTable,
 					Strategy: MaterializationStrategyMerge,
 				},
+				RefreshRestricted: tt.refreshRestricted,
 			}
 
 			result, err := materializer.Render(asset, tt.query)

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -326,34 +326,42 @@ func notificationsOrNil(n Notifications) *Notifications {
 }
 
 type taskDefinition struct {
-	Name              string            `yaml:"name"`
-	URI               string            `yaml:"uri"`
-	Description       string            `yaml:"description"`
-	Type              string            `yaml:"type"`
-	RunFile           string            `yaml:"run"`
-	Depends           depends           `yaml:"depends"`
-	Parameters        map[string]string `yaml:"parameters"`
-	Connections       map[string]string `yaml:"connections"`
-	Secrets           []secretMapping   `yaml:"secrets"`
-	Connection        string            `yaml:"connection"`
-	Image             string            `yaml:"image"`
-	Instance          string            `yaml:"instance"`
-	Materialization   materialization   `yaml:"materialization"`
-	Owner             string            `yaml:"owner"`
-	StartDate         string            `yaml:"start_date"`
-	Extends           []string          `yaml:"extends"`
-	Columns           []column          `yaml:"columns"`
-	CustomChecks      []customCheck     `yaml:"custom_checks"`
-	Hooks             Hooks             `yaml:"hooks"`
-	Tags              []string          `yaml:"tags"`
-	Snowflake         snowflake         `yaml:"snowflake"`
-	Athena            athena            `yaml:"athena"`
-	IntervalModifiers IntervalModifiers `yaml:"interval_modifiers"`
-	Domains           []string          `yaml:"domains"`
-	Meta              map[string]string `yaml:"meta"`
-	RerunCooldown     *int              `yaml:"rerun_cooldown"`
-	RefreshRestricted *bool             `yaml:"refresh_restricted,omitempty"`
-	Notifications     Notifications     `yaml:"notifications"`
+	Name                  string            `yaml:"name"`
+	URI                   string            `yaml:"uri"`
+	Description           string            `yaml:"description"`
+	Type                  string            `yaml:"type"`
+	RunFile               string            `yaml:"run"`
+	Depends               depends           `yaml:"depends"`
+	Parameters            map[string]string `yaml:"parameters"`
+	Connections           map[string]string `yaml:"connections"`
+	Secrets               []secretMapping   `yaml:"secrets"`
+	Connection            string            `yaml:"connection"`
+	Image                 string            `yaml:"image"`
+	Instance              string            `yaml:"instance"`
+	Materialization       materialization   `yaml:"materialization"`
+	Owner                 string            `yaml:"owner"`
+	StartDate             string            `yaml:"start_date"`
+	Extends               []string          `yaml:"extends"`
+	Columns               []column          `yaml:"columns"`
+	CustomChecks          []customCheck     `yaml:"custom_checks"`
+	Hooks                 Hooks             `yaml:"hooks"`
+	Tags                  []string          `yaml:"tags"`
+	Snowflake             snowflake         `yaml:"snowflake"`
+	Athena                athena            `yaml:"athena"`
+	IntervalModifiers     IntervalModifiers `yaml:"interval_modifiers"`
+	Domains               []string          `yaml:"domains"`
+	Meta                  map[string]string `yaml:"meta"`
+	RerunCooldown         *int              `yaml:"rerun_cooldown"`
+	RefreshRestricted     *bool             `yaml:"refresh_restricted,omitempty"`
+	FullRefreshRestricted *bool             `yaml:"full_refresh_restricted,omitempty"`
+	Notifications         Notifications     `yaml:"notifications"`
+}
+
+func (d taskDefinition) refreshRestricted() *bool {
+	if d.FullRefreshRestricted != nil {
+		return d.FullRefreshRestricted
+	}
+	return d.RefreshRestricted
 }
 
 func CreateTaskFromYamlDefinition(fs afero.Fs) TaskCreator {
@@ -534,7 +542,7 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 		Domains:           definition.Domains,
 		Meta:              definition.Meta,
 		RerunCooldown:     definition.RerunCooldown,
-		RefreshRestricted: definition.RefreshRestricted,
+		RefreshRestricted: definition.refreshRestricted(),
 		Notifications:     notificationsOrNil(definition.Notifications),
 	}
 

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -340,6 +340,62 @@ func TestUpstreams(t *testing.T) {
 	require.Equal(t, expected, got)
 }
 
+func TestConvertYamlToTask_FullRefreshRestrictedAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "existing refresh_restricted field",
+			content: `
+name: dataset.asset
+type: duckdb.sql
+refresh_restricted: true
+`,
+		},
+		{
+			name: "full_refresh_restricted alias",
+			content: `
+name: dataset.asset
+type: duckdb.sql
+full_refresh_restricted: true
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			task, err := pipeline.ConvertYamlToTask([]byte(strings.TrimSpace(tt.content)))
+			require.NoError(t, err)
+			require.NotNil(t, task.RefreshRestricted)
+			require.True(t, *task.RefreshRestricted)
+		})
+	}
+}
+
+func TestCreateTaskFromFileComments_FullRefreshRestrictedAlias(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	err := afero.WriteFile(fs, "asset.sql", []byte(strings.TrimSpace(`
+-- @bruin.name: dataset.asset
+-- @bruin.type: duckdb.sql
+-- @bruin.full_refresh_restricted: true
+select 1
+`)), 0o644)
+	require.NoError(t, err)
+
+	creator := pipeline.CreateTaskFromFileComments(fs)
+	task, err := creator("asset.sql")
+	require.NoError(t, err)
+	require.NotNil(t, task.RefreshRestricted)
+	require.True(t, *task.RefreshRestricted)
+}
+
 func TestConvertYamlToTask_Hooks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds `.bruin.yml` `config.full_refresh_restricted` support for run and render so full refresh materialization respects environment-level restrictions.
Keeps asset-level `refresh_restricted` working while adding `full_refresh_restricted` as the new asset field.
Validated with `make format` and `make test`.