### PR TITLE
Add Bruin Cloud security IP docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -156,6 +156,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     {text: "Governance", link: "/cloud/governance"},
                     {text: "Instance Types", link: "/cloud/instance-types"},
                     {
+                        text: "Security",
+                        link: "/cloud/security",
+                        collapsed: true,
+                        items: [
+                            {text: "Bruin's IP Addresses", link: "/cloud/security/ip-addresses"},
+                        ],
+                    },
+                    {
                         text: "Team",
                         collapsed: true,
                         items: [

--- a/docs/cloud/overview.md
+++ b/docs/cloud/overview.md
@@ -39,6 +39,7 @@ From there:
 - [Cross-pipeline dependencies](/cloud/cross-pipeline): depend on assets that live in other pipelines.
 - [Governance](/cloud/governance): the rules that drive quality scores and the risk report.
 - [Instance Types](/cloud/instance-types): sizing assets at run time.
+- [Security](/cloud/security): network access and dedicated egress IPs for allowlisting.
 - [Team Settings](/cloud/team-settings), [API Tokens](/cloud/api-tokens), [Audit Logs](/cloud/audit-logs): team administration.
 - [Cloud MCP](/cloud/mcp-setup): talk to Bruin Cloud from Cursor, Claude Code, or Codex.
 - [FAQ](/cloud/faq): short answers to common questions, including patterns that look plausible but are not real features.

--- a/docs/cloud/security.md
+++ b/docs/cloud/security.md
@@ -1,0 +1,13 @@
+# Security
+
+Bruin Cloud is designed to run your pipelines and AI agents against private systems without asking you to make those systems broadly accessible. Use this section for network access, allowlisting, and other security controls that affect how Bruin Cloud connects to your repositories, databases, warehouses, and internal services.
+
+## Network Access
+
+For teams that require IP allowlisting, Bruin Cloud can provision dedicated egress IP addresses. Your account manager will share the IP address assigned to your team and help coordinate the rollout.
+
+## Related
+
+- [Bruin's IP Addresses](/cloud/security/ip-addresses) - dedicated egress IPs for repository, database, and service access.
+- [Connections](/cloud/connections) - configure the credentials Bruin Cloud uses to reach your data platforms.
+- [Audit Logs](/cloud/audit-logs) - review security-relevant activity in your team.

--- a/docs/cloud/security/ip-addresses.md
+++ b/docs/cloud/security/ip-addresses.md
@@ -1,0 +1,34 @@
+# Bruin's IP Addresses
+
+Bruin Cloud can set up dedicated egress IP addresses for customers that need to restrict access to private systems. This lets your security team allowlist a known IP address instead of opening access to the wider internet.
+
+Your dedicated egress IP can be used by Bruin Cloud when it needs to reach systems such as:
+
+- Git providers, to clone and sync your repositories.
+- Databases and data warehouses, to run assets and validate connections.
+- Internal APIs, object stores, and other network-restricted services used by your pipelines.
+
+## How It Works
+
+Dedicated egress IPs are configured per customer. Once the IP is provisioned, your account manager will share it with you directly. You can then add that IP to the allowlist, firewall rule, network policy, or access control list for the systems Bruin Cloud needs to reach.
+
+The IP address is dedicated to your team and is not shared with other customers. Because these addresses are customer-specific, Bruin does not publish a public list of Cloud egress IPs.
+
+## Setup Process
+
+1. Contact your account manager and request a dedicated egress IP for Bruin Cloud.
+2. Bruin provisions an IP address dedicated to your team.
+3. Your account manager shares the IP address with your team.
+4. You allowlist the IP address in your Git provider, database, warehouse, firewall, or other protected service.
+5. Bruin Cloud uses that IP for outbound access to the systems covered by the setup.
+
+## When To Use This
+
+Use a dedicated egress IP when your organization requires network-level allowlisting for:
+
+- Private Git repositories.
+- Databases or warehouses that reject unknown source IPs.
+- Internal services used by Python assets or ingestion jobs.
+- Vendor APIs or storage systems protected by IP restrictions.
+
+If you are unsure whether your project needs a dedicated egress IP, contact your account manager with the systems Bruin Cloud needs to access and the allowlisting requirements from your security team.


### PR DESCRIPTION
Adds a Bruin Cloud Security section with a page for dedicated egress IP addresses. Documents how customers receive and use their dedicated IP for allowlisting repos, databases, and other protected services.