### PR TITLE
Skip default hooks for non-SQL assets

### DIFF
--- a/integration-tests/test-pipelines/parse-default-option/expectations/asset.py.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/asset.py.json
@@ -49,18 +49,7 @@
     "extends": null,
     "columns": [],
     "custom_checks": [],
-    "hooks": {
-      "pre": [
-        {
-          "query": "select 1"
-        }
-      ],
-      "post": [
-        {
-          "query": "select 2"
-        }
-      ]
-    },
+    "hooks": {},
     "metadata": {},
     "snowflake": null,
     "athena": null,

--- a/integration-tests/test-pipelines/parse-default-option/expectations/chess_games.asset.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/chess_games.asset.yml.json
@@ -39,18 +39,7 @@
     "extends": null,
     "columns": [],
     "custom_checks": [],
-    "hooks": {
-      "pre": [
-        {
-          "query": "select 1"
-        }
-      ],
-      "post": [
-        {
-          "query": "select 2"
-        }
-      ]
-    },
+    "hooks": {},
     "metadata": {},
     "snowflake": null,
     "athena": null,

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -66,18 +66,7 @@
       "extends": null,
       "columns": [],
       "custom_checks": [],
-      "hooks": {
-        "pre": [
-          {
-            "query": "select 1"
-          }
-        ],
-        "post": [
-          {
-            "query": "select 2"
-          }
-        ]
-      },
+      "hooks": {},
       "metadata": {},
       "snowflake": null,
       "athena": null,
@@ -123,18 +112,7 @@
       "extends": null,
       "columns": [],
       "custom_checks": [],
-      "hooks": {
-        "pre": [
-          {
-            "query": "select 1"
-          }
-        ],
-        "post": [
-          {
-            "query": "select 2"
-          }
-        ]
-      },
+      "hooks": {},
       "metadata": {},
       "snowflake": null,
       "athena": null,
@@ -180,18 +158,7 @@
       "extends": null,
       "columns": [],
       "custom_checks": [],
-      "hooks": {
-        "pre": [
-          {
-            "query": "select 1"
-          }
-        ],
-        "post": [
-          {
-            "query": "select 2"
-          }
-        ]
-      },
+      "hooks": {},
       "metadata": {},
       "snowflake": null,
       "athena": null,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -541,9 +540,6 @@ func ValidateScriptAssetHooksUnsupported(ctx context.Context, p *pipeline.Pipeli
 	if asset.Hooks.IsZero() {
 		return issues, nil
 	}
-	if hooksOnlyFromPipelineDefaults(asset, p) {
-		return issues, nil
-	}
 
 	assetTypeLabel := "Python"
 	if asset.Type == pipeline.AssetTypeR {
@@ -556,15 +552,6 @@ func ValidateScriptAssetHooksUnsupported(ctx context.Context, p *pipeline.Pipeli
 	})
 
 	return issues, nil
-}
-
-func hooksOnlyFromPipelineDefaults(asset *pipeline.Asset, p *pipeline.Pipeline) bool {
-	if asset == nil || p == nil || p.DefaultValues == nil {
-		return false
-	}
-
-	return reflect.DeepEqual(asset.Hooks.Pre, p.DefaultValues.Hooks.Pre) &&
-		reflect.DeepEqual(asset.Hooks.Post, p.DefaultValues.Hooks.Post)
 }
 
 func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3056,7 +3056,7 @@ func TestValidateScriptAssetHooksUnsupported(t *testing.T) {
 			wantIssue: false,
 		},
 		{
-			name: "script asset with only default-inherited hooks does not return warning",
+			name: "script asset with hooks matching pipeline defaults returns warning",
 			asset: &pipeline.Asset{
 				Name: "py_asset",
 				Type: pipeline.AssetTypePython,
@@ -3071,7 +3071,7 @@ func TestValidateScriptAssetHooksUnsupported(t *testing.T) {
 					Post: []pipeline.Hook{{Query: "select default post"}},
 				},
 			},
-			wantIssue: false,
+			wantIssue: true,
 		},
 	}
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2431,10 +2431,10 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 	if (asset.IntervalModifiers.End == TimeModifier{}) {
 		asset.IntervalModifiers.End = foundPipeline.DefaultValues.IntervalModifiers.End
 	}
-	if len(asset.Hooks.Pre) == 0 {
+	if assetAcceptsDefaultHooks(asset) && len(asset.Hooks.Pre) == 0 {
 		asset.Hooks.Pre = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Pre...)
 	}
-	if len(asset.Hooks.Post) == 0 {
+	if assetAcceptsDefaultHooks(asset) && len(asset.Hooks.Post) == 0 {
 		asset.Hooks.Post = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Post...)
 	}
 	if !foundPipeline.DefaultValues.Routing.IsZero() {
@@ -2446,6 +2446,10 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 	}
 
 	return asset, nil
+}
+
+func assetAcceptsDefaultHooks(asset *Asset) bool {
+	return strings.HasSuffix(asset.ExecutableFile.Path, ".sql")
 }
 
 func (b *Builder) InjectConnectionAsSecret(ctx context.Context, asset *Asset, foundPipeline *Pipeline) (*Asset, error) {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2449,7 +2449,7 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 }
 
 func assetAcceptsDefaultHooks(asset *Asset) bool {
-	return strings.HasSuffix(asset.ExecutableFile.Path, ".sql")
+	return asset.IsSQLAsset()
 }
 
 func (b *Builder) InjectConnectionAsSecret(ctx context.Context, asset *Asset, foundPipeline *Pipeline) (*Asset, error) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2058,6 +2058,9 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			name: "should apply default hooks when missing",
 			asset: &pipeline.Asset{
 				Name: "test-asset",
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.sql",
+				},
 			},
 			foundPipeline: &pipeline.Pipeline{
 				DefaultValues: &pipeline.DefaultValues{
@@ -2070,9 +2073,64 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			want: &pipeline.Asset{
 				Name:       "test-asset",
 				Parameters: pipeline.EmptyStringMap{},
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.sql",
+				},
 				Hooks: pipeline.Hooks{
 					Pre:  []pipeline.Hook{{Query: "select 1"}},
 					Post: []pipeline.Hook{{Query: "select 2"}},
+				},
+			},
+		},
+		{
+			name: "should not apply default hooks to Python assets",
+			asset: &pipeline.Asset{
+				Name: "test-asset",
+				Type: pipeline.AssetTypePython,
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.py",
+				},
+			},
+			foundPipeline: &pipeline.Pipeline{
+				DefaultValues: &pipeline.DefaultValues{
+					Hooks: pipeline.Hooks{
+						Pre:  []pipeline.Hook{{Query: "select 1"}},
+						Post: []pipeline.Hook{{Query: "select 2"}},
+					},
+				},
+			},
+			want: &pipeline.Asset{
+				Name:       "test-asset",
+				Type:       pipeline.AssetTypePython,
+				Parameters: pipeline.EmptyStringMap{},
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.py",
+				},
+			},
+		},
+		{
+			name: "should not apply default hooks to non sql files",
+			asset: &pipeline.Asset{
+				Name: "test-asset",
+				Type: pipeline.AssetTypeBigqueryQuery,
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.asset.yml",
+				},
+			},
+			foundPipeline: &pipeline.Pipeline{
+				DefaultValues: &pipeline.DefaultValues{
+					Hooks: pipeline.Hooks{
+						Pre:  []pipeline.Hook{{Query: "select 1"}},
+						Post: []pipeline.Hook{{Query: "select 2"}},
+					},
+				},
+			},
+			want: &pipeline.Asset{
+				Name:       "test-asset",
+				Type:       pipeline.AssetTypeBigqueryQuery,
+				Parameters: pipeline.EmptyStringMap{},
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.asset.yml",
 				},
 			},
 		},

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2058,6 +2058,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			name: "should apply default hooks when missing",
 			asset: &pipeline.Asset{
 				Name: "test-asset",
+				Type: pipeline.AssetTypeBigqueryQuery,
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.sql",
 				},
@@ -2072,6 +2073,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
+				Type:       pipeline.AssetTypeBigqueryQuery,
 				Parameters: pipeline.EmptyStringMap{},
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.sql",
@@ -2109,7 +2111,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 		},
 		{
-			name: "should not apply default hooks to non sql files",
+			name: "should apply default hooks to SQL assets based on type",
 			asset: &pipeline.Asset{
 				Name: "test-asset",
 				Type: pipeline.AssetTypeBigqueryQuery,
@@ -2131,6 +2133,36 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 				Parameters: pipeline.EmptyStringMap{},
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.asset.yml",
+				},
+				Hooks: pipeline.Hooks{
+					Pre:  []pipeline.Hook{{Query: "select 1"}},
+					Post: []pipeline.Hook{{Query: "select 2"}},
+				},
+			},
+		},
+		{
+			name: "should not apply default hooks to non SQL assets based on type",
+			asset: &pipeline.Asset{
+				Name: "test-asset",
+				Type: pipeline.AssetTypeIngestr,
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.sql",
+				},
+			},
+			foundPipeline: &pipeline.Pipeline{
+				DefaultValues: &pipeline.DefaultValues{
+					Hooks: pipeline.Hooks{
+						Pre:  []pipeline.Hook{{Query: "select 1"}},
+						Post: []pipeline.Hook{{Query: "select 2"}},
+					},
+				},
+			},
+			want: &pipeline.Asset{
+				Name:       "test-asset",
+				Type:       pipeline.AssetTypeIngestr,
+				Parameters: pipeline.EmptyStringMap{},
+				ExecutableFile: pipeline.ExecutableFile{
+					Path: "/tmp/test-asset.sql",
 				},
 			},
 		},


### PR DESCRIPTION
Default pipeline hooks now apply only to SQL assets backed by .sql files, so Python and other non-SQL assets no longer inherit unsupported hooks. Updated lint behavior and parse expectations to match. Validated with make format and make test.