### PR TITLE
Add Postgres Data Vault materializations

### DIFF
--- a/cmd/lineage.go
+++ b/cmd/lineage.go
@@ -49,8 +49,12 @@ type printer interface {
 	Print(a ...interface{}) (n int, err error)
 }
 
+type lineagePipelineCreator interface {
+	CreatePipelineFromPath(ctx context.Context, path string, opts ...pipeline.CreatePipelineOption) (*pipeline.Pipeline, error)
+}
+
 type LineageCommand struct {
-	builder      taskCreator
+	builder      lineagePipelineCreator
 	infoPrinter  printer
 	errorPrinter printer
 }
@@ -71,7 +75,7 @@ func (r *LineageCommand) Run(ctx context.Context, assetPath string, fullLineage 
 	if variantName != "" {
 		opts = append(opts, pipeline.WithVariant(variantName))
 	}
-	foundPipeline, err := DefaultPipelineBuilder.CreatePipelineFromPath(ctx, pipelinePath, opts...)
+	foundPipeline, err := r.builder.CreatePipelineFromPath(ctx, pipelinePath, opts...)
 	if err != nil {
 		printError(err, output, "Failed to build pipeline")
 		r.errorPrinter.Println("\nHint: You need to run this command with a path to the asset file itself directly, and it needs to be inside a pipeline.")

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -3312,6 +3312,125 @@ func TestWorkflowTasks(t *testing.T) {
 			},
 		},
 		{
+			name: "duckdb_data_vault_materialization",
+			workflow: e2e.Workflow{
+				Name: "duckdb_data_vault_materialization",
+				Steps: []e2e.Task{
+					{
+						Name:    "mat-dv-00: ensure initial customer_orders.sql",
+						Command: "cp",
+						Args:    []string{filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v1.sql"), filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/assets/customer_orders.sql")},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					{
+						Name:    "mat-dv-01: run pipeline with initial Data Vault rows",
+						Command: binary,
+						Args:    []string{"run", "--full-refresh", filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization")},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					{
+						Name:    "mat-dv-02: replace customer_orders.sql with customer_orders_v2.sql",
+						Command: "cp",
+						Args:    []string{filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v2.sql"), filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/assets/customer_orders.sql")},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					{
+						Name:    "mat-dv-03: run pipeline with changed Data Vault rows",
+						Command: binary,
+						Args:    []string{"run", filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization")},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					{
+						Name:    "mat-dv-04: run pipeline again to verify idempotency",
+						Command: binary,
+						Args:    []string{"run", filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization")},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+					{
+						Name:    "mat-dv-05: query final hub data",
+						Command: binary,
+						Args:    []string{"query", "--connection", "duckdb-mat-test", "--query", "SELECT customer_hk, customer_bk, strftime(load_dts, '%Y-%m-%d %H:%M:%S') AS load_dts, record_source FROM rdv.hub_customer ORDER BY customer_hk;", "--output", "csv"},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/expectations/final_hub.csv"),
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByCSV,
+						},
+					},
+					{
+						Name:    "mat-dv-06: query final link data",
+						Command: binary,
+						Args:    []string{"query", "--connection", "duckdb-mat-test", "--query", "SELECT customer_order_hk, customer_hk, order_hk FROM rdv.link_customer_order ORDER BY customer_order_hk;", "--output", "csv"},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/expectations/final_link.csv"),
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByCSV,
+						},
+					},
+					{
+						Name:    "mat-dv-07: query final satellite data",
+						Command: binary,
+						Args:    []string{"query", "--connection", "duckdb-mat-test", "--query", "SELECT customer_hk, hashdiff, strftime(load_dts, '%Y-%m-%d %H:%M:%S') AS load_dts, customer_name, email FROM rdv.sat_customer_details ORDER BY customer_hk, load_dts;", "--output", "csv"},
+						Env:     []string{},
+						Expected: e2e.Output{
+							ExitCode: 0,
+							CSVFile:  filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/expectations/final_satellite.csv"),
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+							e2e.AssertByCSV,
+						},
+					},
+					{
+						Name:    "mat-dv-08: restore original customer_orders.sql",
+						Command: "cp",
+						Args:    []string{filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v1.sql"), filepath.Join(currentFolder, "test-pipelines/duckdb-datavault-materialization/assets/customer_orders.sql")},
+						Expected: e2e.Output{
+							ExitCode: 0,
+						},
+						Asserts: []func(*e2e.Task) error{
+							e2e.AssertByExitCode,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "duckdb_ddl_materialization",
 			workflow: e2e.Workflow{
 				Name: "duckdb_ddl_materialization",

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/customer_orders.sql
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/customer_orders.sql
@@ -1,0 +1,39 @@
+/* @bruin
+name: stg.customer_orders
+type: duckdb.sql
+materialization:
+  type: table
+@bruin */
+
+SELECT
+  'cust_1_hk' AS customer_hk,
+  'C001' AS customer_bk,
+  'order_10_hk' AS order_hk,
+  'cust1_order10_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-01 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_alice_v1' AS hashdiff,
+  'Alice' AS customer_name,
+  'alice@example.com' AS email
+UNION ALL
+SELECT
+  'cust_2_hk' AS customer_hk,
+  'C002' AS customer_bk,
+  'order_20_hk' AS order_hk,
+  'cust2_order20_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-01 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_bob_v1' AS hashdiff,
+  'Bob' AS customer_name,
+  'bob@example.com' AS email
+UNION ALL
+SELECT
+  'cust_1_hk' AS customer_hk,
+  'C001' AS customer_bk,
+  'order_11_hk' AS order_hk,
+  'cust1_order11_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-02 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_alice_v1' AS hashdiff,
+  'Alice' AS customer_name,
+  'alice@example.com' AS email

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/hub_customer.sql
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/hub_customer.sql
@@ -1,0 +1,22 @@
+/* @bruin
+name: rdv.hub_customer
+type: duckdb.sql
+depends:
+  - stg.customer_orders
+materialization:
+  type: table
+  strategy: datavault_hub
+columns:
+  - name: customer_hk
+    type: VARCHAR
+    primary_key: true
+  - name: customer_bk
+    type: VARCHAR
+  - name: load_dts
+    type: TIMESTAMP
+  - name: record_source
+    type: VARCHAR
+@bruin */
+
+SELECT customer_hk, customer_bk, load_dts, record_source
+FROM stg.customer_orders

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/link_customer_order.sql
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/link_customer_order.sql
@@ -1,0 +1,24 @@
+/* @bruin
+name: rdv.link_customer_order
+type: duckdb.sql
+depends:
+  - stg.customer_orders
+materialization:
+  type: table
+  strategy: datavault_link
+columns:
+  - name: customer_order_hk
+    type: VARCHAR
+    primary_key: true
+  - name: customer_hk
+    type: VARCHAR
+  - name: order_hk
+    type: VARCHAR
+  - name: load_dts
+    type: TIMESTAMP
+  - name: record_source
+    type: VARCHAR
+@bruin */
+
+SELECT customer_order_hk, customer_hk, order_hk, load_dts, record_source
+FROM stg.customer_orders

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/sat_customer_details.sql
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/assets/sat_customer_details.sql
@@ -1,0 +1,26 @@
+/* @bruin
+name: rdv.sat_customer_details
+type: duckdb.sql
+depends:
+  - stg.customer_orders
+materialization:
+  type: table
+  strategy: datavault_satellite
+columns:
+  - name: customer_hk
+    type: VARCHAR
+    primary_key: true
+  - name: hashdiff
+    type: VARCHAR
+  - name: load_dts
+    type: TIMESTAMP
+  - name: record_source
+    type: VARCHAR
+  - name: customer_name
+    type: VARCHAR
+  - name: email
+    type: VARCHAR
+@bruin */
+
+SELECT customer_hk, hashdiff, load_dts, record_source, customer_name, email
+FROM stg.customer_orders

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/expectations/final_hub.csv
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/expectations/final_hub.csv
@@ -1,0 +1,4 @@
+customer_hk,customer_bk,load_dts,record_source
+cust_1_hk,C001,2024-01-01 00:00:00,CRM
+cust_2_hk,C002,2024-01-01 00:00:00,CRM
+cust_3_hk,C003,2024-01-03 00:00:00,ERP

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/expectations/final_link.csv
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/expectations/final_link.csv
@@ -1,0 +1,6 @@
+customer_order_hk,customer_hk,order_hk
+cust1_order10_hk,cust_1_hk,order_10_hk
+cust1_order11_hk,cust_1_hk,order_11_hk
+cust1_order12_hk,cust_1_hk,order_12_hk
+cust2_order20_hk,cust_2_hk,order_20_hk
+cust3_order30_hk,cust_3_hk,order_30_hk

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/expectations/final_satellite.csv
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/expectations/final_satellite.csv
@@ -1,0 +1,5 @@
+customer_hk,hashdiff,load_dts,customer_name,email
+cust_1_hk,hash_alice_v1,2024-01-01 00:00:00,Alice,alice@example.com
+cust_1_hk,hash_alice_v2,2024-01-03 00:00:00,Alice A.,alice.a@example.com
+cust_2_hk,hash_bob_v1,2024-01-01 00:00:00,Bob,bob@example.com
+cust_3_hk,hash_carol_v1,2024-01-03 00:00:00,Carol,carol@example.com

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/pipeline.yml
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/pipeline.yml
@@ -1,0 +1,6 @@
+name: duckdb_datavault_materialization
+schedule: daily
+start_date: "2024-01-01"
+
+default_connections:
+  duckdb: duckdb-mat-test

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v1.sql
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v1.sql
@@ -1,0 +1,39 @@
+/* @bruin
+name: stg.customer_orders
+type: duckdb.sql
+materialization:
+  type: table
+@bruin */
+
+SELECT
+  'cust_1_hk' AS customer_hk,
+  'C001' AS customer_bk,
+  'order_10_hk' AS order_hk,
+  'cust1_order10_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-01 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_alice_v1' AS hashdiff,
+  'Alice' AS customer_name,
+  'alice@example.com' AS email
+UNION ALL
+SELECT
+  'cust_2_hk' AS customer_hk,
+  'C002' AS customer_bk,
+  'order_20_hk' AS order_hk,
+  'cust2_order20_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-01 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_bob_v1' AS hashdiff,
+  'Bob' AS customer_name,
+  'bob@example.com' AS email
+UNION ALL
+SELECT
+  'cust_1_hk' AS customer_hk,
+  'C001' AS customer_bk,
+  'order_11_hk' AS order_hk,
+  'cust1_order11_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-02 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_alice_v1' AS hashdiff,
+  'Alice' AS customer_name,
+  'alice@example.com' AS email

--- a/integration-tests/test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v2.sql
+++ b/integration-tests/test-pipelines/duckdb-datavault-materialization/resources/customer_orders_v2.sql
@@ -1,0 +1,50 @@
+/* @bruin
+name: stg.customer_orders
+type: duckdb.sql
+materialization:
+  type: table
+@bruin */
+
+SELECT
+  'cust_1_hk' AS customer_hk,
+  'C001' AS customer_bk,
+  'order_10_hk' AS order_hk,
+  'cust1_order10_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-03 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_alice_v2' AS hashdiff,
+  'Alice A.' AS customer_name,
+  'alice.a@example.com' AS email
+UNION ALL
+SELECT
+  'cust_2_hk' AS customer_hk,
+  'C002' AS customer_bk,
+  'order_20_hk' AS order_hk,
+  'cust2_order20_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-03 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_bob_v1' AS hashdiff,
+  'Bob' AS customer_name,
+  'bob@example.com' AS email
+UNION ALL
+SELECT
+  'cust_3_hk' AS customer_hk,
+  'C003' AS customer_bk,
+  'order_30_hk' AS order_hk,
+  'cust3_order30_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-03 00:00:00' AS load_dts,
+  'ERP' AS record_source,
+  'hash_carol_v1' AS hashdiff,
+  'Carol' AS customer_name,
+  'carol@example.com' AS email
+UNION ALL
+SELECT
+  'cust_1_hk' AS customer_hk,
+  'C001' AS customer_bk,
+  'order_12_hk' AS order_hk,
+  'cust1_order12_hk' AS customer_order_hk,
+  TIMESTAMP '2024-01-04 00:00:00' AS load_dts,
+  'CRM' AS record_source,
+  'hash_alice_v2' AS hashdiff,
+  'Alice A.' AS customer_name,
+  'alice.a@example.com' AS email

--- a/pkg/duckdb/datavault_materialization.go
+++ b/pkg/duckdb/datavault_materialization.go
@@ -1,0 +1,566 @@
+package duck
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/pkg/errors"
+)
+
+func buildDataVaultHubQuery(asset *pipeline.Asset, query string) (string, error) {
+	return buildDataVaultHubQueryWithOptions(asset, query, false)
+}
+
+func buildDataVaultHubQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	hashKey, businessKeys, loadDatetime, recordSource, err := resolveDataVaultHubColumns(asset)
+	if err != nil {
+		return "", err
+	}
+
+	mandatoryColumns := append([]*pipeline.Column{hashKey, loadDatetime, recordSource}, businessKeys...)
+	statements, err := buildDataVaultTableStatements(asset, []string{hashKey.Name}, mandatoryColumns, fullRefresh)
+	if err != nil {
+		return "", err
+	}
+
+	insertQuery := fmt.Sprintf(`WITH __bruin_source AS (
+%s
+),
+__bruin_ranked AS (
+  SELECT
+    %s,
+    ROW_NUMBER() OVER (PARTITION BY source.%s ORDER BY source.%s ASC) AS __bruin_row_number
+  FROM __bruin_source AS source
+  WHERE %s
+),
+__bruin_dedup AS (
+  SELECT %s
+  FROM __bruin_ranked AS source
+  WHERE source.__bruin_row_number = 1
+)
+INSERT INTO %s (%s)
+SELECT %s
+FROM __bruin_dedup AS source
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM %s AS target
+  WHERE target.%s = source.%s
+)`,
+		trimMaterializationQuery(query),
+		dataVaultIndentedSourceSelectList(asset, 4),
+		hashKey.Name,
+		loadDatetime.Name,
+		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		strings.Join(dataVaultColumnNames(asset), ", "),
+		asset.Name,
+		strings.Join(dataVaultColumnNames(asset), ", "),
+		dataVaultSourceSelectList(asset),
+		asset.Name,
+		hashKey.Name,
+		hashKey.Name,
+	)
+
+	statements = append(statements, insertQuery)
+	return dataVaultTransaction(statements), nil
+}
+
+func buildDataVaultLinkQuery(asset *pipeline.Asset, query string) (string, error) {
+	return buildDataVaultLinkQueryWithOptions(asset, query, false)
+}
+
+func buildDataVaultLinkQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	linkHashKey, relatedHashKeys, loadDatetime, recordSource, err := resolveDataVaultLinkColumns(asset)
+	if err != nil {
+		return "", err
+	}
+
+	mandatoryColumns := append([]*pipeline.Column{linkHashKey, loadDatetime, recordSource}, relatedHashKeys...)
+	statements, err := buildDataVaultTableStatements(asset, []string{linkHashKey.Name}, mandatoryColumns, fullRefresh)
+	if err != nil {
+		return "", err
+	}
+
+	insertQuery := fmt.Sprintf(`WITH __bruin_source AS (
+%s
+),
+__bruin_ranked AS (
+  SELECT
+    %s,
+    ROW_NUMBER() OVER (PARTITION BY source.%s ORDER BY source.%s ASC) AS __bruin_row_number
+  FROM __bruin_source AS source
+  WHERE %s
+),
+__bruin_dedup AS (
+  SELECT %s
+  FROM __bruin_ranked AS source
+  WHERE source.__bruin_row_number = 1
+)
+INSERT INTO %s (%s)
+SELECT %s
+FROM __bruin_dedup AS source
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM %s AS target
+  WHERE target.%s = source.%s
+)`,
+		trimMaterializationQuery(query),
+		dataVaultIndentedSourceSelectList(asset, 4),
+		linkHashKey.Name,
+		loadDatetime.Name,
+		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		strings.Join(dataVaultColumnNames(asset), ", "),
+		asset.Name,
+		strings.Join(dataVaultColumnNames(asset), ", "),
+		dataVaultSourceSelectList(asset),
+		asset.Name,
+		linkHashKey.Name,
+		linkHashKey.Name,
+	)
+
+	statements = append(statements, insertQuery)
+	return dataVaultTransaction(statements), nil
+}
+
+func buildDataVaultSatelliteQuery(asset *pipeline.Asset, query string) (string, error) {
+	return buildDataVaultSatelliteQueryWithOptions(asset, query, false)
+}
+
+func buildDataVaultSatelliteQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	parentHashKey, hashDiff, loadDatetime, recordSource, err := resolveDataVaultSatelliteColumns(asset)
+	if err != nil {
+		return "", err
+	}
+
+	primaryKeys := dataVaultSatellitePrimaryKeys(asset, parentHashKey, loadDatetime)
+	mandatoryColumns := []*pipeline.Column{parentHashKey, hashDiff, loadDatetime, recordSource}
+	statements, err := buildDataVaultTableStatements(asset, primaryKeys, mandatoryColumns, fullRefresh)
+	if err != nil {
+		return "", err
+	}
+
+	insertQuery := fmt.Sprintf(`WITH __bruin_source AS (
+%s
+),
+__bruin_valid AS (
+  SELECT
+    %s
+  FROM __bruin_source AS source
+  WHERE %s
+),
+__bruin_dedup AS (
+  SELECT %s
+  FROM (
+    SELECT
+      valid.*,
+      ROW_NUMBER() OVER (PARTITION BY %s ORDER BY valid.%s) AS __bruin_pk_row_number
+    FROM __bruin_valid AS valid
+  ) AS ranked
+  WHERE ranked.__bruin_pk_row_number = 1
+),
+__bruin_ordered AS (
+  SELECT
+    dedup.*,
+    LAG(dedup.%s) OVER (PARTITION BY dedup.%s ORDER BY dedup.%s, dedup.%s) AS __bruin_previous_hashdiff,
+    ROW_NUMBER() OVER (PARTITION BY dedup.%s ORDER BY dedup.%s, dedup.%s) AS __bruin_row_number
+  FROM __bruin_dedup AS dedup
+),
+__bruin_latest AS (
+  SELECT %s
+  FROM (
+    SELECT
+      %s,
+      ROW_NUMBER() OVER (PARTITION BY target.%s ORDER BY target.%s DESC) AS __bruin_latest_row_number
+    FROM %s AS target
+    WHERE target.%s IS NOT NULL
+  ) AS ranked_latest
+  WHERE ranked_latest.__bruin_latest_row_number = 1
+)
+INSERT INTO %s (%s)
+SELECT %s
+FROM __bruin_ordered AS source
+LEFT JOIN __bruin_latest AS latest
+  ON latest.%s = source.%s
+WHERE (
+    (
+      source.__bruin_row_number = 1
+      AND (latest.%s IS NULL OR latest.%s IS DISTINCT FROM source.%s)
+    )
+    OR (
+      source.__bruin_row_number > 1
+      AND source.__bruin_previous_hashdiff IS DISTINCT FROM source.%s
+    )
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM %s AS target
+    WHERE %s
+  )`,
+		trimMaterializationQuery(query),
+		dataVaultIndentedSourceSelectList(asset, 4),
+		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		strings.Join(dataVaultColumnNames(asset), ", "),
+		strings.Join(dataVaultAliasColumnNames("valid", primaryKeys), ", "),
+		hashDiff.Name,
+		hashDiff.Name,
+		parentHashKey.Name,
+		loadDatetime.Name,
+		hashDiff.Name,
+		parentHashKey.Name,
+		loadDatetime.Name,
+		hashDiff.Name,
+		strings.Join([]string{parentHashKey.Name, hashDiff.Name}, ", "),
+		strings.Join(dataVaultAliasColumnNames("target", []string{parentHashKey.Name, hashDiff.Name}), ",\n      "),
+		parentHashKey.Name,
+		loadDatetime.Name,
+		asset.Name,
+		parentHashKey.Name,
+		asset.Name,
+		strings.Join(dataVaultColumnNames(asset), ", "),
+		dataVaultSourceSelectList(asset),
+		parentHashKey.Name,
+		parentHashKey.Name,
+		parentHashKey.Name,
+		hashDiff.Name,
+		hashDiff.Name,
+		hashDiff.Name,
+		asset.Name,
+		strings.Join(dataVaultEqualityConditions("target", "source", primaryKeys), " AND "),
+	)
+
+	statements = append(statements, insertQuery)
+	return dataVaultTransaction(statements), nil
+}
+
+func resolveDataVaultHubColumns(asset *pipeline.Asset) (*pipeline.Column, []*pipeline.Column, *pipeline.Column, *pipeline.Column, error) {
+	if len(asset.Columns) == 0 {
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires the `columns` field to be set")
+	}
+
+	hashKey := findDataVaultColumn(asset, []string{"hash_key", "hub_hash_key"}, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	})
+	if hashKey == nil {
+		hashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	}
+
+	businessKeys := findDataVaultColumns(asset, []string{"business_key"}, func(col *pipeline.Column) bool {
+		return strings.HasSuffix(strings.ToLower(col.Name), "_bk")
+	}, nil)
+	loadDatetime := findDataVaultLoadDatetimeColumn(asset)
+	recordSource := findDataVaultRecordSourceColumn(asset)
+
+	switch {
+	case hashKey == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires a hash key column with datavault_role: hash_key or primary_key: true")
+	case len(businessKeys) == 0:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires at least one business key column with datavault_role: business_key")
+	case loadDatetime == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires a load datetime column with datavault_role: load_datetime")
+	case recordSource == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires a record source column with datavault_role: record_source")
+	default:
+		return hashKey, businessKeys, loadDatetime, recordSource, nil
+	}
+}
+
+func resolveDataVaultLinkColumns(asset *pipeline.Asset) (*pipeline.Column, []*pipeline.Column, *pipeline.Column, *pipeline.Column, error) {
+	if len(asset.Columns) == 0 {
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires the `columns` field to be set")
+	}
+
+	linkHashKey := findDataVaultColumn(asset, []string{"link_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	})
+	if linkHashKey == nil {
+		linkHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	}
+
+	excludedColumns := []*pipeline.Column{linkHashKey}
+	relatedHashKeys := findDataVaultColumns(asset, []string{"hub_hash_key", "parent_hash_key", "foreign_hash_key"}, func(col *pipeline.Column) bool {
+		return strings.HasSuffix(strings.ToLower(col.Name), "_hk")
+	}, excludedColumns)
+	loadDatetime := findDataVaultLoadDatetimeColumn(asset)
+	recordSource := findDataVaultRecordSourceColumn(asset)
+
+	switch {
+	case linkHashKey == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires a link hash key column with datavault_role: link_hash_key or primary_key: true")
+	case len(relatedHashKeys) == 0:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires at least one related hash key column with datavault_role: hub_hash_key")
+	case loadDatetime == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires a load datetime column with datavault_role: load_datetime")
+	case recordSource == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires a record source column with datavault_role: record_source")
+	default:
+		return linkHashKey, relatedHashKeys, loadDatetime, recordSource, nil
+	}
+}
+
+func resolveDataVaultSatelliteColumns(asset *pipeline.Asset) (*pipeline.Column, *pipeline.Column, *pipeline.Column, *pipeline.Column, error) {
+	if len(asset.Columns) == 0 {
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires the `columns` field to be set")
+	}
+
+	parentHashKey := findDataVaultColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	})
+	if parentHashKey == nil {
+		parentHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	}
+
+	hashDiff := findDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col *pipeline.Column) bool {
+		name := strings.ToLower(col.Name)
+		return name == "hashdiff" || name == "hash_diff"
+	})
+	loadDatetime := findDataVaultLoadDatetimeColumn(asset)
+	recordSource := findDataVaultRecordSourceColumn(asset)
+
+	switch {
+	case parentHashKey == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a parent hash key column with datavault_role: parent_hash_key or primary_key: true")
+	case hashDiff == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a hashdiff column with datavault_role: hashdiff")
+	case loadDatetime == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a load datetime column with datavault_role: load_datetime")
+	case recordSource == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a record source column with datavault_role: record_source")
+	default:
+		return parentHashKey, hashDiff, loadDatetime, recordSource, nil
+	}
+}
+
+func buildDataVaultTableStatements(asset *pipeline.Asset, primaryKeys []string, mandatoryColumns []*pipeline.Column, fullRefresh bool) ([]string, error) {
+	if len(asset.Columns) == 0 {
+		return nil, errors.New("data vault materialization requires the `columns` field to be set")
+	}
+
+	mandatoryColumnNames := make(map[string]bool, len(mandatoryColumns))
+	for _, col := range mandatoryColumns {
+		if col != nil {
+			mandatoryColumnNames[strings.ToLower(col.Name)] = true
+		}
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	for _, col := range asset.Columns {
+		if strings.TrimSpace(col.Name) == "" {
+			return nil, errors.New("data vault materialization requires every column to have a name")
+		}
+		if strings.TrimSpace(col.Type) == "" {
+			return nil, fmt.Errorf("data vault materialization requires column %q to have a type", col.Name)
+		}
+
+		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+		if mandatoryColumnNames[strings.ToLower(col.Name)] || !col.Nullable.Bool() {
+			def += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, def)
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
+	}
+
+	statements := make([]string, 0, 4)
+	if schemaStatement := createSchemaStatement(asset.Name); schemaStatement != "" {
+		statements = append(statements, schemaStatement)
+	}
+	if fullRefresh {
+		statements = append(statements, "DROP TABLE IF EXISTS "+asset.Name)
+	}
+	statements = append(statements, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)",
+		asset.Name,
+		strings.Join(columnDefs, ",\n  "),
+	))
+
+	return statements, nil
+}
+
+func createSchemaStatement(name string) string {
+	parts := strings.Split(name, ".")
+	if len(parts) != 2 {
+		return ""
+	}
+	return "CREATE SCHEMA IF NOT EXISTS " + parts[0]
+}
+
+func dataVaultTransaction(statements []string) string {
+	return "BEGIN TRANSACTION;\n" + strings.Join(statements, ";\n") + ";\nCOMMIT;"
+}
+
+func trimMaterializationQuery(query string) string {
+	return strings.TrimSuffix(strings.TrimSpace(query), ";")
+}
+
+func dataVaultSatellitePrimaryKeys(asset *pipeline.Asset, parentHashKey, loadDatetime *pipeline.Column) []string {
+	primaryKeys := asset.ColumnNamesWithPrimaryKey()
+	if len(primaryKeys) == 0 || (len(primaryKeys) == 1 && strings.EqualFold(primaryKeys[0], parentHashKey.Name)) {
+		return []string{parentHashKey.Name, loadDatetime.Name}
+	}
+	return primaryKeys
+}
+
+func dataVaultSourceSelectList(asset *pipeline.Asset) string {
+	return strings.Join(dataVaultSelectColumns(asset, "source"), ", ")
+}
+
+func dataVaultIndentedSourceSelectList(asset *pipeline.Asset, spaces int) string {
+	return strings.Join(dataVaultSelectColumns(asset, "source"), ",\n"+strings.Repeat(" ", spaces))
+}
+
+func dataVaultSelectColumns(asset *pipeline.Asset, tableAlias string) []string {
+	columns := make([]string, 0, len(asset.Columns))
+	for _, col := range asset.Columns {
+		columns = append(columns, fmt.Sprintf("%s.%s", tableAlias, col.Name))
+	}
+	return columns
+}
+
+func dataVaultColumnNames(asset *pipeline.Asset) []string {
+	columns := make([]string, 0, len(asset.Columns))
+	for _, col := range asset.Columns {
+		columns = append(columns, col.Name)
+	}
+	return columns
+}
+
+func dataVaultAliasColumnNames(tableAlias string, columns []string) []string {
+	aliased := make([]string, 0, len(columns))
+	for _, col := range columns {
+		aliased = append(aliased, tableAlias+"."+col)
+	}
+	return aliased
+}
+
+func dataVaultEqualityConditions(leftAlias, rightAlias string, columns []string) []string {
+	conditions := make([]string, 0, len(columns))
+	for _, col := range columns {
+		conditions = append(conditions, fmt.Sprintf("%s.%s = %s.%s", leftAlias, col, rightAlias, col))
+	}
+	return conditions
+}
+
+func dataVaultNotNullConditions(tableAlias string, columns []*pipeline.Column) []string {
+	conditions := make([]string, 0, len(columns))
+	seen := make(map[string]bool, len(columns))
+	for _, col := range columns {
+		if col == nil {
+			continue
+		}
+		key := strings.ToLower(col.Name)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		conditions = append(conditions, fmt.Sprintf("%s.%s IS NOT NULL", tableAlias, col.Name))
+	}
+	return conditions
+}
+
+func findDataVaultLoadDatetimeColumn(asset *pipeline.Asset) *pipeline.Column {
+	return findDataVaultColumn(asset, []string{"load_datetime", "load_dts"}, func(col *pipeline.Column) bool {
+		switch strings.ToLower(col.Name) {
+		case "load_dts", "load_datetime", "loaded_at":
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+func findDataVaultRecordSourceColumn(asset *pipeline.Asset) *pipeline.Column {
+	return findDataVaultColumn(asset, []string{"record_source"}, func(col *pipeline.Column) bool {
+		return strings.EqualFold(col.Name, "record_source")
+	})
+}
+
+func findDataVaultColumn(asset *pipeline.Asset, roles []string, fallback func(*pipeline.Column) bool) *pipeline.Column {
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if dataVaultRoleMatches(col, roles) {
+			return col
+		}
+	}
+
+	if fallback == nil {
+		return nil
+	}
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if fallback(col) {
+			return col
+		}
+	}
+
+	return nil
+}
+
+func findDataVaultColumns(asset *pipeline.Asset, roles []string, fallback func(*pipeline.Column) bool, excludedColumns []*pipeline.Column) []*pipeline.Column {
+	columns := make([]*pipeline.Column, 0)
+	seen := make(map[string]bool)
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if dataVaultColumnIsExcluded(col, excludedColumns) || !dataVaultRoleMatches(col, roles) {
+			continue
+		}
+		columns = append(columns, col)
+		seen[strings.ToLower(col.Name)] = true
+	}
+
+	if fallback == nil {
+		return columns
+	}
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		key := strings.ToLower(col.Name)
+		if seen[key] || dataVaultColumnIsExcluded(col, excludedColumns) || !fallback(col) {
+			continue
+		}
+		columns = append(columns, col)
+		seen[key] = true
+	}
+
+	return columns
+}
+
+func findSingleDataVaultColumnBySuffix(asset *pipeline.Asset, suffix string, excludedColumns []*pipeline.Column) *pipeline.Column {
+	var matched *pipeline.Column
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if dataVaultColumnIsExcluded(col, excludedColumns) || !strings.HasSuffix(strings.ToLower(col.Name), suffix) {
+			continue
+		}
+		if matched != nil {
+			return nil
+		}
+		matched = col
+	}
+	return matched
+}
+
+func dataVaultRoleMatches(col *pipeline.Column, roles []string) bool {
+	if col == nil || len(col.Meta) == 0 {
+		return false
+	}
+
+	role := strings.ToLower(strings.TrimSpace(col.Meta["datavault_role"]))
+	for _, candidate := range roles {
+		if role == strings.ToLower(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func dataVaultColumnIsExcluded(col *pipeline.Column, excludedColumns []*pipeline.Column) bool {
+	if col == nil {
+		return true
+	}
+	for _, excluded := range excludedColumns {
+		if excluded != nil && strings.EqualFold(col.Name, excluded.Name) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/duckdb/materialization.go
+++ b/pkg/duckdb/materialization.go
@@ -25,16 +25,19 @@ var matMap = pipeline.AssetMaterializationMap{
 		pipeline.MaterializationStrategyDeleteInsert:  errorMaterializer,
 	},
 	pipeline.MaterializationTypeTable: {
-		pipeline.MaterializationStrategyNone:           buildCreateReplaceQuery,
-		pipeline.MaterializationStrategyAppend:         buildAppendQuery,
-		pipeline.MaterializationStrategyCreateReplace:  buildCreateReplaceQuery,
-		pipeline.MaterializationStrategyDeleteInsert:   buildIncrementalQuery,
-		pipeline.MaterializationStrategyTruncateInsert: ansisql.BuildTruncateInsertQuery,
-		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
-		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
-		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
-		pipeline.MaterializationStrategySCD2ByTime:     buildSCD2ByTimeQuery,
-		pipeline.MaterializationStrategySCD2ByColumn:   buildSCD2ByColumnQuery,
+		pipeline.MaterializationStrategyNone:               buildCreateReplaceQuery,
+		pipeline.MaterializationStrategyAppend:             buildAppendQuery,
+		pipeline.MaterializationStrategyCreateReplace:      buildCreateReplaceQuery,
+		pipeline.MaterializationStrategyDeleteInsert:       buildIncrementalQuery,
+		pipeline.MaterializationStrategyTruncateInsert:     ansisql.BuildTruncateInsertQuery,
+		pipeline.MaterializationStrategyMerge:              buildMergeQuery,
+		pipeline.MaterializationStrategyTimeInterval:       buildTimeIntervalQuery,
+		pipeline.MaterializationStrategyDDL:                buildDDLQuery,
+		pipeline.MaterializationStrategySCD2ByTime:         buildSCD2ByTimeQuery,
+		pipeline.MaterializationStrategySCD2ByColumn:       buildSCD2ByColumnQuery,
+		pipeline.MaterializationStrategyDataVaultHub:       buildDataVaultHubQuery,
+		pipeline.MaterializationStrategyDataVaultLink:      buildDataVaultLinkQuery,
+		pipeline.MaterializationStrategyDataVaultSatellite: buildDataVaultSatelliteQuery,
 	},
 }
 
@@ -171,6 +174,15 @@ func buildCreateReplaceQuery(task *pipeline.Asset, query string) (string, error)
 	}
 	if task.Materialization.Strategy == pipeline.MaterializationStrategySCD2ByColumn {
 		return buildSCD2ByColumnfullRefresh(task, query)
+	}
+	if task.Materialization.Strategy == pipeline.MaterializationStrategyDataVaultHub {
+		return buildDataVaultHubQueryWithOptions(task, query, true)
+	}
+	if task.Materialization.Strategy == pipeline.MaterializationStrategyDataVaultLink {
+		return buildDataVaultLinkQueryWithOptions(task, query, true)
+	}
+	if task.Materialization.Strategy == pipeline.MaterializationStrategyDataVaultSatellite {
+		return buildDataVaultSatelliteQueryWithOptions(task, query, true)
 	}
 	query = strings.TrimSuffix(query, ";")
 	return fmt.Sprintf(

--- a/pkg/duckdb/materialization_test.go
+++ b/pkg/duckdb/materialization_test.go
@@ -432,6 +432,119 @@ func TestBuildDDLQuery(t *testing.T) {
 	}
 }
 
+func TestDataVaultMaterializations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hub creates table and inserts only new hash keys", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.hub_customer",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultHub,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "VARCHAR", PrimaryKey: true},
+				{Name: "customer_bk", Type: "VARCHAR"},
+				{Name: "load_dts", Type: "TIMESTAMP"},
+				{Name: "record_source", Type: "VARCHAR"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, "CREATE SCHEMA IF NOT EXISTS rdv")
+		assert.Contains(t, got, "CREATE TABLE IF NOT EXISTS rdv.hub_customer")
+		assert.Contains(t, got, "PRIMARY KEY (customer_hk)")
+		assert.Contains(t, got, "ROW_NUMBER() OVER (PARTITION BY source.customer_hk ORDER BY source.load_dts ASC) AS __bruin_row_number")
+		assert.Contains(t, got, "WHERE target.customer_hk = source.customer_hk")
+		assert.NotContains(t, got, "ON CONFLICT")
+	})
+
+	t.Run("link dedupes by link hash key", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.link_customer_order",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultLink,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_order_hk", Type: "VARCHAR", PrimaryKey: true},
+				{Name: "customer_hk", Type: "VARCHAR"},
+				{Name: "order_hk", Type: "VARCHAR"},
+				{Name: "load_dts", Type: "TIMESTAMP"},
+				{Name: "record_source", Type: "VARCHAR"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_order_hk, customer_hk, order_hk, load_dts, record_source from stg.customer_orders")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, "PRIMARY KEY (customer_order_hk)")
+		assert.Contains(t, got, "ROW_NUMBER() OVER (PARTITION BY source.customer_order_hk ORDER BY source.load_dts ASC) AS __bruin_row_number")
+		assert.Contains(t, got, "source.customer_hk IS NOT NULL")
+		assert.Contains(t, got, "source.order_hk IS NOT NULL")
+		assert.Contains(t, got, "WHERE target.customer_order_hk = source.customer_order_hk")
+	})
+
+	t.Run("satellite inserts only changed hashdiff rows", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.sat_customer_details",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "VARCHAR", PrimaryKey: true},
+				{Name: "hashdiff", Type: "VARCHAR"},
+				{Name: "load_dts", Type: "TIMESTAMP"},
+				{Name: "record_source", Type: "VARCHAR"},
+				{Name: "customer_name", Type: "VARCHAR"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_hk, hashdiff, load_dts, record_source, customer_name from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, "PRIMARY KEY (customer_hk, load_dts)")
+		assert.Contains(t, got, "LAG(dedup.hashdiff) OVER (PARTITION BY dedup.customer_hk ORDER BY dedup.load_dts, dedup.hashdiff) AS __bruin_previous_hashdiff")
+		assert.Contains(t, got, "latest.hashdiff IS DISTINCT FROM source.hashdiff")
+		assert.Contains(t, got, "source.__bruin_previous_hashdiff IS DISTINCT FROM source.hashdiff")
+		assert.Contains(t, got, "target.customer_hk = source.customer_hk AND target.load_dts = source.load_dts")
+	})
+
+	t.Run("full refresh keeps Data Vault DDL and load semantics", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.hub_customer",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultHub,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "VARCHAR", PrimaryKey: true},
+				{Name: "customer_bk", Type: "VARCHAR"},
+				{Name: "load_dts", Type: "TIMESTAMP"},
+				{Name: "record_source", Type: "VARCHAR"},
+			},
+		}
+
+		got, err := NewMaterializer(true).Render(asset, "select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, "DROP TABLE IF EXISTS rdv.hub_customer;")
+		assert.Contains(t, got, "CREATE TABLE IF NOT EXISTS rdv.hub_customer")
+		assert.NotContains(t, got, "CREATE TABLE rdv.hub_customer AS")
+	})
+}
+
 func TestDuckDBTimestampWithTimeZone(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1217,7 +1217,7 @@ func ensureDataVaultLinkColumnsAreValid(asset *pipeline.Asset) []*Issue {
 
 	linkHashKeyName := ""
 	for _, col := range asset.Columns {
-		if dataVaultColumnMatches(col, []string{"link_hash_key", "hash_key"}) || col.PrimaryKey {
+		if dataVaultColumnMatches(col, []string{"link_hash_key", "hash_key"}) || col.PrimaryKey || strings.HasSuffix(strings.ToLower(col.Name), "_hk") {
 			linkHashKeyName = col.Name
 			break
 		}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1131,6 +1131,12 @@ func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *p
 				})
 			}
 
+		case pipeline.MaterializationStrategyDataVaultHub:
+			issues = append(issues, ensureDataVaultHubColumnsAreValid(asset)...)
+		case pipeline.MaterializationStrategyDataVaultLink:
+			issues = append(issues, ensureDataVaultLinkColumnsAreValid(asset)...)
+		case pipeline.MaterializationStrategyDataVaultSatellite:
+			issues = append(issues, ensureDataVaultSatelliteColumnsAreValid(asset)...)
 		case pipeline.MaterializationStrategyTimeInterval:
 			if asset.Materialization.IncrementalKey == "" {
 				issues = append(issues, &Issue{
@@ -1175,6 +1181,180 @@ func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *p
 	}
 
 	return issues, nil
+}
+
+func ensureDataVaultHubColumnsAreValid(asset *pipeline.Asset) []*Issue {
+	issues := ensureDataVaultColumnsHaveNamesAndTypes(asset, "datavault_hub")
+	if len(asset.Columns) == 0 {
+		return issues
+	}
+
+	if !hasDataVaultColumn(asset, []string{"hash_key", "hub_hash_key"}, func(col pipeline.Column) bool {
+		return col.PrimaryKey || strings.HasSuffix(strings.ToLower(col.Name), "_hk")
+	}) {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Materialization strategy 'datavault_hub' requires a hash key column",
+		})
+	}
+	if !hasDataVaultColumn(asset, []string{"business_key"}, func(col pipeline.Column) bool {
+		return strings.HasSuffix(strings.ToLower(col.Name), "_bk")
+	}) {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Materialization strategy 'datavault_hub' requires at least one business key column",
+		})
+	}
+	appendCommonDataVaultColumnIssues(asset, "datavault_hub", &issues)
+	return issues
+}
+
+func ensureDataVaultLinkColumnsAreValid(asset *pipeline.Asset) []*Issue {
+	issues := ensureDataVaultColumnsHaveNamesAndTypes(asset, "datavault_link")
+	if len(asset.Columns) == 0 {
+		return issues
+	}
+
+	linkHashKeyName := ""
+	for _, col := range asset.Columns {
+		if dataVaultColumnMatches(col, []string{"link_hash_key", "hash_key"}) || col.PrimaryKey {
+			linkHashKeyName = col.Name
+			break
+		}
+	}
+	if linkHashKeyName == "" {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Materialization strategy 'datavault_link' requires a link hash key column",
+		})
+	}
+
+	hasRelatedHashKey := false
+	for _, col := range asset.Columns {
+		if strings.EqualFold(col.Name, linkHashKeyName) {
+			continue
+		}
+		if dataVaultColumnMatches(col, []string{"hub_hash_key", "parent_hash_key", "foreign_hash_key"}) || strings.HasSuffix(strings.ToLower(col.Name), "_hk") {
+			hasRelatedHashKey = true
+			break
+		}
+	}
+	if !hasRelatedHashKey {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Materialization strategy 'datavault_link' requires at least one related hash key column",
+		})
+	}
+	appendCommonDataVaultColumnIssues(asset, "datavault_link", &issues)
+	return issues
+}
+
+func ensureDataVaultSatelliteColumnsAreValid(asset *pipeline.Asset) []*Issue {
+	issues := ensureDataVaultColumnsHaveNamesAndTypes(asset, "datavault_satellite")
+	if len(asset.Columns) == 0 {
+		return issues
+	}
+
+	if !hasDataVaultColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, func(col pipeline.Column) bool {
+		return col.PrimaryKey || strings.HasSuffix(strings.ToLower(col.Name), "_hk")
+	}) {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Materialization strategy 'datavault_satellite' requires a parent hash key column",
+		})
+	}
+	if !hasDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col pipeline.Column) bool {
+		name := strings.ToLower(col.Name)
+		return name == "hashdiff" || name == "hash_diff"
+	}) {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Materialization strategy 'datavault_satellite' requires a hashdiff column",
+		})
+	}
+	appendCommonDataVaultColumnIssues(asset, "datavault_satellite", &issues)
+	return issues
+}
+
+func ensureDataVaultColumnsHaveNamesAndTypes(asset *pipeline.Asset, strategy string) []*Issue {
+	issues := make([]*Issue, 0)
+	if len(asset.Columns) == 0 {
+		return append(issues, &Issue{
+			Task:        asset,
+			Description: fmt.Sprintf("Materialization strategy '%s' requires the 'columns' field to be set with actual columns", strategy),
+		})
+	}
+
+	for _, col := range asset.Columns {
+		if strings.TrimSpace(col.Name) == "" {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Materialization strategy '%s' requires every column to have a name", strategy),
+			})
+		}
+		if strings.TrimSpace(col.Type) == "" {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Materialization strategy '%s' requires column '%s' to have a type", strategy, col.Name),
+			})
+		}
+	}
+
+	return issues
+}
+
+func appendCommonDataVaultColumnIssues(asset *pipeline.Asset, strategy string, issues *[]*Issue) {
+	if !hasDataVaultColumn(asset, []string{"load_datetime", "load_dts"}, func(col pipeline.Column) bool {
+		switch strings.ToLower(col.Name) {
+		case "load_dts", "load_datetime", "loaded_at":
+			return true
+		default:
+			return false
+		}
+	}) {
+		*issues = append(*issues, &Issue{
+			Task:        asset,
+			Description: fmt.Sprintf("Materialization strategy '%s' requires a load datetime column", strategy),
+		})
+	}
+	if !hasDataVaultColumn(asset, []string{"record_source"}, func(col pipeline.Column) bool {
+		return strings.EqualFold(col.Name, "record_source")
+	}) {
+		*issues = append(*issues, &Issue{
+			Task:        asset,
+			Description: fmt.Sprintf("Materialization strategy '%s' requires a record source column", strategy),
+		})
+	}
+}
+
+func hasDataVaultColumn(asset *pipeline.Asset, roles []string, fallback func(pipeline.Column) bool) bool {
+	for _, col := range asset.Columns {
+		if dataVaultColumnMatches(col, roles) {
+			return true
+		}
+	}
+	if fallback == nil {
+		return false
+	}
+	for _, col := range asset.Columns {
+		if fallback(col) {
+			return true
+		}
+	}
+	return false
+}
+
+func dataVaultColumnMatches(col pipeline.Column, roles []string) bool {
+	if len(col.Meta) == 0 {
+		return false
+	}
+	role := strings.ToLower(strings.TrimSpace(col.Meta["datavault_role"]))
+	for _, candidate := range roles {
+		if role == strings.ToLower(candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func EnsureSnowflakeSensorHasQueryParameterForASingleAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1400,6 +1400,81 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "table materialization has datavault_hub and it is successful",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultHub,
+					},
+					Columns: []pipeline.Column{
+						{Name: "customer_hk", Type: "text", PrimaryKey: true},
+						{Name: "customer_bk", Type: "text"},
+						{Name: "load_dts", Type: "timestamptz"},
+						{Name: "record_source", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "table materialization has datavault_link and it is successful",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultLink,
+					},
+					Columns: []pipeline.Column{
+						{Name: "customer_order_hk", Type: "text", PrimaryKey: true},
+						{Name: "customer_hk", Type: "text"},
+						{Name: "order_hk", Type: "text"},
+						{Name: "load_dts", Type: "timestamptz"},
+						{Name: "record_source", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "table materialization has datavault_satellite and it is successful",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+					},
+					Columns: []pipeline.Column{
+						{Name: "customer_hk", Type: "text", PrimaryKey: true},
+						{Name: "hashdiff", Type: "text"},
+						{Name: "load_dts", Type: "timestamptz"},
+						{Name: "record_source", Type: "text"},
+						{Name: "customer_name", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "table materialization has datavault_hub but no columns",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultHub,
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: []string{
+				"Materialization strategy 'datavault_hub' requires the 'columns' field to be set with actual columns",
+			},
+		},
 	}
 	ctx := t.Context()
 	for _, tt := range tests {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1440,6 +1440,26 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "table materialization has datavault_link with hk suffix link key and it is successful",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultLink,
+					},
+					Columns: []pipeline.Column{
+						{Name: "customer_order_hk", Type: "text"},
+						{Name: "customer_key", Type: "text", Meta: map[string]string{"datavault_role": "hub_hash_key"}},
+						{Name: "order_key", Type: "text", Meta: map[string]string{"datavault_role": "hub_hash_key"}},
+						{Name: "load_dts", Type: "timestamptz"},
+						{Name: "record_source", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "table materialization has datavault_satellite and it is successful",
 			assets: []*pipeline.Asset{
 				{

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -366,18 +366,21 @@ type (
 )
 
 const (
-	MaterializationStrategyNone             MaterializationStrategy        = ""
-	MaterializationStrategyCreateReplace    MaterializationStrategy        = "create+replace"
-	MaterializationStrategyDeleteInsert     MaterializationStrategy        = "delete+insert"
-	MaterializationStrategyTruncateInsert   MaterializationStrategy        = "truncate+insert"
-	MaterializationStrategyAppend           MaterializationStrategy        = "append"
-	MaterializationStrategyMerge            MaterializationStrategy        = "merge"
-	MaterializationStrategyTimeInterval     MaterializationStrategy        = "time_interval"
-	MaterializationStrategyDDL              MaterializationStrategy        = "ddl"
-	MaterializationTimeGranularityDate      MaterializationTimeGranularity = "date"
-	MaterializationTimeGranularityTimestamp MaterializationTimeGranularity = "timestamp"
-	MaterializationStrategySCD2ByTime       MaterializationStrategy        = "scd2_by_time"
-	MaterializationStrategySCD2ByColumn     MaterializationStrategy        = "scd2_by_column"
+	MaterializationStrategyNone               MaterializationStrategy        = ""
+	MaterializationStrategyCreateReplace      MaterializationStrategy        = "create+replace"
+	MaterializationStrategyDeleteInsert       MaterializationStrategy        = "delete+insert"
+	MaterializationStrategyTruncateInsert     MaterializationStrategy        = "truncate+insert"
+	MaterializationStrategyAppend             MaterializationStrategy        = "append"
+	MaterializationStrategyMerge              MaterializationStrategy        = "merge"
+	MaterializationStrategyTimeInterval       MaterializationStrategy        = "time_interval"
+	MaterializationStrategyDDL                MaterializationStrategy        = "ddl"
+	MaterializationTimeGranularityDate        MaterializationTimeGranularity = "date"
+	MaterializationTimeGranularityTimestamp   MaterializationTimeGranularity = "timestamp"
+	MaterializationStrategySCD2ByTime         MaterializationStrategy        = "scd2_by_time"
+	MaterializationStrategySCD2ByColumn       MaterializationStrategy        = "scd2_by_column"
+	MaterializationStrategyDataVaultHub       MaterializationStrategy        = "datavault_hub"
+	MaterializationStrategyDataVaultLink      MaterializationStrategy        = "datavault_link"
+	MaterializationStrategyDataVaultSatellite MaterializationStrategy        = "datavault_satellite"
 )
 
 var AllAvailableMaterializationStrategies = []MaterializationStrategy{
@@ -390,6 +393,9 @@ var AllAvailableMaterializationStrategies = []MaterializationStrategy{
 	MaterializationStrategyDDL,
 	MaterializationStrategySCD2ByTime,
 	MaterializationStrategySCD2ByColumn,
+	MaterializationStrategyDataVaultHub,
+	MaterializationStrategyDataVaultLink,
+	MaterializationStrategyDataVaultSatellite,
 }
 
 type Materialization struct {

--- a/pkg/postgres/materialization.go
+++ b/pkg/postgres/materialization.go
@@ -36,16 +36,19 @@ var matMap = pipeline.AssetMaterializationMap{
 		pipeline.MaterializationStrategyDeleteInsert:  errorMaterializer,
 	},
 	pipeline.MaterializationTypeTable: {
-		pipeline.MaterializationStrategyNone:           buildCreateReplaceQuery,
-		pipeline.MaterializationStrategyAppend:         buildAppendQuery,
-		pipeline.MaterializationStrategyCreateReplace:  buildCreateReplaceQuery,
-		pipeline.MaterializationStrategyDeleteInsert:   buildIncrementalQuery,
-		pipeline.MaterializationStrategyTruncateInsert: buildTruncateInsertQuery,
-		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
-		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
-		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
-		pipeline.MaterializationStrategySCD2ByColumn:   buildSCD2ByColumnQuery,
-		pipeline.MaterializationStrategySCD2ByTime:     buildSCD2QueryByTime,
+		pipeline.MaterializationStrategyNone:               buildCreateReplaceQuery,
+		pipeline.MaterializationStrategyAppend:             buildAppendQuery,
+		pipeline.MaterializationStrategyCreateReplace:      buildCreateReplaceQuery,
+		pipeline.MaterializationStrategyDeleteInsert:       buildIncrementalQuery,
+		pipeline.MaterializationStrategyTruncateInsert:     buildTruncateInsertQuery,
+		pipeline.MaterializationStrategyMerge:              buildMergeQuery,
+		pipeline.MaterializationStrategyTimeInterval:       buildTimeIntervalQuery,
+		pipeline.MaterializationStrategyDDL:                buildDDLQuery,
+		pipeline.MaterializationStrategySCD2ByColumn:       buildSCD2ByColumnQuery,
+		pipeline.MaterializationStrategySCD2ByTime:         buildSCD2QueryByTime,
+		pipeline.MaterializationStrategyDataVaultHub:       buildDataVaultHubQuery,
+		pipeline.MaterializationStrategyDataVaultLink:      buildDataVaultLinkQuery,
+		pipeline.MaterializationStrategyDataVaultSatellite: buildDataVaultSatelliteQuery,
 	},
 }
 
@@ -231,6 +234,12 @@ func buildCreateReplaceQuery(task *pipeline.Asset, query string) (string, error)
 		return buildSCD2ByTimefullRefresh(task, query)
 	case pipeline.MaterializationStrategySCD2ByColumn:
 		return buildSCD2ByColumnfullRefresh(task, query)
+	case pipeline.MaterializationStrategyDataVaultHub:
+		return buildDataVaultHubQueryWithOptions(task, query, true)
+	case pipeline.MaterializationStrategyDataVaultLink:
+		return buildDataVaultLinkQueryWithOptions(task, query, true)
+	case pipeline.MaterializationStrategyDataVaultSatellite:
+		return buildDataVaultSatelliteQueryWithOptions(task, query, true)
 	default:
 		query = strings.TrimSuffix(query, ";")
 		return fmt.Sprintf(
@@ -312,6 +321,519 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 	}
 
 	return q, nil
+}
+
+func buildDataVaultHubQuery(asset *pipeline.Asset, query string) (string, error) {
+	return buildDataVaultHubQueryWithOptions(asset, query, false)
+}
+
+func buildDataVaultHubQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	hashKey, businessKeys, loadDatetime, recordSource, err := resolveDataVaultHubColumns(asset)
+	if err != nil {
+		return "", err
+	}
+
+	mandatoryColumns := append([]*pipeline.Column{hashKey, loadDatetime, recordSource}, businessKeys...)
+	statements, err := buildDataVaultTableStatements(asset, []string{hashKey.Name}, mandatoryColumns, fullRefresh)
+	if err != nil {
+		return "", err
+	}
+
+	insertQuery := fmt.Sprintf(`WITH __bruin_source AS (
+%s
+),
+__bruin_dedup AS (
+  SELECT DISTINCT ON (source.%s)
+    %s
+  FROM __bruin_source AS source
+  WHERE %s
+  ORDER BY source.%s, source.%s ASC
+)
+INSERT INTO %s (%s)
+SELECT %s
+FROM __bruin_dedup AS source
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM %s AS target
+  WHERE target.%s = source.%s
+)
+ON CONFLICT (%s) DO NOTHING`,
+		trimMaterializationQuery(query),
+		QuoteIdentifier(hashKey.Name),
+		dataVaultSourceSelectList(asset),
+		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		QuoteIdentifier(hashKey.Name),
+		QuoteIdentifier(loadDatetime.Name),
+		QuoteIdentifier(asset.Name),
+		strings.Join(quoteNames(asset.ColumnNames()), ", "),
+		dataVaultSourceSelectList(asset),
+		QuoteIdentifier(asset.Name),
+		QuoteIdentifier(hashKey.Name),
+		QuoteIdentifier(hashKey.Name),
+		QuoteIdentifier(hashKey.Name),
+	)
+
+	statements = append(statements, insertQuery)
+	return dataVaultTransaction(statements), nil
+}
+
+func buildDataVaultLinkQuery(asset *pipeline.Asset, query string) (string, error) {
+	return buildDataVaultLinkQueryWithOptions(asset, query, false)
+}
+
+func buildDataVaultLinkQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	linkHashKey, relatedHashKeys, loadDatetime, recordSource, err := resolveDataVaultLinkColumns(asset)
+	if err != nil {
+		return "", err
+	}
+
+	mandatoryColumns := append([]*pipeline.Column{linkHashKey, loadDatetime, recordSource}, relatedHashKeys...)
+	statements, err := buildDataVaultTableStatements(asset, []string{linkHashKey.Name}, mandatoryColumns, fullRefresh)
+	if err != nil {
+		return "", err
+	}
+
+	insertQuery := fmt.Sprintf(`WITH __bruin_source AS (
+%s
+),
+__bruin_dedup AS (
+  SELECT DISTINCT ON (source.%s)
+    %s
+  FROM __bruin_source AS source
+  WHERE %s
+  ORDER BY source.%s, source.%s ASC
+)
+INSERT INTO %s (%s)
+SELECT %s
+FROM __bruin_dedup AS source
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM %s AS target
+  WHERE target.%s = source.%s
+)
+ON CONFLICT (%s) DO NOTHING`,
+		trimMaterializationQuery(query),
+		QuoteIdentifier(linkHashKey.Name),
+		dataVaultSourceSelectList(asset),
+		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		QuoteIdentifier(linkHashKey.Name),
+		QuoteIdentifier(loadDatetime.Name),
+		QuoteIdentifier(asset.Name),
+		strings.Join(quoteNames(asset.ColumnNames()), ", "),
+		dataVaultSourceSelectList(asset),
+		QuoteIdentifier(asset.Name),
+		QuoteIdentifier(linkHashKey.Name),
+		QuoteIdentifier(linkHashKey.Name),
+		QuoteIdentifier(linkHashKey.Name),
+	)
+
+	statements = append(statements, insertQuery)
+	return dataVaultTransaction(statements), nil
+}
+
+func buildDataVaultSatelliteQuery(asset *pipeline.Asset, query string) (string, error) {
+	return buildDataVaultSatelliteQueryWithOptions(asset, query, false)
+}
+
+func buildDataVaultSatelliteQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	parentHashKey, hashDiff, loadDatetime, recordSource, err := resolveDataVaultSatelliteColumns(asset)
+	if err != nil {
+		return "", err
+	}
+
+	primaryKeys := dataVaultSatellitePrimaryKeys(asset, parentHashKey, loadDatetime)
+	mandatoryColumns := []*pipeline.Column{parentHashKey, hashDiff, loadDatetime, recordSource}
+	statements, err := buildDataVaultTableStatements(asset, primaryKeys, mandatoryColumns, fullRefresh)
+	if err != nil {
+		return "", err
+	}
+
+	insertQuery := fmt.Sprintf(`WITH __bruin_source AS (
+%s
+),
+__bruin_valid AS (
+  SELECT
+    %s
+  FROM __bruin_source AS source
+  WHERE %s
+),
+__bruin_ordered AS (
+  SELECT
+    valid.*,
+    LAG(valid.%s) OVER (PARTITION BY valid.%s ORDER BY valid.%s, valid.%s) AS __bruin_previous_hashdiff,
+    ROW_NUMBER() OVER (PARTITION BY valid.%s ORDER BY valid.%s, valid.%s) AS __bruin_row_number
+  FROM __bruin_valid AS valid
+),
+__bruin_latest AS (
+  SELECT DISTINCT ON (target.%s)
+    target.%s,
+    target.%s
+  FROM %s AS target
+  WHERE target.%s IS NOT NULL
+  ORDER BY target.%s, target.%s DESC
+)
+INSERT INTO %s (%s)
+SELECT %s
+FROM __bruin_ordered AS source
+LEFT JOIN __bruin_latest AS latest
+  ON latest.%s = source.%s
+WHERE (
+    source.__bruin_row_number = 1
+    AND (latest.%s IS NULL OR latest.%s IS DISTINCT FROM source.%s)
+  )
+  OR (
+    source.__bruin_row_number > 1
+    AND source.__bruin_previous_hashdiff IS DISTINCT FROM source.%s
+  )
+ON CONFLICT (%s) DO NOTHING`,
+		trimMaterializationQuery(query),
+		dataVaultIndentedSelectList(asset, "source", 4),
+		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		QuoteIdentifier(hashDiff.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(loadDatetime.Name),
+		QuoteIdentifier(hashDiff.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(loadDatetime.Name),
+		QuoteIdentifier(hashDiff.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(hashDiff.Name),
+		QuoteIdentifier(asset.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(loadDatetime.Name),
+		QuoteIdentifier(asset.Name),
+		strings.Join(quoteNames(asset.ColumnNames()), ", "),
+		dataVaultSourceSelectList(asset),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(parentHashKey.Name),
+		QuoteIdentifier(hashDiff.Name),
+		QuoteIdentifier(hashDiff.Name),
+		QuoteIdentifier(hashDiff.Name),
+		strings.Join(quoteNames(primaryKeys), ", "),
+	)
+
+	statements = append(statements, insertQuery)
+	return dataVaultTransaction(statements), nil
+}
+
+func resolveDataVaultHubColumns(asset *pipeline.Asset) (*pipeline.Column, []*pipeline.Column, *pipeline.Column, *pipeline.Column, error) {
+	if len(asset.Columns) == 0 {
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires the `columns` field to be set")
+	}
+
+	hashKey := findDataVaultColumn(asset, []string{"hash_key", "hub_hash_key"}, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	})
+	if hashKey == nil {
+		hashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	}
+
+	businessKeys := findDataVaultColumns(asset, []string{"business_key"}, func(col *pipeline.Column) bool {
+		return strings.HasSuffix(strings.ToLower(col.Name), "_bk")
+	}, nil)
+	loadDatetime := findDataVaultLoadDatetimeColumn(asset)
+	recordSource := findDataVaultRecordSourceColumn(asset)
+
+	switch {
+	case hashKey == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires a hash key column with datavault_role: hash_key or primary_key: true")
+	case len(businessKeys) == 0:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires at least one business key column with datavault_role: business_key")
+	case loadDatetime == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires a load datetime column with datavault_role: load_datetime")
+	case recordSource == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires a record source column with datavault_role: record_source")
+	default:
+		return hashKey, businessKeys, loadDatetime, recordSource, nil
+	}
+}
+
+func resolveDataVaultLinkColumns(asset *pipeline.Asset) (*pipeline.Column, []*pipeline.Column, *pipeline.Column, *pipeline.Column, error) {
+	if len(asset.Columns) == 0 {
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires the `columns` field to be set")
+	}
+
+	linkHashKey := findDataVaultColumn(asset, []string{"link_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	})
+	if linkHashKey == nil {
+		linkHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	}
+
+	excludedColumns := []*pipeline.Column{linkHashKey}
+	relatedHashKeys := findDataVaultColumns(asset, []string{"hub_hash_key", "parent_hash_key", "foreign_hash_key"}, func(col *pipeline.Column) bool {
+		return strings.HasSuffix(strings.ToLower(col.Name), "_hk")
+	}, excludedColumns)
+	loadDatetime := findDataVaultLoadDatetimeColumn(asset)
+	recordSource := findDataVaultRecordSourceColumn(asset)
+
+	switch {
+	case linkHashKey == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires a link hash key column with datavault_role: link_hash_key or primary_key: true")
+	case len(relatedHashKeys) == 0:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires at least one related hash key column with datavault_role: hub_hash_key")
+	case loadDatetime == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires a load datetime column with datavault_role: load_datetime")
+	case recordSource == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires a record source column with datavault_role: record_source")
+	default:
+		return linkHashKey, relatedHashKeys, loadDatetime, recordSource, nil
+	}
+}
+
+func resolveDataVaultSatelliteColumns(asset *pipeline.Asset) (*pipeline.Column, *pipeline.Column, *pipeline.Column, *pipeline.Column, error) {
+	if len(asset.Columns) == 0 {
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires the `columns` field to be set")
+	}
+
+	parentHashKey := findDataVaultColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	})
+	if parentHashKey == nil {
+		parentHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	}
+
+	hashDiff := findDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col *pipeline.Column) bool {
+		name := strings.ToLower(col.Name)
+		return name == "hashdiff" || name == "hash_diff"
+	})
+	loadDatetime := findDataVaultLoadDatetimeColumn(asset)
+	recordSource := findDataVaultRecordSourceColumn(asset)
+
+	switch {
+	case parentHashKey == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a parent hash key column with datavault_role: parent_hash_key or primary_key: true")
+	case hashDiff == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a hashdiff column with datavault_role: hashdiff")
+	case loadDatetime == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a load datetime column with datavault_role: load_datetime")
+	case recordSource == nil:
+		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires a record source column with datavault_role: record_source")
+	default:
+		return parentHashKey, hashDiff, loadDatetime, recordSource, nil
+	}
+}
+
+func buildDataVaultTableStatements(asset *pipeline.Asset, primaryKeys []string, mandatoryColumns []*pipeline.Column, fullRefresh bool) ([]string, error) {
+	if len(asset.Columns) == 0 {
+		return nil, errors.New("data vault materialization requires the `columns` field to be set")
+	}
+
+	mandatoryColumnNames := make(map[string]bool, len(mandatoryColumns))
+	for _, col := range mandatoryColumns {
+		if col != nil {
+			mandatoryColumnNames[strings.ToLower(col.Name)] = true
+		}
+	}
+
+	columnDefs := make([]string, 0, len(asset.Columns)+1)
+	for _, col := range asset.Columns {
+		if strings.TrimSpace(col.Name) == "" {
+			return nil, errors.New("data vault materialization requires every column to have a name")
+		}
+		if strings.TrimSpace(col.Type) == "" {
+			return nil, fmt.Errorf("data vault materialization requires column %q to have a type", col.Name)
+		}
+
+		def := fmt.Sprintf("%s %s", QuoteIdentifier(col.Name), col.Type)
+		if mandatoryColumnNames[strings.ToLower(col.Name)] || !col.Nullable.Bool() {
+			def += " NOT NULL"
+		}
+		columnDefs = append(columnDefs, def)
+	}
+
+	if len(primaryKeys) > 0 {
+		columnDefs = append(columnDefs, fmt.Sprintf("primary key (%s)", strings.Join(quoteNames(primaryKeys), ", ")))
+	}
+
+	statements := make([]string, 0, 4)
+	if schemaStatement := createSchemaStatement(asset.Name); schemaStatement != "" {
+		statements = append(statements, schemaStatement)
+	}
+	if fullRefresh {
+		statements = append(statements, "DROP TABLE IF EXISTS "+QuoteIdentifier(asset.Name))
+	}
+	statements = append(statements, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n%s\n)",
+		QuoteIdentifier(asset.Name),
+		strings.Join(columnDefs, ",\n"),
+	))
+
+	return statements, nil
+}
+
+func createSchemaStatement(name string) string {
+	parts := strings.Split(name, ".")
+	if len(parts) != 2 {
+		return ""
+	}
+	return "CREATE SCHEMA IF NOT EXISTS " + QuoteIdentifier(parts[0])
+}
+
+func dataVaultTransaction(statements []string) string {
+	return "BEGIN TRANSACTION;\n" + strings.Join(statements, ";\n") + ";\nCOMMIT;"
+}
+
+func trimMaterializationQuery(query string) string {
+	return strings.TrimSuffix(strings.TrimSpace(query), ";")
+}
+
+func dataVaultSatellitePrimaryKeys(asset *pipeline.Asset, parentHashKey, loadDatetime *pipeline.Column) []string {
+	primaryKeys := asset.ColumnNamesWithPrimaryKey()
+	if len(primaryKeys) == 0 || (len(primaryKeys) == 1 && strings.EqualFold(primaryKeys[0], parentHashKey.Name)) {
+		return []string{parentHashKey.Name, loadDatetime.Name}
+	}
+	return primaryKeys
+}
+
+func dataVaultSourceSelectList(asset *pipeline.Asset) string {
+	return strings.Join(dataVaultSelectColumns(asset, "source"), ", ")
+}
+
+func dataVaultIndentedSelectList(asset *pipeline.Asset, tableAlias string, spaces int) string {
+	return strings.Join(dataVaultSelectColumns(asset, tableAlias), ",\n"+strings.Repeat(" ", spaces))
+}
+
+func dataVaultSelectColumns(asset *pipeline.Asset, tableAlias string) []string {
+	columns := make([]string, 0, len(asset.Columns))
+	for _, col := range asset.Columns {
+		columns = append(columns, fmt.Sprintf("%s.%s", tableAlias, QuoteIdentifier(col.Name)))
+	}
+	return columns
+}
+
+func dataVaultNotNullConditions(tableAlias string, columns []*pipeline.Column) []string {
+	conditions := make([]string, 0, len(columns))
+	seen := make(map[string]bool, len(columns))
+	for _, col := range columns {
+		if col == nil {
+			continue
+		}
+		key := strings.ToLower(col.Name)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		conditions = append(conditions, fmt.Sprintf("%s.%s IS NOT NULL", tableAlias, QuoteIdentifier(col.Name)))
+	}
+	return conditions
+}
+
+func quoteNames(names []string) []string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, QuoteIdentifier(name))
+	}
+	return quoted
+}
+
+func findDataVaultLoadDatetimeColumn(asset *pipeline.Asset) *pipeline.Column {
+	return findDataVaultColumn(asset, []string{"load_datetime", "load_dts"}, func(col *pipeline.Column) bool {
+		switch strings.ToLower(col.Name) {
+		case "load_dts", "load_datetime", "loaded_at":
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+func findDataVaultRecordSourceColumn(asset *pipeline.Asset) *pipeline.Column {
+	return findDataVaultColumn(asset, []string{"record_source"}, func(col *pipeline.Column) bool {
+		return strings.EqualFold(col.Name, "record_source")
+	})
+}
+
+func findDataVaultColumn(asset *pipeline.Asset, roles []string, fallback func(*pipeline.Column) bool) *pipeline.Column {
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if dataVaultRoleMatches(col, roles) {
+			return col
+		}
+	}
+
+	if fallback == nil {
+		return nil
+	}
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if fallback(col) {
+			return col
+		}
+	}
+
+	return nil
+}
+
+func findDataVaultColumns(asset *pipeline.Asset, roles []string, fallback func(*pipeline.Column) bool, excludedColumns []*pipeline.Column) []*pipeline.Column {
+	columns := make([]*pipeline.Column, 0)
+	seen := make(map[string]bool)
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if dataVaultColumnIsExcluded(col, excludedColumns) || !dataVaultRoleMatches(col, roles) {
+			continue
+		}
+		columns = append(columns, col)
+		seen[strings.ToLower(col.Name)] = true
+	}
+
+	if fallback == nil {
+		return columns
+	}
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		key := strings.ToLower(col.Name)
+		if seen[key] || dataVaultColumnIsExcluded(col, excludedColumns) || !fallback(col) {
+			continue
+		}
+		columns = append(columns, col)
+		seen[key] = true
+	}
+
+	return columns
+}
+
+func findSingleDataVaultColumnBySuffix(asset *pipeline.Asset, suffix string, excludedColumns []*pipeline.Column) *pipeline.Column {
+	var matched *pipeline.Column
+	for i := range asset.Columns {
+		col := &asset.Columns[i]
+		if dataVaultColumnIsExcluded(col, excludedColumns) || !strings.HasSuffix(strings.ToLower(col.Name), suffix) {
+			continue
+		}
+		if matched != nil {
+			return nil
+		}
+		matched = col
+	}
+	return matched
+}
+
+func dataVaultRoleMatches(col *pipeline.Column, roles []string) bool {
+	if col == nil || len(col.Meta) == 0 {
+		return false
+	}
+
+	role := strings.ToLower(strings.TrimSpace(col.Meta["datavault_role"]))
+	for _, candidate := range roles {
+		if role == strings.ToLower(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func dataVaultColumnIsExcluded(col *pipeline.Column, excludedColumns []*pipeline.Column) bool {
+	if col == nil {
+		return true
+	}
+	for _, excluded := range excludedColumns {
+		if excluded != nil && strings.EqualFold(col.Name, excluded.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildSCD2ByColumnfullRefresh(asset *pipeline.Asset, query string) (string, error) {

--- a/pkg/postgres/materialization_test.go
+++ b/pkg/postgres/materialization_test.go
@@ -443,6 +443,167 @@ WHEN NOT MATCHED THEN INSERT\("id", "col_a"\) VALUES\("id", "col_a"\);$`,
 	}
 }
 
+func TestDataVaultMaterializations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hub creates table and inserts only new hash keys", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.hub_customer",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultHub,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "text", PrimaryKey: true},
+				{Name: "customer_bk", Type: "text"},
+				{Name: "load_dts", Type: "timestamptz"},
+				{Name: "record_source", Type: "text"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Equal(t, `BEGIN TRANSACTION;
+CREATE SCHEMA IF NOT EXISTS "rdv";
+CREATE TABLE IF NOT EXISTS "rdv"."hub_customer" (
+"customer_hk" text NOT NULL,
+"customer_bk" text NOT NULL,
+"load_dts" timestamptz NOT NULL,
+"record_source" text NOT NULL,
+primary key ("customer_hk")
+);
+WITH __bruin_source AS (
+select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed
+),
+__bruin_dedup AS (
+  SELECT DISTINCT ON (source."customer_hk")
+    source."customer_hk", source."customer_bk", source."load_dts", source."record_source"
+  FROM __bruin_source AS source
+  WHERE source."customer_hk" IS NOT NULL AND source."load_dts" IS NOT NULL AND source."record_source" IS NOT NULL AND source."customer_bk" IS NOT NULL
+  ORDER BY source."customer_hk", source."load_dts" ASC
+)
+INSERT INTO "rdv"."hub_customer" ("customer_hk", "customer_bk", "load_dts", "record_source")
+SELECT source."customer_hk", source."customer_bk", source."load_dts", source."record_source"
+FROM __bruin_dedup AS source
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "rdv"."hub_customer" AS target
+  WHERE target."customer_hk" = source."customer_hk"
+)
+ON CONFLICT ("customer_hk") DO NOTHING;
+COMMIT;`, got)
+	})
+
+	t.Run("link dedupes by link hash key", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.link_customer_order",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultLink,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_order_hk", Type: "text", PrimaryKey: true},
+				{Name: "customer_hk", Type: "text"},
+				{Name: "order_hk", Type: "text"},
+				{Name: "load_dts", Type: "timestamptz"},
+				{Name: "record_source", Type: "text"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_order_hk, customer_hk, order_hk, load_dts, record_source from stg.customer_orders")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, `primary key ("customer_order_hk")`)
+		assert.Contains(t, got, `SELECT DISTINCT ON (source."customer_order_hk")`)
+		assert.Contains(t, got, `source."customer_hk" IS NOT NULL`)
+		assert.Contains(t, got, `source."order_hk" IS NOT NULL`)
+		assert.Contains(t, got, `WHERE target."customer_order_hk" = source."customer_order_hk"`)
+		assert.Contains(t, got, `ON CONFLICT ("customer_order_hk") DO NOTHING`)
+	})
+
+	t.Run("satellite inserts only changed hashdiff rows", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.sat_customer_details",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "text", PrimaryKey: true},
+				{Name: "hashdiff", Type: "text"},
+				{Name: "load_dts", Type: "timestamptz"},
+				{Name: "record_source", Type: "text"},
+				{Name: "customer_name", Type: "text"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_hk, hashdiff, load_dts, record_source, customer_name from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, `primary key ("customer_hk", "load_dts")`)
+		assert.Contains(t, got, `LAG(valid."hashdiff") OVER (PARTITION BY valid."customer_hk" ORDER BY valid."load_dts", valid."hashdiff") AS __bruin_previous_hashdiff`)
+		assert.Contains(t, got, `SELECT DISTINCT ON (target."customer_hk")`)
+		assert.Contains(t, got, `latest."hashdiff" IS DISTINCT FROM source."hashdiff"`)
+		assert.Contains(t, got, `source.__bruin_previous_hashdiff IS DISTINCT FROM source."hashdiff"`)
+		assert.Contains(t, got, `ON CONFLICT ("customer_hk", "load_dts") DO NOTHING`)
+	})
+
+	t.Run("full refresh keeps Data Vault DDL and load semantics", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.hub_customer",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultHub,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "text", PrimaryKey: true},
+				{Name: "customer_bk", Type: "text"},
+				{Name: "load_dts", Type: "timestamptz"},
+				{Name: "record_source", Type: "text"},
+			},
+		}
+
+		got, err := NewMaterializer(true).Render(asset, "select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, `DROP TABLE IF EXISTS "rdv"."hub_customer";`)
+		assert.Contains(t, got, `CREATE TABLE IF NOT EXISTS "rdv"."hub_customer"`)
+		assert.Contains(t, got, `ON CONFLICT ("customer_hk") DO NOTHING`)
+		assert.NotContains(t, got, `CREATE TABLE "rdv"."hub_customer" AS`)
+	})
+
+	t.Run("requires typed columns", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.hub_customer",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultHub,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", PrimaryKey: true},
+				{Name: "customer_bk", Type: "text"},
+				{Name: "load_dts", Type: "timestamptz"},
+				{Name: "record_source", Type: "text"},
+			},
+		}
+
+		_, err := NewMaterializer(false).Render(asset, "select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `requires column "customer_hk" to have a type`)
+	})
+}
+
 func TestBuildSCD2QueryByTime(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Adds Postgres materialization strategies for Data Vault hubs, links, and satellites.

Includes lint validation, generated SQL tests, and a small lineage builder injection fix found while running the full suite.

Validated with `make format` and `make test`.