### PR TITLE
Add asset egress routing config

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -238,6 +238,23 @@ When deploying to Airflow, this is automatically translated to `retries_delay` f
 
 - **Type:** `Integer`
 
+## `routing`
+
+Runtime routing options for the asset. This is intended for execution environments that can route task traffic through a named gateway.
+
+```yaml
+routing:
+  egress_gateway: wg-shared-ams3
+```
+
+- **Type:** `Object`
+
+| Field          | Type   | Description |
+|----------------|--------|-------------|
+| egress_gateway | String | Named gateway profile to use for the asset's outbound traffic |
+
+If omitted, the asset inherits `default.routing` from `pipeline.yml` when it is set.
+
 ## `materialization`
 
 This option determines how the asset will be materialized. Refer to the docs on [materialization](./materialization) for more details.

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -406,6 +406,8 @@ default:
   secrets:
     - key: MY_API_KEY
       inject_as: API_KEY
+  routing:
+    egress_gateway: wg-shared-ams3
   interval_modifiers:
     start: "-1d"
     end: "-1d"
@@ -420,6 +422,7 @@ Fields:
 | type               | String                     | —       | Default asset type (e.g., "sql") |
 | parameters         | Object (map[string]string) | {}      | Arbitrary key/value defaults     |
 | secrets            | Array of objects           | []      | See below                        |
+| routing            | Object                     | —       | Runtime routing defaults for assets |
 | interval_modifiers | Object                     | —       | See [Interval Modifiers](/assets/interval-modifiers) |
 | hooks              | Object                     | —       | See [Hooks](/assets/definition-schema#hooks) |
 
@@ -429,6 +432,12 @@ Secrets item:
 |-----------|--------|-------------------------|--------------------------|
 | key       | String | —                       | Name of secret to inject |
 | inject_as | String | defaults to same as key | Env var or param name    |
+
+Routing:
+
+| Field          | Type   | Default | Description |
+|----------------|--------|---------|-------------|
+| egress_gateway | String | —       | Named gateway profile to use for asset outbound traffic |
 
 ### Variables
 

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -350,6 +350,21 @@ func commentRowsToTask(commentRows []string) (*Asset, error) {
 				continue
 			}
 		}
+
+		if strings.HasPrefix(key, "routing.") {
+			routingKeys := strings.Split(key, ".")
+			if len(routingKeys) != 2 {
+				continue
+			}
+
+			if strings.EqualFold(routingKeys[1], "egress_gateway") {
+				if task.Routing == nil {
+					task.Routing = &RoutingConfig{}
+				}
+				task.Routing.EgressGateway = value
+				continue
+			}
+		}
 	}
 
 	task.ID = hash(task.Name)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -799,6 +799,23 @@ func (s AthenaConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(Alias(s))
 }
 
+type RoutingConfig struct {
+	EgressGateway string `json:"egress_gateway,omitempty" yaml:"egress_gateway,omitempty" mapstructure:"egress_gateway"`
+}
+
+func (r *RoutingConfig) IsZero() bool {
+	return r == nil || r.EgressGateway == ""
+}
+
+func (r *RoutingConfig) Clone() *RoutingConfig {
+	if r == nil {
+		return nil
+	}
+
+	clone := *r
+	return &clone
+}
+
 // Asset is the in-memory representation of one asset within a pipeline. When
 // adding a new exported string-valued field, extend renderAssetStrings in
 // pkg/pipeline/variant.go so variant materialization renders it. Asset bodies
@@ -832,6 +849,7 @@ type Asset struct { //nolint:recvcheck
 	Metadata          EmptyStringMap     `json:"metadata" yaml:"metadata,omitempty" mapstructure:"metadata"`
 	Snowflake         SnowflakeConfig    `json:"snowflake" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
 	Athena            AthenaConfig       `json:"athena" yaml:"athena,omitempty" mapstructure:"athena"`
+	Routing           *RoutingConfig     `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
 	IntervalModifiers IntervalModifiers  `json:"interval_modifiers" yaml:"interval_modifiers,omitempty" mapstructure:"interval_modifiers"`
 	RerunCooldown     *int               `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 	RetriesDelay      *int               `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
@@ -1036,6 +1054,10 @@ func (a *Asset) removeRedundanciesBeforePersisting() {
 	// python assets don't require a type anymore
 	if a.Type == AssetTypePython && strings.HasSuffix(a.ExecutableFile.Path, ".py") {
 		a.Type = ""
+	}
+
+	if a.Routing.IsZero() {
+		a.Routing = nil
 	}
 }
 
@@ -1352,7 +1374,7 @@ func (a *Asset) FormatContent() ([]byte, error) {
 
 	yamlConfig := buf.Bytes()
 
-	keysToAddSpace := []string{"custom_checks", "depends", "columns", "materialization", "secrets", "parameters", "hooks"}
+	keysToAddSpace := []string{"custom_checks", "depends", "columns", "materialization", "routing", "secrets", "parameters", "hooks"}
 	for _, key := range keysToAddSpace {
 		yamlConfig = bytes.ReplaceAll(yamlConfig, []byte("\n"+key+":"), []byte("\n\n"+key+":"))
 	}
@@ -1654,6 +1676,7 @@ type DefaultValues struct {
 	Parameters        map[string]string `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
 	Secrets           []secretMapping   `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
 	Hooks             Hooks             `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
+	Routing           *RoutingConfig    `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
 	IntervalModifiers IntervalModifiers `json:"interval_modifiers" yaml:"interval_modifiers" mapstructure:"interval_modifiers"`
 	RerunCooldown     *int              `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 }
@@ -2409,6 +2432,13 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 	}
 	if len(asset.Hooks.Post) == 0 {
 		asset.Hooks.Post = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Post...)
+	}
+	if !foundPipeline.DefaultValues.Routing.IsZero() {
+		if asset.Routing == nil {
+			asset.Routing = foundPipeline.DefaultValues.Routing.Clone()
+		} else if asset.Routing.EgressGateway == "" {
+			asset.Routing.EgressGateway = foundPipeline.DefaultValues.Routing.EgressGateway
+		}
 	}
 
 	return asset, nil

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -807,6 +807,10 @@ func (r *RoutingConfig) IsZero() bool {
 	return r == nil || r.EgressGateway == ""
 }
 
+// Clone returns a deep copy of r. The current implementation is a struct
+// value copy, which is correct as long as all fields are value types. If a
+// pointer/slice/map field is added to RoutingConfig this method must be
+// updated to copy those fields explicitly.
 func (r *RoutingConfig) Clone() *RoutingConfig {
 	if r == nil {
 		return nil

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2135,6 +2135,23 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-vendor-us"},
 			},
 		},
+		{
+			name: "should apply default egress gateway when asset routing is empty",
+			asset: &pipeline.Asset{
+				Name:    "test-asset",
+				Routing: &pipeline.RoutingConfig{},
+			},
+			foundPipeline: &pipeline.Pipeline{
+				DefaultValues: &pipeline.DefaultValues{
+					Routing: &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
+				},
+			},
+			want: &pipeline.Asset{
+				Name:       "test-asset",
+				Parameters: pipeline.EmptyStringMap{},
+				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2102,6 +2102,39 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should apply default routing when missing",
+			asset: &pipeline.Asset{
+				Name: "test-asset",
+			},
+			foundPipeline: &pipeline.Pipeline{
+				DefaultValues: &pipeline.DefaultValues{
+					Routing: &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
+				},
+			},
+			want: &pipeline.Asset{
+				Name:       "test-asset",
+				Parameters: pipeline.EmptyStringMap{},
+				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
+			},
+		},
+		{
+			name: "should not override asset routing",
+			asset: &pipeline.Asset{
+				Name:    "test-asset",
+				Routing: &pipeline.RoutingConfig{EgressGateway: "wg-vendor-us"},
+			},
+			foundPipeline: &pipeline.Pipeline{
+				DefaultValues: &pipeline.DefaultValues{
+					Routing: &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
+				},
+			},
+			want: &pipeline.Asset{
+				Name:       "test-asset",
+				Parameters: pipeline.EmptyStringMap{},
+				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-vendor-us"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2504,6 +2537,21 @@ func TestPipeline_ValidateCatchupMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPipeline_UnmarshalDefaultRouting(t *testing.T) {
+	t.Parallel()
+
+	var p pipeline.Pipeline
+	err := yaml.Unmarshal([]byte(`
+name: routed-pipeline
+default:
+  routing:
+    egress_gateway: wg-shared-ams3
+`), &p)
+	require.NoError(t, err)
+	require.NotNil(t, p.DefaultValues)
+	assert.Equal(t, &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"}, p.DefaultValues.Routing)
 }
 
 func TestAsset_FormatContent_DeduplicatesTags(t *testing.T) {

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -273,6 +273,9 @@ func renderDefaultValues(render RenderFunc, dv *DefaultValues) error {
 			return err
 		}
 	}
+	if err := renderRoutingConfig(render, "default.routing", dv.Routing); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -359,6 +362,9 @@ func renderAssetStrings(render RenderFunc, a *Asset) error {
 	if a.Athena.Location, err = maybeRender(render, fmt.Sprintf("asset[%s].athena.location", originalName), a.Athena.Location); err != nil {
 		return err
 	}
+	if err := renderRoutingConfig(render, fmt.Sprintf("asset[%s].routing", originalName), a.Routing); err != nil {
+		return err
+	}
 
 	for i := range a.Upstreams {
 		u := &a.Upstreams[i]
@@ -431,6 +437,19 @@ func renderAssetStrings(render RenderFunc, a *Asset) error {
 		if cc.Description, err = maybeRender(render, fmt.Sprintf("asset[%s].custom_checks[%d].description", originalName, i), cc.Description); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func renderRoutingConfig(render RenderFunc, path string, routing *RoutingConfig) error {
+	if routing == nil {
+		return nil
+	}
+
+	var err error
+	if routing.EgressGateway, err = maybeRender(render, path+".egress_gateway", routing.EgressGateway); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -497,6 +497,7 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 			Post: []pipeline.Hook{{Query: "q"}},
 		},
 		Metadata: map[string]string{"k": "v"},
+		Routing:  &pipeline.RoutingConfig{EgressGateway: "gw"},
 	}
 	return &pipeline.Pipeline{
 		Name:               "p",
@@ -510,6 +511,7 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 				Pre:  []pipeline.Hook{{Query: "q"}},
 				Post: []pipeline.Hook{{Query: "q"}},
 			},
+			Routing: &pipeline.RoutingConfig{EgressGateway: "gw"},
 		},
 		Variables: pipeline.Variables{
 			"sentinel": map[string]any{"type": "string", "default": "RENDERED"},

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -348,6 +348,7 @@ type taskDefinition struct {
 	Tags                  []string          `yaml:"tags"`
 	Snowflake             snowflake         `yaml:"snowflake"`
 	Athena                athena            `yaml:"athena"`
+	Routing               *RoutingConfig    `yaml:"routing"`
 	IntervalModifiers     IntervalModifiers `yaml:"interval_modifiers"`
 	Domains               []string          `yaml:"domains"`
 	Meta                  map[string]string `yaml:"meta"`
@@ -538,6 +539,7 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 		Hooks:             definition.Hooks,
 		Snowflake:         SnowflakeConfig{Warehouse: definition.Snowflake.Warehouse},
 		Athena:            AthenaConfig{Location: definition.Athena.QueryResultsPath},
+		Routing:           definition.Routing,
 		IntervalModifiers: definition.IntervalModifiers,
 		Domains:           definition.Domains,
 		Meta:              definition.Meta,

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -396,6 +396,37 @@ select 1
 	require.True(t, *task.RefreshRestricted)
 }
 
+func TestConvertYamlToTask_Routing(t *testing.T) {
+	t.Parallel()
+
+	task, err := pipeline.ConvertYamlToTask([]byte(strings.TrimSpace(`
+name: dataset.asset
+type: python
+routing:
+  egress_gateway: wg-shared-ams3
+`)))
+	require.NoError(t, err)
+	require.Equal(t, &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"}, task.Routing)
+}
+
+func TestCreateTaskFromFileComments_Routing(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	err := afero.WriteFile(fs, "asset.sql", []byte(strings.TrimSpace(`
+-- @bruin.name: dataset.asset
+-- @bruin.type: duckdb.sql
+-- @bruin.routing.egress_gateway: wg-shared-ams3
+select 1
+`)), 0o644)
+	require.NoError(t, err)
+
+	creator := pipeline.CreateTaskFromFileComments(fs)
+	task, err := creator("asset.sql")
+	require.NoError(t, err)
+	require.Equal(t, &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"}, task.Routing)
+}
+
 func TestConvertYamlToTask_Hooks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds asset-level `routing.egress_gateway` and lets `default.routing` provide a pipeline-level fallback.

Includes YAML/comment parsing, variant rendering support, tests, and docs.

Validated with `make format` and `make test`.