### PR TITLE
run: restore --use-gong as hidden no-op for compat

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -655,6 +655,11 @@ func Run(isDebug *bool) *cli.Command {
 				Usage:  "deprecated compatibility flag; passing this flag returns an explicit deprecation error",
 				Hidden: true,
 			},
+			&cli.BoolFlag{
+				Name:   "use-gong",
+				Usage:  "deprecated no-op flag; gong is now bundled with ingestr and selected per-asset",
+				Hidden: true,
+			},
 			&cli.StringFlag{
 				Name:  "debug-ingestr-src",
 				Usage: "Use ingestr from the given path instead of the builtin version.",


### PR DESCRIPTION
Some environments still pass --use-gong to the CLI; without the flag defined urfave/cli aborts the run with "flag provided but not defined". Re-add it as a hidden no-op so those callers keep working until they drop the flag.