### PR TITLE
Add BigQuery query cost guards

### DIFF
--- a/cmd/connections_add_tui.go
+++ b/cmd/connections_add_tui.go
@@ -473,6 +473,12 @@ func collectCredentials(fields []config.ConnectionFieldDef, inputs []textinput.M
 			} else {
 				creds[f.Name] = val
 			}
+		case "float":
+			if n, err := strconv.ParseFloat(val, 64); err == nil {
+				creds[f.Name] = n
+			} else {
+				creds[f.Name] = val
+			}
 		default:
 			creds[f.Name] = val
 		}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/bigquery"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
@@ -105,6 +106,10 @@ func Query() *cli.Command {
 			&cli.BoolFlag{
 				Name:  "dry-run",
 				Usage: "validate the query without executing it; show estimated cost and metadata when available",
+			},
+			&cli.BoolFlag{
+				Name:  "dangerously-bypass-soft-limits",
+				Usage: "bypass BigQuery soft query limits configured on the connection",
 			},
 			&cli.StringFlag{
 				Name:    "query-annotations",
@@ -214,6 +219,9 @@ func Query() *cli.Command {
 
 				timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Duration(c.Int("timeout"))*time.Second)
 				defer timeoutCancel()
+				if !c.Bool("dangerously-bypass-soft-limits") {
+					timeoutCtx = bigquery.WithSoftQueryLimits(timeoutCtx)
+				}
 
 				q := query.Query{Query: queryStr}
 				annotationsInput := c.String("query-annotations")

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -25,6 +25,7 @@ You can run it in three modes:
 | `--export`           |       | Export results to a CSV file.                                              |
 | `--split-rows`       |       | Split export into multiple CSV files with at most this many rows per file (requires `--export`). |
 | `--config-file`      |       | The path to the `.bruin.yml` file.                                         |
+| `--dangerously-bypass-soft-limits` | | Bypass BigQuery soft query limits configured on the connection. |
 
 ## Example
 

--- a/docs/platforms/bigquery.md
+++ b/docs/platforms/bigquery.md
@@ -29,6 +29,16 @@ Google BigQuery requires a Google Cloud Platform connection, which can be added 
               "type": "service_account",
               ...
             }
+
+          # Optional query safety limits. When set, Bruin dry-runs each BigQuery
+          # query before execution and stops if the estimate exceeds either limit.
+          max_billable_bytes: 1000000000000
+          max_query_cost: 5.00 # USD
+
+          # Optional soft limits for `bruin query` only. Agents receive a
+          # descriptive error unless they pass --dangerously-bypass-soft-limits.
+          max_billable_bytes_soft: 100000000000
+          max_query_cost_soft: 0.50 # USD
 ```
 
 ### Authentication Options

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1803,6 +1803,18 @@
         },
         "use_application_default_credentials": {
           "type": "boolean"
+        },
+        "max_billable_bytes": {
+          "type": "integer"
+        },
+        "max_query_cost": {
+          "type": "number"
+        },
+        "max_billable_bytes_soft": {
+          "type": "integer"
+        },
+        "max_query_cost_soft": {
+          "type": "number"
         }
       },
       "additionalProperties": false,

--- a/pkg/bigquery/config.go
+++ b/pkg/bigquery/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	Location            string `envconfig:"BIGQUERY_LOCATION"`
 	// Add support for Application Default Credentials
 	UseApplicationDefaultCredentials bool `envconfig:"BIGQUERY_USE_ADC"`
+	MaxBillableBytes                 *int64
+	MaxQueryCost                     *float64
+	MaxBillableBytesSoft             *int64
+	MaxQueryCostSoft                 *float64
 }
 
 func (c Config) IsValid() bool {

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -31,6 +31,8 @@ var scopes = []string{
 	"https://www.googleapis.com/auth/drive",
 }
 
+const bigQueryOnDemandCostPerTBUSD = 5.0
+
 type Querier interface {
 	RunQueryWithoutResult(ctx context.Context, query *query.Query) error
 	Ping(ctx context.Context) error
@@ -64,6 +66,16 @@ var (
 	datasetNameCache sync.Map // Global cache for dataset existence
 	datasetLocks     sync.Map // Global map for dataset-specific locks
 )
+
+type (
+	queryLimitsCheckedContextKey struct{}
+	softQueryLimitsContextKey    struct{}
+)
+
+// WithSoftQueryLimits enables BigQuery soft-limit checks for query execution paths.
+func WithSoftQueryLimits(ctx context.Context) context.Context {
+	return context.WithValue(ctx, softQueryLimitsContextKey{}, true)
+}
 
 type Client struct {
 	client      *bigquery.Client
@@ -252,7 +264,10 @@ func (d *Client) RunQueryWithoutResult(ctx context.Context, q *query.Query) erro
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return err
 	}
-	bqQuery := d.client.Query(q.String())
+	if err := d.checkQueryLimits(ctx, q); err != nil {
+		return err
+	}
+	bqQuery := d.queryForExecution(q.String())
 	job, err := bqQuery.Run(ctx)
 	if err != nil {
 		return formatError(err)
@@ -270,7 +285,10 @@ func (d *Client) Select(ctx context.Context, q *query.Query) ([][]interface{}, e
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return nil, err
 	}
-	bqQuery := d.client.Query(q.String())
+	if err := d.checkQueryLimits(ctx, q); err != nil {
+		return nil, err
+	}
+	bqQuery := d.queryForExecution(q.String())
 	job, err := bqQuery.Run(ctx)
 	if err != nil {
 		return nil, formatError(err)
@@ -307,7 +325,10 @@ func (d *Client) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return nil, err
 	}
-	bqQuery := d.client.Query(queryObj.String())
+	if err := d.checkQueryLimits(ctx, queryObj); err != nil {
+		return nil, err
+	}
+	bqQuery := d.queryForExecution(queryObj.String())
 	job, err := bqQuery.Run(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run query: %w", formatError(err))
@@ -358,6 +379,86 @@ func (d *Client) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*
 	result.ColumnTypes = columnTypes
 
 	return result, nil
+}
+
+func (d *Client) checkQueryLimits(ctx context.Context, queryObj *query.Query) error {
+	if d == nil || d.config == nil || !d.hasActiveQueryLimits(ctx) {
+		return nil
+	}
+	if checked, ok := ctx.Value(queryLimitsCheckedContextKey{}).(bool); ok && checked {
+		return nil
+	}
+
+	stats, err := d.QueryDryRun(ctx, queryObj)
+	if err != nil {
+		return fmt.Errorf("failed to estimate BigQuery query cost before execution: %w", err)
+	}
+
+	return d.validateQueryLimits(stats, d.shouldEnforceSoftQueryLimits(ctx))
+}
+
+// CheckQueryLimits estimates a query and returns an error when configured limits are exceeded.
+func (d *Client) CheckQueryLimits(ctx context.Context, queryObj *query.Query) error {
+	return d.checkQueryLimits(ctx, queryObj)
+}
+
+func (d *Client) hasActiveQueryLimits(ctx context.Context) bool {
+	if d.config.MaxBillableBytes != nil || d.config.MaxQueryCost != nil {
+		return true
+	}
+
+	return d.shouldEnforceSoftQueryLimits(ctx) && (d.config.MaxBillableBytesSoft != nil || d.config.MaxQueryCostSoft != nil)
+}
+
+func (d *Client) shouldEnforceSoftQueryLimits(ctx context.Context) bool {
+	enforce, _ := ctx.Value(softQueryLimitsContextKey{}).(bool)
+	return enforce
+}
+
+func (d *Client) queryForExecution(queryString string) *bigquery.Query {
+	bqQuery := d.client.Query(queryString)
+	if d.config != nil && d.config.MaxBillableBytes != nil {
+		bqQuery.MaxBytesBilled = *d.config.MaxBillableBytes
+	}
+	return bqQuery
+}
+
+func (d *Client) validateQueryLimits(stats *bigquery.QueryStatistics, enforceSoftLimits bool) error {
+	if d == nil || d.config == nil || stats == nil {
+		return nil
+	}
+
+	estimatedBillableBytes := stats.TotalBytesBilled
+	if estimatedBillableBytes == 0 {
+		estimatedBillableBytes = stats.TotalBytesProcessed
+	}
+	estimatedCost := float64(estimatedBillableBytes) / 1e12 * bigQueryOnDemandCostPerTBUSD
+
+	var violations []string
+	if d.config.MaxBillableBytes != nil && estimatedBillableBytes > *d.config.MaxBillableBytes {
+		violations = append(violations, fmt.Sprintf("estimated billable bytes %d exceeds max_billable_bytes %d", estimatedBillableBytes, *d.config.MaxBillableBytes))
+	}
+	if d.config.MaxQueryCost != nil && estimatedCost > *d.config.MaxQueryCost {
+		violations = append(violations, fmt.Sprintf("estimated query cost $%.6f exceeds max_query_cost $%.6f", estimatedCost, *d.config.MaxQueryCost))
+	}
+	if len(violations) > 0 {
+		return fmt.Errorf("BigQuery query exceeds configured cost limits: %s. Query was not executed", strings.Join(violations, "; "))
+	}
+
+	if enforceSoftLimits {
+		var softViolations []string
+		if d.config.MaxBillableBytesSoft != nil && estimatedBillableBytes > *d.config.MaxBillableBytesSoft {
+			softViolations = append(softViolations, fmt.Sprintf("estimated billable bytes %d exceeds max_billable_bytes_soft %d", estimatedBillableBytes, *d.config.MaxBillableBytesSoft))
+		}
+		if d.config.MaxQueryCostSoft != nil && estimatedCost > *d.config.MaxQueryCostSoft {
+			softViolations = append(softViolations, fmt.Sprintf("estimated query cost $%.6f exceeds max_query_cost_soft $%.6f", estimatedCost, *d.config.MaxQueryCostSoft))
+		}
+		if len(softViolations) > 0 {
+			return fmt.Errorf("BigQuery query exceeds configured soft limits for bruin query: %s. Estimated query cost: $%.6f. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits", strings.Join(softViolations, "; "), estimatedCost)
+		}
+	}
+
+	return nil
 }
 
 func (d *Client) QueryDryRun(ctx context.Context, queryObj *query.Query) (*bigquery.QueryStatistics, error) {

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -454,11 +454,19 @@ func (d *Client) validateQueryLimits(stats *bigquery.QueryStatistics, enforceSof
 			softViolations = append(softViolations, fmt.Sprintf("estimated query cost $%.6f exceeds max_query_cost_soft $%.6f", estimatedCost, *d.config.MaxQueryCostSoft))
 		}
 		if len(softViolations) > 0 {
-			return fmt.Errorf("BigQuery query exceeds configured soft limits for bruin query: %s. Estimated query cost: $%.6f. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits", strings.Join(softViolations, "; "), estimatedCost)
+			return fmt.Errorf("BigQuery query exceeds configured soft limits for bruin query: %s. Estimated query cost: %s. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits", strings.Join(softViolations, "; "), formatBigQueryCostUSD(estimatedCost))
 		}
 	}
 
 	return nil
+}
+
+func formatBigQueryCostUSD(cost float64) string {
+	if cost > 0 && cost < 0.000001 {
+		return fmt.Sprintf("$%.3e", cost)
+	}
+
+	return fmt.Sprintf("$%.6f", cost)
 }
 
 func (d *Client) QueryDryRun(ctx context.Context, queryObj *query.Query) (*bigquery.QueryStatistics, error) {
@@ -506,7 +514,7 @@ func (d *Client) DryRunQuery(ctx context.Context, q *query.Query) (*query.DryRun
 		ConnectionType:      "bigquery",
 		Valid:               true,
 		TotalBytesProcessed: stats.TotalBytesProcessed,
-		EstimatedCostUSD:    float64(stats.TotalBytesProcessed) / 1e12 * 5.0,
+		EstimatedCostUSD:    float64(stats.TotalBytesProcessed) / 1e12 * bigQueryOnDemandCostPerTBUSD,
 		StatementType:       stats.StatementType,
 	}
 

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -263,6 +263,166 @@ func TestDB_RunQueryWithoutResult(t *testing.T) {
 	}
 }
 
+func TestClientValidateQueryLimits(t *testing.T) {
+	t.Parallel()
+
+	maxBytes := int64(1_000)
+	maxCost := 0.01
+
+	tests := []struct {
+		name              string
+		config            *Config
+		stats             *bigquery.QueryStatistics
+		enforceSoftLimits bool
+		wantErr           string
+	}{
+		{
+			name:   "no limits configured",
+			config: &Config{},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 10_000,
+			},
+		},
+		{
+			name: "within configured limits",
+			config: &Config{
+				MaxBillableBytes: &maxBytes,
+				MaxQueryCost:     &maxCost,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 1_000,
+			},
+		},
+		{
+			name: "billable bytes over limit",
+			config: &Config{
+				MaxBillableBytes: &maxBytes,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 1_001,
+			},
+			wantErr: "BigQuery query exceeds configured cost limits: estimated billable bytes 1001 exceeds max_billable_bytes 1000. Query was not executed",
+		},
+		{
+			name: "query cost over limit",
+			config: &Config{
+				MaxQueryCost: &maxCost,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 3_000_000_000,
+			},
+			wantErr: "BigQuery query exceeds configured cost limits: estimated query cost $0.015000 exceeds max_query_cost $0.010000. Query was not executed",
+		},
+		{
+			name: "uses billed bytes when available",
+			config: &Config{
+				MaxBillableBytes: &maxBytes,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesBilled:    2_000,
+				TotalBytesProcessed: 1,
+			},
+			wantErr: "BigQuery query exceeds configured cost limits: estimated billable bytes 2000 exceeds max_billable_bytes 1000. Query was not executed",
+		},
+		{
+			name: "soft limit ignored unless enforced",
+			config: &Config{
+				MaxBillableBytesSoft: &maxBytes,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 1_001,
+			},
+		},
+		{
+			name: "soft billable bytes over limit",
+			config: &Config{
+				MaxBillableBytesSoft: &maxBytes,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 1_001,
+			},
+			enforceSoftLimits: true,
+			wantErr:           "BigQuery query exceeds configured soft limits for bruin query: estimated billable bytes 1001 exceeds max_billable_bytes_soft 1000. Estimated query cost: $0.000000. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits",
+		},
+		{
+			name: "soft query cost over limit",
+			config: &Config{
+				MaxQueryCostSoft: &maxCost,
+			},
+			stats: &bigquery.QueryStatistics{
+				TotalBytesProcessed: 3_000_000_000,
+			},
+			enforceSoftLimits: true,
+			wantErr:           "BigQuery query exceeds configured soft limits for bruin query: estimated query cost $0.015000 exceeds max_query_cost_soft $0.010000. Estimated query cost: $0.015000. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := Client{config: tt.config}
+			err := d.validateQueryLimits(tt.stats, tt.enforceSoftLimits)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClientHasActiveQueryLimits(t *testing.T) {
+	t.Parallel()
+
+	maxBytes := int64(1_000)
+	tests := []struct {
+		name     string
+		withSoft bool
+		cfg      *Config
+		want     bool
+	}{
+		{
+			name: "no limits",
+			cfg:  &Config{},
+		},
+		{
+			name: "hard limits active without context",
+			cfg: &Config{
+				MaxBillableBytes: &maxBytes,
+			},
+			want: true,
+		},
+		{
+			name: "soft limits inactive without context",
+			cfg: &Config{
+				MaxBillableBytesSoft: &maxBytes,
+			},
+		},
+		{
+			name:     "soft limits active with query context",
+			withSoft: true,
+			cfg: &Config{
+				MaxBillableBytesSoft: &maxBytes,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			if tt.withSoft {
+				ctx = WithSoftQueryLimits(ctx)
+			}
+			d := Client{config: tt.cfg}
+			assert.Equal(t, tt.want, d.hasActiveQueryLimits(ctx))
+		})
+	}
+}
+
 func TestBuildSchemaQuery(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -342,7 +342,7 @@ func TestClientValidateQueryLimits(t *testing.T) {
 				TotalBytesProcessed: 1_001,
 			},
 			enforceSoftLimits: true,
-			wantErr:           "BigQuery query exceeds configured soft limits for bruin query: estimated billable bytes 1001 exceeds max_billable_bytes_soft 1000. Estimated query cost: $0.000000. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits",
+			wantErr:           "BigQuery query exceeds configured soft limits for bruin query: estimated billable bytes 1001 exceeds max_billable_bytes_soft 1000. Estimated query cost: $5.005e-09. Query was not executed. If you are an AI agent, rewrite the query to scan less data, for example by adding partition/date filters or narrowing selected columns. If you still need to run it, get explicit confirmation from the user before passing --dangerously-bypass-soft-limits",
 		},
 		{
 			name: "soft query cost over limit",
@@ -421,6 +421,14 @@ func TestClientHasActiveQueryLimits(t *testing.T) {
 			assert.Equal(t, tt.want, d.hasActiveQueryLimits(ctx))
 		})
 	}
+}
+
+func TestFormatBigQueryCostUSD(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "$0.000000", formatBigQueryCostUSD(0))
+	assert.Equal(t, "$5.005e-09", formatBigQueryCostUSD(0.000000005005))
+	assert.Equal(t, "$0.015000", formatBigQueryCostUSD(0.015))
 }
 
 func TestBuildSchemaQuery(t *testing.T) {

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -315,6 +315,12 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 	sensorTimeout := helpers.GetSensorTimeout(t)
 	timeout := time.After(sensorTimeout)
 	var lastJobID string
+	if checker, ok := conn.(queryLimitChecker); ok {
+		if err := checker.CheckQueryLimits(ctx, qry[0]); err != nil {
+			return err
+		}
+		ctx = context.WithValue(ctx, queryLimitsCheckedContextKey{}, true)
+	}
 	sinkCtx := query.WithQueryIDSink(ctx, &lastJobID)
 	for {
 		select {
@@ -409,6 +415,12 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	sensorTimeout := helpers.GetSensorTimeout(t)
 	timeout := time.After(sensorTimeout)
 	var lastJobID string
+	if checker, ok := conn.(queryLimitChecker); ok {
+		if err := checker.CheckQueryLimits(ctx, extractedQuery); err != nil {
+			return err
+		}
+		ctx = context.WithValue(ctx, queryLimitsCheckedContextKey{}, true)
+	}
 	sinkCtx := query.WithQueryIDSink(ctx, &lastJobID)
 	for {
 		select {

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -32,6 +32,10 @@ type devEnv interface {
 	RegisterAssetForSchemaCache(ctx context.Context, p *pipeline.Pipeline, a *pipeline.Asset, q *query.Query) error
 }
 
+type queryLimitChecker interface {
+	CheckQueryLimits(ctx context.Context, q *query.Query) error
+}
+
 type BasicOperator struct {
 	connection   config.ConnectionGetter
 	extractor    query.QueryExtractor
@@ -111,6 +115,26 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return errors.Errorf("connection '%s' is not a bigquery connection", connName)
 	}
 
+	queryToRun := q
+	if o.devEnv != nil {
+		queryToRun, err = o.devEnv.Modify(ctx, p, t, q)
+		if err != nil {
+			return err
+		}
+	}
+
+	annotatedQuery, err := ansisql.AddAnnotationComment(ctx, queryToRun, t.Name, "main", p.Name)
+	if err != nil {
+		return err
+	}
+
+	if checker, ok := conn.(queryLimitChecker); ok {
+		if err := checker.CheckQueryLimits(ctx, annotatedQuery); err != nil {
+			return err
+		}
+		ctx = context.WithValue(ctx, queryLimitsCheckedContextKey{}, true)
+	}
+
 	if t.Materialization.Type != pipeline.MaterializationTypeNone {
 		if err := conn.CreateDataSetIfNotExist(t, ctx); err != nil {
 			return err
@@ -124,11 +148,6 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	annotatedQuery, err := ansisql.AddAnnotationComment(ctx, q, t.Name, "main", p.Name)
-	if err != nil {
-		return err
-	}
-
 	// Print SQL query in verbose mode
 	if verbose := ctx.Value(executor.KeyVerbose); verbose != nil && verbose.(bool) {
 		if w, ok := writer.(io.Writer); ok {
@@ -140,28 +159,16 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	if o.devEnv == nil {
-		return conn.RunQueryWithoutResult(ctx, annotatedQuery)
-	}
-
-	q, err = o.devEnv.Modify(ctx, p, t, q)
-	if err != nil {
-		return err
-	}
-
-	annotatedQuery, err = ansisql.AddAnnotationComment(ctx, q, t.Name, "main", p.Name)
-	if err != nil {
-		return err
-	}
-
 	err = conn.RunQueryWithoutResult(ctx, annotatedQuery)
 	if err != nil {
 		return err
 	}
 
-	err = o.devEnv.RegisterAssetForSchemaCache(ctx, p, t, q)
-	if err != nil {
-		return errors.Wrap(err, "cannot register asset for schema cache")
+	if o.devEnv != nil {
+		err = o.devEnv.RegisterAssetForSchemaCache(ctx, p, t, queryToRun)
+		if err != nil {
+			return errors.Wrap(err, "cannot register asset for schema cache")
+		}
 	}
 
 	return nil

--- a/pkg/config/connection_fields.go
+++ b/pkg/config/connection_fields.go
@@ -111,7 +111,7 @@ func extractFields(t reflect.Type) []ConnectionFieldDef {
 			continue
 		}
 
-		fieldType := kindToTypeString(sf.Type.Kind())
+		fieldType := kindToTypeString(sf.Type)
 		if fieldType == "" {
 			continue
 		}
@@ -149,12 +149,19 @@ func extractFields(t reflect.Type) []ConnectionFieldDef {
 	return fields
 }
 
-func kindToTypeString(k reflect.Kind) string {
+func kindToTypeString(t reflect.Type) string {
+	k := t.Kind()
+	if k == reflect.Ptr {
+		k = t.Elem().Kind()
+	}
+
 	switch k { //nolint:exhaustive
 	case reflect.String:
 		return "string"
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return "int"
+	case reflect.Float32, reflect.Float64:
+		return "float"
 	case reflect.Bool:
 		return "bool"
 	default:

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -25,12 +25,16 @@ func (c AwsConnection) GetName() string {
 }
 
 type GoogleCloudPlatformConnection struct { //nolint:recvcheck
-	Name                             string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
-	ServiceAccountJSON               string `yaml:"service_account_json,omitempty" json:"service_account_json,omitempty" mapstructure:"service_account_json"`
-	ServiceAccountFile               string `yaml:"service_account_file,omitempty" json:"service_account_file,omitempty" mapstructure:"service_account_file"`
-	ProjectID                        string `yaml:"project_id,omitempty" json:"project_id" mapstructure:"project_id"`
-	Location                         string `yaml:"location,omitempty" json:"location,omitempty" mapstructure:"location"`
-	UseApplicationDefaultCredentials bool   `yaml:"use_application_default_credentials,omitempty" json:"use_application_default_credentials,omitempty" mapstructure:"use_application_default_credentials"`
+	Name                             string   `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	ServiceAccountJSON               string   `yaml:"service_account_json,omitempty" json:"service_account_json,omitempty" mapstructure:"service_account_json"`
+	ServiceAccountFile               string   `yaml:"service_account_file,omitempty" json:"service_account_file,omitempty" mapstructure:"service_account_file"`
+	ProjectID                        string   `yaml:"project_id,omitempty" json:"project_id" mapstructure:"project_id"`
+	Location                         string   `yaml:"location,omitempty" json:"location,omitempty" mapstructure:"location"`
+	UseApplicationDefaultCredentials bool     `yaml:"use_application_default_credentials,omitempty" json:"use_application_default_credentials,omitempty" mapstructure:"use_application_default_credentials"`
+	MaxBillableBytes                 *int64   `yaml:"max_billable_bytes,omitempty" json:"max_billable_bytes,omitempty" mapstructure:"max_billable_bytes"`
+	MaxQueryCost                     *float64 `yaml:"max_query_cost,omitempty" json:"max_query_cost,omitempty" mapstructure:"max_query_cost"`
+	MaxBillableBytesSoft             *int64   `yaml:"max_billable_bytes_soft,omitempty" json:"max_billable_bytes_soft,omitempty" mapstructure:"max_billable_bytes_soft"`
+	MaxQueryCostSoft                 *float64 `yaml:"max_query_cost_soft,omitempty" json:"max_query_cost_soft,omitempty" mapstructure:"max_query_cost_soft"`
 	rawCredentials                   *google.Credentials
 }
 
@@ -53,6 +57,18 @@ func (c GoogleCloudPlatformConnection) MarshalYAML() (interface{}, error) {
 
 	if c.UseApplicationDefaultCredentials {
 		m["use_application_default_credentials"] = c.UseApplicationDefaultCredentials
+	}
+	if c.MaxBillableBytes != nil {
+		m["max_billable_bytes"] = *c.MaxBillableBytes
+	}
+	if c.MaxQueryCost != nil {
+		m["max_query_cost"] = *c.MaxQueryCost
+	}
+	if c.MaxBillableBytesSoft != nil {
+		m["max_billable_bytes_soft"] = *c.MaxBillableBytesSoft
+	}
+	if c.MaxQueryCostSoft != nil {
+		m["max_query_cost_soft"] = *c.MaxQueryCostSoft
 	}
 
 	// Include only one of ServiceAccountJSON or ServiceAccountFile, whichever is not empty
@@ -82,14 +98,28 @@ func (c GoogleCloudPlatformConnection) MarshalJSON() ([]byte, error) {
 		c.ServiceAccountJSON = string(contents)
 	}
 
-	return json.Marshal(map[string]string{
+	payload := map[string]interface{}{
 		"name":                                c.Name,
 		"service_account_json":                c.ServiceAccountJSON,
 		"service_account_file":                c.ServiceAccountFile,
 		"project_id":                          c.ProjectID,
 		"location":                            c.Location,
 		"use_application_default_credentials": strconv.FormatBool(c.UseApplicationDefaultCredentials),
-	})
+	}
+	if c.MaxBillableBytes != nil {
+		payload["max_billable_bytes"] = *c.MaxBillableBytes
+	}
+	if c.MaxQueryCost != nil {
+		payload["max_query_cost"] = *c.MaxQueryCost
+	}
+	if c.MaxBillableBytesSoft != nil {
+		payload["max_billable_bytes_soft"] = *c.MaxBillableBytesSoft
+	}
+	if c.MaxQueryCostSoft != nil {
+		payload["max_query_cost_soft"] = *c.MaxQueryCostSoft
+	}
+
+	return json.Marshal(payload)
 }
 
 type AthenaConnection struct { //nolint:recvcheck

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -312,6 +312,10 @@ func (m *Manager) AddBqConnectionFromConfig(connection *config.GoogleCloudPlatfo
 		Credentials:                      connection.GetCredentials(),
 		Location:                         connection.Location,
 		UseApplicationDefaultCredentials: connection.UseApplicationDefaultCredentials,
+		MaxBillableBytes:                 connection.MaxBillableBytes,
+		MaxQueryCost:                     connection.MaxQueryCost,
+		MaxBillableBytesSoft:             connection.MaxBillableBytesSoft,
+		MaxQueryCostSoft:                 connection.MaxQueryCostSoft,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds hard and soft BigQuery query cost limits on GCP connections.
Hard limits apply to query and run; soft limits apply to bruin query and can be bypassed with --dangerously-bypass-soft-limits after user confirmation.
Validated with make format and make test.