### PR TITLE
[codex] add MSSQL DDL materialization

### DIFF
--- a/pkg/mssql/materialization.go
+++ b/pkg/mssql/materialization.go
@@ -25,6 +25,7 @@ var matMap = pipeline.AssetMaterializationMap{
 		pipeline.MaterializationStrategyTruncateInsert: ansisql.BuildTruncateInsertQuery,
 		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
 		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
+		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
 	},
 }
 
@@ -165,6 +166,69 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 			strings.TrimSuffix(query, ";")),
 		"COMMIT",
 	}
+
+	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func quoteIdentifier(identifier string) string {
+	parts := strings.Split(identifier, ".")
+	quotedParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		quotedParts = append(quotedParts, "["+strings.ReplaceAll(part, "]", "]]")+"]")
+	}
+
+	return strings.Join(quotedParts, ".")
+}
+
+func sqlStringLiteral(value string) string {
+	return "N'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	nameParts := strings.Split(asset.Name, ".")
+	queries := make([]string, 0, 2)
+	if len(nameParts) == 2 {
+		schemaName := nameParts[0]
+		queries = append(queries, fmt.Sprintf(
+			"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
+			sqlStringLiteral(schemaName),
+			strings.ReplaceAll(quoteIdentifier(schemaName), "'", "''"),
+		))
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	primaryKeys := make([]string, 0)
+	for _, col := range asset.Columns {
+		if col.Type == "" {
+			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
+		}
+
+		def := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.Type)
+		if col.PrimaryKey || !col.Nullable.Bool() {
+			def += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, def)
+
+		if col.PrimaryKey {
+			primaryKeys = append(primaryKeys, quoteIdentifier(col.Name))
+		}
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("    PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
+	}
+
+	createTable := fmt.Sprintf(
+		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\nCREATE TABLE %s (\n%s\n)\nEND",
+		sqlStringLiteral(asset.Name),
+		quoteIdentifier(asset.Name),
+		strings.Join(columnDefs, ",\n"),
+	)
+	queries = append(queries, createTable)
 
 	return strings.Join(queries, ";\n") + ";", nil
 }

--- a/pkg/mssql/materialization_test.go
+++ b/pkg/mssql/materialization_test.go
@@ -304,6 +304,66 @@ func TestMaterializer_Render(t *testing.T) {
 				"INSERT INTO my\\.asset SELECT dt, event_name from source_table where dt between '{{start_date}}' and '{{end_date}}';\n" +
 				"COMMIT;$",
 		},
+		{
+			name: "ddl materialization creates schema and table from columns",
+			task: &pipeline.Asset{
+				Name: "cfg.ProfileTarget",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "TargetId", Type: "integer", PrimaryKey: true},
+					{Name: "SchemaName", Type: "NVARCHAR(128)"},
+					{Name: "TableName", Type: "NVARCHAR(128)"},
+					{Name: "FilterPredicate", Type: "NVARCHAR(MAX)"},
+					{Name: "IsEnabled", Type: "BIT"},
+					{Name: "Notes", Type: "NVARCHAR(4000)"},
+				},
+			},
+			query: "",
+			want: "^IF SCHEMA_ID\\(N'cfg'\\) IS NULL\n" +
+				"    EXEC\\(N'CREATE SCHEMA \\[cfg\\]'\\);\n" +
+				"IF OBJECT_ID\\(N'cfg\\.ProfileTarget', N'U'\\) IS NULL\n" +
+				"BEGIN\n" +
+				"CREATE TABLE \\[cfg\\]\\.\\[ProfileTarget\\] \\(\n" +
+				"    \\[TargetId\\] integer NOT NULL,\n" +
+				"    \\[SchemaName\\] NVARCHAR\\(128\\),\n" +
+				"    \\[TableName\\] NVARCHAR\\(128\\),\n" +
+				"    \\[FilterPredicate\\] NVARCHAR\\(MAX\\),\n" +
+				"    \\[IsEnabled\\] BIT,\n" +
+				"    \\[Notes\\] NVARCHAR\\(4000\\),\n" +
+				"    PRIMARY KEY \\(\\[TargetId\\]\\)\n" +
+				"\\)\n" +
+				"END;$",
+		},
+		{
+			name: "ddl materialization requires columns",
+			task: &pipeline.Asset{
+				Name: "cfg.ProfileTarget",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+			},
+			query:   "",
+			wantErr: true,
+		},
+		{
+			name: "ddl materialization requires column types",
+			task: &pipeline.Asset{
+				Name: "cfg.ProfileTarget",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "TargetId", PrimaryKey: true},
+				},
+			},
+			query:   "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/mssql/operator.go
+++ b/pkg/mssql/operator.go
@@ -63,7 +63,10 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	if len(queries) == 0 {
-		return nil
+		if t.Materialization.Strategy != pipeline.MaterializationStrategyDDL {
+			return nil
+		}
+		queries = []*query.Query{{Query: ""}}
 	}
 
 	if len(queries) > 1 && t.Materialization.Type != pipeline.MaterializationTypeNone {

--- a/pkg/mssql/operator_test.go
+++ b/pkg/mssql/operator_test.go
@@ -93,6 +93,33 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "no queries found in DDL asset runs materialized metadata query",
+			setup: func(f *fields) {
+				f.e.On("ExtractQueriesFromString", "").
+					Return([]*query.Query{}, nil)
+
+				f.m.On("Render", mock.Anything, "").
+					Return("CREATE TABLE cfg.ProfileTarget (TargetId integer)", nil)
+
+				f.q.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "CREATE TABLE cfg.ProfileTarget (TargetId integer)"}).
+					Return(nil)
+			},
+			args: args{
+				t: &pipeline.Asset{
+					Type: pipeline.AssetTypeMsSQLQuery,
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDDL,
+					},
+					ExecutableFile: pipeline.ExecutableFile{
+						Path:    "test-file.sql",
+						Content: "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "multiple queries found but materialization is enabled, should fail",
 			setup: func(f *fields) {
 				f.e.On("ExtractQueriesFromString", "some content").


### PR DESCRIPTION
## Summary

Adds metadata-driven `ddl` materialization support for MSSQL assets.

## Changes

- Registers `MaterializationStrategyDDL` for MSSQL table materializations.
- Generates MSSQL `CREATE TABLE` DDL from asset column metadata, including schema creation, bracketed identifiers, required column types, `NOT NULL` for primary keys and non-nullable columns, and primary key constraints.
- Allows metadata-only MSSQL DDL assets to execute even when the SQL file has no query body.
- Adds focused unit coverage for DDL rendering and metadata-only execution.

## Root Cause

MSSQL assets with `strategy: ddl` were not supported by the MSSQL materializer, and metadata-only SQL assets were skipped before materialization because the operator returned early when no executable query body was found.

## Validation

- `go test -tags="no_duckdb_arrow" ./pkg/mssql`
- `make format`
- `make test`
- Verified against a local SQL Server container by dropping `cfg.ProfileTarget`/`cfg`, running the asset, and confirming `cfg.ProfileTarget` was created with the expected columns and primary key.

Note: the local `mssql-profile-target/` test pipeline used for manual verification was intentionally left uncommitted and is not included in this PR.