### PR TITLE
Support DDL strategy across SQL platforms

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -19,16 +19,20 @@ import (
 	"github.com/bruin-data/bruin/pkg/databricks"
 	"github.com/bruin-data/bruin/pkg/date"
 	duck "github.com/bruin-data/bruin/pkg/duckdb"
+	"github.com/bruin-data/bruin/pkg/fabric"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/mysql"
+	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/postgres"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/snowflake"
 	"github.com/bruin-data/bruin/pkg/synapse"
+	"github.com/bruin-data/bruin/pkg/trino"
+	"github.com/bruin-data/bruin/pkg/vertica"
 	"github.com/muesli/termenv"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -257,27 +261,36 @@ func Render() *cli.Command {
 					Renderer: forAsset,
 				},
 				materializers: map[pipeline.AssetType]queryMaterializer{
-					pipeline.AssetTypeMySQLQuery:            mysql.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeBigqueryQuery:         bigquery.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeBigqueryQuerySensor:   bigquery.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeSnowflakeQuery:        snowflake.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeSnowflakeQuerySensor:  snowflake.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeRedshiftQuery:         postgres.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeRedshiftQuerySensor:   postgres.NewMaterializer(fullRefresh),
-					pipeline.AssetTypePostgresQuery:         postgres.NewMaterializer(fullRefresh),
-					pipeline.AssetTypePostgresQuerySensor:   postgres.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeMsSQLQuery:            mssql.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeMsSQLQuerySensor:      mssql.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeDatabricksQuery:       databricks.NewRenderer(fullRefresh),
-					pipeline.AssetTypeDatabricksQuerySensor: databricks.NewRenderer(fullRefresh),
-					pipeline.AssetTypeSynapseQuery:          synapse.NewRenderer(fullRefresh),
-					pipeline.AssetTypeSynapseQuerySensor:    synapse.NewRenderer(fullRefresh),
-					pipeline.AssetTypeAthenaQuery:           athena.NewRenderer(fullRefresh, resultsLocation),
-					pipeline.AssetTypeAthenaSQLSensor:       athena.NewRenderer(fullRefresh, resultsLocation),
-					pipeline.AssetTypeDuckDBQuery:           duck.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeDuckDBQuerySensor:     duck.NewMaterializer(fullRefresh),
-					pipeline.AssetTypeClickHouse:            clickhouse.NewRenderer(fullRefresh),
-					pipeline.AssetTypeClickHouseQuerySensor: clickhouse.NewRenderer(fullRefresh),
+					pipeline.AssetTypeMySQLQuery:              mysql.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeBigqueryQuery:           bigquery.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeBigqueryQuerySensor:     bigquery.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeSnowflakeQuery:          snowflake.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeSnowflakeQuerySensor:    snowflake.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeRedshiftQuery:           postgres.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeRedshiftQuerySensor:     postgres.NewMaterializer(fullRefresh),
+					pipeline.AssetTypePostgresQuery:           postgres.NewMaterializer(fullRefresh),
+					pipeline.AssetTypePostgresQuerySensor:     postgres.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeTrinoQuery:              trino.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeTrinoQuerySensor:        trino.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeOracleQuery:             oracle.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeMsSQLQuery:              mssql.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeMsSQLQuerySensor:        mssql.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeDatabricksQuery:         databricks.NewRenderer(fullRefresh),
+					pipeline.AssetTypeDatabricksQuerySensor:   databricks.NewRenderer(fullRefresh),
+					pipeline.AssetTypeSynapseQuery:            synapse.NewRenderer(fullRefresh),
+					pipeline.AssetTypeSynapseQuerySensor:      synapse.NewRenderer(fullRefresh),
+					pipeline.AssetTypeVerticaQuery:            vertica.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeVerticaQuerySensor:      vertica.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeFabricQuery:             fabric.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeFabricQueryLegacy:       fabric.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeFabricQuerySensor:       fabric.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeFabricQuerySensorLegacy: fabric.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeAthenaQuery:             athena.NewRenderer(fullRefresh, resultsLocation),
+					pipeline.AssetTypeAthenaSQLSensor:         athena.NewRenderer(fullRefresh, resultsLocation),
+					pipeline.AssetTypeDuckDBQuery:             duck.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeDuckDBQuerySensor:       duck.NewMaterializer(fullRefresh),
+					pipeline.AssetTypeClickHouse:              clickhouse.NewRenderer(fullRefresh),
+					pipeline.AssetTypeClickHouseQuerySensor:   clickhouse.NewRenderer(fullRefresh),
 				},
 				builder:  DefaultPipelineBuilder,
 				writer:   os.Stdout,

--- a/cmd/render_ddl.go
+++ b/cmd/render_ddl.go
@@ -14,16 +14,20 @@ import (
 	"github.com/bruin-data/bruin/pkg/databricks"
 	"github.com/bruin-data/bruin/pkg/date"
 	duck "github.com/bruin-data/bruin/pkg/duckdb"
+	"github.com/bruin-data/bruin/pkg/fabric"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/mysql"
+	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/path"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/postgres"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/snowflake"
 	"github.com/bruin-data/bruin/pkg/synapse"
+	"github.com/bruin-data/bruin/pkg/trino"
+	"github.com/bruin-data/bruin/pkg/vertica"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/urfave/cli/v3"
@@ -211,27 +215,36 @@ func RenderDDL() *cli.Command {
 					Renderer: forAsset,
 				},
 				materializers: map[pipeline.AssetType]queryMaterializer{
-					pipeline.AssetTypeMySQLQuery:            mysql.NewMaterializer(false),
-					pipeline.AssetTypeBigqueryQuery:         bigquery.NewMaterializer(false),
-					pipeline.AssetTypeBigqueryQuerySensor:   bigquery.NewMaterializer(false),
-					pipeline.AssetTypeSnowflakeQuery:        snowflake.NewMaterializer(false),
-					pipeline.AssetTypeSnowflakeQuerySensor:  snowflake.NewMaterializer(false),
-					pipeline.AssetTypeRedshiftQuery:         postgres.NewMaterializer(false),
-					pipeline.AssetTypeRedshiftQuerySensor:   postgres.NewMaterializer(false),
-					pipeline.AssetTypePostgresQuery:         postgres.NewMaterializer(false),
-					pipeline.AssetTypePostgresQuerySensor:   postgres.NewMaterializer(false),
-					pipeline.AssetTypeMsSQLQuery:            mssql.NewMaterializer(false),
-					pipeline.AssetTypeMsSQLQuerySensor:      mssql.NewMaterializer(false),
-					pipeline.AssetTypeDatabricksQuery:       databricks.NewRenderer(false),
-					pipeline.AssetTypeDatabricksQuerySensor: databricks.NewRenderer(false),
-					pipeline.AssetTypeSynapseQuery:          synapse.NewRenderer(false),
-					pipeline.AssetTypeSynapseQuerySensor:    synapse.NewRenderer(false),
-					pipeline.AssetTypeAthenaQuery:           athena.NewRenderer(false, resultsLocation),
-					pipeline.AssetTypeAthenaSQLSensor:       athena.NewRenderer(false, resultsLocation),
-					pipeline.AssetTypeDuckDBQuery:           duck.NewMaterializer(false),
-					pipeline.AssetTypeDuckDBQuerySensor:     duck.NewMaterializer(false),
-					pipeline.AssetTypeClickHouse:            clickhouse.NewRenderer(false),
-					pipeline.AssetTypeClickHouseQuerySensor: clickhouse.NewRenderer(false),
+					pipeline.AssetTypeMySQLQuery:              mysql.NewMaterializer(false),
+					pipeline.AssetTypeBigqueryQuery:           bigquery.NewMaterializer(false),
+					pipeline.AssetTypeBigqueryQuerySensor:     bigquery.NewMaterializer(false),
+					pipeline.AssetTypeSnowflakeQuery:          snowflake.NewMaterializer(false),
+					pipeline.AssetTypeSnowflakeQuerySensor:    snowflake.NewMaterializer(false),
+					pipeline.AssetTypeRedshiftQuery:           postgres.NewMaterializer(false),
+					pipeline.AssetTypeRedshiftQuerySensor:     postgres.NewMaterializer(false),
+					pipeline.AssetTypePostgresQuery:           postgres.NewMaterializer(false),
+					pipeline.AssetTypePostgresQuerySensor:     postgres.NewMaterializer(false),
+					pipeline.AssetTypeTrinoQuery:              trino.NewMaterializer(false),
+					pipeline.AssetTypeTrinoQuerySensor:        trino.NewMaterializer(false),
+					pipeline.AssetTypeOracleQuery:             oracle.NewMaterializer(false),
+					pipeline.AssetTypeMsSQLQuery:              mssql.NewMaterializer(false),
+					pipeline.AssetTypeMsSQLQuerySensor:        mssql.NewMaterializer(false),
+					pipeline.AssetTypeDatabricksQuery:         databricks.NewRenderer(false),
+					pipeline.AssetTypeDatabricksQuerySensor:   databricks.NewRenderer(false),
+					pipeline.AssetTypeSynapseQuery:            synapse.NewRenderer(false),
+					pipeline.AssetTypeSynapseQuerySensor:      synapse.NewRenderer(false),
+					pipeline.AssetTypeVerticaQuery:            vertica.NewMaterializer(false),
+					pipeline.AssetTypeVerticaQuerySensor:      vertica.NewMaterializer(false),
+					pipeline.AssetTypeFabricQuery:             fabric.NewMaterializer(false),
+					pipeline.AssetTypeFabricQueryLegacy:       fabric.NewMaterializer(false),
+					pipeline.AssetTypeFabricQuerySensor:       fabric.NewMaterializer(false),
+					pipeline.AssetTypeFabricQuerySensorLegacy: fabric.NewMaterializer(false),
+					pipeline.AssetTypeAthenaQuery:             athena.NewRenderer(false, resultsLocation),
+					pipeline.AssetTypeAthenaSQLSensor:         athena.NewRenderer(false, resultsLocation),
+					pipeline.AssetTypeDuckDBQuery:             duck.NewMaterializer(false),
+					pipeline.AssetTypeDuckDBQuerySensor:       duck.NewMaterializer(false),
+					pipeline.AssetTypeClickHouse:              clickhouse.NewRenderer(false),
+					pipeline.AssetTypeClickHouseQuerySensor:   clickhouse.NewRenderer(false),
 				},
 				builder: DefaultPipelineBuilder,
 				writer:  os.Stdout,

--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -117,7 +117,8 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
 	}
 
-	columnDefs := make([]string, 0, len(asset.Columns))
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	primaryKeys := make([]string, 0)
 	for _, col := range asset.Columns {
 		if col.Type == "" {
 			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
@@ -128,6 +129,14 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 			definition += " NOT NULL"
 		}
 		columnDefs = append(columnDefs, definition)
+
+		if col.PrimaryKey {
+			primaryKeys = append(primaryKeys, QuoteIdentifier(col.Name))
+		}
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("    PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
 	}
 
 	return fmt.Sprintf(

--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -22,6 +22,7 @@ var matMap = pipeline.AssetMaterializationMap{
 		pipeline.MaterializationStrategyDeleteInsert:   buildDeleteInsertQuery,
 		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
 		pipeline.MaterializationStrategyTruncateInsert: buildTruncateInsertQuery,
+		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
 	},
 }
 
@@ -109,6 +110,32 @@ func buildTruncateInsertQuery(asset *pipeline.Asset, query string) (string, erro
 		"INSERT INTO " + QuoteIdentifier(asset.Name) + "\n" + strings.TrimSuffix(query, ";"),
 	}
 	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns))
+	for _, col := range asset.Columns {
+		if col.Type == "" {
+			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
+		}
+
+		definition := fmt.Sprintf("    %s %s", QuoteIdentifier(col.Name), col.Type)
+		if col.PrimaryKey || !col.Nullable.Bool() {
+			definition += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, definition)
+	}
+
+	return fmt.Sprintf(
+		"IF OBJECT_ID('%s', 'U') IS NULL\nBEGIN\nCREATE TABLE %s (\n%s\n)\nEND;",
+		strings.ReplaceAll(asset.Name, "'", "''"),
+		QuoteIdentifier(asset.Name),
+		strings.Join(columnDefs, ",\n"),
+	), nil
 }
 
 func getPrimaryKeyColumns(asset *pipeline.Asset) []string {

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -98,3 +98,32 @@ func TestBuildDeleteInsertQuery(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 }
+
+func TestBuildDDLQuery(t *testing.T) {
+	t.Parallel()
+
+	nullable := false
+	asset := &pipeline.Asset{
+		Name: "dbo.Table",
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyDDL,
+		},
+		Columns: []pipeline.Column{
+			{Name: "id", Type: "INT", PrimaryKey: true},
+			{Name: "name", Type: "VARCHAR(100)", Nullable: pipeline.DefaultTrueBool{Value: &nullable}},
+		},
+	}
+
+	result, err := buildDDLQuery(asset, "")
+	require.NoError(t, err)
+
+	expected := "IF OBJECT_ID('dbo.Table', 'U') IS NULL\n" +
+		"BEGIN\n" +
+		"CREATE TABLE [dbo].[Table] (\n" +
+		"    [id] INT NOT NULL,\n" +
+		"    [name] VARCHAR(100) NOT NULL\n" +
+		")\n" +
+		"END;"
+	assert.Equal(t, expected, result)
+}

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -122,7 +122,8 @@ func TestBuildDDLQuery(t *testing.T) {
 		"BEGIN\n" +
 		"CREATE TABLE [dbo].[Table] (\n" +
 		"    [id] INT NOT NULL,\n" +
-		"    [name] VARCHAR(100) NOT NULL\n" +
+		"    [name] VARCHAR(100) NOT NULL,\n" +
+		"    PRIMARY KEY ([id])\n" +
 		")\n" +
 		"END;"
 	assert.Equal(t, expected, result)

--- a/pkg/oracle/materialization.go
+++ b/pkg/oracle/materialization.go
@@ -47,6 +47,7 @@ var matMap = pipeline.AssetMaterializationMap{
 		pipeline.MaterializationStrategyTruncateInsert: buildTruncateInsertQuery,
 		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
 		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
+		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
 		pipeline.MaterializationStrategySCD2ByTime:     buildSCD2ByTimeQuery,
 	},
 }
@@ -190,6 +191,67 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 %s
 ;
 END;`, asset.Name, asset.Materialization.IncrementalKey, startVar, endVar, asset.Name, query), nil
+}
+
+func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
+	if err := validateIdentifier(asset.Name, "table name"); err != nil {
+		return "", err
+	}
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	primaryKeys := make([]string, 0)
+	commentStatements := make([]string, 0)
+	for _, col := range asset.Columns {
+		if err := validateIdentifier(col.Name, "column name"); err != nil {
+			return "", err
+		}
+		if col.Type == "" {
+			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
+		}
+
+		definition := fmt.Sprintf("   %s %s", col.Name, col.Type)
+		if col.PrimaryKey || !col.Nullable.Bool() {
+			definition += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, definition)
+
+		if col.PrimaryKey {
+			primaryKeys = append(primaryKeys, col.Name)
+		}
+		if col.Description != "" {
+			commentStatements = append(commentStatements, fmt.Sprintf(
+				"   EXECUTE IMMEDIATE 'COMMENT ON COLUMN %s.%s IS ''%s''';",
+				escapeOracleString(asset.Name),
+				escapeOracleString(col.Name),
+				escapeOracleString(escapeOracleString(col.Description)),
+			))
+		}
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("   PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
+	}
+
+	createTable := fmt.Sprintf("CREATE TABLE %s (\n%s\n)", asset.Name, strings.Join(columnDefs, ",\n"))
+	parts := make([]string, 0, 10+len(commentStatements))
+	parts = append(parts,
+		"BEGIN",
+		"   BEGIN",
+		fmt.Sprintf("      EXECUTE IMMEDIATE '%s';", escapeOracleString(createTable)),
+		"   EXCEPTION",
+		"      WHEN OTHERS THEN",
+		"         IF SQLCODE != -955 THEN",
+		"            RAISE;",
+		"         END IF;",
+		"   END;",
+	)
+	parts = append(parts, commentStatements...)
+	parts = append(parts, "END;")
+
+	return strings.Join(parts, "\n"), nil
 }
 
 func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {

--- a/pkg/oracle/materialization_test.go
+++ b/pkg/oracle/materialization_test.go
@@ -327,6 +327,67 @@ END;`,
 			query:   "SELECT 1",
 			wantErr: true,
 		},
+		{
+			name: "ddl builds create table",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "NUMBER", PrimaryKey: true},
+					{Name: "name", Type: "VARCHAR2(100)", Description: "Customer's name"},
+				},
+			},
+			query: "SELECT 1",
+			want: strings.Join([]string{
+				"BEGIN",
+				"   BEGIN",
+				"      EXECUTE IMMEDIATE 'CREATE TABLE my.asset (",
+				"   id NUMBER NOT NULL,",
+				"   name VARCHAR2(100),",
+				"   PRIMARY KEY (id)",
+				")';",
+				"   EXCEPTION",
+				"      WHEN OTHERS THEN",
+				"         IF SQLCODE != -955 THEN",
+				"            RAISE;",
+				"         END IF;",
+				"   END;",
+				"   EXECUTE IMMEDIATE 'COMMENT ON COLUMN my.asset.name IS ''Customer''''s name''';",
+				"END;",
+			}, "\n"),
+		},
+		{
+			name: "ddl is preserved on full refresh",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "NUMBER"},
+				},
+			},
+			fullRefresh: true,
+			query:       "SELECT 1",
+			want: strings.Join([]string{
+				"BEGIN",
+				"   BEGIN",
+				"      EXECUTE IMMEDIATE 'CREATE TABLE my.asset (",
+				"   id NUMBER",
+				")';",
+				"   EXCEPTION",
+				"      WHEN OTHERS THEN",
+				"         IF SQLCODE != -955 THEN",
+				"            RAISE;",
+				"         END IF;",
+				"   END;",
+				"END;",
+			}, "\n"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/synapse/materialization.go
+++ b/pkg/synapse/materialization.go
@@ -30,6 +30,7 @@ var matMap = AssetMaterializationMap{
 		pipeline.MaterializationStrategyTruncateInsert: buildTruncateInsertQuery,
 		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
 		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
+		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
 	},
 }
 
@@ -180,6 +181,68 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 		fmt.Sprintf(`INSERT INTO %s %s`,
 			asset.Name, query),
 	}
+
+	return queries, nil
+}
+
+func quoteIdentifier(identifier string) string {
+	parts := strings.Split(identifier, ".")
+	quotedParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		quotedParts = append(quotedParts, "["+strings.ReplaceAll(part, "]", "]]")+"]")
+	}
+
+	return strings.Join(quotedParts, ".")
+}
+
+func sqlStringLiteral(value string) string {
+	return "N'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func buildDDLQuery(asset *pipeline.Asset, _ string) ([]string, error) {
+	if len(asset.Columns) == 0 {
+		return nil, fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	nameParts := strings.Split(asset.Name, ".")
+	queries := make([]string, 0, 2)
+	if len(nameParts) == 2 {
+		schemaName := nameParts[0]
+		queries = append(queries, fmt.Sprintf(
+			"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
+			sqlStringLiteral(schemaName),
+			strings.ReplaceAll(quoteIdentifier(schemaName), "'", "''"),
+		))
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	primaryKeys := make([]string, 0)
+	for _, col := range asset.Columns {
+		if col.Type == "" {
+			return nil, fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
+		}
+
+		definition := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.Type)
+		if col.PrimaryKey || !col.Nullable.Bool() {
+			definition += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, definition)
+
+		if col.PrimaryKey {
+			primaryKeys = append(primaryKeys, quoteIdentifier(col.Name))
+		}
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("    PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
+	}
+
+	queries = append(queries, fmt.Sprintf(
+		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\nCREATE TABLE %s (\n%s\n)\nEND",
+		sqlStringLiteral(asset.Name),
+		quoteIdentifier(asset.Name),
+		strings.Join(columnDefs, ",\n"),
+	))
 
 	return queries, nil
 }

--- a/pkg/synapse/materialization_test.go
+++ b/pkg/synapse/materialization_test.go
@@ -220,6 +220,50 @@ func TestMaterializer_Render(t *testing.T) {
 				"INSERT INTO my.asset SELECT dt, event_name from source_table where dt between '{{start_date}}' and '{{end_date}}'",
 			},
 		},
+		{
+			name: "ddl builds schema and create table statements",
+			task: &pipeline.Asset{
+				Name: "dbo.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "INT", PrimaryKey: true},
+					{Name: "name", Type: "VARCHAR(100)"},
+				},
+			},
+			query: "SELECT 1",
+			want: []string{
+				"^IF SCHEMA_ID\\(N'dbo'\\) IS NULL\n    EXEC\\(N'CREATE SCHEMA \\[dbo\\]'\\)$",
+				"^IF OBJECT_ID\\(N'dbo\\.asset', N'U'\\) IS NULL\nBEGIN\nCREATE TABLE \\[dbo\\]\\.\\[asset\\] \\(\n" +
+					"    \\[id\\] INT NOT NULL,\n" +
+					"    \\[name\\] VARCHAR\\(100\\),\n" +
+					"    PRIMARY KEY \\(\\[id\\]\\)\n" +
+					"\\)\nEND$",
+			},
+		},
+		{
+			name: "ddl is preserved on full refresh",
+			task: &pipeline.Asset{
+				Name: "dbo.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "INT"},
+				},
+			},
+			fullRefresh: true,
+			query:       "SELECT 1",
+			want: []string{
+				"^IF SCHEMA_ID\\(N'dbo'\\) IS NULL\n    EXEC\\(N'CREATE SCHEMA \\[dbo\\]'\\)$",
+				"^IF OBJECT_ID\\(N'dbo\\.asset', N'U'\\) IS NULL\nBEGIN\nCREATE TABLE \\[dbo\\]\\.\\[asset\\] \\(\n" +
+					"    \\[id\\] INT\n" +
+					"\\)\nEND$",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/synapse/materializer.go
+++ b/pkg/synapse/materializer.go
@@ -23,7 +23,9 @@ func (m *Materializer) Render(asset *pipeline.Asset, query string) ([]string, er
 
 	strategy := mat.Strategy
 	if m.fullRefresh && mat.Type == pipeline.MaterializationTypeTable {
-		strategy = pipeline.MaterializationStrategyCreateReplace
+		if mat.Strategy != pipeline.MaterializationStrategyDDL {
+			strategy = pipeline.MaterializationStrategyCreateReplace
+		}
 	}
 
 	query = strings.TrimSuffix(strings.TrimSpace(query), ";")

--- a/pkg/trino/operator.go
+++ b/pkg/trino/operator.go
@@ -60,7 +60,10 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	if len(queries) == 0 {
-		return nil
+		if t.Materialization.Strategy != pipeline.MaterializationStrategyDDL {
+			return nil
+		}
+		queries = []*query.Query{{Query: ""}}
 	}
 
 	if len(queries) > 1 && t.Materialization.Type != pipeline.MaterializationTypeNone {

--- a/pkg/vertica/materialization.go
+++ b/pkg/vertica/materialization.go
@@ -25,6 +25,7 @@ var matMap = pipeline.AssetMaterializationMap{
 		pipeline.MaterializationStrategyTruncateInsert: ansisql.BuildTruncateInsertQuery,
 		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
 		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
+		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
 	},
 }
 
@@ -173,6 +174,50 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 			strings.TrimSuffix(query, ";")),
 		"COMMIT",
 	}
+
+	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	primaryKeys := make([]string, 0)
+	columnComments := make([]string, 0)
+	for _, col := range asset.Columns {
+		if col.Type == "" {
+			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
+		}
+
+		quotedColName := QuoteIdentifier(col.Name)
+		definition := fmt.Sprintf("%s %s", quotedColName, col.Type)
+		if col.PrimaryKey || !col.Nullable.Bool() {
+			definition += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, definition)
+
+		if col.PrimaryKey {
+			primaryKeys = append(primaryKeys, quotedColName)
+		}
+		if col.Description != "" {
+			columnComments = append(columnComments, fmt.Sprintf(
+				"COMMENT ON COLUMN %s.%s IS '%s'",
+				QuoteIdentifier(asset.Name),
+				quotedColName,
+				strings.ReplaceAll(col.Description, "'", "''"),
+			))
+		}
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
+	}
+
+	queries := make([]string, 0, 1+len(columnComments))
+	queries = append(queries, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n%s\n)", QuoteIdentifier(asset.Name), strings.Join(columnDefs, ",\n")))
+	queries = append(queries, columnComments...)
 
 	return strings.Join(queries, ";\n") + ";", nil
 }

--- a/pkg/vertica/materialization_test.go
+++ b/pkg/vertica/materialization_test.go
@@ -287,6 +287,45 @@ func TestMaterializer_Render(t *testing.T) {
 			want:  "BEGIN TRANSACTION;\nTRUNCATE TABLE my.asset;\nINSERT INTO my.asset SELECT 1;\nCOMMIT;",
 		},
 		{
+			name: "ddl builds create table",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "INTEGER", PrimaryKey: true},
+					{Name: "name", Type: "VARCHAR(100)", Description: "Customer's name"},
+				},
+			},
+			query: "SELECT 1",
+			want: "^CREATE TABLE IF NOT EXISTS \"my\"\\.\"asset\" \\(\n" +
+				"\"id\" INTEGER NOT NULL,\n" +
+				"\"name\" VARCHAR\\(100\\),\n" +
+				"PRIMARY KEY \\(\"id\"\\)\n" +
+				"\\);\n" +
+				"COMMENT ON COLUMN \"my\"\\.\"asset\"\\.\"name\" IS 'Customer''s name';$",
+		},
+		{
+			name: "ddl is preserved on full refresh",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "INTEGER"},
+				},
+			},
+			fullRefresh: true,
+			query:       "SELECT 1",
+			want: "^CREATE TABLE IF NOT EXISTS \"my\"\\.\"asset\" \\(\n" +
+				"\"id\" INTEGER\n" +
+				"\\);$",
+		},
+		{
 			name: "view with append strategy is unsupported",
 			task: &pipeline.Asset{
 				Name: "my.asset",


### PR DESCRIPTION
Adds DDL strategy materializers for Fabric, Oracle, Synapse, and Vertica, and keeps Synapse full refresh from rewriting DDL assets.

Extends render/render-ddl support for Trino, Oracle, Vertica, and Fabric, plus lets Trino execute DDL-only assets with empty SQL bodies.

Validated with make format, targeted Go tests, and make test.
