### PR TITLE
Improve connections CLI ergonomics

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	path2 "path"
@@ -401,8 +402,9 @@ func printErrorForOutput(output string, err error) {
 
 func PingConnection() *cli.Command {
 	return &cli.Command{
-		Name:  "test",
-		Usage: "Test the validity of a connection in an environment",
+		Name:      "test",
+		Usage:     "Test the validity of a connection in an environment",
+		ArgsUsage: "[connection name]",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "environment",
@@ -415,10 +417,9 @@ func PingConnection() *cli.Command {
 				Hidden: true,
 			},
 			&cli.StringFlag{
-				Name:     "name",
-				Aliases:  []string{"n"},
-				Usage:    "the name of the connection to test",
-				Required: true,
+				Name:    "name",
+				Aliases: []string{"n", "connection", "c"},
+				Usage:   "the name of the connection to test",
 			},
 			&cli.StringFlag{
 				Name:        "output",
@@ -436,7 +437,14 @@ func PingConnection() *cli.Command {
 			// Extract command-line arguments
 			environment := c.String("environment")
 			name := c.String("name")
+			if name == "" {
+				name = c.Args().Get(0)
+			}
 			output := c.String("output")
+			if name == "" {
+				printErrorForOutput(output, errors.New("connection name is required"))
+				return cli.Exit("", 1)
+			}
 
 			repoRoot, err := git.FindRepoFromPath(".")
 			if err != nil {

--- a/cmd/connections_add_tui.go
+++ b/cmd/connections_add_tui.go
@@ -75,8 +75,9 @@ type addConnectionModel struct {
 	step int
 
 	// Step 0: environment selection
-	envList list.Model
-	envs    []string
+	envList          list.Model
+	envs             []string
+	skipEnvSelection bool
 
 	// Step 1: name input
 	nameInput textinput.Model
@@ -117,6 +118,11 @@ func newAddConnectionModel(cfg *config.Config) addConnectionModel {
 	envs := cfg.GetEnvironmentNames()
 	sort.Strings(envs)
 	m.envs = envs
+	if len(envs) == 1 {
+		m.step = stepEnterName
+		m.environment = envs[0]
+		m.skipEnvSelection = true
+	}
 
 	items := make([]list.Item, len(envs))
 	for i, e := range envs {
@@ -133,6 +139,9 @@ func newAddConnectionModel(cfg *config.Config) addConnectionModel {
 	m.nameInput = textinput.New()
 	m.nameInput.Placeholder = "my-connection"
 	m.nameInput.CharLimit = 128
+	if m.skipEnvSelection {
+		m.nameInput.Focus()
+	}
 
 	// Step 2: type list
 	typeNames := config.GetConnectionTypeNames()
@@ -216,6 +225,9 @@ func (m addConnectionModel) updateEnterName(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
 		case "esc":
+			if m.skipEnvSelection {
+				return m, nil
+			}
 			m.step = stepSelectEnv
 			m.nameErr = ""
 			return m, nil

--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/config"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
 
 // Test config constants.
@@ -298,6 +300,43 @@ func TestAddConnectionCommand_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewAddConnectionModel_SkipsEnvironmentSelectionForSingleEnvironment(t *testing.T) {
+	t.Parallel()
+
+	fs, configFile := setupTestConfig(t, emptyConfig)
+	cm, err := config.LoadOrCreate(fs, configFile)
+	require.NoError(t, err)
+
+	model := newAddConnectionModel(cm)
+
+	assert.Equal(t, stepEnterName, model.step)
+	assert.Equal(t, "dev", model.environment)
+	assert.True(t, model.skipEnvSelection)
+	assert.True(t, model.nameInput.Focused())
+	assert.NotContains(t, model.View(), "Select environment")
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, ok := updated.(addConnectionModel)
+	require.True(t, ok)
+	assert.Equal(t, stepEnterName, updatedModel.step)
+}
+
+func TestNewAddConnectionModel_ShowsEnvironmentSelectionForMultipleEnvironments(t *testing.T) {
+	t.Parallel()
+
+	fs, configFile := setupTestConfig(t, testConfigWithConnections)
+	cm, err := config.LoadOrCreate(fs, configFile)
+	require.NoError(t, err)
+
+	model := newAddConnectionModel(cm)
+
+	assert.Equal(t, stepSelectEnv, model.step)
+	assert.Empty(t, model.environment)
+	assert.False(t, model.skipEnvSelection)
+	assert.False(t, model.nameInput.Focused())
+	assert.Contains(t, model.View(), "Select environment")
 }
 
 func TestListConnectionsCommand_Run(t *testing.T) {
@@ -727,6 +766,27 @@ func TestPingConnectionCommand_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPingConnectionCommand_AcceptsConnectionNameArgumentAndAliases(t *testing.T) {
+	t.Parallel()
+
+	command := PingConnection()
+
+	assert.Equal(t, "[connection name]", command.ArgsUsage)
+
+	var nameFlag *cli.StringFlag
+	for _, flag := range command.Flags {
+		stringFlag, ok := flag.(*cli.StringFlag)
+		if ok && stringFlag.Name == "name" {
+			nameFlag = stringFlag
+			break
+		}
+	}
+
+	require.NotNil(t, nameFlag)
+	assert.False(t, nameFlag.Required)
+	assert.ElementsMatch(t, []string{"n", "connection", "c"}, nameFlag.Aliases)
 }
 
 func TestConnectionsCommand_ListConnections(t *testing.T) {


### PR DESCRIPTION
Updates connections add to skip the environment picker when only one environment exists. Allows connections test to take the connection name positionally while keeping --name and adding --connection/-c aliases. Validated with make format and make test.