### PR TITLE
patch: add --connection flag to fill-columns-from-db

### DIFF
--- a/cmd/enhance.go
+++ b/cmd/enhance.go
@@ -396,7 +396,7 @@ func enhanceSingleAsset(ctx context.Context, c *cli.Command, assetPath string, f
 		if pp.Asset.Name != "" {
 			logPrefix = pp.Asset.Name
 		}
-		status, fillErr := fillColumnsFromDB(pp, fs, c.String("environment"), nil) //nolint:contextcheck
+		status, fillErr := fillColumnsFromDB(pp, fs, c.String("environment"), "", nil) //nolint:contextcheck
 		if fillErr != nil && !quiet && output != "json" {
 			warningPrinter.Printf("[%s] Warning: fill columns failed: %v\n", logPrefix, fillErr)
 		} else if status == fillStatusUpdated && !quiet && output != "json" {

--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/mssql"
@@ -65,14 +66,18 @@ func updateAssetDependencies(ctx context.Context, asset *pipeline.Asset, p *pipe
 }
 
 // Returns: status ("updated", "skipped", "failed").
-func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment string, manager config.ConnectionGetter) (string, error) {
+func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride string, manager config.ConnectionGetter) (string, error) {
 	var conn interface{}
 	var err error
 
-	if manager != nil {
-		connName, err := pp.Pipeline.GetConnectionNameForAsset(pp.Asset)
-		if err != nil {
-			return fillStatusFailed, err
+	switch {
+	case manager != nil:
+		connName := connectionOverride
+		if connName == "" {
+			connName, err = pp.Pipeline.GetConnectionNameForAsset(pp.Asset)
+			if err != nil {
+				return fillStatusFailed, err
+			}
 		}
 
 		conn = manager.GetConnection(connName)
@@ -87,7 +92,29 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment string, manager conf
 				},
 			)
 		}
-	} else {
+	case connectionOverride != "":
+		if environment != "" {
+			if err := pp.Config.SelectEnvironment(environment); err != nil {
+				return fillStatusFailed, errors.Wrapf(err, "failed to use the environment '%s'", environment)
+			}
+		}
+		m, errs := connection.NewManagerFromConfigWithContext(context.Background(), pp.Config)
+		if len(errs) > 0 {
+			return fillStatusFailed, errors.Wrap(errs[0], "failed to create connection manager")
+		}
+		conn = m.GetConnection(connectionOverride)
+		if conn == nil {
+			return fillStatusFailed, fmt.Errorf(
+				"failed to get connection for asset '%s': %w",
+				pp.Asset.Name,
+				&config.MissingConnectionError{
+					Name:            connectionOverride,
+					ConfigFilePath:  pp.Config.Path(),
+					EnvironmentName: pp.Config.SelectedEnvironmentName,
+				},
+			)
+		}
+	default:
 		_, conn, err = getConnectionFromPipelineInfoWithContext(context.Background(), pp, environment)
 		if err != nil {
 			return fillStatusFailed, fmt.Errorf("failed to get connection for asset '%s': %w", pp.Asset.Name, err)
@@ -364,6 +391,11 @@ func Patch() *cli.Command {
 						Aliases: []string{"env"},
 						Usage:   "Target environment name as defined in .bruin.yml.",
 					},
+					&cli.StringFlag{
+						Name:    "connection",
+						Aliases: []string{"c"},
+						Usage:   "Override the connection used to read the schema (defaults to the asset's destination connection).",
+					},
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					inputPath := c.Args().First()
@@ -373,6 +405,7 @@ func Patch() *cli.Command {
 
 					output := c.String("output")
 					environment := c.String("environment")
+					connectionOverride := c.String("connection")
 					fs := afero.NewOsFs()
 					// ctx is already available from function signature
 
@@ -383,7 +416,7 @@ func Patch() *cli.Command {
 							printErrorForOutput(output, err)
 							return cli.Exit("", 1)
 						}
-						status, err := fillColumnsFromDB(pp, fs, environment, nil) //nolint:contextcheck
+						status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, nil) //nolint:contextcheck
 						if err != nil {
 							printErrorForOutput(output, fmt.Errorf("failed to fill columns from DB for asset '%s': %w", pp.Asset.Name, err))
 							return cli.Exit("", 1)
@@ -426,7 +459,7 @@ func Patch() *cli.Command {
 
 						for _, asset := range foundPipeline.Assets {
 							pp := &ppInfo{Pipeline: foundPipeline, Asset: asset, Config: cm}
-							status, err := fillColumnsFromDB(pp, fs, environment, nil) //nolint:contextcheck
+							status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, nil) //nolint:contextcheck
 							processedAssets++
 							assetName := asset.Name
 							switch status {

--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -65,13 +65,29 @@ func updateAssetDependencies(ctx context.Context, asset *pipeline.Asset, p *pipe
 	return nil
 }
 
+// buildOverrideManager builds a connection manager scoped to the given environment.
+// It's invoked once per `bruin patch fill-columns-from-db --connection ...` invocation
+// (before any per-asset loop) so that we don't re-initialise every configured connection
+// for each asset in a pipeline.
+func buildOverrideManager(ctx context.Context, cfg *config.Config, environment string) (config.ConnectionGetter, error) {
+	if environment != "" {
+		if err := cfg.SelectEnvironment(environment); err != nil {
+			return nil, errors.Wrapf(err, "failed to use the environment '%s'", environment)
+		}
+	}
+	m, errs := connection.NewManagerFromConfigWithContext(ctx, cfg)
+	if len(errs) > 0 {
+		return nil, errors.Wrap(errs[0], "failed to create connection manager")
+	}
+	return m, nil
+}
+
 // Returns: status ("updated", "skipped", "failed").
 func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride string, manager config.ConnectionGetter) (string, error) {
 	var conn interface{}
 	var err error
 
-	switch {
-	case manager != nil:
+	if manager != nil {
 		connName := connectionOverride
 		if connName == "" {
 			connName, err = pp.Pipeline.GetConnectionNameForAsset(pp.Asset)
@@ -92,29 +108,7 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride 
 				},
 			)
 		}
-	case connectionOverride != "":
-		if environment != "" {
-			if err := pp.Config.SelectEnvironment(environment); err != nil {
-				return fillStatusFailed, errors.Wrapf(err, "failed to use the environment '%s'", environment)
-			}
-		}
-		m, errs := connection.NewManagerFromConfigWithContext(context.Background(), pp.Config)
-		if len(errs) > 0 {
-			return fillStatusFailed, errors.Wrap(errs[0], "failed to create connection manager")
-		}
-		conn = m.GetConnection(connectionOverride)
-		if conn == nil {
-			return fillStatusFailed, fmt.Errorf(
-				"failed to get connection for asset '%s': %w",
-				pp.Asset.Name,
-				&config.MissingConnectionError{
-					Name:            connectionOverride,
-					ConfigFilePath:  pp.Config.Path(),
-					EnvironmentName: pp.Config.SelectedEnvironmentName,
-				},
-			)
-		}
-	default:
+	} else {
 		_, conn, err = getConnectionFromPipelineInfoWithContext(context.Background(), pp, environment)
 		if err != nil {
 			return fillStatusFailed, fmt.Errorf("failed to get connection for asset '%s': %w", pp.Asset.Name, err)
@@ -416,7 +410,15 @@ func Patch() *cli.Command {
 							printErrorForOutput(output, err)
 							return cli.Exit("", 1)
 						}
-						status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, nil) //nolint:contextcheck
+						var overrideManager config.ConnectionGetter
+						if connectionOverride != "" {
+							overrideManager, err = buildOverrideManager(ctx, pp.Config, environment)
+							if err != nil {
+								printErrorForOutput(output, err)
+								return cli.Exit("", 1)
+							}
+						}
+						status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, overrideManager) //nolint:contextcheck
 						if err != nil {
 							printErrorForOutput(output, fmt.Errorf("failed to fill columns from DB for asset '%s': %w", pp.Asset.Name, err))
 							return cli.Exit("", 1)
@@ -451,6 +453,14 @@ func Patch() *cli.Command {
 							printErrorForOutput(output, fmt.Errorf("failed to load the config file: %w", err))
 							return cli.Exit("", 1)
 						}
+						var overrideManager config.ConnectionGetter
+						if connectionOverride != "" {
+							overrideManager, err = buildOverrideManager(ctx, cm, environment)
+							if err != nil {
+								printErrorForOutput(output, err)
+								return cli.Exit("", 1)
+							}
+						}
 						updatedAssets := []string{}
 						skippedAssets := []string{}
 						failedAssets := []string{}
@@ -459,7 +469,7 @@ func Patch() *cli.Command {
 
 						for _, asset := range foundPipeline.Assets {
 							pp := &ppInfo{Pipeline: foundPipeline, Asset: asset, Config: cm}
-							status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, nil) //nolint:contextcheck
+							status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, overrideManager) //nolint:contextcheck
 							processedAssets++
 							assetName := asset.Name
 							switch status {

--- a/cmd/patch_test.go
+++ b/cmd/patch_test.go
@@ -233,7 +233,7 @@ func TestFillColumnsFromDB(t *testing.T) {
 			fs := afero.NewMemMapFs()
 
 			// Execute the function with mock manager
-			status, err := fillColumnsFromDB(pp, fs, "test", mockManager)
+			status, err := fillColumnsFromDB(pp, fs, "test", "", mockManager)
 
 			// Verify results
 			if tt.expectError {
@@ -251,4 +251,72 @@ func TestFillColumnsFromDB(t *testing.T) {
 			mockManager.AssertExpectations(t)
 		})
 	}
+}
+
+func TestFillColumnsFromDB_ConnectionOverride(t *testing.T) {
+	t.Parallel()
+
+	mockConn := new(MockConnection)
+	mockConn.On("SelectWithSchema", mock.Anything, mock.Anything).Return(&query.QueryResult{
+		Columns:     []string{"id", "name"},
+		ColumnTypes: []string{"INTEGER", "STRING"},
+	}, nil)
+
+	mockManager := new(MockConnectionManager)
+	// Override should bypass the asset's destination connection and use the override name.
+	mockManager.On("GetConnection", "source_connection").Return(mockConn, nil)
+
+	asset := &pipeline.Asset{
+		Name:       "test_asset",
+		Columns:    []pipeline.Column{},
+		Type:       pipeline.AssetTypePostgresQuery,
+		Connection: "destination_connection",
+	}
+
+	pp := &ppInfo{
+		Asset: asset,
+		Pipeline: &pipeline.Pipeline{
+			Name: "test_pipeline",
+		},
+		Config: &config.Config{},
+	}
+
+	fs := afero.NewMemMapFs()
+
+	status, err := fillColumnsFromDB(pp, fs, "", "source_connection", mockManager)
+	require.NoError(t, err)
+	assert.Equal(t, fillStatusUpdated, status)
+	assert.Equal(t, []pipeline.Column{
+		{Name: "id", Type: "INTEGER", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
+		{Name: "name", Type: "STRING", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
+	}, asset.Columns)
+
+	mockConn.AssertExpectations(t)
+	mockManager.AssertExpectations(t)
+}
+
+func TestFillColumnsFromDB_ConnectionOverrideMissing(t *testing.T) {
+	t.Parallel()
+
+	mockManager := new(MockConnectionManager)
+	mockManager.On("GetConnection", "missing_connection").Return(nil, nil)
+
+	asset := &pipeline.Asset{
+		Name:       "test_asset",
+		Type:       pipeline.AssetTypePostgresQuery,
+		Connection: "destination_connection",
+	}
+
+	pp := &ppInfo{
+		Asset:    asset,
+		Pipeline: &pipeline.Pipeline{Name: "test_pipeline"},
+		Config:   &config.Config{},
+	}
+
+	status, err := fillColumnsFromDB(pp, afero.NewMemMapFs(), "", "missing_connection", mockManager)
+	require.Error(t, err)
+	assert.Equal(t, fillStatusFailed, status)
+	assert.Contains(t, err.Error(), "missing_connection")
+
+	mockManager.AssertExpectations(t)
 }

--- a/cmd/patch_test.go
+++ b/cmd/patch_test.go
@@ -253,6 +253,10 @@ func TestFillColumnsFromDB(t *testing.T) {
 	}
 }
 
+// TestFillColumnsFromDB_ConnectionOverride exercises the production path the CLI
+// uses for `--connection`: the action layer builds the manager once, then passes
+// it together with the override name into fillColumnsFromDB. The override must
+// take precedence over the asset's destination connection.
 func TestFillColumnsFromDB_ConnectionOverride(t *testing.T) {
 	t.Parallel()
 
@@ -263,8 +267,9 @@ func TestFillColumnsFromDB_ConnectionOverride(t *testing.T) {
 	}, nil)
 
 	mockManager := new(MockConnectionManager)
-	// Override should bypass the asset's destination connection and use the override name.
 	mockManager.On("GetConnection", "source_connection").Return(mockConn, nil)
+	// The destination connection must never be looked up when --connection is set.
+	mockManager.AssertNotCalled(t, "GetConnection", "destination_connection")
 
 	asset := &pipeline.Asset{
 		Name:       "test_asset",
@@ -274,16 +279,12 @@ func TestFillColumnsFromDB_ConnectionOverride(t *testing.T) {
 	}
 
 	pp := &ppInfo{
-		Asset: asset,
-		Pipeline: &pipeline.Pipeline{
-			Name: "test_pipeline",
-		},
-		Config: &config.Config{},
+		Asset:    asset,
+		Pipeline: &pipeline.Pipeline{Name: "test_pipeline"},
+		Config:   &config.Config{},
 	}
 
-	fs := afero.NewMemMapFs()
-
-	status, err := fillColumnsFromDB(pp, fs, "", "source_connection", mockManager)
+	status, err := fillColumnsFromDB(pp, afero.NewMemMapFs(), "", "source_connection", mockManager)
 	require.NoError(t, err)
 	assert.Equal(t, fillStatusUpdated, status)
 	assert.Equal(t, []pipeline.Column{
@@ -295,6 +296,10 @@ func TestFillColumnsFromDB_ConnectionOverride(t *testing.T) {
 	mockManager.AssertExpectations(t)
 }
 
+// TestFillColumnsFromDB_ConnectionOverrideMissing covers the failure case where
+// the user passes a connection name that doesn't exist. The action layer builds
+// the manager fine (the name is only invalid at lookup time), so the error must
+// surface from fillColumnsFromDB with the override name in the message.
 func TestFillColumnsFromDB_ConnectionOverrideMissing(t *testing.T) {
 	t.Parallel()
 
@@ -319,4 +324,23 @@ func TestFillColumnsFromDB_ConnectionOverrideMissing(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing_connection")
 
 	mockManager.AssertExpectations(t)
+}
+
+// TestBuildOverrideManager_UnknownEnvironment makes sure the CLI action gives a
+// useful error when --environment names a missing environment, instead of
+// silently proceeding with the default. This is the only code path that runs
+// before fillColumnsFromDB, so it's worth covering here.
+func TestBuildOverrideManager_UnknownEnvironment(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		DefaultEnvironmentName: "default",
+		Environments: map[string]config.Environment{
+			"default": {Connections: &config.Connections{}},
+		},
+	}
+
+	_, err := buildOverrideManager(t.Context(), cfg, "does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
 }

--- a/docs/commands/patch.md
+++ b/docs/commands/patch.md
@@ -46,6 +46,7 @@ Retrieves column metadata from the database and updates the asset's column defin
 |----------------------|-------|-----------------------------------------------------------------------------|
 | `--output [format]`  | `-o`  | Specifies the output type, possible values: `plain`, `json`. Default: `plain` |
 | `--environment`      | `-e`  | Target environment name as defined in .bruin.yml                            |
+| `--connection`       | `-c`  | Override the connection used to read the schema. Defaults to the asset's destination connection. Useful when you want to seed columns from a source database (e.g. when copying MSSQL → MSSQL and you want to clone the source table's schema). |
 
 **Example:**
 
@@ -55,6 +56,9 @@ bruin patch fill-columns-from-db path/to/asset.yml
 
 # Update columns for all assets in a pipeline
 bruin patch fill-columns-from-db path/to/pipeline 
+
+# Fill columns from a specific connection (e.g. the source database)
+bruin patch fill-columns-from-db --connection my_postgres path/to/asset.yml
 ```
 
 **Example output (JSON):**


### PR DESCRIPTION
## Summary

- Adds a `--connection` / `-c` flag to `bruin patch fill-columns-from-db` so users can override which connection the schema is read from. Defaults to the asset's destination connection (existing behavior unchanged).
- Unblocks BRU-4473: VSCode wants to add a "Fill from source DB" action so users copying e.g. MSSQL → MSSQL can clone the source table's schema without first hand-editing `pipeline.yml`.
- The flag is intentionally a generic connection name rather than `--use-source-connection` — that keeps the CLI primitive simple and lets the VSCode side resolve "source" however it likes (ingestr's `source_connection`, a sole upstream's connection, or a user-picked one).

## What changed

- `cmd/patch.go`: new flag, threaded through both the single-asset and pipeline-path action branches. When `--connection` is set without a pre-built manager, `fillColumnsFromDB` now builds one from `pp.Config` (after applying `--environment`) and looks up the named connection — missing names produce a clear `MissingConnectionError`. The existing `SelectWithSchema` assertion still validates that whatever connection was chosen supports schema introspection.
- `cmd/enhance.go`: one existing caller updated to pass `""` for the new arg (default behavior).
- `cmd/patch_test.go`: two new tests — one for the override happy path, one for the missing-connection failure mode.
- `docs/commands/patch.md`: documented the new flag with a source-DB example.

## Test plan

- [x] `make test` passes (cmd tests included).
- [x] Manual end-to-end with two DuckDB connections (`duckdb-source` + `duckdb-dest`) seeded with distinct schemas — confirmed the asset gets the source schema when `--connection duckdb-source` is passed and the destination schema when no flag is passed.
- [ ] Manual smoke against real source/destination connections (e.g. Postgres source → BigQuery destination) — optional, identical code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)