### PR TITLE
athena: url-encode ingestr URI query values

### DIFF
--- a/pkg/athena/config.go
+++ b/pkg/athena/config.go
@@ -2,6 +2,7 @@ package athena
 
 import (
 	"log"
+	"net/url"
 
 	drv "github.com/uber/athenadriver/go"
 )
@@ -36,9 +37,13 @@ func (c *Config) ToDBConnectionURI() (string, error) {
 }
 
 func (c *Config) GetIngestrURI() string {
-	str := "athena://?bucket=" + c.OutputBucket + "&access_key_id=" + c.AccessID + "&secret_access_key=" + c.SecretAccessKey + "&region_name=" + c.Region
+	q := url.Values{}
+	q.Set("bucket", c.OutputBucket)
+	q.Set("access_key_id", c.AccessID)
+	q.Set("secret_access_key", c.SecretAccessKey)
+	q.Set("region_name", c.Region)
 	if c.SessionToken != "" {
-		str += "&session_token=" + c.SessionToken
+		q.Set("session_token", c.SessionToken)
 	}
-	return str
+	return "athena://?" + q.Encode()
 }

--- a/pkg/athena/config_test.go
+++ b/pkg/athena/config_test.go
@@ -1,6 +1,7 @@
 package athena
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,4 +21,33 @@ func TestConfig_ToDSNNoQuery(t *testing.T) {
 	actual, err := c.ToDBConnectionURI()
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+func TestConfig_GetIngestrURI_EncodesSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	// AWS secrets are base64-ish and frequently contain '+', '/', '='.
+	// Session tokens also include these characters. Raw concatenation
+	// produces a URI that ingestr parses incorrectly.
+	c := Config{
+		OutputBucket:    "s3://my-bucket/path",
+		Region:          "us-west-2",
+		AccessID:        "AKIA/EXAMPLE+ID",
+		SecretAccessKey: "abc+def/ghi=jkl",
+		SessionToken:    "tok+en/with=chars&extra",
+		Database:        "some_db",
+	}
+
+	uri := c.GetIngestrURI()
+
+	parsed, err := url.Parse(uri)
+	require.NoError(t, err)
+	require.Equal(t, "athena", parsed.Scheme)
+
+	q := parsed.Query()
+	require.Equal(t, "s3://my-bucket/path", q.Get("bucket"))
+	require.Equal(t, "AKIA/EXAMPLE+ID", q.Get("access_key_id"))
+	require.Equal(t, "abc+def/ghi=jkl", q.Get("secret_access_key"))
+	require.Equal(t, "us-west-2", q.Get("region_name"))
+	require.Equal(t, "tok+en/with=chars&extra", q.Get("session_token"))
 }


### PR DESCRIPTION
AWS access keys, secret keys, and session tokens commonly contain '+', '/', and '=' (base64 characters). The previous raw string concatenation produced URIs where '+' was decoded as a space and other characters broke query parsing in ingestr.