### PR TITLE
dataproc_serverless: add container_image parameter

### DIFF
--- a/docs/platforms/dataproc_serverless.md
+++ b/docs/platforms/dataproc_serverless.md
@@ -209,6 +209,10 @@ parameters:
   # Spark runtime version (optional, defaults to "2.2")
   runtime_version: "2.2"
 
+  # Custom container image for the job runtime environment (optional)
+  # Equivalent to gcloud's --container-image flag.
+  container_image: us-central1-docker.pkg.dev/my-project/my-repo/my-image:latest
+
   # args to pass to the entrypoint (optional)
   args: arg1 arg2
 
@@ -225,6 +229,7 @@ parameters:
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `runtime_version` | No | `2.2` | Dataproc Serverless Spark runtime version |
+| `container_image` | No | - | Custom container image URI for the job runtime environment (equivalent to gcloud's `--container-image`) |
 | `args` | No | - | Space-separated arguments passed to the PySpark script |
 | `config` | No | - | Spark configuration in `--conf key=value` format |
 | `timeout` | No | - | Job timeout using Go duration format (e.g., `1h`, `30m`) |

--- a/pkg/dataproc_serverless/job.go
+++ b/pkg/dataproc_serverless/job.go
@@ -45,6 +45,7 @@ type JobRunParams struct {
 	Project          string
 	Region           string
 	RuntimeVersion   string
+	ContainerImage   string
 	Config           string
 	Args             []string
 	Timeout          time.Duration
@@ -62,6 +63,7 @@ func parseParams(cfg *Client, params map[string]string) *JobRunParams {
 		Project:          cfg.ProjectID,
 		Region:           cfg.Region,
 		RuntimeVersion:   params["runtime_version"],
+		ContainerImage:   params["container_image"],
 		Config:           params["config"],
 		Workspace:        cfg.Workspace,
 		ExecutionRole:    cfg.ExecutionRole,
@@ -249,8 +251,9 @@ func (job Job) buildBatchConfig(ws *workspace) *dataprocpb.CreateBatchRequest {
 			PysparkBatch: pysparkBatch,
 		},
 		RuntimeConfig: &dataprocpb.RuntimeConfig{
-			Version:    job.params.RuntimeVersion,
-			Properties: sparkProperties,
+			Version:        job.params.RuntimeVersion,
+			ContainerImage: job.params.ContainerImage,
+			Properties:     sparkProperties,
 		},
 		EnvironmentConfig: batchEnvironmentConfig(job.params),
 	}


### PR DESCRIPTION
Wires gcloud's `--container-image` flag through to the Dataproc Serverless RuntimeConfig, letting assets specify a custom runtime container image.