### PR TITLE
Support pipeline macros in query rendering

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -471,10 +471,7 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 		return "", nil, "", "", nil, err
 	}
 
-	renderer := jinja.NewRendererWithStartEndDates(&startDate, &endDate, &defaultExecutionDate, "your-pipeline-name", "your-run-id", nil)
-	for k, v := range vars {
-		renderer.SetContextValue(k, v)
-	}
+	renderer := newQueryRenderer(startDate, endDate, "your-pipeline-name", vars, "")
 	extractor := &query.WholeFileExtractor{
 		Fs:       fs,
 		Renderer: renderer,
@@ -508,10 +505,7 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 		fetchCtx = context.WithValue(fetchCtx, pipeline.RunConfigRunID, "your-run-id")
 		fetchCtx = context.WithValue(fetchCtx, config.EnvironmentContextKey, pipelineInfo.Config.SelectedEnvironment)
 		// Auto-detect mode (both asset path and query)
-		autoRenderer := jinja.NewRendererWithStartEndDates(&startDate, &endDate, &defaultExecutionDate, pipelineInfo.Pipeline.Name, "your-run-id", nil)
-		for k, v := range vars {
-			autoRenderer.SetContextValue(k, v)
-		}
+		autoRenderer := newQueryRenderer(startDate, endDate, pipelineInfo.Pipeline.Name, vars, pipelineMacroContent(pipelineInfo.Pipeline))
 		extractor = &query.WholeFileExtractor{
 			Fs:       fs,
 			Renderer: autoRenderer,
@@ -552,10 +546,7 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 	fetchCtx = context.WithValue(fetchCtx, pipeline.RunConfigExecutionDate, defaultExecutionDate)
 	fetchCtx = context.WithValue(fetchCtx, pipeline.RunConfigRunID, "your-run-id")
 	fetchCtx = context.WithValue(fetchCtx, config.EnvironmentContextKey, pipelineInfo.Config.SelectedEnvironment)
-	assetRenderer := jinja.NewRendererWithStartEndDates(&startDate, &endDate, &defaultExecutionDate, pipelineInfo.Pipeline.Name, "your-run-id", nil)
-	for k, v := range vars {
-		assetRenderer.SetContextValue(k, v)
-	}
+	assetRenderer := newQueryRenderer(startDate, endDate, pipelineInfo.Pipeline.Name, vars, pipelineMacroContent(pipelineInfo.Pipeline))
 	extractor = &query.WholeFileExtractor{
 		Fs:       fs,
 		Renderer: assetRenderer,
@@ -723,11 +714,33 @@ func semanticQueryContext(ctx context.Context, pipelineInfo *ppInfo, startDate t
 }
 
 func newSemanticRenderer(pipelineInfo *ppInfo, vars map[string]any, startDate time.Time, endDate time.Time) *jinja.Renderer {
-	renderer := jinja.NewRendererWithStartEndDates(&startDate, &endDate, &defaultExecutionDate, pipelineInfo.Pipeline.Name, "your-run-id", pipelineInfo.Pipeline.Variables.Value())
+	renderer := jinja.NewRendererWithStartEndDatesAndMacros(&startDate, &endDate, &defaultExecutionDate, pipelineInfo.Pipeline.Name, "your-run-id", pipelineInfo.Pipeline.Variables.Value(), pipelineMacroContent(pipelineInfo.Pipeline))
 	for k, v := range vars {
 		renderer.SetContextValue(k, v)
 	}
 	return renderer
+}
+
+func newQueryRenderer(startDate, endDate time.Time, pipelineName string, vars map[string]any, macroContent string) *jinja.Renderer {
+	renderer := jinja.NewRendererWithStartEndDatesAndMacros(&startDate, &endDate, &defaultExecutionDate, pipelineName, "your-run-id", nil, macroContent)
+	for k, v := range vars {
+		renderer.SetContextValue(k, v)
+	}
+	return renderer
+}
+
+func pipelineMacroContent(pl *pipeline.Pipeline) string {
+	if pl == nil || len(pl.Macros) == 0 {
+		return ""
+	}
+
+	var macroContent strings.Builder
+	for _, macro := range pl.Macros {
+		macroContent.WriteString(string(macro))
+		macroContent.WriteString("\n")
+	}
+
+	return macroContent.String()
 }
 
 func semanticQueryFromCommand(c *cli.Command) (*semantic.Query, error) {

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -505,6 +507,46 @@ metrics:
 	assert.Equal(t, filepath.Join(projectDir, "semantic"), semanticPath)
 	assert.Contains(t, models, "orders")
 	assert.NotContains(t, models, "root_orders")
+}
+
+func TestQueryRendererRendersPipelineMacroWithListArgument(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	pl := &pipeline.Pipeline{
+		Name: "issue_758",
+		Macros: []pipeline.Macro{
+			`{% macro generate_surrogate_key(columns) -%}
+MD5(CONCAT_WS('||',
+    {%- for col in columns %}
+        CAST({{ col }} AS VARCHAR)
+        {%- if not loop.last %}, {% endif %}
+    {%- endfor %}
+))
+{%- endmacro %}`,
+		},
+	}
+	asset := &pipeline.Asset{Name: "issue_758.game_team"}
+	renderer := newQueryRenderer(now, now, pl.Name, nil, pipelineMacroContent(pl))
+	extractor := &query.WholeFileExtractor{
+		Fs:       afero.NewMemMapFs(),
+		Renderer: renderer,
+	}
+
+	runCtx := context.WithValue(context.Background(), pipeline.RunConfigStartDate, now)
+	runCtx = context.WithValue(runCtx, pipeline.RunConfigEndDate, now)
+	runCtx = context.WithValue(runCtx, pipeline.RunConfigExecutionDate, now)
+	runCtx = context.WithValue(runCtx, pipeline.RunConfigRunID, "test-run")
+
+	clonedExtractor, err := extractor.CloneForAsset(runCtx, pl, asset)
+	require.NoError(t, err)
+
+	queries, err := clonedExtractor.ExtractQueriesFromString(`select
+  {{ generate_surrogate_key(['team.game_id', 'team.team_id']) }} as game_team_id`)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	assert.Contains(t, queries[0].Query, "CAST(team.game_id AS VARCHAR)")
+	assert.Contains(t, queries[0].Query, "CAST(team.team_id AS VARCHAR)")
 }
 
 // MockMSSQLDB implements the Limiter interface like mssql.DB does.

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -242,18 +242,13 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 	}
 	u.binaryFullPath = binaryFullPath
 
-	// uv tool run uses the mutable installed tool environment, so keep the
-	// matching install and run in one critical section.
-	ingestrInstallMutex.Lock()
-	defer ingestrInstallMutex.Unlock()
-
-	if err := u.ensureIngestrInstalledLocked(ctx, extraPackages, repo); err != nil {
+	if err := u.ensureIngestrInstalled(ctx, extraPackages, repo); err != nil {
 		return err
 	}
 
 	noDependencyCommand := &CommandInstance{
 		Name: u.binaryFullPath,
-		Args: ingestrRunCmd(args),
+		Args: u.ingestrRunCmd(ctx, extraPackages, args),
 		EnvVars: map[string]string{
 			"PYTHONUNBUFFERED": "1",
 		},
@@ -526,17 +521,12 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		ingestrCtx = context.WithValue(ctx, executor.KeyPrinter, io.Writer(logBuffer))
 	}
 
-	// uv tool run uses the mutable installed tool environment, so keep the
-	// matching install and run in one critical section.
-	ingestrInstallMutex.Lock()
-	defer ingestrInstallMutex.Unlock()
-
-	err = u.ensureIngestrInstalledLocked(ctx, extraPackages, execCtx.repo)
+	err = u.ensureIngestrInstalled(ctx, extraPackages, execCtx.repo)
 	if err != nil {
 		return err
 	}
 
-	runArgs := ingestrRunCmd(cmdArgs)
+	runArgs := u.ingestrRunCmd(ctx, extraPackages, cmdArgs)
 
 	if debug := ctx.Value(executor.KeyIsDebug); debug != nil {
 		boolVal := debug.(*bool)
@@ -605,9 +595,14 @@ func (u *UvPythonRunner) ingestrInstallCmd(ctx context.Context, pkgs []string, f
 	return cmdline
 }
 
-func ingestrRunCmd(args []string) []string {
-	cmdline := make([]string, 0, 8+len(args))
-	cmdline = append(cmdline, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr, "ingestr")
+func (u *UvPythonRunner) ingestrRunCmd(ctx context.Context, extraPackages, args []string) []string {
+	ingestrPackageName, _ := u.ingestrPackage(ctx)
+	cmdline := make([]string, 0, 10+(2*len(extraPackages))+len(args))
+	cmdline = append(cmdline, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr, "--from", ingestrPackageName)
+	for _, pkg := range extraPackages {
+		cmdline = append(cmdline, "--with", pkg)
+	}
+	cmdline = append(cmdline, "ingestr")
 	return append(cmdline, args...)
 }
 
@@ -624,14 +619,10 @@ func (u *UvPythonRunner) buildIngestrPackageKey(ctx context.Context, extraPackag
 // It prevents parallel workers from installing ingestr simultaneously, which causes file lock
 // conflicts on Windows (OS error 32).
 func (u *UvPythonRunner) ensureIngestrInstalled(ctx context.Context, extraPackages []string, repo *git.Repo) error {
+	packageKey := u.buildIngestrPackageKey(ctx, extraPackages)
+
 	ingestrInstallMutex.Lock()
 	defer ingestrInstallMutex.Unlock()
-
-	return u.ensureIngestrInstalledLocked(ctx, extraPackages, repo)
-}
-
-func (u *UvPythonRunner) ensureIngestrInstalledLocked(ctx context.Context, extraPackages []string, repo *git.Repo) error {
-	packageKey := u.buildIngestrPackageKey(ctx, extraPackages)
 
 	_, isLocal := u.ingestrPackage(ctx)
 	if !isLocal {

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -242,11 +242,18 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 	}
 	u.binaryFullPath = binaryFullPath
 
-	flags := u.ingestrRunCmd(ctx, extraPackages, args)
+	// uv tool run uses the mutable installed tool environment, so keep the
+	// matching install and run in one critical section.
+	ingestrInstallMutex.Lock()
+	defer ingestrInstallMutex.Unlock()
+
+	if err := u.ensureIngestrInstalledLocked(ctx, extraPackages, repo); err != nil {
+		return err
+	}
 
 	noDependencyCommand := &CommandInstance{
 		Name: u.binaryFullPath,
-		Args: flags,
+		Args: ingestrRunCmd(args),
 		EnvVars: map[string]string{
 			"PYTHONUNBUFFERED": "1",
 		},
@@ -519,7 +526,17 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		ingestrCtx = context.WithValue(ctx, executor.KeyPrinter, io.Writer(logBuffer))
 	}
 
-	runArgs := u.ingestrRunCmd(ctx, extraPackages, cmdArgs)
+	// uv tool run uses the mutable installed tool environment, so keep the
+	// matching install and run in one critical section.
+	ingestrInstallMutex.Lock()
+	defer ingestrInstallMutex.Unlock()
+
+	err = u.ensureIngestrInstalledLocked(ctx, extraPackages, execCtx.repo)
+	if err != nil {
+		return err
+	}
+
+	runArgs := ingestrRunCmd(cmdArgs)
 
 	if debug := ctx.Value(executor.KeyIsDebug); debug != nil {
 		boolVal := debug.(*bool)
@@ -588,14 +605,9 @@ func (u *UvPythonRunner) ingestrInstallCmd(ctx context.Context, pkgs []string, f
 	return cmdline
 }
 
-func (u *UvPythonRunner) ingestrRunCmd(ctx context.Context, extraPackages, args []string) []string {
-	ingestrPackageName, _ := u.ingestrPackage(ctx)
-	cmdline := make([]string, 0, 11+(2*len(extraPackages))+len(args))
-	cmdline = append(cmdline, "tool", "run", "--no-config", "--isolated", "--prerelease", "allow", "--python", pythonVersionForIngestr, "--from", ingestrPackageName)
-	for _, pkg := range extraPackages {
-		cmdline = append(cmdline, "--with", pkg)
-	}
-	cmdline = append(cmdline, "ingestr")
+func ingestrRunCmd(args []string) []string {
+	cmdline := make([]string, 0, 8+len(args))
+	cmdline = append(cmdline, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr, "ingestr")
 	return append(cmdline, args...)
 }
 
@@ -612,10 +624,14 @@ func (u *UvPythonRunner) buildIngestrPackageKey(ctx context.Context, extraPackag
 // It prevents parallel workers from installing ingestr simultaneously, which causes file lock
 // conflicts on Windows (OS error 32).
 func (u *UvPythonRunner) ensureIngestrInstalled(ctx context.Context, extraPackages []string, repo *git.Repo) error {
-	packageKey := u.buildIngestrPackageKey(ctx, extraPackages)
-
 	ingestrInstallMutex.Lock()
 	defer ingestrInstallMutex.Unlock()
+
+	return u.ensureIngestrInstalledLocked(ctx, extraPackages, repo)
+}
+
+func (u *UvPythonRunner) ensureIngestrInstalledLocked(ctx context.Context, extraPackages []string, repo *git.Repo) error {
+	packageKey := u.buildIngestrPackageKey(ctx, extraPackages)
 
 	_, isLocal := u.ingestrPackage(ctx)
 	if !isLocal {

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -243,14 +242,7 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 	}
 	u.binaryFullPath = binaryFullPath
 
-	err = u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	if err != nil {
-		return err
-	}
-
-	flags := make([]string, 0, 8+len(args))
-	flags = append(flags, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr, "ingestr")
-	flags = append(flags, args...)
+	flags := u.ingestrRunCmd(ctx, extraPackages, args)
 
 	noDependencyCommand := &CommandInstance{
 		Name: u.binaryFullPath,
@@ -527,12 +519,7 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		ingestrCtx = context.WithValue(ctx, executor.KeyPrinter, io.Writer(logBuffer))
 	}
 
-	err = u.ensureIngestrInstalled(ctx, extraPackages, execCtx.repo)
-	if err != nil {
-		return err
-	}
-
-	runArgs := slices.Concat([]string{"tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr, "ingestr"}, cmdArgs)
+	runArgs := u.ingestrRunCmd(ctx, extraPackages, cmdArgs)
 
 	if debug := ctx.Value(executor.KeyIsDebug); debug != nil {
 		boolVal := debug.(*bool)
@@ -599,6 +586,17 @@ func (u *UvPythonRunner) ingestrInstallCmd(ctx context.Context, pkgs []string, f
 	}
 	cmdline = append(cmdline, ingestrPackageName)
 	return cmdline
+}
+
+func (u *UvPythonRunner) ingestrRunCmd(ctx context.Context, extraPackages, args []string) []string {
+	ingestrPackageName, _ := u.ingestrPackage(ctx)
+	cmdline := make([]string, 0, 11+(2*len(extraPackages))+len(args))
+	cmdline = append(cmdline, "tool", "run", "--no-config", "--isolated", "--prerelease", "allow", "--python", pythonVersionForIngestr, "--from", ingestrPackageName)
+	for _, pkg := range extraPackages {
+		cmdline = append(cmdline, "--with", pkg)
+	}
+	cmdline = append(cmdline, "ingestr")
+	return append(cmdline, args...)
 }
 
 // buildIngestrPackageKey creates a unique key for the combination of ingestr version and extra packages.

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -205,29 +205,19 @@ func Test_ingestrPackage_HonorsCtxIngestrVersion(t *testing.T) {
 	assert.True(t, isLocal)
 }
 
-func Test_ingestrRunCmd_UsesResolvedPackageInIsolatedRun(t *testing.T) {
+func Test_ingestrRunCmd_UsesInstalledTool(t *testing.T) {
 	t.Parallel()
 
-	u := &UvPythonRunner{}
-	ctx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.155")
-
-	args := u.ingestrRunCmd(ctx, []string{"pyodbc", "duckdb"}, []string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
+	args := ingestrRunCmd([]string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
 
 	assert.Equal(t, []string{
 		"tool",
 		"run",
 		"--no-config",
-		"--isolated",
 		"--prerelease",
 		"allow",
 		"--python",
 		"3.11",
-		"--from",
-		"ingestr@0.14.155",
-		"--with",
-		"pyodbc",
-		"--with",
-		"duckdb",
 		"ingestr",
 		"ingest",
 		"--source-uri",

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -205,10 +205,13 @@ func Test_ingestrPackage_HonorsCtxIngestrVersion(t *testing.T) {
 	assert.True(t, isLocal)
 }
 
-func Test_ingestrRunCmd_UsesInstalledTool(t *testing.T) {
+func Test_ingestrRunCmd_UsesResolvedPackage(t *testing.T) {
 	t.Parallel()
 
-	args := ingestrRunCmd([]string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
+	u := &UvPythonRunner{}
+	ctx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.155")
+
+	args := u.ingestrRunCmd(ctx, []string{"pyodbc", "duckdb"}, []string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
 
 	assert.Equal(t, []string{
 		"tool",
@@ -218,6 +221,12 @@ func Test_ingestrRunCmd_UsesInstalledTool(t *testing.T) {
 		"allow",
 		"--python",
 		"3.11",
+		"--from",
+		"ingestr@0.14.155",
+		"--with",
+		"pyodbc",
+		"--with",
+		"duckdb",
 		"ingestr",
 		"ingest",
 		"--source-uri",

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -205,6 +205,36 @@ func Test_ingestrPackage_HonorsCtxIngestrVersion(t *testing.T) {
 	assert.True(t, isLocal)
 }
 
+func Test_ingestrRunCmd_UsesResolvedPackageInIsolatedRun(t *testing.T) {
+	t.Parallel()
+
+	u := &UvPythonRunner{}
+	ctx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.155")
+
+	args := u.ingestrRunCmd(ctx, []string{"pyodbc", "duckdb"}, []string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
+
+	assert.Equal(t, []string{
+		"tool",
+		"run",
+		"--no-config",
+		"--isolated",
+		"--prerelease",
+		"allow",
+		"--python",
+		"3.11",
+		"--from",
+		"ingestr@0.14.155",
+		"--with",
+		"pyodbc",
+		"--with",
+		"duckdb",
+		"ingestr",
+		"ingest",
+		"--source-uri",
+		"csv:///tmp/seed.csv",
+	}, args)
+}
+
 func Test_buildIngestrPackageKey_DiffersByVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Query rendering now carries pipeline macros into asset, auto-detect, and semantic query paths.

This fixes CLI query rendering for macros such as surrogate key helpers that take list arguments. Added a regression test for the macro rendering path.

This PR fixes https://github.com/bruin-data/bruin-vscode/issues/758