### PR TITLE
Add built-in Bruin SQL helper macros

### DIFF
--- a/docs/assets/templating/macros.md
+++ b/docs/assets/templating/macros.md
@@ -181,6 +181,165 @@ WHERE country = '{{ country }}'
 {% endfor %}
 ```
 
+## Built-in Bruin SQL Helpers
+
+Bruin also provides built-in SQL helpers under the `bruin` namespace. These are available in SQL assets without creating files in `macros/`, and many of them render platform-specific SQL for the asset type.
+
+For example, the same helper can render different SQL in BigQuery, Snowflake, Postgres, DuckDB, SQL Server, and other supported platforms:
+
+```bruin-sql
+select
+    {{ bruin.generate_surrogate_key(['customer_id', 'order_id']) }} as order_key,
+    {{ bruin.safe_divide('revenue', 'sessions') }} as revenue_per_session
+from orders
+{{ bruin.group_by(1) }}
+```
+
+### `bruin.group_by(n)`
+
+Generates a positional `GROUP BY` clause from `1` through `n`.
+
+```bruin-sql
+select customer_id, order_date, count(*) as orders
+from orders
+{{ bruin.group_by(2) }}
+```
+
+Renders to:
+
+```sql
+group by 1, 2
+```
+
+### `bruin.safe_divide(numerator, denominator)`
+
+Divides two expressions and returns `null` instead of failing on division by zero.
+
+```bruin-sql
+{{ bruin.safe_divide('revenue', 'sessions') }}
+```
+
+### `bruin.safe_add(fields)` and `bruin.safe_subtract(fields)`
+
+Adds or subtracts expressions while treating `null` values as `0`.
+
+```bruin-sql
+{{ bruin.safe_add(['revenue', 'tax', 'shipping']) }}
+{{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }}
+```
+
+### `bruin.generate_surrogate_key(fields)`
+
+Generates a stable MD5-based surrogate key expression from one or more fields. The rendered SQL uses the right cast, concatenation, and hash syntax for the asset platform where Bruin has a platform override.
+
+```bruin-sql
+{{ bruin.generate_surrogate_key(['customer_id', 'order_id']) }}
+```
+
+### `bruin.pivot(column, values, ...)`
+
+Generates aggregate `case` expressions for pivoting known values into columns.
+
+```bruin-sql
+select
+    customer_id,
+    {{ bruin.pivot('status', ['paid', 'refunded'], prefix='orders_') }}
+from orders
+group by customer_id
+```
+
+Optional keyword arguments:
+
+- `alias`: add aliases to generated expressions, defaults to `true`
+- `agg`: aggregate function, defaults to `sum`
+- `cmp`: comparison operator, defaults to `=`
+- `prefix`: alias prefix, defaults to empty
+- `suffix`: alias suffix, defaults to empty
+- `then_value`: value used when the comparison matches, defaults to `1`
+- `else_value`: value used when the comparison does not match, defaults to `0`
+- `quote_identifiers`: quote generated aliases, defaults to `true`
+- `distinct`: add `distinct` inside the aggregate, defaults to `false`
+
+### `bruin.haversine_distance(lat1, lon1, lat2, lon2, unit='mi')`
+
+Generates a haversine distance expression. `unit` can be `mi` or `km`.
+
+```bruin-sql
+{{ bruin.haversine_distance('pickup_lat', 'pickup_lon', 'dropoff_lat', 'dropoff_lon', unit='km') }}
+```
+
+### `bruin.degrees_to_radians(degrees)`
+
+Converts a degree expression to radians.
+
+```bruin-sql
+{{ bruin.degrees_to_radians('angle_degrees') }}
+```
+
+### `bruin.width_bucket(expr, min_value, max_value, num_buckets)`
+
+Generates a bucket number expression for a numeric value. Platforms with native `width_bucket` support use the native function where applicable.
+
+```bruin-sql
+{{ bruin.width_bucket('price', '0', '100', '10') }}
+```
+
+### `bruin.deduplicate(relation, partition_by, order_by)`
+
+Generates a query that keeps the first row per partition according to the given ordering.
+
+```bruin-sql
+{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}
+```
+
+Bruin uses platform-specific patterns such as `qualify`, `distinct on`, ordered array aggregation, or subqueries depending on the asset type.
+
+### `bruin.generate_series(upper_bound)`
+
+Generates a single-column relation named `generated_number` with values from `1` through `upper_bound`.
+
+```bruin-sql
+{{ bruin.generate_series(30) }}
+```
+
+### `bruin.date_spine(datepart, start_date, end_date)`
+
+Generates a single-column date or timestamp spine. The output column is named `date_<datepart>`.
+
+```bruin-sql
+{{ bruin.date_spine('day', "'2024-01-01'", "'2024-02-01'") }}
+```
+
+Supported date parts include `day`, `week`, `month`, `quarter`, `year`, `hour`, `minute`, `second`, `millisecond`, and `microsecond`. Exact support depends on the target database.
+
+### `bruin.slugify(value)`
+
+Converts text into a lowercase SQL-friendly identifier.
+
+```bruin-sql
+select 1 as {{ bruin.slugify('9 Active Users!') }}
+```
+
+Renders to:
+
+```sql
+select 1 as _9_active_users
+```
+
+### URL Helpers
+
+These helpers generate SQL expressions for parsing URL strings:
+
+```bruin-sql
+{{ bruin.get_url_host('page_url') }}
+{{ bruin.get_url_path('page_url') }}
+{{ bruin.get_url_parameter('page_url', 'utm_source') }}
+```
+
+- `bruin.get_url_host(field)` extracts the host
+- `bruin.get_url_path(field)` extracts the path without query parameters
+- `bruin.get_url_parameter(field, parameter)` extracts one query parameter value
+
 ## Practical Examples
 
 ### Aggregation Patterns

--- a/pkg/ansisql/bruin_funcs.go
+++ b/pkg/ansisql/bruin_funcs.go
@@ -1,0 +1,79 @@
+package ansisql
+
+import "fmt"
+
+// DeduplicateQualify generates a deduplication query using the QUALIFY clause.
+// Supported by Snowflake, BigQuery, Databricks, Redshift, and DuckDB.
+func DeduplicateQualify(relation, partitionBy, orderBy string) string {
+	return fmt.Sprintf(`select *
+    from %s as _bruin_source
+    qualify
+        row_number() over (
+            partition by %s
+            order by %s
+        ) = 1`, relation, partitionBy, orderBy)
+}
+
+// DeduplicateDistinctOn generates a deduplication query using DISTINCT ON.
+// Supported by Postgres.
+func DeduplicateDistinctOn(relation, partitionBy, orderBy string) string {
+	return fmt.Sprintf(`select
+        distinct on (%s) *
+    from %s
+    order by %s, %s`, partitionBy, relation, partitionBy, orderBy)
+}
+
+// DeduplicateSubquery generates a deduplication query using TOP WITH TIES.
+// For platforms without QUALIFY or DISTINCT ON support (MSSQL, Synapse, Fabric).
+// The output contains only the original relation columns (no internal helper columns).
+func DeduplicateSubquery(relation, partitionBy, orderBy string) string {
+	return fmt.Sprintf(`select top (1) with ties *
+    from %s
+    order by row_number() over (
+        partition by %s
+        order by %s
+    )`, relation, partitionBy, orderBy)
+}
+
+// DeduplicateArrayAgg generates a deduplication query using ordered array aggregation.
+// Supported by Trino and Athena, where QUALIFY/NATURAL JOIN are unavailable.
+func DeduplicateArrayAgg(relation, partitionBy, orderBy string) string {
+	return fmt.Sprintf(`select (array_agg(_bruin_source order by %s)[1]).*
+    from %s as _bruin_source
+    group by %s`, orderBy, relation, partitionBy)
+}
+
+// DeduplicateNaturalJoinNoAs generates the fallback natural-join deduplication shape without AS table aliases.
+// This is useful for dialects like Oracle that do not support AS for table aliases.
+func DeduplicateNaturalJoinNoAs(relation, partitionBy, orderBy string) string {
+	return fmt.Sprintf(`with row_numbered as (
+        select
+            bruin_inner.*,
+            row_number() over (
+                partition by %s
+                order by %s
+            ) as __bruin_row_number
+        from %s bruin_inner
+    )
+
+    select
+        distinct data.*
+    from %s data
+    natural join row_numbered
+    where row_numbered.__bruin_row_number = 1`, partitionBy, orderBy, relation, relation)
+}
+
+// DateAddInterval generates DATE_ADD(start, INTERVAL n datepart) syntax used by BigQuery and MySQL.
+func DateAddInterval(datepart, n, start string) string {
+	return fmt.Sprintf("DATE_ADD(%s, INTERVAL %s %s)", start, n, datepart)
+}
+
+// DateAddQuoted generates date_add('datepart', n, start) syntax used by Athena and Trino.
+func DateAddQuoted(datepart, n, start string) string {
+	return fmt.Sprintf("date_add('%s', %s, %s)", datepart, n, start)
+}
+
+// HashBytesHashFn returns a MSSQL-family HASHBYTES hash expression for use with SurrogateKeyWith.
+func HashBytesHashFn(expr string) string {
+	return fmt.Sprintf("convert(varchar(32), hashbytes('md5', %s), 2)", expr)
+}

--- a/pkg/athena/bruin_funcs.go
+++ b/pkg/athena/bruin_funcs.go
@@ -1,0 +1,19 @@
+package athena
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformAthena, jinja.MergeBuiltinOverrides(jinja.PrestoURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWithConcat("varchar", jinja.ConcatOperator, func(expr string) string {
+			return fmt.Sprintf("to_hex(md5(to_utf8(%s)))", expr)
+		}),
+		"deduplicate":  ansisql.DeduplicateArrayAgg,
+		"width_bucket": jinja.NativeWidthBucket,
+		"date_spine":   jinja.PrestoDateSpine,
+	}))
+}

--- a/pkg/athena/bruin_funcs_parser_test.go
+++ b/pkg/athena/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package athena
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAthenaGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformAthena, "athena")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/bigquery/bruin_funcs.go
+++ b/pkg/bigquery/bruin_funcs.go
@@ -1,0 +1,23 @@
+package bigquery
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformBigQuery, jinja.MergeBuiltinOverrides(jinja.BigQueryURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWith("string", func(expr string) string {
+			return fmt.Sprintf("to_hex(md5(%s))", expr)
+		}),
+		"deduplicate": ansisql.DeduplicateQualify,
+		"haversine_distance": jinja.HaversineDistanceWithRadians(func(expr string) string {
+			return fmt.Sprintf("(%s) * acos(-1) / 180", expr)
+		}),
+		"pivot":        jinja.PivotWithIdentifierQuote(jinja.BigQueryQuoteIdentifier),
+		"width_bucket": jinja.BigQueryWidthBucket,
+		"date_spine":   jinja.BigQueryDateSpine,
+	}))
+}

--- a/pkg/bigquery/bruin_funcs_parser_test.go
+++ b/pkg/bigquery/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBigQueryGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformBigQuery, "bigquery")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/bigquery/bruin_funcs_test.go
+++ b/pkg/bigquery/bruin_funcs_test.go
@@ -1,0 +1,60 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBigQueryBuiltinOverrides(t *testing.T) {
+	t.Parallel()
+
+	renderer := jinja.NewRenderer(jinja.Context{
+		"bruin": jinja.BuiltinFunctions(jinja.PlatformBigQuery),
+	})
+
+	t.Run("surrogate_key uses to_hex and string cast", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id', 'event_date']) }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "to_hex(md5(")
+		assert.Contains(t, result, "cast(user_id as string)")
+		assert.Contains(t, result, "cast(event_date as string)")
+	})
+
+	t.Run("deduplicate uses QUALIFY", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.deduplicate('my_table', 'user_id', 'updated_at desc') }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "qualify")
+		assert.NotContains(t, result, "natural join")
+	})
+
+	t.Run("pivot quotes identifiers with backticks", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.pivot('status', ['active']) }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "as `active`")
+		assert.NotContains(t, result, `as "active"`)
+	})
+
+	t.Run("haversine uses inline radians", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "acos(-1) / 180")
+		assert.NotContains(t, result, "radians(")
+	})
+
+	t.Run("date_spine uses date_diff-backed array offsets", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render(`{{ bruin.date_spine('day', "'2020-01-01'", "'2025-01-01'") }}`)
+		require.NoError(t, err)
+		assert.Contains(t, result, "generate_array")
+		assert.Contains(t, result, "date_diff")
+		assert.Contains(t, result, "date_add")
+		assert.NotContains(t, result, "generated_number <= 10000")
+	})
+}

--- a/pkg/clickhouse/bruin_funcs.go
+++ b/pkg/clickhouse/bruin_funcs.go
@@ -1,0 +1,22 @@
+package clickhouse
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformClickhouse, jinja.MergeBuiltinOverrides(jinja.ClickHouseURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWithCoalesceExpr(func(field string) string {
+			return fmt.Sprintf("coalesce(toString(%s), '%s')", field, jinja.SurrogateKeyNullValue())
+		}, jinja.ConcatFunction, func(expr string) string {
+			return fmt.Sprintf("lower(hex(MD5(%s)))", expr)
+		}),
+		"deduplicate":  ansisql.DeduplicateQualify,
+		"pivot":        jinja.PivotWithIdentifierQuote(jinja.BacktickQuoteIdentifier),
+		"width_bucket": jinja.ClickHouseWidthBucket,
+		"date_spine":   jinja.ClickHouseDateSpine,
+	}))
+}

--- a/pkg/clickhouse/bruin_funcs_parser_test.go
+++ b/pkg/clickhouse/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClickHouseGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformClickhouse, "clickhouse")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/databricks/bruin_funcs.go
+++ b/pkg/databricks/bruin_funcs.go
@@ -1,0 +1,19 @@
+package databricks
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformDatabricks, jinja.MergeBuiltinOverrides(jinja.SparkURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWith("string", func(expr string) string {
+			return fmt.Sprintf("md5(%s)", expr)
+		}),
+		"deduplicate": ansisql.DeduplicateQualify,
+		"pivot":       jinja.PivotWithIdentifierQuote(jinja.BacktickQuoteIdentifier),
+		"date_spine":  jinja.SparkDateSpine,
+	}))
+}

--- a/pkg/databricks/bruin_funcs_parser_test.go
+++ b/pkg/databricks/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package databricks
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabricksGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformDatabricks, "databricks")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/duckdb/bruin_funcs.go
+++ b/pkg/duckdb/bruin_funcs.go
@@ -1,0 +1,14 @@
+package duck
+
+import (
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformDuckDB, jinja.MergeBuiltinOverrides(jinja.SplitPartURLHelpers("varchar"), map[string]any{
+		"deduplicate":     ansisql.DeduplicateQualify,
+		"date_spine":      jinja.DuckDBDateSpine,
+		"generate_series": jinja.DuckDBGenerateSeries,
+	}))
+}

--- a/pkg/duckdb/bruin_funcs_parser_test.go
+++ b/pkg/duckdb/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package duck
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuckDBGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformDuckDB, "duckdb")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/fabric/bruin_funcs.go
+++ b/pkg/fabric/bruin_funcs.go
@@ -1,0 +1,16 @@
+package fabric
+
+import (
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformFabric, jinja.MergeBuiltinOverrides(jinja.TSQLURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar", ansisql.HashBytesHashFn),
+		"deduplicate":            ansisql.DeduplicateSubquery,
+		"pivot":                  jinja.PivotWithIdentifierQuote(jinja.BracketQuoteIdentifier),
+		"width_bucket":           jinja.TSQLWidthBucket,
+		"date_spine":             jinja.TSQLDateSpineWithTally,
+	}))
+}

--- a/pkg/fabric/bruin_funcs_parser_test.go
+++ b/pkg/fabric/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package fabric
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFabricGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformFabric, "fabric")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/jinja/bruin_funcs.go
+++ b/pkg/jinja/bruin_funcs.go
@@ -1,0 +1,1077 @@
+package jinja
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"math/bits"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/nikolalohinski/gonja/v2/exec"
+)
+
+// Platform represents a target database platform for SQL generation.
+type Platform string
+
+const (
+	PlatformDefault    Platform = ""
+	PlatformBigQuery   Platform = "bigquery"
+	PlatformSnowflake  Platform = "snowflake"
+	PlatformPostgres   Platform = "postgres"
+	PlatformRedshift   Platform = "redshift"
+	PlatformMySQL      Platform = "mysql"
+	PlatformDuckDB     Platform = "duckdb"
+	PlatformDatabricks Platform = "databricks"
+	PlatformMSSQL      Platform = "mssql"
+	PlatformClickhouse Platform = "clickhouse"
+	PlatformAthena     Platform = "athena"
+	PlatformTrino      Platform = "trino"
+	PlatformSynapse    Platform = "synapse"
+	PlatformOracle     Platform = "oracle"
+	PlatformFabric     Platform = "fabric"
+	PlatformVertica    Platform = "vertica"
+)
+
+// ---------------------------------------------------------------------------
+// Platform override registry
+// ---------------------------------------------------------------------------
+
+var (
+	platformOverridesMu sync.RWMutex
+	platformOverrides   = map[Platform]map[string]any{}
+)
+
+// RegisterPlatformOverrides registers platform-specific function overrides.
+// Platform packages call this in their init() to replace default built-in
+// functions with platform-appropriate SQL generation. The platform package
+// must be imported (directly or transitively) for its init() to execute.
+func RegisterPlatformOverrides(platform Platform, overrides map[string]any) {
+	platformOverridesMu.Lock()
+	defer platformOverridesMu.Unlock()
+	platformOverrides[platform] = overrides
+}
+
+// BuiltinFunctions returns a map of built-in SQL helper functions for use in Jinja templates.
+// When a platform is specified, any registered overrides for that platform are merged on top of defaults.
+func BuiltinFunctions(platform ...Platform) map[string]any {
+	funcs := defaultBuiltinFunctions()
+	if len(platform) > 0 && platform[0] != PlatformDefault {
+		platformOverridesMu.RLock()
+		overrides := platformOverrides[platform[0]]
+		platformOverridesMu.RUnlock()
+		maps.Copy(funcs, overrides)
+	}
+	return funcs
+}
+
+// MergeBuiltinOverrides combines override maps left-to-right.
+func MergeBuiltinOverrides(overrides ...map[string]any) map[string]any {
+	result := map[string]any{}
+	for _, override := range overrides {
+		maps.Copy(result, override)
+	}
+	return result
+}
+
+func defaultBuiltinFunctions() map[string]any {
+	return map[string]any{
+		"group_by":               bruinGroupBy,
+		"safe_divide":            bruinSafeDivide,
+		"safe_add":               bruinSafeAdd,
+		"safe_subtract":          bruinSafeSubtract,
+		"generate_surrogate_key": defaultSurrogateKey,
+		"pivot":                  bruinPivot,
+		"haversine_distance":     defaultHaversineDistance,
+		"degrees_to_radians":     bruinDegreesToRadians,
+		"width_bucket":           bruinWidthBucket,
+		"deduplicate":            bruinDeduplicate,
+		"generate_series":        bruinGenerateSeries,
+		"date_spine":             defaultDateSpine,
+		"slugify":                bruinSlugify,
+		"get_url_host":           bruinGetURLHost,
+		"get_url_parameter":      bruinGetURLParameter,
+		"get_url_path":           bruinGetURLPath,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Builder functions for platform packages
+//
+// These let platform packages construct override functions without importing
+// gonja/exec directly. The caller provides only the SQL-level differences
+// (cast type, hash wrapper, radians expression, dateadd syntax) and the
+// builder handles VarArgs/Value plumbing.
+// ---------------------------------------------------------------------------
+
+// SurrogateKeyWith builds a generate_surrogate_key function using the given cast type and hash wrapper.
+func SurrogateKeyWith(castType string, hashFn func(concatExpr string) string) func(*exec.VarArgs) *exec.Value {
+	return SurrogateKeyWithConcat(castType, concatFunction, hashFn)
+}
+
+// SurrogateKeyWithConcat builds a generate_surrogate_key function using platform-specific concat and hash syntax.
+func SurrogateKeyWithConcat(castType string, concatFn func(parts []string) string, hashFn func(concatExpr string) string) func(*exec.VarArgs) *exec.Value {
+	return SurrogateKeyWithCoalesceExpr(func(field string) string {
+		return fmt.Sprintf("coalesce(cast(%s as %s), '%s')", field, castType, surrogateKeyNullValue)
+	}, concatFn, hashFn)
+}
+
+const surrogateKeyNullValue = "_bruin_surrogate_key_null_"
+
+// SurrogateKeyNullValue returns the sentinel used to preserve null positions while hashing.
+func SurrogateKeyNullValue() string {
+	return surrogateKeyNullValue
+}
+
+// SurrogateKeyWithCoalesceExpr builds a generate_surrogate_key function using a caller-provided per-field expression.
+func SurrogateKeyWithCoalesceExpr(valueFn func(field string) string, concatFn func(parts []string) string, hashFn func(concatExpr string) string) func(*exec.VarArgs) *exec.Value {
+	return func(va *exec.VarArgs) *exec.Value {
+		fields := extractStringListFromVarArgs(va)
+		if len(fields) == 0 {
+			return exec.AsValue("")
+		}
+
+		concatParts := make([]string, 0, len(fields)*2-1)
+		for i, f := range fields {
+			concatParts = append(concatParts, valueFn(f))
+			if i < len(fields)-1 {
+				concatParts = append(concatParts, "'-'")
+			}
+		}
+		concatExpr := concatFn(concatParts)
+		return exec.AsValue(hashFn(concatExpr))
+	}
+}
+
+func concatFunction(parts []string) string {
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return fmt.Sprintf("concat(%s)", strings.Join(parts, ", "))
+}
+
+// ConcatFunction joins expressions with a variadic concat function, returning the expression unchanged for one part.
+func ConcatFunction(parts []string) string {
+	return concatFunction(parts)
+}
+
+// ConcatOperator joins expressions with the ANSI string concatenation operator.
+func ConcatOperator(parts []string) string {
+	return strings.Join(parts, " || ")
+}
+
+// PivotWithIdentifierQuote builds a pivot function using platform-specific quoted identifier syntax.
+func PivotWithIdentifierQuote(quoteIdentifier func(string) string) func(*exec.VarArgs) *exec.Value {
+	return func(va *exec.VarArgs) *exec.Value {
+		return bruinPivotWithIdentifierQuote(va, quoteIdentifier)
+	}
+}
+
+// DoubleQuoteIdentifier quotes an identifier with ANSI double quotes.
+func DoubleQuoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+// BacktickQuoteIdentifier quotes an identifier with backticks.
+func BacktickQuoteIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
+// BigQueryQuoteIdentifier quotes a GoogleSQL identifier with backticks and backslash-escaped backticks.
+func BigQueryQuoteIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "\\`") + "`"
+}
+
+// BracketQuoteIdentifier quotes an identifier with SQL Server square brackets.
+func BracketQuoteIdentifier(identifier string) string {
+	return "[" + strings.ReplaceAll(identifier, "]", "]]") + "]"
+}
+
+// HaversineDistanceWithRadians builds a haversine_distance function using the given radians conversion.
+func HaversineDistanceWithRadians(radiansFn func(expr string) string) func(*exec.VarArgs) (*exec.Value, error) {
+	return func(va *exec.VarArgs) (*exec.Value, error) {
+		if len(va.Args) < 4 {
+			return nil, errors.New("haversine_distance requires 4 arguments: lat1, lon1, lat2, lon2")
+		}
+
+		lat1 := va.Args[0].String()
+		lon1 := va.Args[1].String()
+		lat2 := va.Args[2].String()
+		lon2 := va.Args[3].String()
+
+		unit := "mi"
+		if v, ok := va.KwArgs["unit"]; ok {
+			unit = v.String()
+		} else if len(va.Args) > 4 {
+			unit = va.Args[4].String()
+		}
+
+		conversionRate := "1"
+		switch unit {
+		case "mi":
+		case "km":
+			conversionRate = "1.60934"
+		default:
+			return nil, fmt.Errorf("haversine_distance unit must be 'mi' or 'km', got %q", unit)
+		}
+
+		return exec.AsValue(fmt.Sprintf(
+			"2 * 3961 * asin(sqrt(power((sin(%s)), 2) +\n"+
+				"    cos(%s) * cos(%s) *\n"+
+				"    power((sin(%s)), 2))) * %s",
+			radiansFn(fmt.Sprintf("(%s - %s) / 2", lat2, lat1)),
+			radiansFn(lat1),
+			radiansFn(lat2),
+			radiansFn(fmt.Sprintf("(%s - %s) / 2", lon2, lon1)),
+			conversionRate,
+		)), nil
+	}
+}
+
+// DateSpineWithDateAdd builds a date_spine function using the given date-addition expression builder.
+func DateSpineWithDateAdd(dateAddFn func(datepart, n, start string) string) func(string, string, string) string {
+	return DateSpineWithRecursiveDateAdd(true, "", dateAddFn)
+}
+
+// DateSpineWithDateAddAndDateDiff builds a recursive date_spine function using an interval count.
+func DateSpineWithDateAddAndDateDiff(withRecursive bool, suffix string, dateAddFn, dateDiffFn func(datepart, start, end string) string) func(string, string, string) string {
+	return func(datepart, startDate, endDate string) string {
+		columnName := "date_" + datepart
+		diffExpr := dateDiffFn(datepart, startDate, endDate)
+		nextExpr := dateAddFn(datepart, "(n + 1)", startDate)
+		withKeyword := "with"
+		if withRecursive {
+			withKeyword = "with recursive"
+		}
+
+		return fmt.Sprintf(`%s date_spine(n, %s) as (
+
+    select 0 as n, %s as %s
+    where %s > 0
+
+    union all
+
+    select n + 1, %s
+    from date_spine
+    where n + 1 < %s
+
+)
+
+select %s
+from date_spine%s`, withKeyword, columnName, startDate, columnName, diffExpr, nextExpr, diffExpr, columnName, suffix)
+	}
+}
+
+// DateSpineWithRecursiveDateAdd builds a recursive CTE date_spine function.
+func DateSpineWithRecursiveDateAdd(withRecursive bool, suffix string, dateAddFn func(datepart, n, start string) string) func(string, string, string) string {
+	return func(datepart, startDate, endDate string) string {
+		columnName := "date_" + datepart
+		nextExpr := dateAddFn(datepart, "(n + 1)", startDate)
+		withKeyword := "with"
+		if withRecursive {
+			withKeyword = "with recursive"
+		}
+
+		return fmt.Sprintf(`%s date_spine(n, %s) as (
+
+    select 0 as n, %s as %s
+    where %s < %s
+
+    union all
+
+    select n + 1, %s
+    from date_spine
+    where %s < %s
+
+)
+
+select %s
+from date_spine%s`, withKeyword, columnName, startDate, columnName, startDate, endDate, nextExpr, nextExpr, endDate, columnName, suffix)
+	}
+}
+
+// BigQueryDateSpine builds date_spine using BigQuery's array generators.
+func BigQueryDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	part := strings.ToUpper(datepart)
+	if IsTimestampDatepart(datepart) {
+		spineExpr := fmt.Sprintf("timestamp_add(timestamp(%s), interval n %s)", startDate, part)
+		return fmt.Sprintf(`select %s as %s
+from unnest(generate_array(0, greatest(timestamp_diff(timestamp(%s), timestamp(%s), %s), 0))) as n
+where %s < timestamp(%s)`, spineExpr, columnName, endDate, startDate, part, spineExpr, endDate)
+	}
+	spineExpr := fmt.Sprintf("date_add(date(%s), interval n %s)", startDate, part)
+	return fmt.Sprintf(`select %s as %s
+from unnest(generate_array(0, greatest(date_diff(date(%s), date(%s), %s), 0))) as n
+where %s < date(%s)`, spineExpr, columnName, endDate, startDate, part, spineExpr, endDate)
+}
+
+// DuckDBDateSpine builds date_spine using DuckDB's generate_series table function.
+func DuckDBDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	castType := "date"
+	selectExpr := columnName
+	if IsTimestampDatepart(datepart) {
+		castType = "timestamp"
+	} else {
+		selectExpr = fmt.Sprintf("cast(%s as date)", columnName)
+	}
+	step := IntervalStepLiteral(datepart)
+	return fmt.Sprintf(`select %s as %s
+from generate_series(cast(%s as %s), cast(%s as %s), interval '%s') as t(%s)
+where %s < cast(%s as %s)`, selectExpr, columnName, startDate, castType, endDate, castType, step, columnName, columnName, endDate, castType)
+}
+
+// PostgresDateSpine builds date_spine using Postgres generate_series.
+func PostgresDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	selectExpr := columnName
+	if !IsTimestampDatepart(datepart) {
+		selectExpr = fmt.Sprintf("cast(%s as date)", columnName)
+	}
+	step := IntervalStepLiteral(datepart)
+	return fmt.Sprintf(`select %s as %s
+from generate_series(cast(%s as timestamp), cast(%s as timestamp), interval '%s') as t(%s)
+where %s < cast(%s as timestamp)`, selectExpr, columnName, startDate, endDate, step, columnName, columnName, endDate)
+}
+
+// SparkDateSpine builds date_spine using Spark/Databricks sequence + explode.
+func SparkDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	castFn := "to_date"
+	arrayType := "array<date>"
+	if IsTimestampDatepart(datepart) {
+		castFn = "to_timestamp"
+		arrayType = "array<timestamp>"
+	}
+	step := IntervalStepLiteral(datepart)
+	return fmt.Sprintf(`select explode(
+    case
+        when %s(%s) + interval %s <= %s(%s)
+            then filter(sequence(%s(%s), %s(%s), interval %s), x -> x < %s(%s))
+        else cast(array() as %s)
+    end
+) as %s`, castFn, startDate, step, castFn, endDate, castFn, startDate, castFn, endDate, step, castFn, endDate, arrayType, columnName)
+}
+
+// PrestoDateSpine builds date_spine for Trino/Athena using sequence + unnest.
+func PrestoDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	castType := "date"
+	if IsTimestampDatepart(datepart) {
+		castType = "timestamp"
+	}
+	diffExpr := fmt.Sprintf("date_diff('%s', cast(%s as %s), cast(%s as %s))", datepart, startDate, castType, endDate, castType)
+	spineExpr := fmt.Sprintf("date_add('%s', n, cast(%s as %s))", datepart, startDate, castType)
+	return fmt.Sprintf(`select date_add('%s', n, cast(%s as %s)) as %s
+from unnest(sequence(cast(0 as bigint), greatest(%s, cast(0 as bigint)))) as t(n)
+where %s < cast(%s as %s)`, datepart, startDate, castType, columnName, diffExpr, spineExpr, endDate, castType)
+}
+
+// ClickHouseDateSpine builds date_spine using numbers and dateDiff/dateAdd.
+func ClickHouseDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	castFn := "toDate"
+	switch datepart {
+	case "millisecond":
+		castFn = "toDateTime64"
+		startDate += ", 3"
+		endDate += ", 3"
+	case "microsecond":
+		castFn = "toDateTime64"
+		startDate += ", 6"
+		endDate += ", 6"
+	case "hour", "minute", "second":
+		castFn = "toDateTime"
+	}
+	return fmt.Sprintf(`select date_add(%s, number, %s(%s)) as %s
+from numbers(greatest(dateDiff('%s', %s(%s), %s(%s)), 0) + 1)
+where date_add(%s, number, %s(%s)) < %s(%s)`, datepart, castFn, startDate, columnName, datepart, castFn, startDate, castFn, endDate, datepart, castFn, startDate, castFn, endDate)
+}
+
+// OracleDateSpine builds date_spine using CONNECT BY LEVEL.
+func OracleDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	startExpr := fmt.Sprintf("cast(%s as date)", startDate)
+	endExpr := fmt.Sprintf("cast(%s as date)", endDate)
+	switch datepart {
+	case "quarter":
+		return fmt.Sprintf(`select %s
+from (
+    select ADD_MONTHS(base_date, (level - 1) * 3) as %s, end_date
+    from (select %s as base_date, %s as end_date from dual where %s < %s)
+    connect by level <= (ceil(months_between(end_date, base_date) / 3) + 1)
+)
+where %s < end_date`, columnName, columnName, startExpr, endExpr, startExpr, endExpr, columnName)
+	case "month":
+		return fmt.Sprintf(`select %s
+from (
+    select ADD_MONTHS(base_date, level - 1) as %s, end_date
+    from (select %s as base_date, %s as end_date from dual where %s < %s)
+    connect by level <= (ceil(months_between(end_date, base_date)) + 1)
+)
+where %s < end_date`, columnName, columnName, startExpr, endExpr, startExpr, endExpr, columnName)
+	case "year":
+		return fmt.Sprintf(`select %s
+from (
+    select ADD_MONTHS(base_date, (level - 1) * 12) as %s, end_date
+    from (select %s as base_date, %s as end_date from dual where %s < %s)
+    connect by level <= (ceil(months_between(end_date, base_date) / 12) + 1)
+)
+where %s < end_date`, columnName, columnName, startExpr, endExpr, startExpr, endExpr, columnName)
+	case "hour", "minute", "second":
+		multiplier := map[string]string{"hour": "24", "minute": "1440", "second": "86400"}[datepart]
+		return fmt.Sprintf(`select %s
+from (
+    select (base_date + NUMTODSINTERVAL(level - 1, '%s')) as %s, end_date
+    from (select %s as base_date, %s as end_date from dual where %s < %s)
+    connect by level <= (ceil((end_date - base_date) * %s) + 1)
+)
+where %s < end_date`, columnName, datepart, columnName, startExpr, endExpr, startExpr, endExpr, multiplier, columnName)
+	case "week":
+		return fmt.Sprintf(`select %s
+from (
+    select (base_date + ((level - 1) * 7)) as %s, end_date
+    from (select %s as base_date, %s as end_date from dual where %s < %s)
+    connect by level <= (ceil((end_date - base_date) / 7) + 1)
+)
+where %s < end_date`, columnName, columnName, startExpr, endExpr, startExpr, endExpr, columnName)
+	default:
+		return fmt.Sprintf(`select %s
+from (
+    select (base_date + level - 1) as %s, end_date
+    from (select %s as base_date, %s as end_date from dual where %s < %s)
+    connect by level <= (ceil(end_date - base_date) + 1)
+)
+where %s < end_date`, columnName, columnName, startExpr, endExpr, startExpr, endExpr, columnName)
+	}
+}
+
+// MySQLDateSpine builds a recursive date_spine with MySQL casts and a per-query recursion-depth hint.
+func MySQLDateSpine(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	castType := dateSpineCastType(datepart, "date", "datetime")
+	startExpr := fmt.Sprintf("cast(%s as %s)", startDate, castType)
+	endExpr := fmt.Sprintf("cast(%s as %s)", endDate, castType)
+	nextExpr := fmt.Sprintf("DATE_ADD(%s, INTERVAL (n + 1) %s)", startExpr, datepart)
+
+	return fmt.Sprintf(`with recursive date_spine(n, %s) as (
+
+    select 0 as n, %s as %s
+    where %s < %s
+
+    union all
+
+    select n + 1, %s
+    from date_spine
+    where %s < %s
+
+)
+
+select /*+ SET_VAR(cte_max_recursion_depth=1000000) */ %s
+from date_spine`, columnName, startExpr, columnName, startExpr, endExpr, nextExpr, nextExpr, endExpr, columnName)
+}
+
+// TSQLDateSpine builds date_spine for SQL Server-family dialects.
+func TSQLDateSpine(datepart, startDate, endDate string) string {
+	castType := dateSpineCastType(datepart, "date", "datetime2")
+	startExpr := fmt.Sprintf("cast(%s as %s)", startDate, castType)
+	endExpr := fmt.Sprintf("cast(%s as %s)", endDate, castType)
+	return DateSpineWithRecursiveDateAdd(false, "\noption (maxrecursion 0)", func(datepart, n, start string) string {
+		return fmt.Sprintf("dateadd(%s, %s, %s)", datepart, n, start)
+	})(datepart, startExpr, endExpr)
+}
+
+// TSQLDateSpineWithTally builds date_spine without recursive CTEs for Synapse/Fabric.
+func TSQLDateSpineWithTally(datepart, startDate, endDate string) string {
+	columnName := "date_" + datepart
+	castType := dateSpineCastType(datepart, "date", "datetime2")
+	startExpr := fmt.Sprintf("cast(%s as %s)", startDate, castType)
+	endExpr := fmt.Sprintf("cast(%s as %s)", endDate, castType)
+	diffExpr := fmt.Sprintf("datediff(%s, %s, %s)", datepart, startExpr, endExpr)
+	topExpr := fmt.Sprintf("case when %s < 0 then 0 else %s + 2 end", diffExpr, diffExpr)
+	nextExpr := fmt.Sprintf("dateadd(%s, cast(n as int), %s)", datepart, startExpr)
+
+	return fmt.Sprintf(`with digits(n) as (
+    select 0 union all select 1 union all select 2 union all select 3 union all select 4
+    union all select 5 union all select 6 union all select 7 union all select 8 union all select 9
+), numbers(n) as (
+    select top (%s)
+        row_number() over (order by d0.n, d1.n, d2.n, d3.n, d4.n, d5.n, d6.n) - 1 as n
+    from digits d0
+    cross join digits d1
+    cross join digits d2
+    cross join digits d3
+    cross join digits d4
+    cross join digits d5
+    cross join digits d6
+)
+select %s as %s
+from numbers
+where %s < %s`, topExpr, nextExpr, columnName, nextExpr, endExpr)
+}
+
+func dateSpineCastType(datepart, dateType, timestampType string) string {
+	if IsTimestampDatepart(datepart) {
+		return timestampType
+	}
+	return dateType
+}
+
+// IntervalStepLiteral returns a SQL interval literal body for dateparts that are not universally accepted as interval units.
+func IntervalStepLiteral(datepart string) string {
+	switch datepart {
+	case "quarter":
+		return "3 month"
+	case "week":
+		return "7 day"
+	default:
+		return "1 " + datepart
+	}
+}
+
+// IsTimestampDatepart reports whether a date_spine datepart needs timestamp rather than date values.
+func IsTimestampDatepart(datepart string) bool {
+	switch strings.ToLower(datepart) {
+	case "hour", "minute", "second", "millisecond", "microsecond":
+		return true
+	default:
+		return false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default implementations (used when no platform override is registered)
+// ---------------------------------------------------------------------------
+
+var defaultSurrogateKey = SurrogateKeyWith("varchar", func(concatExpr string) string {
+	return fmt.Sprintf("md5(%s)", concatExpr)
+})
+
+var defaultHaversineDistance = HaversineDistanceWithRadians(func(expr string) string {
+	return fmt.Sprintf("radians(%s)", expr)
+})
+
+var defaultDateSpine = DateSpineWithDateAdd(func(datepart, n, start string) string {
+	return fmt.Sprintf("dateadd(%s, %s, %s)", datepart, n, start)
+})
+
+// ---------------------------------------------------------------------------
+// Platform-independent functions
+// ---------------------------------------------------------------------------
+
+func bruinGroupBy(n int) string {
+	parts := make([]string, n)
+	for i := range n {
+		parts[i] = strconv.Itoa(i + 1)
+	}
+	return "group by " + strings.Join(parts, ", ")
+}
+
+func bruinSafeDivide(numerator, denominator string) string {
+	return fmt.Sprintf("(%s) / nullif((%s), 0)", numerator, denominator)
+}
+
+func bruinSafeAdd(va *exec.VarArgs) *exec.Value {
+	return safeArithmetic(va, " +\n    ")
+}
+
+func bruinSafeSubtract(va *exec.VarArgs) *exec.Value {
+	return safeArithmetic(va, " -\n    ")
+}
+
+func safeArithmetic(va *exec.VarArgs, operator string) *exec.Value {
+	fields := extractStringListFromVarArgs(va)
+	if len(fields) == 0 {
+		return exec.AsValue("")
+	}
+	parts := make([]string, len(fields))
+	for i, f := range fields {
+		parts[i] = fmt.Sprintf("coalesce(%s, 0)", f)
+	}
+	return exec.AsValue(strings.Join(parts, operator))
+}
+
+func bruinPivot(va *exec.VarArgs) *exec.Value {
+	return bruinPivotWithIdentifierQuote(va, DoubleQuoteIdentifier)
+}
+
+func bruinPivotWithIdentifierQuote(va *exec.VarArgs, quoteIdentifier func(string) string) *exec.Value {
+	if len(va.Args) < 2 {
+		return exec.AsValue("/* pivot requires at least 2 arguments: column, values */")
+	}
+
+	column := va.Args[0].String()
+	values := extractStringListFromValue(va.Args[1])
+
+	alias := getKwArgBool(va, "alias", true)
+	agg := getKwArgString(va, "agg", "sum")
+	cmp := getKwArgString(va, "cmp", "=")
+	prefix := getKwArgString(va, "prefix", "")
+	suffix := getKwArgString(va, "suffix", "")
+	thenValue := getKwArgString(va, "then_value", "1")
+	elseValue := getKwArgString(va, "else_value", "0")
+	quoteIdentifiers := getKwArgBool(va, "quote_identifiers", true)
+	distinct := getKwArgBool(va, "distinct", false)
+
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		escapedValue := strings.ReplaceAll(value, "'", "''")
+
+		distinctStr := ""
+		if distinct {
+			distinctStr = "distinct "
+		}
+
+		expr := fmt.Sprintf("%s(\n        %scase\n        when %s %s '%s'\n            then %s\n        else %s\n        end\n    )",
+			agg, distinctStr, column, cmp, escapedValue, thenValue, elseValue)
+
+		if alias {
+			aliasName := prefix + value + suffix
+			if quoteIdentifiers {
+				expr += "\n        as " + quoteIdentifier(aliasName)
+			} else {
+				expr += "\n        as " + bruinSlugify(aliasName)
+			}
+		}
+
+		parts = append(parts, expr)
+	}
+
+	return exec.AsValue(strings.Join(parts, ",\n    "))
+}
+
+func bruinDegreesToRadians(degrees string) string {
+	return fmt.Sprintf("acos(-1) * %s / 180", degrees)
+}
+
+func bruinWidthBucket(expr, minValue, maxValue, numBuckets string) string {
+	binSize := fmt.Sprintf("((cast(%s as numeric) - cast(%s as numeric)) / cast(%s as numeric))", maxValue, minValue, numBuckets)
+
+	return fmt.Sprintf(`case
+        when cast(%s as numeric) < cast(%s as numeric) then 0
+        when cast(%s as numeric) >= cast(%s as numeric) then cast(%s as numeric) + 1
+        when mod(cast(%s as numeric) - cast(%s as numeric), %s) = 0
+            then ceil((cast(%s as numeric) - cast(%s as numeric)) / %s) + 1
+        else ceil((cast(%s as numeric) - cast(%s as numeric)) / %s)
+    end`, expr, minValue, expr, maxValue, numBuckets, expr, minValue, binSize, expr, minValue, binSize, expr, minValue, binSize)
+}
+
+// NativeWidthBucket returns a platform-native width_bucket implementation.
+func NativeWidthBucket(expr, minValue, maxValue, numBuckets string) string {
+	return fmt.Sprintf("width_bucket(%s, %s, %s, %s)", expr, minValue, maxValue, numBuckets)
+}
+
+// BigQueryWidthBucket builds standard width_bucket behavior for BigQuery, which has no native function.
+func BigQueryWidthBucket(expr, minValue, maxValue, numBuckets string) string {
+	return fmt.Sprintf(`case
+        when cast(%s as numeric) < cast(%s as numeric) then 0
+        when cast(%s as numeric) >= cast(%s as numeric) then cast(%s as int64) + 1
+        else cast(floor(
+            (cast(%s as numeric) - cast(%s as numeric))
+            / ((cast(%s as numeric) - cast(%s as numeric)) / cast(%s as numeric))
+        ) as int64) + 1
+    end`, expr, minValue, expr, maxValue, numBuckets, expr, minValue, maxValue, minValue, numBuckets)
+}
+
+// ClickHouseWidthBucket builds standard width_bucket behavior for ClickHouse.
+func ClickHouseWidthBucket(expr, minValue, maxValue, numBuckets string) string {
+	return fmt.Sprintf(`multiIf(
+        %s < %s, 0,
+        %s >= %s, %s + 1,
+        toInt64(floor((%s - %s) / ((%s - %s) / %s))) + 1
+    )`, expr, minValue, expr, maxValue, numBuckets, expr, minValue, maxValue, minValue, numBuckets)
+}
+
+// TSQLWidthBucket builds standard width_bucket behavior using T-SQL math functions.
+func TSQLWidthBucket(expr, minValue, maxValue, numBuckets string) string {
+	return fmt.Sprintf(`case
+        when cast(%s as float) < cast(%s as float) then 0
+        when cast(%s as float) >= cast(%s as float) then cast(%s as int) + 1
+        else cast(floor(
+            (cast(%s as float) - cast(%s as float))
+            / ((cast(%s as float) - cast(%s as float)) / cast(%s as float))
+        ) as int) + 1
+    end`, expr, minValue, expr, maxValue, numBuckets, expr, minValue, maxValue, minValue, numBuckets)
+}
+
+func bruinDeduplicate(relation, partitionBy, orderBy string) string {
+	return fmt.Sprintf(`with row_numbered as (
+        select
+            _inner.*,
+            row_number() over (
+                partition by %s
+                order by %s
+            ) as __bruin_row_number
+        from %s as _inner
+    )
+
+    select
+        distinct data.*
+    from %s as data
+    natural join row_numbered
+    where row_numbered.__bruin_row_number = 1`, partitionBy, orderBy, relation, relation)
+}
+
+// generateSeriesCTEs returns only the CTE definitions (WITH p AS ..., unioned AS ...)
+// without a terminal SELECT, for use in composite queries like date_spine.
+func generateSeriesCTEs(upperBound int) string {
+	n := getPowersOfTwo(upperBound)
+
+	var sb strings.Builder
+	sb.WriteString("with p as (\n        select 0 as generated_number union all select 1\n    ), unioned as (\n\n        select\n\n        ")
+
+	for i := range n {
+		sb.WriteString("p")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString(".generated_number * power(2, ")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString(")")
+		if i < n-1 {
+			sb.WriteString("\n        + ")
+		}
+	}
+
+	sb.WriteString("\n        + 1\n        as generated_number\n\n        from\n\n        ")
+
+	for i := range n {
+		sb.WriteString("p as p")
+		sb.WriteString(strconv.Itoa(i))
+		if i < n-1 {
+			sb.WriteString("\n        cross join ")
+		}
+	}
+
+	sb.WriteString("\n\n    )")
+
+	return sb.String()
+}
+
+// bruinGenerateSeries produces a cross-join CTE generating numbers 1..upperBound.
+// Works on all SQL databases without platform-specific syntax.
+func bruinGenerateSeries(upperBound int) string {
+	return fmt.Sprintf("%s\n\n    select *\n    from unioned\n    where generated_number <= %d\n    order by generated_number", generateSeriesCTEs(upperBound), upperBound)
+}
+
+// DuckDBGenerateSeries uses DuckDB's native integer series generator.
+func DuckDBGenerateSeries(upperBound int) string {
+	return fmt.Sprintf(`select generated_number
+from generate_series(1, %d) as t(generated_number)
+order by generated_number`, upperBound)
+}
+
+// ---------------------------------------------------------------------------
+// Jinja helpers
+// ---------------------------------------------------------------------------
+
+var (
+	slugifySpaceDash = regexp.MustCompile(`[ -]+`)
+	slugifyNonAlnum  = regexp.MustCompile(`[^a-z0-9_]+`)
+	slugifyLeadDigit = regexp.MustCompile(`^([0-9])`)
+)
+
+func bruinSlugify(s string) string {
+	if s == "" {
+		return ""
+	}
+	s = strings.ToLower(s)
+	s = slugifySpaceDash.ReplaceAllString(s, "_")
+	s = slugifyNonAlnum.ReplaceAllString(s, "")
+	if slugifyLeadDigit.MatchString(s) {
+		s = "_" + s
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Web helpers
+// ---------------------------------------------------------------------------
+
+func bruinGetURLHost(field string) string {
+	return fmt.Sprintf(
+		"split_part(split_part(replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', ''), '/', 1), '?', 1)",
+		field,
+	)
+}
+
+func bruinGetURLParameter(field, urlParameter string) string {
+	queryPart := fmt.Sprintf("case when position('?' in %s) > 0 then split_part(%s, '?', 2) else %s end", field, field, field)
+	return fmt.Sprintf(
+		"nullif(split_part(split_part(concat('&', %s), %s, 2), '&', 1), '')",
+		queryPart,
+		sqlStringLiteral("&"+urlParameter+"="),
+	)
+}
+
+func bruinGetURLPath(field string) string {
+	strippedURL := fmt.Sprintf("replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', '')", field)
+	parsedPath := fmt.Sprintf(
+		"case when position('/' in %s) > 0 then split_part(right(%s, length(%s) - position('/' in %s)), '?', 1) else '' end",
+		strippedURL, strippedURL, strippedURL, strippedURL,
+	)
+	return fmt.Sprintf("cast(%s as varchar)", parsedPath)
+}
+
+// SplitPartURLHelpers returns URL helpers for dialects that support split_part, position, right, and SQL-standard casts.
+func SplitPartURLHelpers(castType string) map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			parsed := fmt.Sprintf(
+				"split_part(split_part(replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', ''), '/', 1), '?', 1)",
+				field,
+			)
+			return fmt.Sprintf("cast(%s as %s)", parsed, castType)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			wrappedField := fmt.Sprintf("case when position('?' in %s) > 0 then split_part(%s, '?', 2) else %s end", field, field, field)
+			return fmt.Sprintf(
+				"nullif(split_part(split_part(concat('&', %s), %s, 2), '&', 1), '')",
+				wrappedField,
+				sqlStringLiteral("&"+urlParameter+"="),
+			)
+		},
+		"get_url_path": func(field string) string {
+			strippedURL := fmt.Sprintf("replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', '')", field)
+			parsedPath := fmt.Sprintf(
+				"case when position('/' in %s) > 0 then split_part(right(%s, length(%s) - position('/' in %s)), '?', 1) else '' end",
+				strippedURL, strippedURL, strippedURL, strippedURL,
+			)
+			return fmt.Sprintf("cast(%s as %s)", parsedPath, castType)
+		},
+	}
+}
+
+// BigQueryURLHelpers returns URL helpers using BigQuery regex functions.
+func BigQueryURLHelpers() map[string]any {
+	return regexURLHelpers("string", "regexp_extract", "regexp_replace", sqlRawStringLiteral)
+}
+
+// SparkURLHelpers returns URL helpers using Spark/Databricks regex functions.
+func SparkURLHelpers() map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			stripped := fmt.Sprintf("regexp_replace(%s, '^(android-app://|https?://)', '')", field)
+			return fmt.Sprintf("cast(regexp_extract(%s, '^([^/?]+)', 1) as string)", stripped)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			return fmt.Sprintf("nullif(regexp_extract(%s, %s, 1), '')", field, sqlRawStringLiteral(urlParameterRegex(urlParameter)))
+		},
+		"get_url_path": func(field string) string {
+			stripped := fmt.Sprintf("regexp_replace(%s, '^(android-app://|https?://)', '')", field)
+			return fmt.Sprintf("cast(regexp_extract(%s, '^[^/?]+/([^?]*)', 1) as string)", stripped)
+		},
+	}
+}
+
+// ClickHouseURLHelpers returns URL helpers using ClickHouse regex functions.
+func ClickHouseURLHelpers() map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			stripped := fmt.Sprintf("replaceRegexpOne(%s, '^(android-app://|https?://)', '')", field)
+			return fmt.Sprintf("extract(%s, '^[^/?]+')", stripped)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			return fmt.Sprintf("nullIf(extract(%s, %s), '')", field, sqlBackslashStringLiteral(urlParameterRegex(urlParameter)))
+		},
+		"get_url_path": func(field string) string {
+			stripped := fmt.Sprintf("replaceRegexpOne(%s, '^(android-app://|https?://)', '')", field)
+			return fmt.Sprintf("extract(%s, '^[^/?]+/([^?]*)')", stripped)
+		},
+	}
+}
+
+// MySQLURLHelpers returns URL helpers using MySQL string functions.
+func MySQLURLHelpers() map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			parsed := fmt.Sprintf(
+				"substring_index(substring_index(replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', ''), '/', 1), '?', 1)",
+				field,
+			)
+			return fmt.Sprintf("cast(%s as char)", parsed)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			needle := sqlStringLiteral("&" + urlParameter + "=")
+			queryPart := fmt.Sprintf("case when locate('?', %s) > 0 then substring(%s, locate('?', %s) + 1) else %s end", field, field, field, field)
+			wrappedQueryPart := fmt.Sprintf("concat('&', %s)", queryPart)
+			return fmt.Sprintf(
+				"case when instr(%s, %s) > 0 then nullif(substring_index(substring_index(%s, %s, -1), '&', 1), '') else null end",
+				wrappedQueryPart, needle, wrappedQueryPart, needle,
+			)
+		},
+		"get_url_path": func(field string) string {
+			stripped := fmt.Sprintf("replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', '')", field)
+			tail := fmt.Sprintf(`case
+        when locate('/', %s) > 0 then substring(%s, locate('/', %s) + 1)
+        else ''
+    end`, stripped, stripped, stripped)
+			return fmt.Sprintf("cast(substring_index(%s, '?', 1) as char)", tail)
+		},
+	}
+}
+
+// TSQLURLHelpers returns URL helpers for SQL Server-family dialects.
+func TSQLURLHelpers() map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			stripped := fmt.Sprintf("replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', '')", field)
+			beforePath := fmt.Sprintf("left(%s, charindex('/', %s + '/') - 1)", stripped, stripped)
+			beforeQuery := fmt.Sprintf("left(%s, charindex('?', %s + '?') - 1)", beforePath, beforePath)
+			return fmt.Sprintf("cast(%s as varchar(max))", beforeQuery)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			needle := sqlStringLiteral("&" + urlParameter + "=")
+			needleLen := len(urlParameter) + 2
+			queryPart := fmt.Sprintf("case when charindex('?', %s) > 0 then substring(%s, charindex('?', %s) + 1, len(%s)) else %s end", field, field, field, field, field)
+			wrappedQueryPart := fmt.Sprintf("concat('&', %s)", queryPart)
+			valueTail := fmt.Sprintf("substring(%s, charindex(%s, %s) + %d, len(%s))", wrappedQueryPart, needle, wrappedQueryPart, needleLen, wrappedQueryPart)
+			value := fmt.Sprintf("left(%s, charindex('&', %s + '&') - 1)", valueTail, valueTail)
+			return fmt.Sprintf("case when charindex(%s, %s) > 0 then nullif(%s, '') else null end", needle, wrappedQueryPart, value)
+		},
+		"get_url_path": func(field string) string {
+			stripped := fmt.Sprintf("replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', '')", field)
+			startPos := fmt.Sprintf(`case
+        when charindex('/', %s) > 0 then charindex('/', %s) + 1
+        else len(%s) + 1
+    end`, stripped, stripped, stripped)
+			tail := fmt.Sprintf("substring(%s, %s, len(%s))", stripped, startPos, stripped)
+			parsed := fmt.Sprintf("left(%s, charindex('?', %s + '?') - 1)", tail, tail)
+			return fmt.Sprintf("cast(%s as varchar(max))", parsed)
+		},
+	}
+}
+
+// OracleURLHelpers returns URL helpers using Oracle regex functions.
+func OracleURLHelpers() map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			stripped := fmt.Sprintf("regexp_replace(regexp_replace(regexp_replace(%s, '^android-app://', ''), '^http://', ''), '^https://', '')", field)
+			return fmt.Sprintf("cast(regexp_substr(%s, '^[^/?]+') as varchar2(4000))", stripped)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			return fmt.Sprintf("nullif(regexp_substr(%s, %s, 1, 1, null, 2), '')", field, sqlStringLiteral("(^|[?&])"+regexp.QuoteMeta(urlParameter)+"=([^&]*)"))
+		},
+		"get_url_path": func(field string) string {
+			stripped := fmt.Sprintf("regexp_replace(regexp_replace(regexp_replace(%s, '^android-app://', ''), '^http://', ''), '^https://', '')", field)
+			return fmt.Sprintf("cast(regexp_substr(%s, '^[^/?]+/([^?]*)', 1, 1, null, 1) as varchar2(4000))", stripped)
+		},
+	}
+}
+
+// PrestoURLHelpers returns URL helpers for Trino/Athena.
+func PrestoURLHelpers() map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			parsed := fmt.Sprintf(
+				"split_part(split_part(replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', ''), '/', 1), '?', 1)",
+				field,
+			)
+			return fmt.Sprintf("cast(%s as varchar)", parsed)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			queryPart := fmt.Sprintf("case when strpos(%s, '?') > 0 then split_part(%s, '?', 2) else %s end", field, field, field)
+			return fmt.Sprintf(
+				"nullif(split_part(split_part(concat('&', %s), %s, 2), '&', 1), '')",
+				queryPart,
+				sqlStringLiteral("&"+urlParameter+"="),
+			)
+		},
+		"get_url_path": func(field string) string {
+			strippedURL := fmt.Sprintf("replace(replace(replace(%s, 'android-app://', ''), 'http://', ''), 'https://', '')", field)
+			parsedPath := fmt.Sprintf(
+				"case when strpos(%s, '/') > 0 then split_part(substr(%s, strpos(%s, '/') + 1), '?', 1) else '' end",
+				strippedURL, strippedURL, strippedURL,
+			)
+			return fmt.Sprintf("cast(%s as varchar)", parsedPath)
+		},
+	}
+}
+
+func regexURLHelpers(castType, extractFn, replaceFn string, literalFn func(string) string) map[string]any {
+	return map[string]any{
+		"get_url_host": func(field string) string {
+			stripped := fmt.Sprintf("%s(%s, '^(android-app://|https?://)', '')", replaceFn, field)
+			return fmt.Sprintf("cast(%s(%s, '^([^/?]+)') as %s)", extractFn, stripped, castType)
+		},
+		"get_url_parameter": func(field, urlParameter string) string {
+			return fmt.Sprintf("nullif(%s(%s, %s), '')", extractFn, field, literalFn(urlParameterRegex(urlParameter)))
+		},
+		"get_url_path": func(field string) string {
+			stripped := fmt.Sprintf("%s(%s, '^(android-app://|https?://)', '')", replaceFn, field)
+			return fmt.Sprintf("cast(%s(%s, '^[^/?]+/([^?]*)') as %s)", extractFn, stripped, castType)
+		},
+	}
+}
+
+func sqlStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+func sqlRawStringLiteral(s string) string {
+	return "r" + sqlStringLiteral(s)
+}
+
+func sqlBackslashStringLiteral(s string) string {
+	return sqlStringLiteral(strings.ReplaceAll(s, `\`, `\\`))
+}
+
+func urlParameterRegex(urlParameter string) string {
+	return "(?:^|[?&])" + regexp.QuoteMeta(urlParameter) + "=([^&]*)"
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+func getPowersOfTwo(upperBound int) int {
+	if upperBound <= 1 {
+		return 1
+	}
+	n := bits.Len(uint(upperBound - 1))
+	if n == 0 {
+		return 1
+	}
+	return n
+}
+
+func extractStringListFromVarArgs(va *exec.VarArgs) []string {
+	if len(va.Args) == 0 {
+		return nil
+	}
+	if va.Args[0].IsList() {
+		return extractStringListFromValue(va.Args[0])
+	}
+	result := make([]string, len(va.Args))
+	for i, arg := range va.Args {
+		result[i] = arg.String()
+	}
+	return result
+}
+
+func extractStringListFromValue(val *exec.Value) []string {
+	if !val.IsList() {
+		return []string{val.String()}
+	}
+	n := val.Len()
+	result := make([]string, n)
+	for i := range n {
+		result[i] = val.Index(i).String()
+	}
+	return result
+}
+
+func getKwArgString(va *exec.VarArgs, key, defaultValue string) string {
+	if v, ok := va.KwArgs[key]; ok {
+		return v.String()
+	}
+	return defaultValue
+}
+
+func getKwArgBool(va *exec.VarArgs, key string, defaultValue bool) bool {
+	if v, ok := va.KwArgs[key]; ok {
+		return v.IsTrue()
+	}
+	return defaultValue
+}

--- a/pkg/jinja/bruin_funcs_parser_test.go
+++ b/pkg/jinja/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package jinja_test
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformDefault, "")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/jinja/bruin_funcs_test.go
+++ b/pkg/jinja/bruin_funcs_test.go
@@ -1,0 +1,777 @@
+package jinja
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltin_GroupBy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "group_by 1",
+			query: "select col1, count(*) from table1 {{ bruin.group_by(1) }}",
+			want:  "select col1, count(*) from table1 group by 1",
+		},
+		{
+			name:  "group_by 3",
+			query: "select col1, col2, col3, count(*) from table1 {{ bruin.group_by(3) }}",
+			want:  "select col1, col2, col3, count(*) from table1 group by 1, 2, 3",
+		},
+		{
+			name:  "group_by 5",
+			query: "{{ bruin.group_by(5) }}",
+			want:  "group by 1, 2, 3, 4, 5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestBuiltin_SafeDivide(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "basic safe_divide",
+			query: "select {{ bruin.safe_divide('revenue', 'sessions') }}",
+			want:  "select (revenue) / nullif((sessions), 0)",
+		},
+		{
+			name:  "safe_divide with expressions",
+			query: "select {{ bruin.safe_divide('sum(revenue)', 'count(distinct user_id)') }}",
+			want:  "select (sum(revenue)) / nullif((count(distinct user_id)), 0)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestBuiltin_SafeAdd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "safe_add with list",
+			query: "select {{ bruin.safe_add(['col1', 'col2', 'col3']) }} as total",
+			want:  "select coalesce(col1, 0) +\n    coalesce(col2, 0) +\n    coalesce(col3, 0) as total",
+		},
+		{
+			name:  "safe_add with two columns",
+			query: "{{ bruin.safe_add(['revenue', 'tax']) }}",
+			want:  "coalesce(revenue, 0) +\n    coalesce(tax, 0)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestBuiltin_SafeSubtract(t *testing.T) {
+	t.Parallel()
+
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.safe_subtract(['revenue', 'cost', 'tax']) }}")
+	require.NoError(t, err)
+	assert.Equal(t, "coalesce(revenue, 0) -\n    coalesce(cost, 0) -\n    coalesce(tax, 0)", result)
+}
+
+func TestBuiltin_GenerateSurrogateKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "single field",
+			query: "{{ bruin.generate_surrogate_key(['user_id']) }}",
+			want:  "md5(coalesce(cast(user_id as varchar), '_bruin_surrogate_key_null_'))",
+		},
+		{
+			name:  "multiple fields",
+			query: "{{ bruin.generate_surrogate_key(['user_id', 'session_id']) }}",
+			want:  "md5(concat(coalesce(cast(user_id as varchar), '_bruin_surrogate_key_null_'), '-', coalesce(cast(session_id as varchar), '_bruin_surrogate_key_null_')))",
+		},
+		{
+			name:  "three fields",
+			query: "{{ bruin.generate_surrogate_key(['a', 'b', 'c']) }}",
+			want:  "md5(concat(coalesce(cast(a as varchar), '_bruin_surrogate_key_null_'), '-', coalesce(cast(b as varchar), '_bruin_surrogate_key_null_'), '-', coalesce(cast(c as varchar), '_bruin_surrogate_key_null_')))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestBuiltin_Pivot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		query    string
+		contains []string
+	}{
+		{
+			name:  "basic pivot",
+			query: "{{ bruin.pivot('status', ['active', 'churned']) }}",
+			contains: []string{
+				"sum(",
+				"when status = 'active'",
+				"when status = 'churned'",
+				`as "active"`,
+				`as "churned"`,
+			},
+		},
+		{
+			name:  "pivot with count agg",
+			query: "{{ bruin.pivot('color', ['red', 'blue'], agg='count') }}",
+			contains: []string{
+				"count(",
+				"when color = 'red'",
+				"when color = 'blue'",
+			},
+		},
+		{
+			name:  "pivot with prefix and suffix",
+			query: "{{ bruin.pivot('status', ['active'], prefix='is_', suffix='_flag') }}",
+			contains: []string{
+				`as "is_active_flag"`,
+			},
+		},
+		{
+			name:  "pivot with distinct",
+			query: "{{ bruin.pivot('type', ['a'], distinct=true) }}",
+			contains: []string{
+				"distinct case",
+			},
+		},
+		{
+			name:  "pivot without alias",
+			query: "{{ bruin.pivot('type', ['a'], alias=false) }}",
+			contains: []string{
+				"sum(",
+			},
+		},
+		{
+			name:  "pivot without quoting",
+			query: "{{ bruin.pivot('type', ['My Value'], quote_identifiers=false) }}",
+			contains: []string{
+				"as my_value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			for _, substr := range tt.contains {
+				assert.Contains(t, result, substr, "expected output to contain %q", substr)
+			}
+		})
+	}
+}
+
+func TestBuiltin_Pivot_NoAlias(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.pivot('type', ['a'], alias=false) }}")
+	require.NoError(t, err)
+	assert.NotContains(t, result, `as "`)
+}
+
+func TestBuiltin_HaversineDistance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		query    string
+		contains []string
+	}{
+		{
+			name:  "default miles",
+			query: "{{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }}",
+			contains: []string{
+				"asin(sqrt(power",
+				"lat2 - lat1",
+				"lon2 - lon1",
+				"* 1",
+			},
+		},
+		{
+			name:  "kilometers",
+			query: "{{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }}",
+			contains: []string{
+				"* 1.60934",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			for _, substr := range tt.contains {
+				assert.Contains(t, result, substr)
+			}
+		})
+	}
+}
+
+func TestBuiltin_HaversineDistanceRejectsUnknownUnit(t *testing.T) {
+	t.Parallel()
+
+	renderer := NewRenderer(Context{})
+	_, err := renderer.Render("{{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='meters') }}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "haversine_distance unit must be 'mi' or 'km'")
+}
+
+func TestBuiltin_DegreesToRadians(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.degrees_to_radians('angle_col') }}")
+	require.NoError(t, err)
+	assert.Equal(t, "acos(-1) * angle_col / 180", result)
+}
+
+func TestBuiltin_WidthBucket(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero min", func(t *testing.T) {
+		t.Parallel()
+		renderer := NewRenderer(Context{})
+		result, err := renderer.Render("{{ bruin.width_bucket('price', '0', '100', '10') }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "mod(")
+		assert.Contains(t, result, "then 0")
+		assert.Contains(t, result, "ceil(")
+		assert.Contains(t, result, "price")
+		assert.Contains(t, result, "cast(10 as numeric) + 1")
+	})
+
+	t.Run("non-zero min offsets mod correctly", func(t *testing.T) {
+		t.Parallel()
+		renderer := NewRenderer(Context{})
+		result, err := renderer.Render("{{ bruin.width_bucket('val', '3', '23', '4') }}")
+		require.NoError(t, err)
+		// The mod must subtract minValue so boundary detection is relative to the range start.
+		assert.Contains(t, result, "cast(val as numeric) - cast(3 as numeric)")
+	})
+}
+
+func TestBuiltin_Deduplicate(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.deduplicate('my_table', 'user_id', 'updated_at desc') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "row_number() over (")
+	assert.Contains(t, result, "partition by user_id")
+	assert.Contains(t, result, "order by updated_at desc")
+	assert.Contains(t, result, "from my_table as _inner")
+	assert.Contains(t, result, "natural join row_numbered")
+	assert.Contains(t, result, "where row_numbered.__bruin_row_number = 1")
+}
+
+func TestBuiltin_GenerateSeries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		query    string
+		contains []string
+	}{
+		{
+			name:  "small series",
+			query: "{{ bruin.generate_series(4) }}",
+			contains: []string{
+				"select 0 as generated_number union all select 1",
+				"p0.generated_number * power(2, 0)",
+				"p1.generated_number * power(2, 1)",
+				"p as p0",
+				"cross join",
+				"p as p1",
+				"where generated_number <= 4",
+			},
+		},
+		{
+			name:  "series of 1",
+			query: "{{ bruin.generate_series(1) }}",
+			contains: []string{
+				"p0.generated_number * power(2, 0)",
+				"where generated_number <= 1",
+			},
+		},
+		{
+			name:  "larger series",
+			query: "{{ bruin.generate_series(100) }}",
+			contains: []string{
+				"p6.generated_number * power(2, 6)",
+				"where generated_number <= 100",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			for _, substr := range tt.contains {
+				assert.Contains(t, result, substr, "expected output to contain %q", substr)
+			}
+		})
+	}
+}
+
+func TestBuiltin_DateSpine(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render(`{{ bruin.date_spine('day', "'2020-01-01'", "'2025-01-01'") }}`)
+	require.NoError(t, err)
+	assert.Contains(t, result, "dateadd(")
+	assert.Contains(t, result, "day,")
+	assert.Contains(t, result, "'2020-01-01'")
+	assert.Contains(t, result, "as date_day")
+	assert.Contains(t, result, "dateadd(day, (n + 1), '2020-01-01')")
+	assert.Contains(t, result, "where dateadd(day, (n + 1), '2020-01-01') < '2025-01-01'")
+	assert.Contains(t, result, "select date_day")
+	assert.Contains(t, result, "with recursive")
+	assert.NotContains(t, result, "generated_number <= 10000")
+}
+
+func TestBuiltin_DateSpine_Month(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render(`{{ bruin.date_spine('month', "'2020-01-01'", "'2025-01-01'") }}`)
+	require.NoError(t, err)
+	assert.Contains(t, result, "as date_month")
+	assert.Contains(t, result, "where dateadd(month, (n + 1), '2020-01-01') < '2025-01-01'")
+}
+
+func TestBuiltin_Slugify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "basic slugify",
+			query: "{{ bruin.slugify('Hello World') }}",
+			want:  "hello_world",
+		},
+		{
+			name:  "special characters",
+			query: "{{ bruin.slugify('My Column Name!@#') }}",
+			want:  "my_column_name",
+		},
+		{
+			name:  "leading digit",
+			query: "{{ bruin.slugify('1st_place') }}",
+			want:  "_1st_place",
+		},
+		{
+			name:  "dashes to underscores",
+			query: "{{ bruin.slugify('some-value-here') }}",
+			want:  "some_value_here",
+		},
+		{
+			name:  "empty string",
+			query: "{{ bruin.slugify('') }}",
+			want:  "",
+		},
+		{
+			name:  "already valid",
+			query: "{{ bruin.slugify('valid_name') }}",
+			want:  "valid_name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := NewRenderer(Context{})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestBuiltin_GetURLHost(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.get_url_host('page_url') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "split_part")
+	assert.Contains(t, result, "replace")
+	assert.Contains(t, result, "page_url")
+	assert.Contains(t, result, "'http://'")
+	assert.Contains(t, result, "'https://'")
+}
+
+func TestBuiltin_GetURLParameter(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.get_url_parameter('page_url', 'utm_source') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "split_part")
+	assert.Contains(t, result, "'&utm_source='")
+	assert.Contains(t, result, "'&'")
+	assert.Contains(t, result, "nullif")
+}
+
+func TestBuiltin_GetURLPath(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render("{{ bruin.get_url_path('page_url') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "replace")
+	assert.Contains(t, result, "page_url")
+	assert.Contains(t, result, "cast(")
+	assert.Contains(t, result, "as varchar)")
+}
+
+func TestBuiltin_FunctionsAvailableByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Ensure bruin functions are available in all renderer types.
+	t.Run("NewRenderer", func(t *testing.T) {
+		t.Parallel()
+		renderer := NewRenderer(Context{})
+		result, err := renderer.Render("{{ bruin.group_by(2) }}")
+		require.NoError(t, err)
+		assert.Equal(t, "group by 1, 2", result)
+	})
+
+	t.Run("NewRendererWithMacros", func(t *testing.T) {
+		t.Parallel()
+		renderer := NewRendererWithMacros(Context{}, "")
+		result, err := renderer.Render("{{ bruin.group_by(2) }}")
+		require.NoError(t, err)
+		assert.Equal(t, "group by 1, 2", result)
+	})
+}
+
+func TestBuiltin_CombinedUsage(t *testing.T) {
+	t.Parallel()
+
+	query := `select
+    {{ bruin.generate_surrogate_key(['user_id', 'event_date']) }} as surrogate_key,
+    user_id,
+    event_date,
+    {{ bruin.safe_divide('revenue', 'sessions') }} as revenue_per_session
+from events
+{{ bruin.group_by(3) }}`
+
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render(query)
+	require.NoError(t, err)
+	assert.Contains(t, result, "md5(concat(")
+	assert.Contains(t, result, "nullif(")
+	assert.Contains(t, result, "group by 1, 2, 3")
+}
+
+func TestBuiltin_PivotEscapesSingleQuotes(t *testing.T) {
+	t.Parallel()
+	renderer := NewRenderer(Context{})
+	result, err := renderer.Render(`{{ bruin.pivot('name', ["it's"]) }}`)
+	require.NoError(t, err)
+	assert.Contains(t, result, "it''s")
+}
+
+// Test helper functions directly.
+func TestGetPowersOfTwo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    int
+		expected int
+	}{
+		{1, 1},
+		{2, 1},
+		{3, 2},
+		{4, 2},
+		{5, 3},
+		{8, 3},
+		{9, 4},
+		{16, 4},
+		{100, 7},
+		{1000, 10},
+		{10000, 14},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Repeat("x", tt.input), func(t *testing.T) {
+			t.Parallel()
+			result := getPowersOfTwo(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Builder and variant function tests
+// ---------------------------------------------------------------------------
+
+// rendererWithOverrides creates a renderer that merges the given overrides on top of defaults.
+func rendererWithOverrides(overrides map[string]any) *Renderer {
+	funcs := BuiltinFunctions()
+	for k, v := range overrides {
+		funcs[k] = v
+	}
+	return NewRenderer(Context{"bruin": funcs})
+}
+
+func TestSurrogateKeyWith(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		castType string
+		hashFn   func(string) string
+		contains []string
+	}{
+		{
+			name:     "string cast with to_hex",
+			castType: "string",
+			hashFn:   func(e string) string { return "to_hex(md5(" + e + "))" },
+			contains: []string{"to_hex(md5(", "cast(user_id as string)"},
+		},
+		{
+			name:     "varchar cast with hashbytes",
+			castType: "varchar",
+			hashFn:   func(e string) string { return "convert(varchar(32), hashbytes('md5', " + e + "), 2)" },
+			contains: []string{"hashbytes('md5',", "cast(user_id as varchar)"},
+		},
+		{
+			name:     "char cast with md5",
+			castType: "char",
+			hashFn:   func(e string) string { return "md5(" + e + ")" },
+			contains: []string{"md5(coalesce(", "cast(user_id as char)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := rendererWithOverrides(map[string]any{
+				"generate_surrogate_key": SurrogateKeyWith(tt.castType, tt.hashFn),
+			})
+			result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id']) }}")
+			require.NoError(t, err)
+			for _, substr := range tt.contains {
+				assert.Contains(t, result, substr, "expected output to contain %q", substr)
+			}
+		})
+	}
+}
+
+func TestDeduplicateOverrideViaRegistry(t *testing.T) {
+	t.Parallel()
+
+	// Test that a custom deduplicate function can be registered and used via the override mechanism.
+	customDeduplicate := func(relation, partitionBy, orderBy string) string {
+		return "select * from " + relation + " qualify row_number() over (partition by " + partitionBy + " order by " + orderBy + ") = 1"
+	}
+
+	renderer := rendererWithOverrides(map[string]any{
+		"deduplicate": customDeduplicate,
+	})
+	result, err := renderer.Render("{{ bruin.deduplicate('my_table', 'user_id', 'updated_at desc') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "qualify")
+	assert.Contains(t, result, "partition by user_id")
+}
+
+func TestHaversineDistanceWithRadians(t *testing.T) {
+	t.Parallel()
+	renderer := rendererWithOverrides(map[string]any{
+		"haversine_distance": HaversineDistanceWithRadians(func(expr string) string {
+			return "(" + expr + ") * acos(-1) / 180"
+		}),
+	})
+	result, err := renderer.Render("{{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "acos(-1) / 180")
+	assert.NotContains(t, result, "radians(")
+}
+
+func TestDateSpineWithDateAdd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		dateAddFn func(string, string, string) string
+		contains  []string
+	}{
+		{
+			name: "DATE_ADD INTERVAL",
+			dateAddFn: func(dp, n, s string) string {
+				return "DATE_ADD(" + s + ", INTERVAL " + n + " " + dp + ")"
+			},
+			contains: []string{"DATE_ADD(", "INTERVAL", "day)"},
+		},
+		{
+			name: "interval addition",
+			dateAddFn: func(dp, n, s string) string {
+				return "(" + s + " + " + n + " * INTERVAL '1 " + dp + "')"
+			},
+			contains: []string{"* INTERVAL '1 day'"},
+		},
+		{
+			name: "quoted datepart",
+			dateAddFn: func(dp, n, s string) string {
+				return "date_add('" + dp + "', " + n + ", " + s + ")"
+			},
+			contains: []string{"date_add('day',"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := rendererWithOverrides(map[string]any{
+				"date_spine": DateSpineWithDateAdd(tt.dateAddFn),
+			})
+			result, err := renderer.Render(`{{ bruin.date_spine('day', "'2020-01-01'", "'2025-01-01'") }}`)
+			require.NoError(t, err)
+			for _, substr := range tt.contains {
+				assert.Contains(t, result, substr, "expected output to contain %q", substr)
+			}
+		})
+	}
+}
+
+func TestRegisterPlatformOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Register overrides for a test-only platform using an inline function.
+	testPlatform := Platform("__test_platform__")
+	RegisterPlatformOverrides(testPlatform, map[string]any{
+		"deduplicate": func(relation, partitionBy, orderBy string) string {
+			return "select * from " + relation + " qualify row_number() over (partition by " + partitionBy + " order by " + orderBy + ") = 1"
+		},
+	})
+
+	renderer := NewRenderer(Context{
+		"bruin": BuiltinFunctions(testPlatform),
+	})
+	result, err := renderer.Render("{{ bruin.deduplicate('t', 'id', 'ts desc') }}")
+	require.NoError(t, err)
+	assert.Contains(t, result, "qualify")
+	assert.NotContains(t, result, "natural join")
+}
+
+func TestPlatformForAssetType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		assetType pipeline.AssetType
+		expected  Platform
+	}{
+		{pipeline.AssetTypeBigqueryQuery, PlatformBigQuery},
+		{pipeline.AssetTypeSnowflakeQuery, PlatformSnowflake},
+		{pipeline.AssetTypePostgresQuery, PlatformPostgres},
+		{pipeline.AssetTypeRedshiftQuery, PlatformRedshift},
+		{pipeline.AssetTypeMsSQLQuery, PlatformMSSQL},
+		{pipeline.AssetTypeDuckDBQuery, PlatformDuckDB},
+		{pipeline.AssetTypeMotherduckQuery, PlatformDuckDB},
+		{pipeline.AssetTypeDatabricksQuery, PlatformDatabricks},
+		{pipeline.AssetTypeAthenaQuery, PlatformAthena},
+		{pipeline.AssetTypeTrinoQuery, PlatformTrino},
+		{pipeline.AssetTypeSynapseQuery, PlatformSynapse},
+		{pipeline.AssetTypeOracleQuery, PlatformOracle},
+		{pipeline.AssetTypeFabricQuery, PlatformFabric},
+		{pipeline.AssetTypeVerticaQuery, PlatformVertica},
+		{pipeline.AssetTypePython, PlatformDefault},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.assetType), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, PlatformForAssetType(tt.assetType))
+		})
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello World", "hello_world"},
+		{"", ""},
+		{"already_valid", "already_valid"},
+		{"with-dashes", "with_dashes"},
+		{"Special!@#Characters", "specialcharacters"},
+		{"123starts_with_number", "_123starts_with_number"},
+		{"MixedCase", "mixedcase"},
+		{"multiple   spaces", "multiple_spaces"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, bruinSlugify(tt.input))
+		})
+	}
+}

--- a/pkg/jinja/bruin_platform_funcs_test.go
+++ b/pkg/jinja/bruin_platform_funcs_test.go
@@ -1,0 +1,148 @@
+package jinja_test
+
+import (
+	"testing"
+
+	_ "github.com/bruin-data/bruin/pkg/athena"
+	_ "github.com/bruin-data/bruin/pkg/bigquery"
+	_ "github.com/bruin-data/bruin/pkg/clickhouse"
+	_ "github.com/bruin-data/bruin/pkg/databricks"
+	_ "github.com/bruin-data/bruin/pkg/duckdb"
+	_ "github.com/bruin-data/bruin/pkg/fabric"
+	"github.com/bruin-data/bruin/pkg/jinja"
+	_ "github.com/bruin-data/bruin/pkg/mssql"
+	_ "github.com/bruin-data/bruin/pkg/mysql"
+	_ "github.com/bruin-data/bruin/pkg/oracle"
+	_ "github.com/bruin-data/bruin/pkg/postgres"
+	_ "github.com/bruin-data/bruin/pkg/redshift"
+	_ "github.com/bruin-data/bruin/pkg/snowflake"
+	_ "github.com/bruin-data/bruin/pkg/synapse"
+	_ "github.com/bruin-data/bruin/pkg/trino"
+	_ "github.com/bruin-data/bruin/pkg/vertica"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformSpecificBuiltinSQL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		platform jinja.Platform
+		query    string
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "bigquery",
+			platform: jinja.PlatformBigQuery,
+			query:    `{{ bruin.get_url_host('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}||{{ bruin.generate_surrogate_key(['a', 'b']) }}`,
+			contains: []string{"regexp_extract", "generate_array", "date_diff", "date_add", "to_hex(md5(", "concat("},
+			excludes: []string{"generated_number <= 10000"},
+		},
+		{
+			name:     "snowflake",
+			platform: jinja.PlatformSnowflake,
+			query:    `{{ bruin.get_url_path('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"split_part", "case when position('/'", "with recursive", "where to_date('2020-01-01') < to_date('2020-01-02')", "dateadd(day, (n + 1)"},
+		},
+		{
+			name:     "postgres",
+			platform: jinja.PlatformPostgres,
+			query:    `{{ bruin.get_url_parameter('page_url', 'utm_source') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"split_part", "&utm_source=", "generate_series", "interval '1 day'"},
+		},
+		{
+			name:     "redshift",
+			platform: jinja.PlatformRedshift,
+			query:    `{{ bruin.generate_surrogate_key(['a', 'b']) }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{" || ", "md5(", "where cast('2020-01-01' as timestamp) < cast('2020-01-02' as timestamp)", "dateadd(day, (n + 1)"},
+			excludes: []string{"concat("},
+		},
+		{
+			name:     "mysql",
+			platform: jinja.PlatformMySQL,
+			query:    `{{ bruin.get_url_host('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"substring_index", "with recursive", "where cast('2020-01-01' as date) < cast('2020-01-02' as date)", "DATE_ADD(cast('2020-01-01' as date), INTERVAL (n + 1) day)", "SET_VAR(cte_max_recursion_depth=1000000)"},
+		},
+		{
+			name:     "duckdb",
+			platform: jinja.PlatformDuckDB,
+			query:    `{{ bruin.get_url_parameter('page_url', 'utm_source') }}||{{ bruin.get_url_path('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}||{{ bruin.generate_series(4) }}`,
+			contains: []string{"concat('&'", "utm_source=", "replace(replace(replace(page_url, 'android-app://', '')", "generate_series", "cast(date_day as date) as date_day", "from generate_series(1, 4)"},
+		},
+		{
+			name:     "databricks",
+			platform: jinja.PlatformDatabricks,
+			query:    `{{ bruin.get_url_parameter('page_url', 'utm_source') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"regexp_extract", "utm_source", ", 1)", "explode(", "sequence("},
+		},
+		{
+			name:     "mssql",
+			platform: jinja.PlatformMSSQL,
+			query:    `{{ bruin.get_url_path('page_url') }}||{{ bruin.deduplicate('events', 'dateadd(day, 0, created_at)', 'updated_at desc') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}||{{ bruin.width_bucket('price', '0', '100', '10') }}`,
+			contains: []string{"charindex", "select top (1) with ties *", "partition by dateadd(day, 0, created_at)", "option (maxrecursion 0)", "floor("},
+			excludes: []string{"cross apply", "mod(", "ceil("},
+		},
+		{
+			name:     "clickhouse",
+			platform: jinja.PlatformClickhouse,
+			query:    `{{ bruin.get_url_host('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"replaceRegexpOne", "extract(", "date_add(day", "numbers(greatest(dateDiff('day'"},
+		},
+		{
+			name:     "athena",
+			platform: jinja.PlatformAthena,
+			query:    `{{ bruin.get_url_path('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"strpos", "substr", "date_add('day'", "date_diff('day'", "sequence(cast(0 as bigint)"},
+		},
+		{
+			name:     "trino",
+			platform: jinja.PlatformTrino,
+			query:    `{{ bruin.get_url_path('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"strpos", "substr", "date_add('day'", "date_diff('day'", "sequence(cast(0 as bigint)"},
+		},
+		{
+			name:     "synapse",
+			platform: jinja.PlatformSynapse,
+			query:    `{{ bruin.get_url_host('page_url') }}||{{ bruin.deduplicate('events', 'dateadd(day, 0, created_at)', 'updated_at desc') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}||{{ bruin.width_bucket('price', '0', '100', '10') }}`,
+			contains: []string{"charindex", "select top (1) with ties *", "partition by dateadd(day, 0, created_at)", "with digits(n)", "cross join digits", "floor("},
+			excludes: []string{"with recursive", "mod(", "ceil("},
+		},
+		{
+			name:     "oracle",
+			platform: jinja.PlatformOracle,
+			query:    `{{ bruin.get_url_parameter('page_url', 'utm_source') }}||{{ bruin.generate_surrogate_key(['a', 'b']) }}||{{ bruin.deduplicate('events', 'user_id', 'updated_at desc') }}||{{ bruin.date_spine('hour', "timestamp '2020-01-01 00:00:00'", "timestamp '2020-01-01 02:00:00'") }}`,
+			contains: []string{"regexp_substr", "standard_hash", " || ", "from events bruin_inner", "from events data", "cast(timestamp '2020-01-01 00:00:00' as date)", "NUMTODSINTERVAL", "connect by level"},
+			excludes: []string{"concat(", "from events as"},
+		},
+		{
+			name:     "fabric",
+			platform: jinja.PlatformFabric,
+			query:    `{{ bruin.get_url_host('page_url') }}||{{ bruin.deduplicate('events', 'dateadd(day, 0, created_at)', 'updated_at desc') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}||{{ bruin.width_bucket('price', '0', '100', '10') }}`,
+			contains: []string{"charindex", "select top (1) with ties *", "partition by dateadd(day, 0, created_at)", "with digits(n)", "cross join digits", "floor("},
+			excludes: []string{"with recursive", "mod(", "ceil("},
+		},
+		{
+			name:     "vertica",
+			platform: jinja.PlatformVertica,
+			query:    `{{ bruin.get_url_path('page_url') }}||{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"split_part", "timestampadd(day, (n + 1)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(tt.platform)})
+			result, err := renderer.Render(tt.query)
+			require.NoError(t, err)
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+			for _, unexpected := range tt.excludes {
+				assert.NotContains(t, result, unexpected)
+			}
+		})
+	}
+}

--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -68,6 +68,7 @@ func LoadMacros(fs afero.Fs, macrosPath string) (string, error) {
 }
 
 func NewRenderer(context Context) *Renderer {
+	addBuiltinFunctions(context)
 	return &Renderer{
 		context:         exec.NewContext(context),
 		queryRenderLock: &sync.Mutex{},
@@ -75,8 +76,16 @@ func NewRenderer(context Context) *Renderer {
 	}
 }
 
+// addBuiltinFunctions ensures built-in SQL helper functions are available in the given context if not already set.
+func addBuiltinFunctions(ctx Context) {
+	if _, ok := ctx["bruin"]; !ok {
+		ctx["bruin"] = BuiltinFunctions()
+	}
+}
+
 // NewRendererWithMacros creates a new Renderer with the given context and macro content.
 func NewRendererWithMacros(context Context, macroContent string) *Renderer {
+	addBuiltinFunctions(context)
 	return &Renderer{
 		context:         exec.NewContext(context),
 		queryRenderLock: &sync.Mutex{},
@@ -156,6 +165,7 @@ func defaultContext(startDate, endDate, executionDate *time.Time, pipelineName, 
 		"full_refresh":          fullRefresh,
 		"commit_hash":           "",
 		"schema_prefix":         "",
+		"bruin":                 BuiltinFunctions(),
 	}
 }
 
@@ -283,6 +293,9 @@ func (r *Renderer) CloneForAsset(ctx context.Context, pipe *pipeline.Pipeline, a
 		jinjaContext["schema_prefix"] = env.SchemaPrefix
 	}
 
+	// Override built-in functions with platform-specific variants for this asset.
+	jinjaContext["bruin"] = BuiltinFunctions(PlatformForAssetType(asset.Type))
+
 	return &Renderer{
 		context:         exec.NewContext(jinjaContext),
 		queryRenderLock: &sync.Mutex{},
@@ -321,6 +334,102 @@ func findParserErrorType(err error) string {
 	}
 
 	return ""
+}
+
+// assetTypePlatform maps asset types directly to their SQL generation platform.
+var assetTypePlatform = map[pipeline.AssetType]Platform{
+	pipeline.AssetTypeBigqueryQuery:       PlatformBigQuery,
+	pipeline.AssetTypeBigqueryTableSensor: PlatformBigQuery,
+	pipeline.AssetTypeBigquerySeed:        PlatformBigQuery,
+	pipeline.AssetTypeBigquerySource:      PlatformBigQuery,
+	pipeline.AssetTypeBigqueryQuerySensor: PlatformBigQuery,
+
+	pipeline.AssetTypeSnowflakeQuery:       PlatformSnowflake,
+	pipeline.AssetTypeSnowflakeQuerySensor: PlatformSnowflake,
+	pipeline.AssetTypeSnowflakeTableSensor: PlatformSnowflake,
+	pipeline.AssetTypeSnowflakeSeed:        PlatformSnowflake,
+	pipeline.AssetTypeSnowflakeSource:      PlatformSnowflake,
+
+	pipeline.AssetTypePostgresQuery:       PlatformPostgres,
+	pipeline.AssetTypePostgresSeed:        PlatformPostgres,
+	pipeline.AssetTypePostgresQuerySensor: PlatformPostgres,
+	pipeline.AssetTypePostgresTableSensor: PlatformPostgres,
+	pipeline.AssetTypePostgresSource:      PlatformPostgres,
+
+	pipeline.AssetTypeRedshiftQuery:       PlatformRedshift,
+	pipeline.AssetTypeRedshiftSeed:        PlatformRedshift,
+	pipeline.AssetTypeRedshiftQuerySensor: PlatformRedshift,
+	pipeline.AssetTypeRedshiftSource:      PlatformRedshift,
+	pipeline.AssetTypeRedshiftTableSensor: PlatformRedshift,
+
+	pipeline.AssetTypeMySQLQuery:       PlatformMySQL,
+	pipeline.AssetTypeMySQLSeed:        PlatformMySQL,
+	pipeline.AssetTypeMySQLQuerySensor: PlatformMySQL,
+	pipeline.AssetTypeMySQLTableSensor: PlatformMySQL,
+
+	pipeline.AssetTypeDuckDBQuery:       PlatformDuckDB,
+	pipeline.AssetTypeDuckDBSeed:        PlatformDuckDB,
+	pipeline.AssetTypeDuckDBQuerySensor: PlatformDuckDB,
+	pipeline.AssetTypeDuckDBSource:      PlatformDuckDB,
+	pipeline.AssetTypeMotherduckQuery:   PlatformDuckDB,
+
+	pipeline.AssetTypeDatabricksQuery:       PlatformDatabricks,
+	pipeline.AssetTypeDatabricksSeed:        PlatformDatabricks,
+	pipeline.AssetTypeDatabricksQuerySensor: PlatformDatabricks,
+	pipeline.AssetTypeDatabricksSource:      PlatformDatabricks,
+	pipeline.AssetTypeDatabricksTableSensor: PlatformDatabricks,
+
+	pipeline.AssetTypeMsSQLQuery:       PlatformMSSQL,
+	pipeline.AssetTypeMsSQLSeed:        PlatformMSSQL,
+	pipeline.AssetTypeMsSQLQuerySensor: PlatformMSSQL,
+	pipeline.AssetTypeMsSQLTableSensor: PlatformMSSQL,
+	pipeline.AssetTypeMsSQLSource:      PlatformMSSQL,
+
+	pipeline.AssetTypeClickHouse:            PlatformClickhouse,
+	pipeline.AssetTypeClickHouseSeed:        PlatformClickhouse,
+	pipeline.AssetTypeClickHouseQuerySensor: PlatformClickhouse,
+	pipeline.AssetTypeClickHouseTableSensor: PlatformClickhouse,
+	pipeline.AssetTypeClickHouseSource:      PlatformClickhouse,
+
+	pipeline.AssetTypeAthenaQuery:       PlatformAthena,
+	pipeline.AssetTypeAthenaSeed:        PlatformAthena,
+	pipeline.AssetTypeAthenaSQLSensor:   PlatformAthena,
+	pipeline.AssetTypeAthenaTableSensor: PlatformAthena,
+	pipeline.AssetTypeAthenaSource:      PlatformAthena,
+
+	pipeline.AssetTypeTrinoQuery:       PlatformTrino,
+	pipeline.AssetTypeTrinoQuerySensor: PlatformTrino,
+
+	pipeline.AssetTypeSynapseQuery:       PlatformSynapse,
+	pipeline.AssetTypeSynapseSeed:        PlatformSynapse,
+	pipeline.AssetTypeSynapseQuerySensor: PlatformSynapse,
+	pipeline.AssetTypeSynapseSource:      PlatformSynapse,
+
+	pipeline.AssetTypeOracleQuery:  PlatformOracle,
+	pipeline.AssetTypeOracleSource: PlatformOracle,
+
+	pipeline.AssetTypeFabricQuery:             PlatformFabric,
+	pipeline.AssetTypeFabricSeed:              PlatformFabric,
+	pipeline.AssetTypeFabricQuerySensor:       PlatformFabric,
+	pipeline.AssetTypeFabricTableSensor:       PlatformFabric,
+	pipeline.AssetTypeFabricQueryLegacy:       PlatformFabric,
+	pipeline.AssetTypeFabricSeedLegacy:        PlatformFabric,
+	pipeline.AssetTypeFabricQuerySensorLegacy: PlatformFabric,
+	pipeline.AssetTypeFabricTableSensorLegacy: PlatformFabric,
+
+	pipeline.AssetTypeVerticaQuery:       PlatformVertica,
+	pipeline.AssetTypeVerticaSeed:        PlatformVertica,
+	pipeline.AssetTypeVerticaQuerySensor: PlatformVertica,
+	pipeline.AssetTypeVerticaTableSensor: PlatformVertica,
+	pipeline.AssetTypeVerticaSource:      PlatformVertica,
+}
+
+// PlatformForAssetType resolves the SQL generation platform for the given asset type.
+func PlatformForAssetType(assetType pipeline.AssetType) Platform {
+	if p, ok := assetTypePlatform[assetType]; ok {
+		return p
+	}
+	return PlatformDefault
 }
 
 // this ugly interface is needed to avoid circular dependencies and the ability to create different renderer instances per asset.

--- a/pkg/jinja/jinja_test.go
+++ b/pkg/jinja/jinja_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1304,6 +1305,65 @@ func TestRenderer_IsFullRefresh(t *testing.T) {
 				require.Equal(t, "full", conditionalResult)
 			} else {
 				require.Equal(t, "incremental", conditionalResult)
+			}
+		})
+	}
+}
+
+func TestRenderer_CloneForAsset_UsesPlatformBuiltins(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	executionDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	ctx := t.Context()
+	ctx = context.WithValue(ctx, pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, executionDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
+	ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, false)
+
+	basePipeline := &pipeline.Pipeline{Name: "test-pipeline"}
+	baseRenderer := NewRendererWithStartEndDates(&startDate, &endDate, &executionDate, basePipeline.Name, "test-run-id", nil)
+
+	tests := []struct {
+		name     string
+		asset    *pipeline.Asset
+		query    string
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "redshift surrogate key uses concat operator",
+			asset:    &pipeline.Asset{Name: "redshift-asset", Type: pipeline.AssetTypeRedshiftQuery},
+			query:    "{{ bruin.generate_surrogate_key(['a', 'b']) }}",
+			contains: []string{" || ", "md5("},
+			excludes: []string{"concat("},
+		},
+		{
+			name:     "bigquery date spine uses bigquery helpers",
+			asset:    &pipeline.Asset{Name: "bigquery-asset", Type: pipeline.AssetTypeBigqueryQuery},
+			query:    `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-02'") }}`,
+			contains: []string{"generate_array", "date_add"},
+			excludes: []string{"with recursive"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clonedRenderer, err := baseRenderer.CloneForAsset(ctx, basePipeline, tt.asset)
+			require.NoError(t, err)
+
+			result, err := clonedRenderer.Render(tt.query)
+			require.NoError(t, err)
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+			for _, unexpected := range tt.excludes {
+				assert.NotContains(t, result, unexpected)
 			}
 		})
 	}

--- a/pkg/mssql/bruin_funcs.go
+++ b/pkg/mssql/bruin_funcs.go
@@ -1,0 +1,16 @@
+package mssql
+
+import (
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformMSSQL, jinja.MergeBuiltinOverrides(jinja.TSQLURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar", ansisql.HashBytesHashFn),
+		"deduplicate":            ansisql.DeduplicateSubquery,
+		"pivot":                  jinja.PivotWithIdentifierQuote(jinja.BracketQuoteIdentifier),
+		"width_bucket":           jinja.TSQLWidthBucket,
+		"date_spine":             jinja.TSQLDateSpine,
+	}))
+}

--- a/pkg/mssql/bruin_funcs_parser_test.go
+++ b/pkg/mssql/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package mssql
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMSSQLGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformMSSQL, "tsql")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/mssql/bruin_funcs_test.go
+++ b/pkg/mssql/bruin_funcs_test.go
@@ -1,0 +1,36 @@
+package mssql
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMSSQLBuiltinOverrides(t *testing.T) {
+	t.Parallel()
+
+	renderer := jinja.NewRenderer(jinja.Context{
+		"bruin": jinja.BuiltinFunctions(jinja.PlatformMSSQL),
+	})
+
+	t.Run("surrogate_key uses hashbytes", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id']) }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "hashbytes('md5',")
+		assert.Contains(t, result, "convert(varchar(32),")
+	})
+
+	t.Run("deduplicate uses TOP WITH TIES", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.deduplicate('my_table', 'user_id', 'updated_at desc') }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "select top (1) with ties *")
+		assert.Contains(t, result, "order by row_number() over")
+		assert.NotContains(t, result, "_bruin_dedup_rn")
+		assert.NotContains(t, result, "natural join")
+		assert.NotContains(t, result, "qualify")
+	})
+}

--- a/pkg/mysql/bruin_funcs.go
+++ b/pkg/mysql/bruin_funcs.go
@@ -1,0 +1,17 @@
+package mysql
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformMySQL, jinja.MergeBuiltinOverrides(jinja.MySQLURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWith("char", func(expr string) string {
+			return fmt.Sprintf("md5(%s)", expr)
+		}),
+		"pivot":      jinja.PivotWithIdentifierQuote(jinja.BacktickQuoteIdentifier),
+		"date_spine": jinja.MySQLDateSpine,
+	}))
+}

--- a/pkg/mysql/bruin_funcs_parser_test.go
+++ b/pkg/mysql/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMySQLGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformMySQL, "mysql")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/oracle/bruin_funcs.go
+++ b/pkg/oracle/bruin_funcs.go
@@ -1,0 +1,18 @@
+package oracle
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformOracle, jinja.MergeBuiltinOverrides(jinja.OracleURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWithConcat("varchar2(4000)", jinja.ConcatOperator, func(expr string) string {
+			return fmt.Sprintf("lower(rawtohex(standard_hash(%s, 'MD5')))", expr)
+		}),
+		"deduplicate": ansisql.DeduplicateNaturalJoinNoAs,
+		"date_spine":  jinja.OracleDateSpine,
+	}))
+}

--- a/pkg/oracle/bruin_funcs_parser_test.go
+++ b/pkg/oracle/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOracleGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformOracle, "oracle")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/postgres/bruin_funcs.go
+++ b/pkg/postgres/bruin_funcs.go
@@ -1,0 +1,13 @@
+package postgres
+
+import (
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformPostgres, jinja.MergeBuiltinOverrides(jinja.SplitPartURLHelpers("varchar"), map[string]any{
+		"deduplicate": ansisql.DeduplicateDistinctOn,
+		"date_spine":  jinja.PostgresDateSpine,
+	}))
+}

--- a/pkg/postgres/bruin_funcs_parser_test.go
+++ b/pkg/postgres/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformPostgres, "postgres")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/postgres/bruin_funcs_test.go
+++ b/pkg/postgres/bruin_funcs_test.go
@@ -1,0 +1,34 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresBuiltinOverrides(t *testing.T) {
+	t.Parallel()
+
+	renderer := jinja.NewRenderer(jinja.Context{
+		"bruin": jinja.BuiltinFunctions(jinja.PlatformPostgres),
+	})
+
+	t.Run("deduplicate uses DISTINCT ON", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.deduplicate('my_table', 'user_id', 'updated_at desc') }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "distinct on (user_id)")
+		assert.Contains(t, result, "order by user_id, updated_at desc")
+		assert.NotContains(t, result, "row_number")
+	})
+
+	t.Run("date_spine uses generate_series", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render(`{{ bruin.date_spine('day', "'2020-01-01'", "'2025-01-01'") }}`)
+		require.NoError(t, err)
+		assert.Contains(t, result, "generate_series")
+		assert.Contains(t, result, "interval '1 day'")
+	})
+}

--- a/pkg/redshift/bruin_funcs.go
+++ b/pkg/redshift/bruin_funcs.go
@@ -1,0 +1,22 @@
+package redshift
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformRedshift, jinja.MergeBuiltinOverrides(jinja.SplitPartURLHelpers("varchar"), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWithConcat("varchar", jinja.ConcatOperator, func(expr string) string {
+			return fmt.Sprintf("md5(%s)", expr)
+		}),
+		"deduplicate": ansisql.DeduplicateQualify,
+		"date_spine": func(datepart, startDate, endDate string) string {
+			return jinja.DateSpineWithRecursiveDateAdd(true, "", func(datepart, n, start string) string {
+				return fmt.Sprintf("dateadd(%s, %s, %s)", datepart, n, start)
+			})(datepart, fmt.Sprintf("cast(%s as timestamp)", startDate), fmt.Sprintf("cast(%s as timestamp)", endDate))
+		},
+	}))
+}

--- a/pkg/redshift/bruin_funcs_parser_test.go
+++ b/pkg/redshift/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package redshift
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedshiftGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformRedshift, "redshift")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/snowflake/bruin_funcs.go
+++ b/pkg/snowflake/bruin_funcs.go
@@ -1,0 +1,24 @@
+package snowflake
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformSnowflake, jinja.MergeBuiltinOverrides(jinja.SplitPartURLHelpers("varchar"), map[string]any{
+		"deduplicate":  ansisql.DeduplicateQualify,
+		"width_bucket": jinja.NativeWidthBucket,
+		"date_spine": func(datepart, startDate, endDate string) string {
+			castFn := "to_date"
+			if jinja.IsTimestampDatepart(datepart) {
+				castFn = "to_timestamp"
+			}
+			return jinja.DateSpineWithRecursiveDateAdd(true, "", func(datepart, n, start string) string {
+				return fmt.Sprintf("dateadd(%s, %s, %s)", datepart, n, start)
+			})(datepart, fmt.Sprintf("%s(%s)", castFn, startDate), fmt.Sprintf("%s(%s)", castFn, endDate))
+		},
+	}))
+}

--- a/pkg/snowflake/bruin_funcs_parser_test.go
+++ b/pkg/snowflake/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnowflakeGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformSnowflake, "snowflake")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/snowflake/bruin_funcs_test.go
+++ b/pkg/snowflake/bruin_funcs_test.go
@@ -1,0 +1,32 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnowflakeBuiltinOverrides(t *testing.T) {
+	t.Parallel()
+
+	renderer := jinja.NewRenderer(jinja.Context{
+		"bruin": jinja.BuiltinFunctions(jinja.PlatformSnowflake),
+	})
+
+	t.Run("deduplicate uses QUALIFY", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.deduplicate('my_table', 'user_id', 'updated_at desc') }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "qualify")
+		assert.NotContains(t, result, "natural join")
+	})
+
+	t.Run("width_bucket uses native function", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.width_bucket('price', '0', '100', '10') }}")
+		require.NoError(t, err)
+		assert.Equal(t, "width_bucket(price, 0, 100, 10)", result)
+	})
+}

--- a/pkg/sqlparser/parser.go
+++ b/pkg/sqlparser/parser.go
@@ -67,19 +67,22 @@ func NewSQLParserWithConfig(randomize bool, maxQueryLength int) (*SQLParser, err
 
 func newSQLParserInternal(tmpDirName string, randomize bool, maxQueryLength int) (*SQLParser, error) {
 	tmpDir := filepath.Join(os.TempDir(), tmpDirName)
-	recreate := randomize // only recreate when using random dirs (production); reuse for cached dirs
+	withHashInDir := randomize // only use hash-suffixed dirs for randomized parser instances; reuse cached dirs.
 
-	ep, err := python.NewEmbeddedPythonWithTmpDir(tmpDir+"-python", recreate)
+	ep, err := python.NewEmbeddedPythonWithTmpDir(tmpDir+"-python", withHashInDir)
 	if err != nil {
 		return nil, err
 	}
-	sqlglotDir, err := embed_util.NewEmbeddedFilesWithTmpDir(data.Data, tmpDir+"-sqlglot-lib", recreate)
+	sqlglotDir, err := embed_util.NewEmbeddedFilesWithTmpDir(data.Data, tmpDir+"-sqlglot-lib", withHashInDir)
 	if err != nil {
 		return nil, err
 	}
 	ep.AddPythonPath(sqlglotDir.GetExtractedPath())
 
-	rendererSrc, err := embed_util.NewEmbeddedFilesWithTmpDir(pythonsrc.RendererSource, tmpDir+"-jinja2-renderer", recreate)
+	// Keep the parser source content-hashed so cached parser instances cannot reuse
+	// stale Python code after pythonsrc changes. This directory is small compared to
+	// the embedded Python/runtime directories above.
+	rendererSrc, err := embed_util.NewEmbeddedFilesWithTmpDir(pythonsrc.RendererSource, tmpDir+"-jinja2-renderer", true)
 	if err != nil {
 		return nil, err
 	}
@@ -340,17 +343,22 @@ type QueryConfig struct {
 }
 
 var assetTypeDialectMap = map[pipeline.AssetType]string{
-	pipeline.AssetTypeBigqueryQuery:   "bigquery",
-	pipeline.AssetTypeSnowflakeQuery:  "snowflake",
-	pipeline.AssetTypePostgresQuery:   "postgres",
-	pipeline.AssetTypeMySQLQuery:      "mysql",
-	pipeline.AssetTypeRedshiftQuery:   "redshift",
-	pipeline.AssetTypeAthenaQuery:     "athena",
-	pipeline.AssetTypeClickHouse:      "clickhouse",
-	pipeline.AssetTypeDatabricksQuery: "databricks",
-	pipeline.AssetTypeMsSQLQuery:      "tsql",
-	pipeline.AssetTypeSynapseQuery:    "tsql",
-	pipeline.AssetTypeDuckDBQuery:     "duckdb",
+	pipeline.AssetTypeBigqueryQuery:     "bigquery",
+	pipeline.AssetTypeSnowflakeQuery:    "snowflake",
+	pipeline.AssetTypePostgresQuery:     "postgres",
+	pipeline.AssetTypeMySQLQuery:        "mysql",
+	pipeline.AssetTypeRedshiftQuery:     "redshift",
+	pipeline.AssetTypeAthenaQuery:       "athena",
+	pipeline.AssetTypeTrinoQuery:        "trino",
+	pipeline.AssetTypeClickHouse:        "clickhouse",
+	pipeline.AssetTypeDatabricksQuery:   "databricks",
+	pipeline.AssetTypeMsSQLQuery:        "tsql",
+	pipeline.AssetTypeSynapseQuery:      "tsql",
+	pipeline.AssetTypeDuckDBQuery:       "duckdb",
+	pipeline.AssetTypeOracleQuery:       "oracle",
+	pipeline.AssetTypeFabricQuery:       "fabric",
+	pipeline.AssetTypeFabricQueryLegacy: "fabric",
+	pipeline.AssetTypeVerticaQuery:      "postgres",
 }
 
 func AssetTypeToDialect(assetType pipeline.AssetType) (string, error) {

--- a/pkg/synapse/bruin_funcs.go
+++ b/pkg/synapse/bruin_funcs.go
@@ -1,0 +1,16 @@
+package synapse
+
+import (
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformSynapse, jinja.MergeBuiltinOverrides(jinja.TSQLURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar", ansisql.HashBytesHashFn),
+		"deduplicate":            ansisql.DeduplicateSubquery,
+		"pivot":                  jinja.PivotWithIdentifierQuote(jinja.BracketQuoteIdentifier),
+		"width_bucket":           jinja.TSQLWidthBucket,
+		"date_spine":             jinja.TSQLDateSpineWithTally,
+	}))
+}

--- a/pkg/synapse/bruin_funcs_parser_test.go
+++ b/pkg/synapse/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package synapse
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSynapseGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformSynapse, "tsql")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/trino/bruin_funcs.go
+++ b/pkg/trino/bruin_funcs.go
@@ -1,0 +1,19 @@
+package trino
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformTrino, jinja.MergeBuiltinOverrides(jinja.PrestoURLHelpers(), map[string]any{
+		"generate_surrogate_key": jinja.SurrogateKeyWithConcat("varchar", jinja.ConcatOperator, func(expr string) string {
+			return fmt.Sprintf("to_hex(md5(to_utf8(%s)))", expr)
+		}),
+		"deduplicate":  ansisql.DeduplicateArrayAgg,
+		"width_bucket": jinja.NativeWidthBucket,
+		"date_spine":   jinja.PrestoDateSpine,
+	}))
+}

--- a/pkg/trino/bruin_funcs_parser_test.go
+++ b/pkg/trino/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package trino
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrinoGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformTrino, "trino")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pkg/vertica/bruin_funcs.go
+++ b/pkg/vertica/bruin_funcs.go
@@ -1,0 +1,17 @@
+package vertica
+
+import (
+	"fmt"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+)
+
+func init() { //nolint:gochecknoinits
+	jinja.RegisterPlatformOverrides(jinja.PlatformVertica, jinja.MergeBuiltinOverrides(jinja.SplitPartURLHelpers("varchar"), map[string]any{
+		"date_spine": func(datepart, startDate, endDate string) string {
+			return jinja.DateSpineWithRecursiveDateAdd(true, "", func(datepart, n, start string) string {
+				return fmt.Sprintf("timestampadd(%s, %s, %s)", datepart, n, start)
+			})(datepart, fmt.Sprintf("cast(%s as timestamp)", startDate), fmt.Sprintf("cast(%s as timestamp)", endDate))
+		},
+	}))
+}

--- a/pkg/vertica/bruin_funcs_parser_test.go
+++ b/pkg/vertica/bruin_funcs_parser_test.go
@@ -1,0 +1,87 @@
+package vertica
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerticaGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	t.Parallel()
+
+	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformVertica, "postgres")
+}
+
+func testBruinGeneratedSQLParsesWithSQLGlot(t *testing.T, platform jinja.Platform, dialect string) {
+	t.Helper()
+
+	parser, err := sqlparser.NewSQLParserCached()
+	require.NoError(t, err)
+	require.NoError(t, parser.Start())
+
+	t.Cleanup(func() {
+		require.NoError(t, parser.Close())
+	})
+
+	for _, tt := range bruinGeneratedSQLParseCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer := jinja.NewRenderer(jinja.Context{"bruin": jinja.BuiltinFunctions(platform)})
+			rendered, err := renderer.Render(tt.template)
+			require.NoErrorf(t, err, "failed to render generated SQL query %q", tt.name)
+
+			isSingleSelect, err := parser.IsSingleSelectQuery(rendered, dialect)
+			require.NoErrorf(t, err, "generated SQL query %q did not parse:\n%s", tt.name, rendered)
+			require.Truef(t, isSingleSelect, "generated SQL query %q is not a single SELECT:\n%s", tt.name, rendered)
+		})
+	}
+}
+
+func bruinGeneratedSQLParseCases() []struct {
+	name     string
+	template string
+} {
+	return []struct {
+		name     string
+		template string
+	}{
+		{"group_by", `select user_id, account_id, count(*) as event_count from events {{ bruin.group_by(2) }}`},
+		{"safe_divide", `select {{ bruin.safe_divide('revenue', 'sessions') }} as safe_divide from events`},
+		{"safe_add", `select {{ bruin.safe_add(['revenue', 'tax']) }} as safe_add from events`},
+		{"safe_add_three_fields", `select {{ bruin.safe_add(['revenue', 'tax', 'shipping']) }} as safe_add from events`},
+		{"safe_subtract", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts']) }} as safe_subtract from events`},
+		{"safe_subtract_three_fields", `select {{ bruin.safe_subtract(['gross_revenue', 'discounts', 'refunds']) }} as safe_subtract from events`},
+		{"surrogate_key", `select {{ bruin.generate_surrogate_key(['user_id', 'session_id']) }} as sk from events`},
+		{"surrogate_key_single_field", `select {{ bruin.generate_surrogate_key(['user_id']) }} as sk from events`},
+		{"pivot", `select user_id, {{ bruin.pivot('status', ['active', 'inactive'], quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_default_quoted_identifiers", `select user_id, {{ bruin.pivot('status', ['active', 'inactive']) }} from events group by user_id`},
+		{"pivot_distinct_count", `select user_id, {{ bruin.pivot('status', ['active'], agg='count', distinct=true, prefix='status_', quote_identifiers=false) }} from events group by user_id`},
+		{"pivot_no_alias", `select user_id, {{ bruin.pivot('status', ['active'], alias=false) }} from events group by user_id`},
+		{"pivot_custom_comparison_values_suffix", `select user_id, {{ bruin.pivot('status', ['active'], cmp='!=', then_value='revenue', else_value='0', suffix='_excluded', quote_identifiers=false) }} from events group by user_id`},
+		{"haversine_distance", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2') }} as distance_miles from events`},
+		{"haversine_distance_km", `select {{ bruin.haversine_distance('lat1', 'lon1', 'lat2', 'lon2', unit='km') }} as distance_km from events`},
+		{"degrees_to_radians", `select {{ bruin.degrees_to_radians('angle_degrees') }} as radians_value from events`},
+		{"width_bucket", `select {{ bruin.width_bucket('price', '0', '100', '10') }} as bucket_number from events`},
+		{"slugify", `select 1 as {{ bruin.slugify('9 Active Users!') }} from events`},
+		{"get_url_host", `select {{ bruin.get_url_host('page_url') }} as url_host from events`},
+		{"get_url_path", `select {{ bruin.get_url_path('page_url') }} as url_path from events`},
+		{"get_url_parameter", `select {{ bruin.get_url_parameter('page_url', 'utm_source') }} as utm_source from events`},
+		{"generate_series", `{{ bruin.generate_series(17) }}`},
+		{"generate_series_one", `{{ bruin.generate_series(1) }}`},
+		{"deduplicate", `{{ bruin.deduplicate('events', 'user_id, account_id', 'updated_at desc') }}`},
+		{"deduplicate_expression_partition", `{{ bruin.deduplicate('events', 'cast(created_at as date), account_id', 'updated_at desc, event_id') }}`},
+		{"date_spine_day", `{{ bruin.date_spine('day', "'2020-01-01'", "'2020-01-05'") }}`},
+		{"date_spine_week", `{{ bruin.date_spine('week', "'2020-01-01'", "'2020-02-01'") }}`},
+		{"date_spine_month_non_aligned", `{{ bruin.date_spine('month', "'2020-01-15'", "'2020-04-01'") }}`},
+		{"date_spine_quarter", `{{ bruin.date_spine('quarter', "'2020-01-15'", "'2020-10-01'") }}`},
+		{"date_spine_year", `{{ bruin.date_spine('year', "'2020-01-15'", "'2023-01-01'") }}`},
+		{"date_spine_hour", `{{ bruin.date_spine('hour', "'2020-01-01 00:00:00'", "'2020-01-01 03:00:00'") }}`},
+		{"date_spine_minute", `{{ bruin.date_spine('minute', "'2020-01-01 00:00:00'", "'2020-01-01 00:03:00'") }}`},
+		{"date_spine_second", `{{ bruin.date_spine('second', "'2020-01-01 00:00:00'", "'2020-01-01 00:00:03'") }}`},
+		{"date_spine_millisecond", `{{ bruin.date_spine('millisecond', "'2020-01-01 00:00:00.000'", "'2020-01-01 00:00:00.003'") }}`},
+		{"date_spine_microsecond", `{{ bruin.date_spine('microsecond', "'2020-01-01 00:00:00.000000'", "'2020-01-01 00:00:00.000003'") }}`},
+	}
+}

--- a/pythonsrc/parser/main.py
+++ b/pythonsrc/parser/main.py
@@ -6,6 +6,13 @@ from sqlglot.optimizer import optimize
 from sqlglot.optimizer.scope import find_all_in_scope, build_scope
 
 
+def normalize_sqlglot_dialect(dialect: str | None) -> str | None:
+    """Map Bruin dialect names that SQLGlot does not expose directly."""
+    if dialect == "vertica":
+        return "postgres"
+    return dialect
+
+
 @dataclass(frozen=True)
 class Column:
     name: str
@@ -238,6 +245,8 @@ def get_tables_tsql(query: str):
 
 
 def get_tables(query: str, dialect: str):
+    dialect = normalize_sqlglot_dialect(dialect)
+
     # Delegate to T-SQL specific implementation if dialect is tsql
     if dialect == "tsql":
         return get_tables_tsql(query)
@@ -266,6 +275,8 @@ def get_tables(query: str, dialect: str):
 
 
 def get_column_lineage(query: str, schema: dict, dialect: str):
+    dialect = normalize_sqlglot_dialect(dialect)
+
     try:
         parsed = parse_one(query, dialect=dialect)
         if not isinstance(parsed, exp.Query):
@@ -497,6 +508,8 @@ def schema_dict_to_schema_object(schema_dict: dict) -> dict:
 def replace_table_references(
     query: str, dialect: str, table_references: dict[str, str]
 ):
+    dialect = normalize_sqlglot_dialect(dialect)
+
     parsed = parse_one(query, dialect=dialect)
     if parsed is None:
         return {"error": "unable to parse query"}
@@ -510,6 +523,8 @@ def replace_table_references(
 
 
 def add_limit(query: str, limit_value: int, dialect: str = None) -> dict:
+    dialect = normalize_sqlglot_dialect(dialect)
+
     try:
         parsed = parse_one(query, dialect=dialect)
         if parsed is None:
@@ -522,6 +537,8 @@ def add_limit(query: str, limit_value: int, dialect: str = None) -> dict:
 
 
 def is_single_select_query(query: str, dialect: str = None) -> dict:
+    dialect = normalize_sqlglot_dialect(dialect)
+
     """
     Check if a query is a single SELECT statement.
     Returns {"is_single_select": bool, "error": str}


### PR DESCRIPTION
Adds built-in `bruin.*` SQL helpers with platform-specific SQL generation across supported warehouses.
Documents the helpers in the macro guide and expands parser coverage for generated SQL.

Validated with `make format` and `make test`.
