### PR TITLE
Refactor firebase template: split events and user_model into stg layers

### DIFF
--- a/templates/firebase/README.md
+++ b/templates/firebase/README.md
@@ -4,11 +4,14 @@ This pipeline is a simple example of a Bruin pipeline for Firebase.
 
 The pipeline includes several sample assets:
 
-- `events/events.asset.yaml`: Monitors for new events data in BigQuery to trigger downstream tasks when new data is detected.
-- `events/events.sql`: Defines a BigQuery view for formatted Firebase Analytics event data to support ad-hoc analysis.
-- `user_model/cohorts.sql`: A SQL asset that defines cohort-based aggregations for user data.
-- `user_model/users.sql`: A SQL asset that defines the users table structure.
-- `user_model/users_daily.sql`: A SQL asset that manages daily updates for user data.
+- `analytics_123456789/events.asset.yaml` / `events_intraday.asset.yaml`: Sensors that watch for new Firebase export tables in BigQuery and trigger downstream tasks. Keep one depending on your export type (daily vs intraday).
+- `analytics_123456789/parse_version.sql`: BigQuery UDF that normalizes app version strings (e.g. `1.20.3` → `001.020.003`) for sortable comparisons.
+- `events/stg_events.sql`: View over the raw `analytics_*.events_*` wildcard table. Owns all parsing/flattening logic (event_params, user_properties, experiments, device, geo).
+- `events/events_json.sql`: Materialized incremental table over `stg_events`, partitioned by `dt`, clustered by `event_name` + `user_pseudo_id`. Used for historical queries.
+- `events/events.sql`: View that unions `events_json` (history, `dt <= end_date`) with `stg_events` (intraday, `dt > end_date`) for near-real-time coverage without re-scanning history. Adds typed columns (screen, session, ads, idfa/idfv).
+- `user_model/stg_users_daily.sql`: Incremental table with daily user-level aggregates (sessions, ad/IAP revenue, first/last device & geo of day) from `events.events`.
+- `user_model/users.sql`: User-level table with install-time attributes and cohorted retention/revenue metrics (`ret_d{1..90}`, `{metric}_d{N}`).
+- `user_model/users_daily.sql`: Enriched daily rollup that joins `stg_users_daily` back with `users` to tag each daily row with install context, `days_since_install`, and `nth_active_day`.
 
 For a more detailed description of each asset, refer to the **description** section within each sql asset. Each file provides specific details and instructions relevant to its functionality.
 
@@ -28,9 +31,9 @@ environments:
  ```
 
 ##  Important Note
-1- Rename analytics_123456789 folder according to yours.
-2- Keep only events_intraday or events in this folder depending on your use case. We recommend you to use events_intraday since streaming data is not bound by 1 million events per day limit.
-3- Review TODOs: The SQL files events/events.sql, user_model/users_daily.sql, and events_json.sql contain TODO comments. These indicate sections where you should make adjustments based on your data and project requirements.
+1- Rename `analytics_123456789` (folder + references in `stg_events.sql`) to your Firebase analytics ID.
+2- Keep only `events_intraday.asset.yaml` or `events.asset.yaml` depending on your use case. We recommend `events_intraday` since streaming data is not bound by the 1M events/day limit. `stg_events.sql` defaults to the intraday sensor — update its `depends:` block if you use daily export instead.
+3- Review TODOs: `events/stg_events.sql`, `events/events.sql`, and `user_model/stg_users_daily.sql` contain TODO comments. These indicate sections where you should make adjustments based on your data and project requirements (analytics ID, user_id vs user_pseudo_id, app-specific event params and metrics).
 
 
 ## Running the pipeline

--- a/templates/firebase/assets/events/events.sql
+++ b/templates/firebase/assets/events/events.sql
@@ -34,7 +34,7 @@ select
   lower(lax_string(device.advertising_id)) as idfa,
   lower(lax_string(device.vendor_id)) as idfv,
   struct(
-    lax_string(device.advertising_id) as advertising_id,
+    lower(lax_string(device.advertising_id)) as advertising_id,
     lax_string(device.browser) as browser,
     lax_string(device.browser_version) as browser_version,
     lax_string(device.category) as category,
@@ -47,7 +47,7 @@ select
     lax_string(device.operating_system) as operating_system,
     lax_string(device.operating_system_version) as operating_system_version,
     lax_int64(device.device_time_zone_offset) as device_time_zone_offset,
-    lax_string(device.vendor_id) as vendor_id,
+    lower(lax_string(device.vendor_id)) as vendor_id,
     lax_string(device.web_info) as web_info
   ) as device,
   struct(
@@ -63,7 +63,7 @@ select
     lax_string(privacy_info.analytics_storage) as analytics_storage,
     lax_string(privacy_info.uses_transient_token) as uses_transient_token
   ) as privacy_info,
-  event_server_timestamp_offset,
+  event_server_ts_offset_seconds,
 
   -- FIREBASE
   lax_string(event_params.firebase_screen) as screen,

--- a/templates/firebase/assets/events/events.sql
+++ b/templates/firebase/assets/events/events.sql
@@ -4,13 +4,19 @@ name: events.events
 type: bq.sql
 materialization:
     type: view
-description:
-    The events table contains all events and parameters from the Firebase Analytics export.
-    The underlying table is partitioned by date and clustered by event_name.
-    This table is used for ad-hoc analysis and is not used for reporting.
+description: |
+  Categorized events view. Unions materialized history (events_json) with live intraday
+  (stg_events where dt > end_date) for near-real-time coverage without re-scanning history.
 depends:
   - events.events_json
+  - events.stg_events
 @bruin */
+
+with base as (
+  select * from `events.events_json` where dt <= '{{ end_date }}'
+  union all
+  select * from `events.stg_events`  where dt >  '{{ end_date }}'
+)
 
 select
   app,
@@ -24,7 +30,9 @@ select
   app_version,
   event_params,
   user_properties,
-  if(array_length(experiments) > 0, (select json_object(array_agg(e.id), array_agg(e.value)) from unnest(experiments) as e), JSON "{}") as experiments,
+  if(array_length(experiments) > 0, (select json_object(array_agg(cast(e.id as string)), array_agg(e.value)) from unnest(experiments) as e), JSON "{}") as experiments,
+  lower(lax_string(device.advertising_id)) as idfa,
+  lower(lax_string(device.vendor_id)) as idfv,
   struct(
     lax_string(device.advertising_id) as advertising_id,
     lax_string(device.browser) as browser,
@@ -64,6 +72,7 @@ select
   lax_string(event_params.firebase_previous_class) as previous_screen_class,
   lax_int64(event_params.ga_session_id) as session_id,
   lax_int64(event_params.ga_session_number) as session_number,
+  lax_int64(event_params.ga_dedupe_id) as ga_dedupe_id,
   lax_int64(event_params.engaged_session_event) as engaged_session_event,
   lax_int64(event_params.engagement_time_msec) / 1000 as engagement_time_sec,
   lax_string(event_params.firebase_event_origin) as event_origin,
@@ -74,6 +83,7 @@ select
   lax_int64(event_params.update_with_analytics) as update_with_analytics,
   lax_int64(event_params.system_app) as system_app,
   lax_int64(event_params.system_app_update) as system_app_update,
+  lax_int64(event_params.debug_event) as debug_event,
   lax_string(event_params.source) as source,
   lax_string(event_params.campaign_info_source) as campaign_info_source,
   lax_string(event_params.medium) as medium,
@@ -85,21 +95,14 @@ select
   lax_string(event_params.error_value) as error_value,
   lax_string(event_params.term) as term,
 
-  -- AD IMPRESSIONS
+  -- ADS
   lax_string(event_params.ad_format) as ad_format,
   lax_float64(event_params.value) as value,
   event_value_in_usd,
 
-  --TODO: add other parameters and properties specific to your app
+  -- USER PROPERTIES
+  timestamp_millis(lax_int64(user_properties.first_open_time)) as user_first_open_ts
 
-  -- ALTERNATIVE 1:
-  -- lax_int64(event_params.level) as level,
-  -- lax_string(event_params.result) as result,
+  --TODO: add parameters and properties specific to your app (IAP product_id/price/quantity/currency, level, tutorial_step, custom currencies, etc.)
 
-  -- ALTERNATIVE 2:
-  -- struct(
-  --   lax_int64(event_params.level) as level,
-  --   lax_string(event_params.result) as result,
-  -- ) as progression
-
-from `events.events_json` 
+from base

--- a/templates/firebase/assets/events/events_json.sql
+++ b/templates/firebase/assets/events/events_json.sql
@@ -3,8 +3,8 @@
 type: bq.sql
 description: |
   Flattened events table with JSON fields.
-  This table is partitioned by date and clustered by event_name.
-  This table can be used for ad-hoc analysis and should not be used for reporting.
+  Partitioned by dt, clustered by event_name + user_pseudo_id.
+  Thin materialized window over events.stg_events (all parsing logic lives there).
 
 materialization:
   type: table
@@ -17,8 +17,7 @@ materialization:
   time_granularity: date
 
 depends:
-  - analytics_123456789.parse_version # TODO: Change 123456789 to your analytics ID
-  - analytics_123456789.events # TODO: If you need intraday, use the events_intraday table instead
+  - events.stg_events
 
 columns:
   - name: app
@@ -46,17 +45,17 @@ columns:
   - name: app_version
     type: STRING
     description: >
-      The cleaned app version, suitable for comparisons like >= or sorting. To standardize the version, we use 3 digits for each part of the version. 
+      The cleaned app version, suitable for comparisons like >= or sorting. To standardize the version, we use 3 digits for each part of the version.
       Ex value: 1.20.3 -> 001.020.003
   - name: event_params
     type: STRING
-    description: Parameters specific to each event, independent of others. In the free version, you are limited to 20 parameters per event, with string values capped at 100 characters each.
+    description: JSON-encoded event parameter map.
   - name: user_properties
     type: STRING
-    description: User properties are characteristics that define segments of your user base, such as language or location. These properties persist across subsequent events unless modified. In the free version, you are limited to assigning 20 user properties per user.
+    description: JSON-encoded user properties (excludes user_id and firebase_exp_*/_ltv_*).
   - name: experiments
     type: ARRAY<STRUCT<id INT64, value INT64>>
-    description: List of all the active experiments for the user. It's extracted from user_properties.
+    description: Active Firebase experiments for the user (extracted from user_properties).
   - name: device
     type: STRING
     description: Device information as JSON
@@ -68,73 +67,13 @@ columns:
     description: Privacy information as JSON
   - name: event_server_timestamp_offset
     type: FLOAT64
-    description: The difference between the event timestamp and the server timestamp.
+    description: The difference between the event timestamp and the server timestamp (milliseconds).
   - name: event_value_in_usd
     type: FLOAT64
     description: The value of the event in USD.
 
 @bruin */
 
-SELECT 
-    app_info.id as app,
-    platform,
-    PARSE_DATE('%Y%m%d', event_date) as dt,
-    TIMESTAMP_MICROS(event_timestamp) as ts,
-    TIMESTAMP_MICROS(user_first_touch_timestamp) as user_first_touch_ts,
-    user_pseudo_id,
-    user_id,
-    lower(event_name) as event_name,
-    analytics_123456789.parse_version(app_info.version) as app_version, -- TODO: Change 123456789 to your analytics ID
-    (
-      select 
-        case when array_length(keys) > 0 then json_object(keys, vals) end 
-      from (
-        select
-            array_agg(p.key) as keys,
-            array_agg(coalesce(
-              p.value.string_value, 
-              cast(p.value.int_value as string), 
-              cast(coalesce(p.value.double_value, p.value.float_value) as string)
-            )) as vals
-          from unnest(event_params) as p 
-      )
-    ) as event_params,
-    (
-      select case when array_length(keys) > 0 then json_object(keys, vals) end 
-      from (
-          select
-            array_agg(p.key) as keys, 
-            array_agg(coalesce(
-              p.value.string_value,
-              cast(p.value.int_value as string),
-              cast(coalesce(p.value.double_value, p.value.float_value) as string)
-            )) as vals
-          from unnest(user_properties) as p 
-          where not starts_with(p.key, '_ltv')
-            and not starts_with(p.key, 'firebase_exp')
-            and p.key not in ("user_id", "first_open_time")
-      )
-    ) as user_properties,
-    (
-      select array_agg(struct(
-        safe_cast(replace(key, "firebase_exp_", "") as int64) as id, 
-        safe_cast(value.string_value as int64) as value
-      ))
-      from unnest(user_properties) where key like 'firebase_exp%'
-    ) as experiments,
-    to_json(geo) as geo,
-    to_json((
-      select as struct device.* except(is_limited_ad_tracking, time_zone_offset_seconds),
-        CASE lower(device.is_limited_ad_tracking)
-          WHEN 'yes' THEN True
-          WHEN 'no' THEN False
-        END as is_limited_ad_tracking,
-        device.time_zone_offset_seconds / 3600 as device_time_zone_offset,
-    )) as device,
-    to_json(privacy_info) as privacy_info,
-    event_server_timestamp_offset / 1000000 as event_server_timestamp_offset,
-    event_value_in_usd,
-from `analytics_123456789.events_*` --TODO: Change 123456789 to your analytics ID
-where true
-  -- Filter by date range
-  and replace(_TABLE_SUFFIX, 'intraday_', '') between greatest('{{ start_date_nodash }}', '20200101') and least('{{ end_date_nodash }}', '21000101')
+SELECT *
+FROM `events.stg_events`
+WHERE dt BETWEEN '{{ start_date }}' AND '{{ end_date }}'

--- a/templates/firebase/assets/events/events_json.sql
+++ b/templates/firebase/assets/events/events_json.sql
@@ -65,9 +65,9 @@ columns:
   - name: privacy_info
     type: STRING
     description: Privacy information as JSON
-  - name: event_server_timestamp_offset
+  - name: event_server_ts_offset_seconds
     type: FLOAT64
-    description: The difference between the event timestamp and the server timestamp (milliseconds).
+    description: The difference between the event timestamp and the server timestamp, in seconds.
   - name: event_value_in_usd
     type: FLOAT64
     description: The value of the event in USD.

--- a/templates/firebase/assets/events/stg_events.sql
+++ b/templates/firebase/assets/events/stg_events.sql
@@ -76,7 +76,7 @@ SELECT
         device.time_zone_offset_seconds / 3600 as device_time_zone_offset,
     )) as device,
     to_json(privacy_info) as privacy_info,
-    event_server_timestamp_offset / 1000 as event_server_timestamp_offset,
+    event_server_timestamp_offset / 1000000 as event_server_ts_offset_seconds,
     event_value_in_usd,
 from `analytics_123456789.events_*` -- TODO: Change 123456789 to your analytics ID
 where replace(_TABLE_SUFFIX, 'intraday_', '') between '20200101' and '21000101'

--- a/templates/firebase/assets/events/stg_events.sql
+++ b/templates/firebase/assets/events/stg_events.sql
@@ -1,0 +1,83 @@
+/* @bruin
+
+type: bq.sql
+description: |
+  Staging view over the raw Firebase events_* wildcard table.
+  Contains all the parsing/flattening logic (event_params, user_properties, experiments, device, geo, etc.) in one place.
+
+  Referenced by:
+    - events.events_json: materialized incremental table, filters by pipeline date range for historical data.
+    - events.events: unions events_json (materialized) with this view filtered to data newer than end_date,
+      providing near-real-time intraday coverage without re-scanning historical partitions.
+
+materialization:
+  type: view
+
+depends:
+  - analytics_123456789.parse_version # TODO: Change 123456789 to your analytics ID
+  - analytics_123456789.events_intraday # TODO: If you only have daily export, depend on events instead
+
+@bruin */
+
+SELECT
+    app_info.id as app,
+    platform,
+    PARSE_DATE('%Y%m%d', replace(_TABLE_SUFFIX, 'intraday_', '')) as dt,
+    TIMESTAMP_MICROS(event_timestamp) as ts,
+    TIMESTAMP_MICROS(user_first_touch_timestamp) as user_first_touch_ts,
+    user_pseudo_id,
+    user_id,
+    lower(event_name) as event_name,
+    analytics_123456789.parse_version(app_info.version) as app_version, -- TODO: Change 123456789 to your analytics ID
+    (
+      select
+        case when array_length(keys) > 0 then json_object(keys, vals) end
+      from (
+        select
+            array_agg(p.key) as keys,
+            array_agg(coalesce(
+              p.value.string_value,
+              cast(p.value.int_value as string),
+              cast(coalesce(p.value.double_value, p.value.float_value) as string)
+            )) as vals
+          from unnest(event_params) as p
+      )
+    ) as event_params,
+    (
+      select case when array_length(keys) > 0 then json_object(keys, vals) end
+      from (
+          select
+            array_agg(p.key) as keys,
+            array_agg(coalesce(
+              p.value.string_value,
+              cast(p.value.int_value as string),
+              cast(coalesce(p.value.double_value, p.value.float_value) as string)
+            )) as vals
+          from unnest(user_properties) as p
+          where not starts_with(p.key, '_ltv')
+            and not starts_with(p.key, 'firebase_exp')
+            and p.key not in ("user_id")
+      )
+    ) as user_properties,
+    (
+      select array_agg(struct(
+        safe_cast(replace(key, "firebase_exp_", "") as int64) as id,
+        safe_cast(value.string_value as int64) as value
+      ))
+      from unnest(user_properties) where key like 'firebase_exp%'
+    ) as experiments,
+    to_json(geo) as geo,
+    to_json((
+      select as struct device.* except(is_limited_ad_tracking, time_zone_offset_seconds),
+        CASE lower(device.is_limited_ad_tracking)
+          WHEN 'yes' THEN True
+          WHEN 'no' THEN False
+        END as is_limited_ad_tracking,
+        device.time_zone_offset_seconds / 3600 as device_time_zone_offset,
+    )) as device,
+    to_json(privacy_info) as privacy_info,
+    event_server_timestamp_offset / 1000 as event_server_timestamp_offset,
+    event_value_in_usd,
+from `analytics_123456789.events_*` -- TODO: Change 123456789 to your analytics ID
+where replace(_TABLE_SUFFIX, 'intraday_', '') between '20200101' and '21000101'
+  and replace(_TABLE_SUFFIX, 'intraday_', '') between '{{ start_date_nodash }}' and '{{ end_date | add_days(1) | date_format("%Y%m%d") }}'

--- a/templates/firebase/assets/user_model/stg_users_daily.sql
+++ b/templates/firebase/assets/user_model/stg_users_daily.sql
@@ -1,0 +1,83 @@
+/* @bruin
+
+type: bq.sql
+description: The stg_users_daily table contains daily user-level metrics and dimensions aggregated from events.events. The underlying table is partitioned by date and clustered by user_id. Used as the source for user_model.users (install-time attrs + cohorts) and user_model.users_daily (enriched daily rollup with install context).
+
+materialization:
+  type: table
+  strategy: time_interval
+  partition_by: dt
+  cluster_by:
+    - user_id
+  incremental_key: dt
+  time_granularity: date
+
+depends:
+  - events.events
+
+columns:
+  - name: user_id
+    type: STRING
+    description: The user ID
+    primary_key: true
+  - name: dt
+    type: DATE
+    description: The date of the event
+    primary_key: true
+  - name: platform
+    type: STRING
+    description: The platform (Android, iOS, Web). Gets the first platform used by the user in the day.
+
+@bruin */
+
+SELECT
+  user_id, --TODO: change to user_pseudo_id if needed
+  dt,
+  min_by(platform, ts) as platform, --TODO: Gets the first platform used by the user. Change it, or convert to dimension if needed.
+
+  -- User Attributes
+  array_agg(app_version ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_app_version,
+  array_agg(app_version ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_app_version,
+  array_agg(geo.country ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_country,
+  array_agg(geo.country ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_country,
+  coalesce(array_agg(device.mobile_brand_name ignore nulls order by ts limit 1)[safe_offset(0)], 'unknown') as daily_first_device_brand,
+  coalesce(array_agg(device.mobile_brand_name ignore nulls order by ts desc limit 1)[safe_offset(0)], 'unknown') as daily_last_device_brand,
+  coalesce(array_agg(device.mobile_model_name ignore nulls order by ts limit 1)[safe_offset(0)], 'unknown') as daily_first_device_model,
+  coalesce(array_agg(device.mobile_model_name ignore nulls order by ts desc limit 1)[safe_offset(0)], 'unknown') as daily_last_device_model,
+  coalesce(array_agg(device.language ignore nulls order by ts limit 1)[safe_offset(0)], 'unknown') as daily_first_device_language,
+  coalesce(array_agg(device.language ignore nulls order by ts desc limit 1)[safe_offset(0)], 'unknown') as daily_last_device_language,
+  array_agg(device.operating_system_version ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_os_version,
+  array_agg(device.operating_system_version ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_os_version,
+
+  -- Session Attributes
+  count(*) as events,
+  min(ts) as min_ts,
+  max(ts) as max_ts,
+  countif(event_name not in ("session_start", "user_engagement", "firebase_campaign", "ad_reward")) > 0 as engaged, --TODO: ADD MORE EVENTS IF NEEDED BY GAMES. DO NOT REMOVE ANY DEFAULT FIREBASE EVENTS
+  countif(event_name = "session_start") as session_starts,
+  min(session_number) as min_session_number,
+  max(session_number) as max_session_number,
+  count(distinct timestamp_trunc(ts, minute)) as session_duration, -- Counts distinct minutes in the session, more robust then max(ts) - min(ts).
+  array_agg(if(event_name not in ("user_engagement"), event_name, null) ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_event,
+  array_agg(if(event_name not in ("user_engagement"), event_name, null) ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_event,
+
+  -- Revenue and Transactions
+  countif(event_name="ad_impression") as ad_imp_cnt,
+  countif(event_name="ad_impression" and ad_format="INTER") as ad_inter_imp_cnt,
+  countif(event_name="ad_impression" and ad_format="REWARDED") as ad_rv_imp_cnt,
+  countif(event_name="ad_impression" and ad_format="BANNER") as ad_banner_imp_cnt,
+  sum(if(event_name="ad_impression", value, 0)) as ad_rev,
+  sum(if(event_name="ad_impression" and ad_format="INTER", value, 0)) as ad_inter_rev,
+  sum(if(event_name="ad_impression" and ad_format="REWARDED", value, 0)) as ad_rv_rev,
+  sum(if(event_name="ad_impression" and ad_format="BANNER", value, 0)) as ad_banner_rev,
+  countif(event_name="in_app_purchase") as iap_cnt,
+  coalesce(sum(event_value_in_usd), 0) as iap_rev,
+  sum(if(event_name="ad_impression", value, 0)) + coalesce(sum(event_value_in_usd), 0) as total_rev,
+
+  --TODO: add game specific metrics
+
+from events.events
+where user_id is not null --TODO: change to user_pseudo_id if needed
+  and event_name not in ("app_remove", "os_update", "app_clear_data", "app_update", "app_exception")
+  and dt between '{{ start_date }}' and '{{ end_date }}'
+group by 1,2

--- a/templates/firebase/assets/user_model/users.sql
+++ b/templates/firebase/assets/user_model/users.sql
@@ -8,7 +8,7 @@ materialization:
     - user_id
 
 depends:
-  - user_model.users_daily
+  - user_model.stg_users_daily
 
 description:
   The users table contains user-level metrics and dimensions.
@@ -89,7 +89,7 @@ t1 as
       {%- endfor %}
     ) order by dt) as daily_metrics,
 
-  from `user_model.users_daily`
+  from `user_model.stg_users_daily`
   group by 1
 )
 select * except(daily_metrics),

--- a/templates/firebase/assets/user_model/users_daily.sql
+++ b/templates/firebase/assets/user_model/users_daily.sql
@@ -1,83 +1,33 @@
 /* @bruin
 
 type: bq.sql
-description: The users_daily table contains daily user-level metrics and dimensions. The underlying table is partitioned by date and clustered by user_id. This table is used for reporting and ad-hoc analysis.
+description: |
+  Enriched daily user rollup. Joins user_model.stg_users_daily (raw daily aggregates)
+  with user_model.users (install-time attributes) so each daily row is tagged with
+  install_dt, install_country, days_since_install, nth_active_day, etc.
+  Enables day-N analysis without re-aggregating.
 
 materialization:
   type: table
-  strategy: time_interval
+  strategy: create+replace
   partition_by: dt
   cluster_by:
     - user_id
-  incremental_key: dt
-  time_granularity: date
 
 depends:
-  - events.events
-
-columns:
-  - name: user_id
-    type: STRING
-    description: The user ID
-    primary_key: true
-  - name: dt
-    type: DATE
-    description: The date of the event
-    primary_key: true
-  - name: platform
-    type: STRING
-    description: The platform (Android, iOS, Web). Gets the first platform used by the user in the day.
+  - user_model.stg_users_daily
+  - user_model.users
 
 @bruin */
 
-SELECT
-  user_id, --TODO: change to user_pseudo_id if needed
-  dt,
-  min_by(platform, ts) as platform, --TODO: Gets the first platform used by the user. Change it, or convert to dimension if needed.
-
-  -- User Attributes
-  array_agg(app_version ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_app_version,
-  array_agg(app_version ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_app_version,
-  array_agg(geo.country ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_country,
-  array_agg(geo.country ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_country,
-  coalesce(array_agg(device.mobile_brand_name ignore nulls order by ts limit 1)[safe_offset(0)], 'unknown') as daily_first_device_brand,
-  coalesce(array_agg(device.mobile_brand_name ignore nulls order by ts desc limit 1)[safe_offset(0)], 'unknown') as daily_last_device_brand,
-  coalesce(array_agg(device.mobile_model_name ignore nulls order by ts limit 1)[safe_offset(0)], 'unknown') as daily_first_device_model,
-  coalesce(array_agg(device.mobile_model_name ignore nulls order by ts desc limit 1)[safe_offset(0)], 'unknown') as daily_last_device_model,
-  coalesce(array_agg(device.language ignore nulls order by ts limit 1)[safe_offset(0)], 'unknown') as daily_first_device_language,
-  coalesce(array_agg(device.language ignore nulls order by ts desc limit 1)[safe_offset(0)], 'unknown') as daily_last_device_language,
-  array_agg(device.operating_system_version ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_os_version,
-  array_agg(device.operating_system_version ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_os_version,
-
-  -- Session Attributes
-  count(*) as events,
-  min(ts) as min_ts,
-  max(ts) as max_ts,
-  countif(event_name not in ("session_start", "user_engagement", "firebase_campaign", "ad_reward")) > 0 as engaged, --TODO: ADD MORE EVENTS IF NEEDED BY GAMES. DO NOT REMOVE ANY DEFAULT FIREBASE EVENTS
-  countif(event_name = "session_start") as session_starts,
-  min(session_number) as min_session_number,
-  max(session_number) as max_session_number,
-  count(distinct timestamp_trunc(ts, minute)) as session_duration, -- Counts distinct minutes in the session, more robust then max(ts) - min(ts).
-  array_agg(if(event_name not in ("user_engagement"), event_name, null) ignore nulls order by ts limit 1)[safe_offset(0)] as daily_first_event,
-  array_agg(if(event_name not in ("user_engagement"), event_name, null) ignore nulls order by ts desc limit 1)[safe_offset(0)] as daily_last_event,
-
-  -- Revenue and Transactions
-  countif(event_name="ad_impression") as ad_imp_cnt,
-  countif(event_name="ad_impression" and ad_format="INTER") as ad_inter_imp_cnt,
-  countif(event_name="ad_impression" and ad_format="REWARDED") as ad_rv_imp_cnt,
-  countif(event_name="ad_impression" and ad_format="BANNER") as ad_banner_imp_cnt,
-  sum(if(event_name="ad_impression", value, 0)) as ad_rev,
-  sum(if(event_name="ad_impression" and ad_format="INTER", value, 0)) as ad_inter_rev,
-  sum(if(event_name="ad_impression" and ad_format="REWARDED", value, 0)) as ad_rv_rev,
-  sum(if(event_name="ad_impression" and ad_format="BANNER", value, 0)) as ad_banner_rev,
-  countif(event_name="in_app_purchase") as iap_cnt,
-  coalesce(sum(event_value_in_usd), 0) as iap_rev,
-  sum(if(event_name="ad_impression", value, 0)) + coalesce(sum(event_value_in_usd), 0) as total_rev,
-
-  --TODO: add game specific metrics 
-
-from events.events
-where user_id is not null --TODO: change to user_pseudo_id if needed
-  and event_name not in ("app_remove", "os_update", "app_clear_data", "app_update", "app_exception")
-  and dt between '{{ start_date }}' and '{{ end_date }}'
-group by 1,2
+select
+  ud.*,
+  u.install_dt,
+  u.install_country,
+  u.install_app_version,
+  u.install_platform,
+  u.install_device_brand,
+  date_diff(dt, u.install_dt, day) as days_since_install,
+  row_number() over (partition by ud.user_id order by ud.dt) as nth_active_day,
+from `user_model.stg_users_daily` as ud
+join `user_model.users` as u using(user_id)


### PR DESCRIPTION
## Summary

Restructures the `templates/firebase` pipeline to use a 3-file pattern in both `events/` and `user_model/`, separating parsing logic, materialized history, and enriched/intraday views.

### `events/`
- **`stg_events.sql`** (new): view over `analytics_*.events_*` that owns all parsing/flattening logic — event_params, user_properties, experiments, device, geo, privacy_info. Wildcard table catches both daily and intraday partitions.
- **`events_json.sql`**: now a thin materialized window over `stg_events`, filtered by pipeline date range. No parsing logic — just `SELECT * WHERE dt BETWEEN start_date AND end_date`. Partitioned by `dt`, clustered by `event_name` + `user_pseudo_id`.
- **`events.sql`**: unions materialized history (`events_json` where `dt <= end_date`) with live intraday (`stg_events` where `dt > end_date`) for near-real-time coverage without re-scanning historical partitions. Kept generic Firebase fields (screen/session/ads); app-specific params left as a TODO comment.

### `user_model/`
- **`stg_users_daily.sql`** (new): raw daily aggregation from `events.events` — device/geo/app first+last of day, session metrics, ad/IAP revenue. Incremental, partitioned by `dt`, clustered by `user_id`. (Body is the previous `users_daily.sql` verbatim.)
- **`users.sql`**: now depends on `stg_users_daily` instead of `users_daily`. Cohort/retention Jinja logic unchanged — generates `ret_d{1..90}` and cumulative `{metric}_d{N}` columns.
- **`users_daily.sql`**: rewritten as an enriched join-back of `stg_users_daily ⋈ users`, tagging each daily row with install_dt, install_country, install_app_version, install_platform, install_device_brand, `days_since_install`, and `nth_active_day`. Enables day-N analysis without re-aggregating. `create+replace` strategy.

### Topology

**events:** `analytics_*.events_* → stg_events → events_json` and `(events_json ∪ stg_events) → events`

**user_model:** `events.events → stg_users_daily → users` and `(stg_users_daily ⋈ users) → users_daily`

## Test plan

- [ ] `make format` clean
- [ ] `make test` passes
- [ ] Render each asset against a sample pipeline: `bruin render templates/firebase/assets/events/stg_events.sql` (and the rest)
- [ ] Lint the template: `bruin lint templates/firebase`
- [ ] Spot-check that `users_daily` row counts match `stg_users_daily` after the join (no user fan-out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)