### PR TITLE
Fix Postgres import column metadata

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -354,6 +354,25 @@ func resolvePipelinePath(pipelinePath string) string {
 }
 
 func fillAssetColumnsFromDB(ctx context.Context, asset *pipeline.Asset, conn interface{}, schemaName, tableName string) error {
+	// Prefer database-native column metadata when available. PostgreSQL supports
+	// this through information_schema, which avoids relying on SELECT field
+	// descriptions that are not always returned by the driver.
+	if columnFetcher, ok := conn.(interface {
+		GetColumnsForTable(ctx context.Context, schemaName, tableName string) ([]*ansisql.DBColumn, error)
+	}); ok {
+		dbColumns, err := columnFetcher.GetColumnsForTable(ctx, schemaName, tableName)
+		if err != nil {
+			return errors2.Wrapf(err, "failed to query columns for table %s.%s", schemaName, tableName)
+		}
+		if len(dbColumns) == 0 {
+			return fmt.Errorf("no columns found for table %s.%s", schemaName, tableName)
+		}
+
+		columnDescriptions := fetchColumnDescriptions(ctx, conn, schemaName, tableName)
+		asset.Columns = buildPipelineColumns(dbColumns, columnDescriptions)
+		return nil
+	}
+
 	// Check if connection supports schema introspection
 	querier, ok := conn.(interface {
 		SelectWithSchema(ctx context.Context, q *query.Query) (*query.QueryResult, error)
@@ -420,6 +439,36 @@ func fillAssetColumnsFromDB(ctx context.Context, asset *pipeline.Asset, conn int
 
 	asset.Columns = columns
 	return nil
+}
+
+func buildPipelineColumns(dbColumns []*ansisql.DBColumn, columnDescriptions map[string]string) []pipeline.Column {
+	skipColumns := map[string]bool{
+		"_IS_CURRENT":  true,
+		"_VALID_UNTIL": true,
+		"_VALID_FROM":  true,
+	}
+
+	columns := make([]pipeline.Column, 0, len(dbColumns))
+	for _, col := range dbColumns {
+		if skipColumns[col.Name] {
+			continue
+		}
+
+		description := col.Description
+		if description == "" {
+			description = columnDescriptions[col.Name]
+		}
+
+		columns = append(columns, pipeline.Column{
+			Name:        col.Name,
+			Type:        col.Type,
+			Description: description,
+			Checks:      []pipeline.ColumnCheck{},
+			Upstreams:   []*pipeline.UpstreamColumn{},
+		})
+	}
+
+	return columns
 }
 
 // fetchColumnDescriptions fetches column descriptions from the database's information schema.

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -484,58 +484,13 @@ func fetchColumnDescriptions(ctx context.Context, conn interface{}, schemaName, 
 		return descriptions
 	}
 
-	var queryStr string
-
-	// Build database-specific query for column descriptions
-	switch conn.(type) {
-	case *postgres.Client:
-		// PostgreSQL: Query pg_description for column comments
-		queryStr = fmt.Sprintf(`
-SELECT 
-    a.attname as column_name,
-    pg_catalog.col_description(a.attrelid, a.attnum) as column_description
-FROM 
-    pg_catalog.pg_attribute a
-JOIN 
-    pg_catalog.pg_class c ON a.attrelid = c.oid
-JOIN 
-    pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-WHERE 
-    n.nspname = '%s'
-    AND c.relname = '%s'
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND pg_catalog.col_description(a.attrelid, a.attnum) IS NOT NULL
-`, schemaName, tableName)
-
-	case *mssql.DB:
-		// MSSQL: Query extended properties for column descriptions
-		queryStr = fmt.Sprintf(`
-SELECT 
-    c.name AS column_name,
-    CAST(ep.value AS NVARCHAR(MAX)) AS column_description
-FROM 
-    sys.columns c
-JOIN 
-    sys.tables t ON c.object_id = t.object_id
-JOIN 
-    sys.schemas s ON t.schema_id = s.schema_id
-LEFT JOIN 
-    sys.extended_properties ep ON c.object_id = ep.major_id 
-    AND c.column_id = ep.minor_id 
-    AND ep.name = 'MS_Description'
-WHERE 
-    s.name = '%s'
-    AND t.name = '%s'
-    AND ep.value IS NOT NULL
-`, schemaName, tableName)
-
-	default:
+	queryObj, ok := columnDescriptionQuery(conn, schemaName, tableName)
+	if !ok {
 		// For other databases, we don't have a standard way to fetch column descriptions
 		return descriptions
 	}
 
-	result, err := selector.Select(ctx, &query.Query{Query: queryStr})
+	result, err := selector.Select(ctx, queryObj)
 	if err != nil {
 		// Silently ignore errors - column descriptions are optional
 		return descriptions
@@ -552,6 +507,62 @@ WHERE
 	}
 
 	return descriptions
+}
+
+func columnDescriptionQuery(conn interface{}, schemaName, tableName string) (*query.Query, bool) {
+	// Build database-specific query for column descriptions
+	switch conn.(type) {
+	case *postgres.Client:
+		// PostgreSQL: Query pg_description for column comments
+		return &query.Query{
+			Query: `
+SELECT 
+    a.attname as column_name,
+    pg_catalog.col_description(a.attrelid, a.attnum) as column_description
+FROM 
+    pg_catalog.pg_attribute a
+JOIN 
+    pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN 
+    pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE 
+    n.nspname = $1
+    AND c.relname = $2
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+    AND pg_catalog.col_description(a.attrelid, a.attnum) IS NOT NULL
+`,
+			Args: []any{schemaName, tableName},
+		}, true
+
+	case *mssql.DB:
+		// MSSQL: Query extended properties for column descriptions
+		return &query.Query{
+			Query: `
+SELECT 
+    c.name AS column_name,
+    CAST(ep.value AS NVARCHAR(MAX)) AS column_description
+FROM 
+    sys.columns c
+JOIN 
+    sys.tables t ON c.object_id = t.object_id
+JOIN 
+    sys.schemas s ON t.schema_id = s.schema_id
+LEFT JOIN 
+    sys.extended_properties ep ON c.object_id = ep.major_id 
+    AND c.column_id = ep.minor_id 
+    AND ep.name = 'MS_Description'
+WHERE 
+    s.name = @p1
+    AND t.name = @p2
+    AND ep.value IS NOT NULL
+`,
+			Args: []any{schemaName, tableName},
+		}, true
+
+	default:
+		return nil, false
+	}
 }
 
 func createAsset(ctx context.Context, assetsPath, schemaName, tableName string, assetType pipeline.AssetType, conn interface{}, fillColumns bool, table *ansisql.DBTable) (*pipeline.Asset, string) {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -52,6 +52,15 @@ func (m *mockConnectionNoSchema) GetDatabases(ctx context.Context) ([]string, er
 	return args.Get(0).([]string), args.Error(1)
 }
 
+type mockColumnMetadataConnection struct {
+	mock.Mock
+}
+
+func (m *mockColumnMetadataConnection) GetColumnsForTable(ctx context.Context, schemaName, tableName string) ([]*ansisql.DBColumn, error) {
+	args := m.Called(ctx, schemaName, tableName)
+	return args.Get(0).([]*ansisql.DBColumn), args.Error(1)
+}
+
 // nolint
 func TestCreateAsset(t *testing.T) {
 	t.Parallel()
@@ -434,6 +443,27 @@ func TestFillAssetColumnsFromDB(t *testing.T) {
 			},
 		},
 		{
+			name: "uses metadata column fetcher when available",
+			setupConn: func() interface{} {
+				conn := &mockColumnMetadataConnection{}
+				conn.On("GetColumnsForTable", mock.Anything, "test_schema", "test_table").Return([]*ansisql.DBColumn{
+					{Name: "id", Type: "integer"},
+					{Name: "_IS_CURRENT", Type: "boolean"},
+					{Name: "name", Type: "text", Description: "Customer name"},
+				}, nil)
+				return conn
+			},
+			setupAsset: func() *pipeline.Asset {
+				return &pipeline.Asset{Name: "test_asset"}
+			},
+			schemaName: "test_schema",
+			tableName:  "test_table",
+			wantCols: []pipeline.Column{
+				{Name: "id", Type: "integer", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
+				{Name: "name", Type: "text", Description: "Customer name", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
+			},
+		},
+		{
 			name: "connection doesn't support schema introspection",
 			setupConn: func() interface{} {
 				// Return a connection that doesn't implement SelectWithSchema
@@ -521,6 +551,9 @@ func TestFillAssetColumnsFromDB(t *testing.T) {
 
 			// Only assert expectations for mockConnection, not mockConnectionNoSchema
 			if mockConn, ok := conn.(*mockConnection); ok {
+				mockConn.AssertExpectations(t)
+			}
+			if mockConn, ok := conn.(*mockColumnMetadataConnection); ok {
 				mockConn.AssertExpectations(t)
 			}
 		})

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -58,7 +58,10 @@ type mockColumnMetadataConnection struct {
 
 func (m *mockColumnMetadataConnection) GetColumnsForTable(ctx context.Context, schemaName, tableName string) ([]*ansisql.DBColumn, error) {
 	args := m.Called(ctx, schemaName, tableName)
-	return args.Get(0).([]*ansisql.DBColumn), args.Error(1)
+	if v := args.Get(0); v != nil {
+		return v.([]*ansisql.DBColumn), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 // nolint
@@ -464,6 +467,20 @@ func TestFillAssetColumnsFromDB(t *testing.T) {
 			},
 		},
 		{
+			name: "metadata column fetcher error with nil columns",
+			setupConn: func() interface{} {
+				conn := &mockColumnMetadataConnection{}
+				conn.On("GetColumnsForTable", mock.Anything, "test_schema", "test_table").Return(nil, errors.New("metadata failed"))
+				return conn
+			},
+			setupAsset: func() *pipeline.Asset {
+				return &pipeline.Asset{Name: "test_asset"}
+			},
+			schemaName: "test_schema",
+			tableName:  "test_table",
+			wantErr:    "failed to query columns for table test_schema.test_table",
+		},
+		{
 			name: "connection doesn't support schema introspection",
 			setupConn: func() interface{} {
 				// Return a connection that doesn't implement SelectWithSchema
@@ -556,6 +573,47 @@ func TestFillAssetColumnsFromDB(t *testing.T) {
 			if mockConn, ok := conn.(*mockColumnMetadataConnection); ok {
 				mockConn.AssertExpectations(t)
 			}
+		})
+	}
+}
+
+func TestColumnDescriptionQuery(t *testing.T) {
+	t.Parallel()
+
+	schemaName := "hw'; DROP TABLE important; --"
+	tableName := "staging_honor_event'; DROP TABLE events; --"
+
+	tests := []struct {
+		name             string
+		conn             interface{}
+		wantSchemaMarker string
+		wantTableMarker  string
+	}{
+		{
+			name:             "postgres uses bind args",
+			conn:             &postgres.Client{},
+			wantSchemaMarker: "n.nspname = $1",
+			wantTableMarker:  "c.relname = $2",
+		},
+		{
+			name:             "mssql uses bind args",
+			conn:             &mssql.DB{},
+			wantSchemaMarker: "s.name = @p1",
+			wantTableMarker:  "t.name = @p2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := columnDescriptionQuery(tt.conn, schemaName, tableName)
+			require.True(t, ok)
+			assert.Contains(t, got.Query, tt.wantSchemaMarker)
+			assert.Contains(t, got.Query, tt.wantTableMarker)
+			assert.NotContains(t, got.Query, schemaName)
+			assert.NotContains(t, got.Query, tableName)
+			assert.Equal(t, []any{schemaName, tableName}, got.Args)
 		})
 	}
 }

--- a/pkg/mssql/db.go
+++ b/pkg/mssql/db.go
@@ -57,7 +57,7 @@ func (db *DB) RunQueryWithoutResult(ctx context.Context, query *query.Query) err
 
 func (db *DB) Select(ctx context.Context, query *query.Query) ([][]interface{}, error) {
 	queryString := query.String()
-	rows, err := db.conn.QueryContext(ctx, queryString)
+	rows, err := db.conn.QueryContext(ctx, queryString, query.Args...)
 	if err == nil {
 		err = rows.Err()
 	}

--- a/pkg/postgres/db.go
+++ b/pkg/postgres/db.go
@@ -270,6 +270,9 @@ ORDER BY table_schema, table_name;
 }
 
 func (c *Client) GetColumns(ctx context.Context, databaseName, tableName string) ([]*ansisql.DBColumn, error) {
+	if databaseName == "" && c.config != nil {
+		databaseName = c.config.GetDatabase()
+	}
 	if databaseName == "" {
 		return nil, errors.New("database name cannot be empty")
 	}
@@ -294,6 +297,28 @@ func (c *Client) GetColumns(ctx context.Context, databaseName, tableName string)
 		return nil, fmt.Errorf("invalid table name format: %s", tableName)
 	}
 
+	return c.getColumns(ctx, databaseName, schemaName, tableNameOnly, tableName)
+}
+
+func (c *Client) GetColumnsForTable(ctx context.Context, schemaName, tableName string) ([]*ansisql.DBColumn, error) {
+	var databaseName string
+	if c.config != nil {
+		databaseName = c.config.GetDatabase()
+	}
+	if databaseName == "" {
+		return nil, errors.New("database name cannot be empty")
+	}
+	if schemaName == "" {
+		return nil, errors.New("schema name cannot be empty")
+	}
+	if tableName == "" {
+		return nil, errors.New("table name cannot be empty")
+	}
+
+	return c.getColumns(ctx, databaseName, schemaName, tableName, schemaName+"."+tableName)
+}
+
+func (c *Client) getColumns(ctx context.Context, databaseName, schemaName, tableNameOnly, displayTableName string) ([]*ansisql.DBColumn, error) {
 	q := `
 SELECT
     column_name,
@@ -310,7 +335,7 @@ ORDER BY ordinal_position;
 
 	rows, err := c.connection.Query(ctx, q, databaseName, schemaName, tableNameOnly)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query columns for table '%s.%s': %w", databaseName, tableName, err)
+		return nil, fmt.Errorf("failed to query columns for table '%s.%s': %w", databaseName, displayTableName, err)
 	}
 	defer rows.Close()
 
@@ -375,8 +400,23 @@ ORDER BY ordinal_position;
 }
 
 func (c *Client) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error) {
+	return c.getDatabaseSummary(ctx, nil)
+}
+
+func (c *Client) GetDatabaseSummaryForSchemas(ctx context.Context, schemaNames []string) (*ansisql.DBDatabase, error) {
+	return c.getDatabaseSummary(ctx, schemaNames)
+}
+
+func (c *Client) getDatabaseSummary(ctx context.Context, schemaNames []string) (*ansisql.DBDatabase, error) {
 	db := c.config.GetDatabase()
-	q := `
+	schemaFilter := ""
+	args := []any{db}
+	if len(schemaNames) > 0 {
+		schemaFilter = "\n    AND t.table_schema = ANY($2)"
+		args = append(args, schemaNames)
+	}
+
+	q := fmt.Sprintf(`
 SELECT
     t.table_schema,
     t.table_name,
@@ -399,12 +439,13 @@ LEFT JOIN
 WHERE
 	t.table_catalog = $1 
     AND t.table_schema NOT IN ('pg_catalog', 'information_schema')
+    %s
     AND t.table_type IN ('BASE TABLE', 'VIEW')
     AND (n.nspname = t.table_schema OR n.nspname IS NULL)
 ORDER BY t.table_schema, t.table_name;
-`
+`, schemaFilter)
 
-	rows, err := c.connection.Query(ctx, q, db)
+	rows, err := c.connection.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/postgres/db.go
+++ b/pkg/postgres/db.go
@@ -68,7 +68,7 @@ func (c *Client) GetIngestrURI() (string, error) {
 
 // Select runs a query and returns the results.
 func (c *Client) Select(ctx context.Context, query *query.Query) ([][]interface{}, error) {
-	rows, err := c.connection.Query(ctx, query.String())
+	rows, err := c.connection.Query(ctx, query.String(), query.Args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/postgres/db_test.go
+++ b/pkg/postgres/db_test.go
@@ -994,6 +994,53 @@ func TestClient_GetColumns(t *testing.T) {
 	}
 }
 
+func TestClient_GetColumnsForTable(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	rows := pgxmock.NewRowsWithColumnDefinition(
+		pgconn.FieldDescription{Name: "column_name"},
+		pgconn.FieldDescription{Name: "data_type"},
+		pgconn.FieldDescription{Name: "is_nullable"},
+		pgconn.FieldDescription{Name: "column_default"},
+		pgconn.FieldDescription{Name: "character_maximum_length"},
+		pgconn.FieldDescription{Name: "numeric_precision"},
+		pgconn.FieldDescription{Name: "numeric_scale"},
+	).
+		AddRow("event_id", "bigint", "NO", nil, nil, int32(64), int32(0)).
+		AddRow("payload", "jsonb", "YES", nil, nil, nil, nil)
+
+	mock.ExpectQuery("SELECT\\s+column_name").
+		WithArgs("database1", "hw", "staging_honor_event").
+		WillReturnRows(rows)
+
+	client := Client{connection: mock, config: Config{Database: "database1"}}
+
+	got, err := client.GetColumnsForTable(t.Context(), "hw", "staging_honor_event")
+	require.NoError(t, err)
+
+	require.Equal(t, []*ansisql.DBColumn{
+		{
+			Name:       "event_id",
+			Type:       "bigint(64)",
+			Nullable:   false,
+			PrimaryKey: false,
+			Unique:     false,
+		},
+		{
+			Name:       "payload",
+			Type:       "jsonb",
+			Nullable:   true,
+			PrimaryKey: false,
+			Unique:     false,
+		},
+	}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDB_GetDatabaseSummary(t *testing.T) {
 	t.Parallel()
 
@@ -1112,6 +1159,55 @@ func TestDB_GetDatabaseSummary(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestDB_GetDatabaseSummaryForSchemas(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	rows := pgxmock.NewRowsWithColumnDefinition(
+		pgconn.FieldDescription{Name: "table_schema"},
+		pgconn.FieldDescription{Name: "table_name"},
+		pgconn.FieldDescription{Name: "table_type"},
+		pgconn.FieldDescription{Name: "view_definition"},
+	).
+		AddRow("hw", "orders", "BASE TABLE", nil).
+		AddRow("hw", "order_summary", "VIEW", "SELECT * FROM orders")
+
+	mock.ExpectQuery("t\\.table_schema = ANY\\(\\$2\\)").
+		WithArgs("database1", []string{"hw"}).
+		WillReturnRows(rows)
+
+	client := Client{connection: mock, config: Config{Database: "database1"}}
+
+	got, err := client.GetDatabaseSummaryForSchemas(t.Context(), []string{"hw"})
+	require.NoError(t, err)
+
+	require.Equal(t, &ansisql.DBDatabase{
+		Name: "database1",
+		Schemas: []*ansisql.DBSchema{
+			{
+				Name: "hw",
+				Tables: []*ansisql.DBTable{
+					{
+						Name:    "orders",
+						Type:    ansisql.DBTableTypeTable,
+						Columns: []*ansisql.DBColumn{},
+					},
+					{
+						Name:           "order_summary",
+						Type:           ansisql.DBTableTypeView,
+						ViewDefinition: "SELECT * FROM orders",
+						Columns:        []*ansisql.DBColumn{},
+					},
+				},
+			},
+		},
+	}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestDB_BuildTableExistsQuery(t *testing.T) {

--- a/pkg/query/extract.go
+++ b/pkg/query/extract.go
@@ -14,6 +14,7 @@ import (
 type Query struct {
 	VariableDefinitions []string
 	Query               string
+	Args                []any
 }
 
 type QueryResult struct {


### PR DESCRIPTION
Fixes Postgres import column filling to use information_schema metadata instead of zero-row SELECT field descriptions.

Also adds schema-filtered Postgres database summaries for import and tests for both paths.

Checks: make format; make test.