### PR TITLE
duckdb: pin ADBC driver to v1.5.2 for MotherDuck compatibility

### DIFF
--- a/pkg/duckdb/driver.go
+++ b/pkg/duckdb/driver.go
@@ -20,7 +20,12 @@ var (
 	uvChecker     = &uv.Checker{}
 )
 
-const adbcDriverName = "adbc_duckdb"
+const (
+	adbcDriverName = "adbc_duckdb"
+	// duckdbDriverVersion pins the DuckDB ADBC driver version installed via dbc.
+	// MotherDuck currently supports up to v1.5.2; newer DuckDB releases are rejected.
+	duckdbDriverVersion = "1.5.2"
+)
 
 //nolint:gochecknoinits
 func init() {
@@ -54,7 +59,7 @@ func ensureDriverInstalledInternal(ctx context.Context) error {
 	cmd.Stderr = nil
 	_ = cmd.Run()
 
-	cmd = exec.CommandContext(ctx, uvPath, "tool", "run", "--no-config", "dbc", "install", "--level", "user", "duckdb")
+	cmd = exec.CommandContext(ctx, uvPath, "tool", "run", "--no-config", "dbc", "install", "--level", "user", "duckdb="+duckdbDriverVersion)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary
- MotherDuck only supports DuckDB up to v1.5.2; the latest release (v1.5.3) is rejected by the `motherduck` extension at init time.
- `dbc install duckdb` resolves to the latest version, so `bruin query` against a MotherDuck connection fails with: `Your DuckDB version (v1.5.3) is not yet supported by MotherDuck. The latest supported version is v1.5.2. Please downgrade to use MotherDuck.`
- Pin the install to `duckdb=1.5.2` via `dbc`'s version-constraint syntax until MotherDuck catches up.

## Test plan
- [ ] Remove any existing ADBC duckdb driver (`dbc uninstall duckdb` / clear `~/.duckdb/extensions`) and run `bruin query --connection motherduck-default --query "SELECT 1"` — should succeed.
- [ ] On a clean machine, the first `bruin` invocation that touches DuckDB installs v1.5.2.