### PR TITLE
tests: skip sqlglot parser tests on Windows

### DIFF
--- a/pkg/athena/bruin_funcs_parser_test.go
+++ b/pkg/athena/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package athena
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestAthenaGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformAthena, "athena")

--- a/pkg/bigquery/bruin_funcs_parser_test.go
+++ b/pkg/bigquery/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package bigquery
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestBigQueryGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformBigQuery, "bigquery")

--- a/pkg/clickhouse/bruin_funcs_parser_test.go
+++ b/pkg/clickhouse/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestClickHouseGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformClickhouse, "clickhouse")

--- a/pkg/databricks/bruin_funcs_parser_test.go
+++ b/pkg/databricks/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package databricks
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestDatabricksGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformDatabricks, "databricks")

--- a/pkg/duckdb/bruin_funcs_parser_test.go
+++ b/pkg/duckdb/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package duck
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestDuckDBGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformDuckDB, "duckdb")

--- a/pkg/fabric/bruin_funcs_parser_test.go
+++ b/pkg/fabric/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package fabric
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestFabricGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformFabric, "fabric")

--- a/pkg/jinja/bruin_funcs_parser_test.go
+++ b/pkg/jinja/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package jinja_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestDefaultGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformDefault, "")

--- a/pkg/mssql/bruin_funcs_parser_test.go
+++ b/pkg/mssql/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package mssql
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestMSSQLGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformMSSQL, "tsql")

--- a/pkg/mysql/bruin_funcs_parser_test.go
+++ b/pkg/mysql/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestMySQLGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformMySQL, "mysql")

--- a/pkg/oracle/bruin_funcs_parser_test.go
+++ b/pkg/oracle/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestOracleGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformOracle, "oracle")

--- a/pkg/postgres/bruin_funcs_parser_test.go
+++ b/pkg/postgres/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestPostgresGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformPostgres, "postgres")

--- a/pkg/redshift/bruin_funcs_parser_test.go
+++ b/pkg/redshift/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package redshift
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestRedshiftGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformRedshift, "redshift")

--- a/pkg/snowflake/bruin_funcs_parser_test.go
+++ b/pkg/snowflake/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package snowflake
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestSnowflakeGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformSnowflake, "snowflake")

--- a/pkg/synapse/bruin_funcs_parser_test.go
+++ b/pkg/synapse/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package synapse
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestSynapseGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformSynapse, "tsql")

--- a/pkg/trino/bruin_funcs_parser_test.go
+++ b/pkg/trino/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package trino
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestTrinoGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformTrino, "trino")

--- a/pkg/vertica/bruin_funcs_parser_test.go
+++ b/pkg/vertica/bruin_funcs_parser_test.go
@@ -1,6 +1,7 @@
 package vertica
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestVerticaGeneratedSQLParsesWithSQLGlot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded Python parser is flaky under parallel Windows test runs; tracked separately")
+	}
 	t.Parallel()
 
 	testBruinGeneratedSQLParsesWithSQLGlot(t, jinja.PlatformVertica, "postgres")


### PR DESCRIPTION
The embedded Python SQL parser is flaky under parallel Windows test runs, causing intermittent "failed to send init command after retries" errors. Skip the *GeneratedSQLParsesWithSQLGlot tests on Windows until the underlying race is addressed.