### PR TITLE
Add Conductor Rust target setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "setup": "set -eu; root=\"${CONDUCTOR_ROOT_PATH:-}\"; src=\"$root/pkg/sqlparser/rustffi/target\"; dst=\"pkg/sqlparser/rustffi/target\"; if [ -n \"$root\" ] && [ \"$root\" != \"$PWD\" ] && [ -d \"$src\" ]; then if command -v rsync >/dev/null 2>&1; then mkdir -p \"$dst\"; rsync -a \"$src/\" \"$dst/\"; else rm -rf \"$dst\"; mkdir -p \"$(dirname \"$dst\")\"; cp -R \"$src\" \"$dst\"; fi; fi"
+    "setup": "set -eu; root=\"${CONDUCTOR_ROOT_PATH:-}\"; src=\"$root/pkg/sqlparser/rustffi/target\"; dst=\"pkg/sqlparser/rustffi/target\"; if [ -n \"$root\" ] && [ \"$root\" != \"$PWD\" ] && [ -d \"$src\" ]; then if command -v rsync >/dev/null 2>&1; then mkdir -p \"$dst\"; rsync -a \"$src/\" \"$dst/\"; else rm -rf \"$dst\"; mkdir -p \"$(dirname \"$dst\")\"; cp -Rp \"$src\" \"$dst\"; fi; fi"
   }
 }

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "set -eu; root=\"${CONDUCTOR_ROOT_PATH:-}\"; src=\"$root/pkg/sqlparser/rustffi/target\"; dst=\"pkg/sqlparser/rustffi/target\"; if [ -n \"$root\" ] && [ \"$root\" != \"$PWD\" ] && [ -d \"$src\" ]; then if command -v rsync >/dev/null 2>&1; then mkdir -p \"$dst\"; rsync -a \"$src/\" \"$dst/\"; else rm -rf \"$dst\"; mkdir -p \"$(dirname \"$dst\")\"; cp -R \"$src\" \"$dst\"; fi; fi"
+  }
+}


### PR DESCRIPTION
Copies the Rust Cargo target from the Conductor root checkout into new workspaces during setup, with a cp fallback when rsync is unavailable.

This avoids rebuilding the rarely changed Rust SQL parser target for each new worktree.

Validation: conductor.json parses and the setup script passes bash syntax checks.