### PR TITLE
Support parquet/json/jsonl/ndjson/avro in seed assets

### DIFF
--- a/docs/assets/seed.md
+++ b/docs/assets/seed.md
@@ -1,6 +1,6 @@
 # Seed Assets
 
-Seeds are CSV-files that contain data that is prepared outside of your pipeline that will be loaded into your data platform. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the destination platform accurately.
+Seeds are files that contain data prepared outside of your pipeline and loaded into your data platform. Bruin supports seed assets natively, allowing you to drop a CSV, Parquet, JSON, JSONL/NDJSON or Avro file in your pipeline and load it to the destination accurately.
 
 You can define seed assets in a file ending with `.asset.yml` or `.asset.yaml`:
 
@@ -22,11 +22,27 @@ The `parameters` key in the configuration defines the parameters for the seed as
 
 | Parameter | Required | Default | Description |
 | --- | --- | --- | --- |
-| `path` | Yes | - | Path to the CSV file to load. Can be a relative path (relative to the asset definition file) or a URL pointing to a publicly accessible CSV file. |
-| `enforce_schema` | No | `true` | When `true`, enforces column types defined in the `columns` section. Set to `false` to let ingestr infer types from the CSV. |
+| `path` | Yes | - | Path to the seed file to load. Can be a relative path (relative to the asset definition file) or a URL pointing to a publicly accessible file. |
+| `file_type` | No | inferred from file extension | Explicit format override. One of `csv`, `parquet`, `json`, `jsonl`, `ndjson`, `avro`. Useful when the file has a non-standard extension. |
+| `enforce_schema` | No | `true` | When `true`, enforces column types defined in the `columns` section. Set to `false` to let the loader infer types from the file. |
 
-::: warning Column validation skipped for URLs
-When using a URL path, column validation is skipped during `bruin validate`. Column mismatches will be caught at runtime when `bruin run` fetches the data.
+## Supported file formats
+
+Bruin detects the format from the file extension and selects the appropriate loader:
+
+| Extension | Format |
+| --- | --- |
+| `.csv` | CSV |
+| `.parquet`, `.pq` | Parquet |
+| `.jsonl` | JSONL |
+| `.ndjson` | NDJSON |
+| `.json` | JSON |
+| `.avro` | Avro |
+
+Use `file_type` to override the inferred format, for example when the file has no extension or uses a non-standard one.
+
+::: warning Column validation skipped for non-CSV files and URLs
+For Parquet, JSON, JSONL, NDJSON, Avro and URL-based seeds, column validation is skipped during `bruin validate`. Mismatches are caught at runtime instead.
 :::
 
 ::: tip
@@ -91,6 +107,29 @@ parameters:
 ```
 
 This will download the CSV from the URL and load it into the database at runtime.
+
+### Loading Parquet, JSON, JSONL or Avro
+
+Drop the file in your pipeline and Bruin will pick the right loader from the extension:
+
+```yaml
+name: dashboard.orders
+type: duckdb.seed
+
+parameters:
+    path: orders.parquet
+```
+
+To override the inferred format (for example when a Parquet file is named `data.bin`), set `file_type`:
+
+```yaml
+name: dashboard.orders
+type: duckdb.seed
+
+parameters:
+    path: data.bin
+    file_type: parquet
+```
 
 ### Enforcing column types
 

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -386,6 +386,47 @@ func schemeOf(uri string) string {
 	return parsed.Scheme
 }
 
+// seedFileSchemes maps a file_type / extension token to the URI scheme that
+// gongestr expects for local file sources. Keep the keys lower-case.
+var seedFileSchemes = map[string]string{
+	"csv":     "csv",
+	"parquet": "parquet",
+	"pq":      "parquet",
+	"jsonl":   "jsonl",
+	"ndjson":  "ndjson",
+	"json":    "json",
+	"avro":    "avro",
+}
+
+// resolveSeedSourceURI builds the source URI for a seed asset's local file or
+// passes through an http(s) URL unchanged. The scheme is selected from the
+// explicit file_type parameter when set, otherwise inferred from the file
+// extension; unknown types fall back to csv for backward compatibility.
+func resolveSeedSourceURI(seedPath, fileType, assetDir string) (string, error) {
+	lowerPath := strings.ToLower(seedPath)
+	if strings.HasPrefix(lowerPath, "http://") || strings.HasPrefix(lowerPath, "https://") {
+		return seedPath, nil
+	}
+
+	var scheme string
+	if ft := strings.ToLower(strings.TrimSpace(fileType)); ft != "" {
+		mapped, ok := seedFileSchemes[ft]
+		if !ok {
+			return "", fmt.Errorf("unsupported seed file_type %q (supported: csv, parquet, json, jsonl, ndjson, avro)", fileType)
+		}
+		scheme = mapped
+	} else {
+		ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(seedPath)), ".")
+		mapped, ok := seedFileSchemes[ext]
+		if !ok {
+			mapped = "csv"
+		}
+		scheme = mapped
+	}
+
+	return scheme + "://" + filepath.Join(assetDir, seedPath), nil
+}
+
 func applyClickHouseEngineParams(destURI string, params map[string]string) string {
 	parsedURI, err := url.Parse(destURI)
 	if err != nil {
@@ -455,12 +496,18 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		return errors.New("source connection not configured")
 	}
 
-	var sourceURI string
-	lowerPath := strings.ToLower(sourceConnectionPath)
-	if strings.HasPrefix(lowerPath, "http://") || strings.HasPrefix(lowerPath, "https://") {
-		sourceURI = sourceConnectionPath
-	} else {
-		sourceURI = "csv://" + filepath.Join(filepath.Dir(asset.ExecutableFile.Path), sourceConnectionPath)
+	sourceURI, err := resolveSeedSourceURI(sourceConnectionPath, asset.Parameters["file_type"], filepath.Dir(asset.ExecutableFile.Path))
+	if err != nil {
+		return err
+	}
+
+	if parsedSource, err := url.Parse(sourceURI); err == nil {
+		if _, ok := gongSources[parsedSource.Scheme]; ok {
+			if asset.Parameters == nil {
+				asset.Parameters = make(map[string]string)
+			}
+			asset.Parameters["use_gong"] = "true"
+		}
 	}
 
 	destConnectionName, err := ti.GetPipeline().GetConnectionNameForAsset(asset)

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -503,9 +503,6 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 
 	if parsedSource, err := url.Parse(sourceURI); err == nil {
 		if _, ok := gongSources[parsedSource.Scheme]; ok {
-			if asset.Parameters == nil {
-				asset.Parameters = make(map[string]string)
-			}
 			asset.Parameters["use_gong"] = "true"
 		}
 	}

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -633,6 +633,79 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				"log",
 			},
 		},
+		{
+			name: "parquet seed uses parquet:// scheme",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Type:       pipeline.AssetTypeDuckDBSeed,
+				Parameters: map[string]string{
+					"path": "seed.parquet",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "parquet://seed.parquet", "--source-table", "seed.raw", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "jsonl seed uses jsonl:// scheme",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Type:       pipeline.AssetTypeDuckDBSeed,
+				Parameters: map[string]string{
+					"path": "seed.jsonl",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "jsonl://seed.jsonl", "--source-table", "seed.raw", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "ndjson extension maps to ndjson:// scheme",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Type:       pipeline.AssetTypeDuckDBSeed,
+				Parameters: map[string]string{
+					"path": "seed.ndjson",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "ndjson://seed.ndjson", "--source-table", "seed.raw", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "json seed uses json:// scheme",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Type:       pipeline.AssetTypeDuckDBSeed,
+				Parameters: map[string]string{
+					"path": "seed.json",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "json://seed.json", "--source-table", "seed.raw", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "avro seed uses avro:// scheme",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Type:       pipeline.AssetTypeDuckDBSeed,
+				Parameters: map[string]string{
+					"path": "seed.avro",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "avro://seed.avro", "--source-table", "seed.raw", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "explicit file_type parameter overrides extension",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Type:       pipeline.AssetTypeDuckDBSeed,
+				Parameters: map[string]string{
+					"path":      "seed.dat",
+					"file_type": "parquet",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "parquet://seed.dat", "--source-table", "seed.raw", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -660,6 +733,63 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 
 			err := o.Run(ctx, &ti)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestResolveSeedSourceURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		seedPath  string
+		fileType  string
+		assetDir  string
+		want      string
+		expectErr string
+	}{
+		{name: "csv extension", seedPath: "data.csv", want: "csv://data.csv"},
+		{name: "parquet extension", seedPath: "data.parquet", want: "parquet://data.parquet"},
+		{name: "pq extension maps to parquet", seedPath: "data.pq", want: "parquet://data.pq"},
+		{name: "jsonl extension", seedPath: "data.jsonl", want: "jsonl://data.jsonl"},
+		{name: "ndjson extension", seedPath: "data.ndjson", want: "ndjson://data.ndjson"},
+		{name: "json extension", seedPath: "data.json", want: "json://data.json"},
+		{name: "avro extension", seedPath: "data.avro", want: "avro://data.avro"},
+		{name: "unknown extension falls back to csv", seedPath: "data.dat", want: "csv://data.dat"},
+		{name: "no extension falls back to csv", seedPath: "data", want: "csv://data"},
+		{
+			name:     "explicit file_type overrides extension",
+			seedPath: "data.csv", fileType: "parquet", want: "parquet://data.csv",
+		},
+		{
+			name:     "file_type is case insensitive",
+			seedPath: "data", fileType: "Parquet", want: "parquet://data",
+		},
+		{
+			name:     "asset dir is joined with relative path",
+			seedPath: "seed.parquet", assetDir: "/repo/assets", want: "parquet:///repo/assets/seed.parquet",
+		},
+		{name: "http URL is passed through unchanged", seedPath: "http://example.com/data.parquet", want: "http://example.com/data.parquet"},
+		{name: "https URL is passed through unchanged", seedPath: "https://example.com/data.parquet", want: "https://example.com/data.parquet"},
+		{
+			name:      "invalid file_type returns error",
+			seedPath:  "data.txt",
+			fileType:  "xml",
+			expectErr: "unsupported seed file_type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveSeedSourceURI(tt.seedPath, tt.fileType, tt.assetDir)
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -821,6 +821,11 @@ var gongSources = map[string]bool{
 	"smartsheet":   true,
 	"stripe":       true,
 	"surveymonkey": true,
+	"parquet":      true,
+	"json":         true,
+	"jsonl":        true,
+	"ndjson":       true,
+	"avro":         true,
 }
 
 // gongDestinations is the set of destination schemes that require gong.

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -601,6 +601,13 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 			return issues, nil
 		}
 
+		if !isCSVSeed(seedPath, asset.Parameters["file_type"]) {
+			// For parquet/json/jsonl/ndjson/avro the schema is binary or
+			// semi-structured; column-vs-header validation is left to gongestr
+			// at runtime, just like the URL case above.
+			return issues, nil
+		}
+
 		file, err := os.Open(seedFilePath)
 		if err != nil {
 			issues = append(issues, &Issue{
@@ -636,6 +643,21 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 		}
 	}
 	return issues, nil
+}
+
+// isCSVSeed reports whether the seed should be treated as a CSV file for the
+// purpose of header/column validation. An explicit file_type parameter wins;
+// otherwise the file extension decides.
+func isCSVSeed(seedPath, fileType string) bool {
+	if ft := strings.ToLower(strings.TrimSpace(fileType)); ft != "" {
+		return ft == "csv"
+	}
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(seedPath)), ".")
+	switch ext {
+	case "parquet", "pq", "jsonl", "ndjson", "json", "avro":
+		return false
+	}
+	return true
 }
 
 var arnPattern = regexp.MustCompile(`^arn:[^:\n]*:[^:\n]*:[^:\n]*:[^:\n]*:(?:[^:\/\n]*[:\/])?.*$`)

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -591,6 +591,15 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 			return issues, nil
 		}
 
+		fileType := strings.ToLower(strings.TrimSpace(asset.Parameters["file_type"]))
+		if fileType != "" && !supportedSeedFileTypes[fileType] {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Unsupported seed file_type %q (supported: csv, parquet, pq, json, jsonl, ndjson, avro)", asset.Parameters["file_type"]),
+			})
+			return issues, nil
+		}
+
 		seedFilePath := filepath.Join(filepath.Dir(asset.DefinitionFile.Path), seedPath)
 		_, err := os.Stat(seedFilePath)
 		if os.IsNotExist(err) {
@@ -643,6 +652,18 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 		}
 	}
 	return issues, nil
+}
+
+// supportedSeedFileTypes is the set of valid file_type values for seed assets.
+// Must stay in sync with seedFileSchemes in pkg/ingestr/operator.go.
+var supportedSeedFileTypes = map[string]bool{
+	"csv":     true,
+	"parquet": true,
+	"pq":      true,
+	"jsonl":   true,
+	"ndjson":  true,
+	"json":    true,
+	"avro":    true,
 }
 
 // isCSVSeed reports whether the seed should be treated as a CSV file for the

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3913,6 +3913,31 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 	}
 }
 
+func TestValidateAssetSeedValidation_InvalidFileType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "data.dat"), []byte{}, 0o600))
+
+	asset := &pipeline.Asset{
+		Name: "test_seed",
+		Type: "duckdb.seed",
+		Parameters: map[string]string{
+			"path":      "data.dat",
+			"file_type": "xml",
+		},
+		DefinitionFile: pipeline.TaskDefinitionFile{
+			Path: filepath.Join(tmpDir, "asset.yml"),
+		},
+	}
+
+	issues, err := ValidateAssetSeedValidation(ctx, &pipeline.Pipeline{}, asset)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0].Description, `Unsupported seed file_type "xml"`)
+}
+
 func TestValidateAssetSeedValidation_NonCSVFormats(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3913,6 +3913,60 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 	}
 }
 
+func TestValidateAssetSeedValidation_NonCSVFormats(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	// Create empty placeholder files for each supported non-CSV format. The
+	// validator should not try to parse them as CSV.
+	for _, name := range []string{"data.parquet", "data.jsonl", "data.ndjson", "data.json", "data.avro", "data.dat"} {
+		path := filepath.Join(tmpDir, name)
+		require.NoError(t, os.WriteFile(path, []byte{}, 0o600))
+	}
+
+	tests := []struct {
+		name     string
+		seedPath string
+		fileType string
+	}{
+		{name: "parquet skips CSV header check", seedPath: "data.parquet"},
+		{name: "jsonl skips CSV header check", seedPath: "data.jsonl"},
+		{name: "ndjson skips CSV header check", seedPath: "data.ndjson"},
+		{name: "json skips CSV header check", seedPath: "data.json"},
+		{name: "avro skips CSV header check", seedPath: "data.avro"},
+		{name: "file_type=parquet on .dat skips CSV header check", seedPath: "data.dat", fileType: "parquet"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			asset := &pipeline.Asset{
+				Name: "test_seed",
+				Type: "duckdb.seed",
+				Parameters: map[string]string{
+					"path": tt.seedPath,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id"},
+					{Name: "name"},
+				},
+				DefinitionFile: pipeline.TaskDefinitionFile{
+					Path: filepath.Join(tmpDir, "asset.yml"),
+				},
+			}
+			if tt.fileType != "" {
+				asset.Parameters["file_type"] = tt.fileType
+			}
+
+			issues, err := ValidateAssetSeedValidation(ctx, &pipeline.Pipeline{}, asset)
+			require.NoError(t, err)
+			assert.Empty(t, issues, "non-CSV seeds should not produce header/column issues")
+		})
+	}
+}
+
 func TestValidateTableSensorTableParameter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Route seed asset local files to the appropriate gongestr scheme based on file extension (`.csv`, `.parquet`/`.pq`, `.jsonl`, `.ndjson`, `.json`, `.avro`), with an optional `file_type` parameter to override inference.
- Auto-enable gong for non-csv schemes (added them to `gongSources`), since these sources only exist in gongestr.
- Skip CSV header/column validation in the lint rule for non-CSV seeds (delegated to runtime, mirroring the URL case), and document the new formats and `file_type` parameter.

Closes [BRU-3650](https://linear.app/bruin/issue/BRU-3650/seed-assets-to-support-parquetjsonavro-files).

## Test plan
- [x] `make format` clean (lint baseline unchanged)
- [x] `make test` passes including new `TestResolveSeedSourceURI`, expanded `TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand`, and `TestValidateAssetSeedValidation_NonCSVFormats`
- [ ] Manual end-to-end run of a `duckdb.seed` against a `.parquet` file once gongestr release is wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)