### PR TITLE
Add bootstrap v0 seed asset

### DIFF
--- a/templates/bootstrap/assets/bootstrap_v0.asset.yml
+++ b/templates/bootstrap/assets/bootstrap_v0.asset.yml
@@ -1,0 +1,7 @@
+name: public.bootstrap_v0
+type: duckdb.seed
+connection: duckdb-default
+
+parameters:
+    path: seed.csv
+    version: v0


### PR DESCRIPTION
Adds a bootstrap seed asset that explicitly uses ingestr version v0 alongside the existing v1 seed asset.

Validated with `make format` and `make test`.