### PR TITLE
bump ingestr to v1.0.7

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -43,7 +43,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.6"
+	IngestrVersionV1 = "1.0.7"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
## Summary
- Bump the default/pinned ingestr v1 package from 1.0.6 to 1.0.7.

## Impact
- Bruin ingestr assets that use the default v1 engine or set `parameters.version: v1` now resolve to `ingestr@1.0.7`.

## Validation
- `make format`
- `make test`