### PR TITLE
docs: clarify YAML vs SQL assets and require single-file SQL definitions

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -52,7 +52,7 @@ union all
 select 2 as one
 ```
 
-And here's an equivalent standalone YAML asset (e.g. an ingestr or sensor asset) saved as `<name>.asset.yml`:
+And here's an example of a standalone YAML asset (e.g. an ingestr or sensor asset) saved as `<name>.asset.yml` — a different kind of asset with no inline code body:
 
 ```yaml
 name: raw.hello_external

--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -1,10 +1,18 @@
 # Asset Definition
 
-Assets are defined in a YAML format in the same file as the asset code.
-This enables the metadata to be right next to the code, reducing the friction when things change and encapsulating the relevant details in a single file.
-The definition includes all the details around an asset from its name to the quality checks that will be executed.
+Every Bruin asset has a YAML definition — its name, type, dependencies, columns, quality checks, and so on. How that definition is stored depends on the kind of asset:
 
-Here's an example asset definition:
+- **SQL assets (`.sql`)** embed the definition inside the same file as the query, between `/* @bruin` and `@bruin */` markers. The definition and the SQL query body live together in one `.sql` file.
+- **Python assets (`.py`)** embed the definition the same way, between `""" @bruin` and `@bruin """` markers, inside the same `.py` file as the code.
+- **YAML assets (`<name>.asset.yml` / `<name>.asset.yaml`)** are standalone YAML files that contain only the definition. They are used for asset types that have no inline code body — for example [ingestr](./ingestr.md), [sensor](./sensor.md), [seed](./seed.md), and [dashboard](./dashboard.md) assets.
+
+::: danger
+The definition and the query body of a SQL asset **cannot** be split across two files. A `hello_world.sql` file containing the query plus a sibling `hello_world.asset.yml` containing the definition is **not** a valid pattern — Bruin will treat them as two unrelated assets. For SQL assets, always put the `/* @bruin ... @bruin */` header at the top of the same `.sql` file that contains the query.
+:::
+
+Embedding the metadata next to the code reduces friction when things change and keeps everything for an asset in a single file. The definition includes all the details around an asset from its name to the quality checks that will be executed.
+
+Here's an example SQL asset with an inline definition:
 
 ```bruin-sql
 /* @bruin
@@ -44,12 +52,25 @@ union all
 select 2 as one
 ```
 
+And here's an equivalent standalone YAML asset (e.g. an ingestr or sensor asset) saved as `<name>.asset.yml`:
+
+```yaml
+name: raw.hello_external
+type: ingestr
+owner: my-team@acme-corp.com
+
+parameters:
+  source_connection: my-source
+  source_table: public.hello
+  destination: bigquery
+```
+
 ::: info
 Bruin has [an open-source Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=bruin.bruin) extension that does syntax-highlighting for the definition syntax and more.
 :::
 
 ::: warning
-Assets that are defined as YAML files have to have file names as `<name>.asset.yml` or `<name>.asset.yaml`. The regular `.yml` files are not considered as assets, since they might be configuration used within the repo.
+Standalone YAML assets must use the file name suffix `<name>.asset.yml` or `<name>.asset.yaml`. Plain `.yml` files are ignored, since they are typically configuration kept alongside the repo.
 :::
 
 ## `name`

--- a/docs/assets/sql.md
+++ b/docs/assets/sql.md
@@ -2,7 +2,7 @@
 
 Bruin supports running SQL assets against a variety of data platforms natively.
 
-You can define SQL assets in a file ending with `.sql`:
+A SQL asset is a single file ending in `.sql` that contains **both** the asset definition and the query body. The definition is a YAML block placed at the top of the file between `/* @bruin` and `@bruin */` markers, followed by the SQL query that produces the asset:
 
 ```bruin-sql
 /* @bruin
@@ -23,6 +23,10 @@ select 2 as one
 The `type` key in the configuration defines what platform to run the query against.
 
 You can see the "Data Platforms" on the left sidebar to see supported types.
+
+::: danger
+The definition and the query body of a SQL asset must live in the **same `.sql` file**. You cannot split them — for example, you cannot keep the SQL in `hello_world.sql` and the YAML definition in a sibling `hello_world.asset.yml`. Bruin treats `<name>.asset.yml` files as standalone YAML assets (used for types like [ingestr](./ingestr.md), [sensor](./sensor.md), [seed](./seed.md), and [dashboard](./dashboard.md)), not as companion files to a `.sql` query. If you want a SQL asset, put the `/* @bruin ... @bruin */` header at the top of the `.sql` file containing the query.
+:::
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Rewrites the intro of `docs/assets/definition-schema.md` to explicitly distinguish SQL/Python assets (definition embedded in the same file via the `@bruin` header) from standalone YAML assets (`<name>.asset.yml`/`.asset.yaml`, used for ingestr, sensor, seed, dashboard, etc.).
- Updates `docs/assets/sql.md` to state that a SQL asset's definition and query body live in the same `.sql` file.
- Adds matching `danger` callouts warning that splitting a SQL asset's definition into a sibling `.asset.yml` is not supported — Bruin treats it as an unrelated YAML asset.

## Test plan
- [ ] `npm run docs:dev` and visit `/bruin/assets/sql.html` and `/bruin/assets/definition-schema.html` to confirm rendering of the new callouts and code samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)