### PR TITLE
ingestr: drop persistent uv tool install

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -24,11 +24,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var (
-	ingestrInstallMutex      sync.Mutex
-	ingestrInstalledPackages = make(map[string]bool)
-)
-
 var AvailablePythonVersions = map[string]bool{
 	"3.8":  true,
 	"3.9":  true,
@@ -241,10 +236,6 @@ func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []s
 		return err
 	}
 	u.binaryFullPath = binaryFullPath
-
-	if err := u.ensureIngestrInstalled(ctx, extraPackages, repo); err != nil {
-		return err
-	}
 
 	noDependencyCommand := &CommandInstance{
 		Name: u.binaryFullPath,
@@ -521,11 +512,6 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		ingestrCtx = context.WithValue(ctx, executor.KeyPrinter, io.Writer(logBuffer))
 	}
 
-	err = u.ensureIngestrInstalled(ctx, extraPackages, execCtx.repo)
-	if err != nil {
-		return err
-	}
-
 	runArgs := u.ingestrRunCmd(ctx, extraPackages, cmdArgs)
 
 	if debug := ctx.Value(executor.KeyIsDebug); debug != nil {
@@ -568,80 +554,24 @@ func (u *UvPythonRunner) ingestrPackage(ctx context.Context) (string, bool) {
 	return "ingestr@" + IngestrVersionV1, false
 }
 
-// ingestrInstallCmd returns the uv tool commandline
-// args necessary for installing ingestr.
-func (u *UvPythonRunner) ingestrInstallCmd(ctx context.Context, pkgs []string, forceReinstall bool) []string {
-	ingestrPackageName, isLocal := u.ingestrPackage(ctx)
-	cmdline := []string{
-		"tool",
-		"install",
-		"--no-config",
-		"--quiet",
-		"--prerelease",
-		"allow",
-		"--python",
-		pythonVersionForIngestr,
-	}
-	if forceReinstall {
-		cmdline = append(cmdline, "--force")
-	}
-	for _, pkg := range pkgs {
-		cmdline = append(cmdline, "--with", pkg)
-	}
-	if isLocal {
-		cmdline = append(cmdline, "--reinstall")
-	}
-	cmdline = append(cmdline, ingestrPackageName)
-	return cmdline
-}
-
+// ingestrRunCmd builds the `uv tool run` invocation for ingestr. Each call resolves
+// a per-version environment via `--from ingestr@<ver>` (or a local path), so v0 and
+// v1 assets in the same pipeline never share — and never clobber — an installation.
 func (u *UvPythonRunner) ingestrRunCmd(ctx context.Context, extraPackages, args []string) []string {
-	ingestrPackageName, _ := u.ingestrPackage(ctx)
-	cmdline := make([]string, 0, 10+(2*len(extraPackages))+len(args))
-	cmdline = append(cmdline, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr, "--from", ingestrPackageName)
+	ingestrPackageName, isLocal := u.ingestrPackage(ctx)
+	cmdline := make([]string, 0, 12+(2*len(extraPackages))+len(args))
+	cmdline = append(cmdline, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr)
+	if isLocal {
+		// Force uv to rebuild the local source on every run so edits in
+		// debug-ingestr-src are picked up.
+		cmdline = append(cmdline, "--reinstall-package", "ingestr")
+	}
+	cmdline = append(cmdline, "--from", ingestrPackageName)
 	for _, pkg := range extraPackages {
 		cmdline = append(cmdline, "--with", pkg)
 	}
 	cmdline = append(cmdline, "ingestr")
 	return append(cmdline, args...)
-}
-
-// buildIngestrPackageKey creates a unique key for the combination of ingestr version and extra packages.
-func (u *UvPythonRunner) buildIngestrPackageKey(ctx context.Context, extraPackages []string) string {
-	ingestrPackageName, _ := u.ingestrPackage(ctx)
-	sortedPkgs := make([]string, len(extraPackages))
-	copy(sortedPkgs, extraPackages)
-	sort.Strings(sortedPkgs)
-	return ingestrPackageName + ":" + strings.Join(sortedPkgs, ",")
-}
-
-// ensureIngestrInstalled installs ingestr with the specified extra packages in a thread-safe manner.
-// It prevents parallel workers from installing ingestr simultaneously, which causes file lock
-// conflicts on Windows (OS error 32).
-func (u *UvPythonRunner) ensureIngestrInstalled(ctx context.Context, extraPackages []string, repo *git.Repo) error {
-	packageKey := u.buildIngestrPackageKey(ctx, extraPackages)
-
-	ingestrInstallMutex.Lock()
-	defer ingestrInstallMutex.Unlock()
-
-	_, isLocal := u.ingestrPackage(ctx)
-	if !isLocal {
-		if ingestrInstalledPackages[packageKey] {
-			return nil
-		}
-	}
-
-	forceReinstall := isLocal || !ingestrInstalledPackages[packageKey]
-	err := u.Cmd.Run(ctx, repo, &CommandInstance{
-		Name: u.binaryFullPath,
-		Args: u.ingestrInstallCmd(ctx, extraPackages, forceReinstall),
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to install ingestr")
-	}
-
-	ingestrInstalledPackages[packageKey] = true
-	return nil
 }
 
 // tailBuffer is a bounded io.Writer that retains at most maxBytes of the most
@@ -682,14 +612,6 @@ func (t *tailBuffer) flushTo(w io.Writer) {
 		_, _ = w.Write([]byte("[earlier ingestr output omitted]\n"))
 	}
 	_, _ = w.Write(t.data)
-}
-
-// ResetIngestrInstallCache resets the ingestr installation cache.
-// This is primarily useful for testing.
-func ResetIngestrInstallCache() {
-	ingestrInstallMutex.Lock()
-	defer ingestrInstallMutex.Unlock()
-	ingestrInstalledPackages = make(map[string]bool)
 }
 
 // pythonArrowInlineMetadata is the PEP 723 inline script metadata header in the arrow template.

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -2,8 +2,6 @@ package python
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/git"
@@ -144,47 +142,6 @@ func Test_uvPythonRunner_Run(t *testing.T) {
 	}
 }
 
-func Test_buildIngestrPackageKey(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		extraPackages []string
-		expected      string
-	}{
-		{
-			name:          "no extra packages",
-			extraPackages: []string{},
-			expected:      "ingestr@" + IngestrVersionV1 + ":",
-		},
-		{
-			name:          "single package",
-			extraPackages: []string{"pyodbc"},
-			expected:      "ingestr@" + IngestrVersionV1 + ":pyodbc",
-		},
-		{
-			name:          "multiple packages sorted",
-			extraPackages: []string{"pyodbc", "duckdb"},
-			expected:      "ingestr@" + IngestrVersionV1 + ":duckdb,pyodbc",
-		},
-		{
-			name:          "packages in different order produce same key",
-			extraPackages: []string{"duckdb", "pyodbc"},
-			expected:      "ingestr@" + IngestrVersionV1 + ":duckdb,pyodbc",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			u := &UvPythonRunner{}
-			key := u.buildIngestrPackageKey(t.Context(), tt.extraPackages)
-			assert.Equal(t, tt.expected, key)
-		})
-	}
-}
-
 func Test_ingestrPackage_HonorsCtxIngestrVersion(t *testing.T) {
 	t.Parallel()
 
@@ -234,135 +191,29 @@ func Test_ingestrRunCmd_UsesResolvedPackage(t *testing.T) {
 	}, args)
 }
 
-func Test_buildIngestrPackageKey_DiffersByVersion(t *testing.T) {
+func Test_ingestrRunCmd_LocalPathForcesReinstall(t *testing.T) {
 	t.Parallel()
 
 	u := &UvPythonRunner{}
-	defaultKey := u.buildIngestrPackageKey(t.Context(), nil)
+	ctx := context.WithValue(t.Context(), LocalIngestr, "/local/ingestr")
 
-	pinnedCtx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.2")
-	pinnedKey := u.buildIngestrPackageKey(pinnedCtx, nil)
+	args := u.ingestrRunCmd(ctx, nil, []string{"ingest"})
 
-	assert.NotEqual(t, defaultKey, pinnedKey)
-	assert.Equal(t, "ingestr@0.14.2:", pinnedKey)
-}
-
-func Test_ensureIngestrInstalled_OnlyInstallsOnce(t *testing.T) { //nolint:paralleltest
-	ResetIngestrInstallCache()
-	defer ResetIngestrInstallCache()
-
-	repo := &git.Repo{}
-	var installCount atomic.Int32
-
-	cmd := new(mockCmd)
-	cmd.On("Run", mock.Anything, repo, mock.MatchedBy(func(c *CommandInstance) bool {
-		return len(c.Args) > 0 && c.Args[0] == "tool" && c.Args[1] == "install"
-	})).Run(func(args mock.Arguments) {
-		installCount.Add(1)
-	}).Return(nil)
-
-	inst := new(mockUvInstaller)
-	inst.On("EnsureUvInstalled", mock.Anything).Return("~/.bruin/uv", nil)
-
-	u := &UvPythonRunner{
-		Cmd:            cmd,
-		UvInstaller:    inst,
-		binaryFullPath: "~/.bruin/uv",
-	}
-
-	ctx := t.Context()
-	extraPackages := []string{"pyodbc"}
-
-	err := u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	require.NoError(t, err)
-
-	err = u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	require.NoError(t, err)
-
-	err = u.ensureIngestrInstalled(ctx, extraPackages, repo)
-	require.NoError(t, err)
-
-	assert.Equal(t, int32(1), installCount.Load(), "ingestr should only be installed once for the same package combination")
-}
-
-func Test_ensureIngestrInstalled_InstallsForDifferentPackages(t *testing.T) { //nolint:paralleltest
-	ResetIngestrInstallCache()
-	defer ResetIngestrInstallCache()
-
-	repo := &git.Repo{}
-	var installCount atomic.Int32
-
-	cmd := new(mockCmd)
-	cmd.On("Run", mock.Anything, repo, mock.MatchedBy(func(c *CommandInstance) bool {
-		return len(c.Args) > 0 && c.Args[0] == "tool" && c.Args[1] == "install"
-	})).Run(func(args mock.Arguments) {
-		installCount.Add(1)
-	}).Return(nil)
-
-	inst := new(mockUvInstaller)
-	inst.On("EnsureUvInstalled", mock.Anything).Return("~/.bruin/uv", nil)
-
-	u := &UvPythonRunner{
-		Cmd:            cmd,
-		UvInstaller:    inst,
-		binaryFullPath: "~/.bruin/uv",
-	}
-
-	ctx := t.Context()
-
-	err := u.ensureIngestrInstalled(ctx, []string{"pyodbc"}, repo)
-	require.NoError(t, err)
-
-	err = u.ensureIngestrInstalled(ctx, []string{"duckdb"}, repo)
-	require.NoError(t, err)
-
-	err = u.ensureIngestrInstalled(ctx, []string{"pyodbc", "duckdb"}, repo)
-	require.NoError(t, err)
-
-	assert.Equal(t, int32(3), installCount.Load(), "ingestr should be installed once for each unique package combination")
-}
-
-func Test_ensureIngestrInstalled_ConcurrentCalls(t *testing.T) { //nolint:paralleltest
-	ResetIngestrInstallCache()
-	defer ResetIngestrInstallCache()
-
-	repo := &git.Repo{}
-	var installCount atomic.Int32
-
-	cmd := new(mockCmd)
-	cmd.On("Run", mock.Anything, repo, mock.MatchedBy(func(c *CommandInstance) bool {
-		return len(c.Args) > 0 && c.Args[0] == "tool" && c.Args[1] == "install"
-	})).Run(func(args mock.Arguments) {
-		installCount.Add(1)
-	}).Return(nil)
-
-	inst := new(mockUvInstaller)
-	inst.On("EnsureUvInstalled", mock.Anything).Return("~/.bruin/uv", nil)
-
-	u := &UvPythonRunner{
-		Cmd:            cmd,
-		UvInstaller:    inst,
-		binaryFullPath: "~/.bruin/uv",
-	}
-
-	ctx := t.Context()
-	extraPackages := []string{"pyodbc"}
-
-	var wg sync.WaitGroup
-	numGoroutines := 10
-
-	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := u.ensureIngestrInstalled(ctx, extraPackages, repo)
-			assert.NoError(t, err)
-		}()
-	}
-
-	wg.Wait()
-
-	assert.Equal(t, int32(1), installCount.Load(), "ingestr should only be installed once even with concurrent calls")
+	assert.Equal(t, []string{
+		"tool",
+		"run",
+		"--no-config",
+		"--prerelease",
+		"allow",
+		"--python",
+		"3.11",
+		"--reinstall-package",
+		"ingestr",
+		"--from",
+		"/local/ingestr",
+		"ingestr",
+		"ingest",
+	}, args)
 }
 
 func TestResolvePythonVersion(t *testing.T) {


### PR DESCRIPTION
uv tool install manages a single persistent installation per tool name, so pinning ingestr@v0 and ingestr@v1 in the same pipeline made the two installs clobber each other. The Go-side cache treated them as independent entries, masking the conflict, and a uv tool install --force for one version could tear down the venv that another worker's uv tool run was still using.

Drop the persistent install path entirely. uv tool run --from ingestr@<ver> already provisions a per-version environment on demand, so v0 and v1 can coexist without sharing or clobbering tool storage. For the LocalIngestr debug override, pass --reinstall-package ingestr so source edits are still picked up on every run.