### PR TITLE
Add idempotent Snowflake read retries

### DIFF
--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -2,8 +2,11 @@ package snowflake
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
+	"math"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,7 +23,9 @@ import (
 )
 
 const (
-	invalidQueryError = "SQL compilation error"
+	invalidQueryError       = "SQL compilation error"
+	snowflakeRetryAttempts  = 3
+	snowflakeRetryBaseDelay = 500 * time.Millisecond
 )
 
 type DB struct {
@@ -30,6 +35,8 @@ type DB struct {
 	dsn           string
 	mutex         sync.Mutex
 	typeMapper    *diff.DatabaseTypeMapper
+	connect       func(ctx context.Context) (*sqlx.DB, error)
+	retryDelay    func(attempt int) time.Duration
 }
 
 func NewDB(c *Config) (*DB, error) {
@@ -46,6 +53,10 @@ func NewDB(c *Config) (*DB, error) {
 		dsn:           dsn,
 		mutex:         sync.Mutex{},
 		typeMapper:    diff.NewSnowflakeTypeMapper(),
+		connect: func(ctx context.Context) (*sqlx.DB, error) {
+			return sqlx.ConnectContext(ctx, "snowflake", dsn)
+		},
+		retryDelay: defaultSnowflakeRetryDelay,
 	}, nil
 }
 
@@ -57,13 +68,105 @@ func (db *DB) initializeDB(ctx context.Context) error {
 		return nil
 	}
 
-	conn, err := sqlx.ConnectContext(ctx, "snowflake", db.dsn)
+	conn, err := db.connectDB(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to snowflake")
 	}
 
 	db.conn = conn
 	return nil
+}
+
+func (db *DB) connectDB(ctx context.Context) (*sqlx.DB, error) {
+	if db.connect != nil {
+		return db.connect(ctx)
+	}
+
+	return sqlx.ConnectContext(ctx, "snowflake", db.dsn)
+}
+
+func (db *DB) delayBeforeRetry(ctx context.Context, attempt int) error {
+	delay := defaultSnowflakeRetryDelay(attempt)
+	if db.retryDelay != nil {
+		delay = db.retryDelay(attempt)
+	}
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func defaultSnowflakeRetryDelay(attempt int) time.Duration {
+	if attempt <= 0 {
+		return snowflakeRetryBaseDelay
+	}
+
+	return time.Duration(math.Pow(2, float64(attempt-1))) * snowflakeRetryBaseDelay
+}
+
+func isRetriableSnowflakeError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+
+	var netErr net.Error
+	if stderrors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	retriableMessages := []string{
+		"client.timeout exceeded",
+		"context deadline exceeded",
+		"connection reset",
+		"connection refused",
+		"connection timed out",
+		"eof",
+		"i/o timeout",
+		"no such host",
+		"temporary failure",
+		"tls handshake timeout",
+		"timeout awaiting response headers",
+		"unexpected eof",
+	}
+
+	for _, retriable := range retriableMessages {
+		if strings.Contains(message, retriable) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (db *DB) withIdempotentRetry(ctx context.Context, fn func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= snowflakeRetryAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		if attempt == snowflakeRetryAttempts || !isRetriableSnowflakeError(ctx, err) {
+			return err
+		}
+
+		if delayErr := db.delayBeforeRetry(ctx, attempt); delayErr != nil {
+			return delayErr
+		}
+	}
+
+	return lastErr
 }
 
 // logSnowflakeQueryID tries to read a query ID from the channel and prints it.
@@ -80,8 +183,16 @@ func logSnowflakeQueryID(ctx context.Context, ch <-chan string) {
 	}
 }
 
+func withSnowflakeRequestID(ctx context.Context, requestID *gosnowflake.UUID) context.Context {
+	if requestID == nil {
+		return ctx
+	}
+
+	return gosnowflake.WithRequestID(ctx, *requestID)
+}
+
 func (db *DB) RunQueryWithoutResult(ctx context.Context, query *query.Query) error {
-	_, err := db.Select(ctx, query)
+	_, err := db.selectOnce(ctx, query, nil)
 	return err
 }
 
@@ -90,12 +201,24 @@ func (db *DB) GetIngestrURI() (string, error) {
 }
 
 func (db *DB) Select(ctx context.Context, query *query.Query) ([][]interface{}, error) {
+	var result [][]interface{}
+	requestID := gosnowflake.NewUUID()
+	err := db.withIdempotentRetry(ctx, func() error {
+		var err error
+		result, err = db.selectOnce(ctx, query, &requestID)
+		return err
+	})
+	return result, err
+}
+
+func (db *DB) selectOnce(ctx context.Context, query *query.Query, requestID *gosnowflake.UUID) ([][]interface{}, error) {
 	if err := db.initializeDB(ctx); err != nil {
 		return nil, err
 	}
 
 	// Attach a query ID channel and multi-statement context
 	qidChan := make(chan string, 1)
+	ctx = withSnowflakeRequestID(ctx, requestID)
 	ctx = gosnowflake.WithQueryIDChan(ctx, qidChan)
 	ctx, err := gosnowflake.WithMultiStatement(ctx, 0)
 	if err != nil {
@@ -149,12 +272,24 @@ func (db *DB) Select(ctx context.Context, query *query.Query) ([][]interface{}, 
 }
 
 func (db *DB) SelectOnlyLastResult(ctx context.Context, query *query.Query) ([][]interface{}, error) {
+	var result [][]interface{}
+	requestID := gosnowflake.NewUUID()
+	err := db.withIdempotentRetry(ctx, func() error {
+		var err error
+		result, err = db.selectOnlyLastResultOnce(ctx, query, &requestID)
+		return err
+	})
+	return result, err
+}
+
+func (db *DB) selectOnlyLastResultOnce(ctx context.Context, query *query.Query, requestID *gosnowflake.UUID) ([][]interface{}, error) {
 	if err := db.initializeDB(ctx); err != nil {
 		return nil, err
 	}
 
 	// Attach a query ID channel and multi-statement context
 	qidChan := make(chan string, 1)
+	ctx = withSnowflakeRequestID(ctx, requestID)
 	ctx = gosnowflake.WithQueryIDChan(ctx, qidChan)
 	ctx, err := gosnowflake.WithMultiStatement(ctx, 0)
 	if err != nil {
@@ -221,12 +356,24 @@ func (db *DB) SelectOnlyLastResult(ctx context.Context, query *query.Query) ([][
 }
 
 func (db *DB) IsValid(ctx context.Context, query *query.Query) (bool, error) {
+	var valid bool
+	requestID := gosnowflake.NewUUID()
+	err := db.withIdempotentRetry(ctx, func() error {
+		var err error
+		valid, err = db.isValidOnce(ctx, query, &requestID)
+		return err
+	})
+	return valid, err
+}
+
+func (db *DB) isValidOnce(ctx context.Context, query *query.Query, requestID *gosnowflake.UUID) (bool, error) {
 	if err := db.initializeDB(ctx); err != nil {
 		return false, err
 	}
 
 	// Attach a query ID channel and multi-statement context
 	qidChan := make(chan string, 1)
+	ctx = withSnowflakeRequestID(ctx, requestID)
 	ctx = gosnowflake.WithQueryIDChan(ctx, qidChan)
 	ctx, err := gosnowflake.WithMultiStatement(ctx, 0)
 	if err != nil {
@@ -289,12 +436,24 @@ func (db *DB) Ping(ctx context.Context) error {
 }
 
 func (db *DB) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*query.QueryResult, error) {
+	var result *query.QueryResult
+	requestID := gosnowflake.NewUUID()
+	err := db.withIdempotentRetry(ctx, func() error {
+		var err error
+		result, err = db.selectWithSchemaOnce(ctx, queryObj, &requestID)
+		return err
+	})
+	return result, err
+}
+
+func (db *DB) selectWithSchemaOnce(ctx context.Context, queryObj *query.Query, requestID *gosnowflake.UUID) (*query.QueryResult, error) {
 	if err := db.initializeDB(ctx); err != nil {
 		return nil, err
 	}
 	// Prepare Snowflake context for the query execution
 	// Attach a query ID channel and multi-statement context
 	qidChan := make(chan string, 1)
+	ctx = withSnowflakeRequestID(ctx, requestID)
 	ctx = gosnowflake.WithQueryIDChan(ctx, qidChan)
 	ctx, err := gosnowflake.WithMultiStatement(ctx, 0)
 	if err != nil {

--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -86,10 +86,12 @@ func (db *DB) connectDB(ctx context.Context) (*sqlx.DB, error) {
 }
 
 func (db *DB) delayBeforeRetry(ctx context.Context, attempt int) error {
-	delay := defaultSnowflakeRetryDelay(attempt)
-	if db.retryDelay != nil {
-		delay = db.retryDelay(attempt)
+	delayFunc := db.retryDelay
+	if delayFunc == nil {
+		delayFunc = defaultSnowflakeRetryDelay
 	}
+
+	delay := delayFunc(attempt)
 	if delay <= 0 {
 		return nil
 	}
@@ -149,13 +151,11 @@ func isRetriableSnowflakeError(ctx context.Context, err error) bool {
 }
 
 func (db *DB) withIdempotentRetry(ctx context.Context, fn func() error) error {
-	var lastErr error
 	for attempt := 1; attempt <= snowflakeRetryAttempts; attempt++ {
 		err := fn()
 		if err == nil {
 			return nil
 		}
-		lastErr = err
 
 		if attempt == snowflakeRetryAttempts || !isRetriableSnowflakeError(ctx, err) {
 			return err
@@ -166,7 +166,7 @@ func (db *DB) withIdempotentRetry(ctx context.Context, fn func() error) error {
 		}
 	}
 
-	return lastErr
+	return nil
 }
 
 // logSnowflakeQueryID tries to read a query ID from the channel and prints it.

--- a/pkg/snowflake/db_test.go
+++ b/pkg/snowflake/db_test.go
@@ -1,10 +1,12 @@
 package snowflake
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -182,6 +184,89 @@ func TestDB_Select(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestDB_SelectRetriesTransientConnectError(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+	mock.ExpectQuery(`SELECT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"one"}).AddRow(1))
+
+	attempts := 0
+	db := DB{
+		connect: func(_ context.Context) (*sqlx.DB, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, errors.New(`Post "https://account.snowflakecomputing.com/session/v1/login-request": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`)
+			}
+
+			return sqlxDB, nil
+		},
+		retryDelay: func(_ int) time.Duration {
+			return 0
+		},
+	}
+
+	got, err := db.Select(t.Context(), &query.Query{Query: "SELECT 1"})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{{int64(1)}}, got)
+	require.Equal(t, 2, attempts)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_SelectRetriesTransientQueryError(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+	mock.ExpectQuery(`SELECT 1`).
+		WillReturnError(errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)"))
+	mock.ExpectQuery(`SELECT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"one"}).AddRow(1))
+
+	db := DB{
+		conn: sqlxDB,
+		retryDelay: func(_ int) time.Duration {
+			return 0
+		},
+	}
+
+	got, err := db.Select(t.Context(), &query.Query{Query: "SELECT 1"})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{{int64(1)}}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_RunQueryWithoutResultDoesNotRetryTransientQueryError(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+	mock.ExpectQuery(`CREATE TABLE test AS SELECT 1`).
+		WillReturnError(errors.New("context deadline exceeded (Client.Timeout exceeded while awaiting headers)"))
+
+	db := DB{
+		conn: sqlxDB,
+		retryDelay: func(_ int) time.Duration {
+			return 0
+		},
+	}
+
+	err = db.RunQueryWithoutResult(t.Context(), &query.Query{Query: "CREATE TABLE test AS SELECT 1"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestDB_SelectOnlyLastResult(t *testing.T) {


### PR DESCRIPTION
Adds bounded retries for transient Snowflake read/connect failures, reusing Snowflake request IDs across attempts. Keeps non-result execution single-attempt to avoid retrying writes. Tests: make format; make test.