### PR TITLE
Add source_column field to map source→destination column names in ing…

### DIFF
--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -39,6 +39,7 @@ Each column will have the following keys:
 | key               | type    | req? | description                                                                     |
 |-------------------|---------|------|---------------------------------------------------------------------------------|
 | `name`            | String  | yes  | The name of the column                                                          |
+| `source_column`   | String  | no   | For ingestr assets, the source column name to map onto `name`. See [Column name mapping](#column-name-mapping-ingestr-assets). |
 | `type`            | String  | no   | The column type in the DB                                                       |
 | `description`     | String  | no   | The description for the column                                                  |
 | `tags`            | String[]| no   | Tags applied to the column for categorization and filtering                     |
@@ -62,3 +63,42 @@ The structure of the quality checks is rather simple:
 | `value`    | Any    | no   | Check-specific expected value                                     |
 
 For more details on the quality checks, please refer to the  [Quality](../quality/overview) documentation.
+
+### Column name mapping (ingestr assets)
+
+For ingestr assets, you can rename a column on its way from the source to the destination
+by setting `source_column` on the column entry. The `name` field stays the destination
+column name; `source_column` is the column that exists on the source.
+
+```yaml
+columns:
+  - name: first_name
+    source_column: fname
+    type: string
+    primary_key: true
+  - name: email
+    source_column: eml
+    type: string
+  - name: created_at
+    source_column: crtd_ts
+    type: timestamp
+```
+
+With the mapping above, the source table's `fname`, `eml`, and `crtd_ts` columns land in
+the destination as `first_name`, `email`, and `created_at`. Columns without
+`source_column` keep their original source names.
+
+For the mapping to take effect, `enforce_schema: "true"` must be set under the asset's
+`parameters` block. 
+
+```yaml
+parameters:
+  enforce_schema: "true"
+
+columns:
+  - name: first_name
+    source_column: fname
+    type: string
+  - name: email
+    source_column: eml          # type omitted: ingestr just renames, no type enforcement
+```

--- a/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
+++ b/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
@@ -55,6 +55,7 @@
         {
           "entity_attribute": null,
           "name": "mycol1",
+          "source_column": "",
           "type": "",
           "description": "",
           "tags": [],
@@ -74,6 +75,7 @@
             "attribute": "Language"
           },
           "name": "street_name",
+          "source_column": "",
           "type": "string",
           "description": "the language the customer picked during registration.",
           "tags": [],
@@ -93,6 +95,7 @@
             "attribute": "Email"
           },
           "name": "Email",
+          "source_column": "",
           "type": "string",
           "description": "the e-mail address the customer used while registering on our website.",
           "tags": [],
@@ -112,6 +115,7 @@
             "attribute": "ID"
           },
           "name": "ID",
+          "source_column": "",
           "type": "integer",
           "description": "The unique identifier of the customer in our systems.",
           "tags": [],

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage-asset.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage-asset.json
@@ -78,6 +78,7 @@
       {
         "entity_attribute": null,
         "name": "country",
+        "source_column": "",
         "type": "varchar",
         "description": "Just a country",
         "tags": [],
@@ -99,6 +100,7 @@
       {
         "entity_attribute": null,
         "name": "last_name",
+        "source_column": "",
         "type": "varchar",
         "description": "Just a last name",
         "tags": [],
@@ -120,6 +122,7 @@
       {
         "entity_attribute": null,
         "name": "name",
+        "source_column": "",
         "type": "varchar",
         "description": "Just a name",
         "tags": [],
@@ -141,6 +144,7 @@
       {
         "entity_attribute": null,
         "name": "updated_at",
+        "source_column": "",
         "type": "timestamp",
         "description": "Just a timestamp",
         "tags": [],

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -225,6 +225,7 @@
         {
           "entity_attribute": null,
           "name": "total_games",
+          "source_column": "",
           "type": "integer",
           "description": "the games",
           "tags": [],

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
@@ -219,6 +219,7 @@
         {
           "entity_attribute": null,
           "name": "total_games",
+          "source_column": "",
           "type": "integer",
           "description": "the games",
           "tags": [],

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/player_summary.sql.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/player_summary.sql.json
@@ -52,6 +52,7 @@
       {
         "entity_attribute": null,
         "name": "total_games",
+        "source_column": "",
         "type": "integer",
         "description": "the games",
         "tags": [],

--- a/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
@@ -69,6 +69,7 @@
         {
           "entity_attribute": null,
           "name": "id",
+          "source_column": "",
           "type": "integer",
           "description": "Just a number",
           "tags": [],
@@ -90,6 +91,7 @@
         {
           "entity_attribute": null,
           "name": "country",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a country",
           "tags": [],
@@ -195,6 +197,7 @@
         {
           "entity_attribute": null,
           "name": "country",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a country",
           "tags": [],
@@ -216,6 +219,7 @@
         {
           "entity_attribute": null,
           "name": "last_name",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a last name",
           "tags": [],
@@ -237,6 +241,7 @@
         {
           "entity_attribute": null,
           "name": "name",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a name",
           "tags": [],
@@ -258,6 +263,7 @@
         {
           "entity_attribute": null,
           "name": "updated_at",
+          "source_column": "",
           "type": "timestamp",
           "description": "Just a timestamp",
           "tags": [],
@@ -352,6 +358,7 @@
         {
           "entity_attribute": null,
           "name": "created_at",
+          "source_column": "",
           "type": "timestamp",
           "description": "Just a timestamp",
           "tags": [],
@@ -373,6 +380,7 @@
         {
           "entity_attribute": null,
           "name": "id",
+          "source_column": "",
           "type": "integer",
           "description": "Just a number",
           "tags": [],
@@ -394,6 +402,7 @@
         {
           "entity_attribute": null,
           "name": "last_name",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a last name",
           "tags": [],
@@ -415,6 +424,7 @@
         {
           "entity_attribute": null,
           "name": "name",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a name",
           "tags": [],
@@ -481,6 +491,7 @@
         {
           "entity_attribute": null,
           "name": "id",
+          "source_column": "",
           "type": "integer",
           "description": "Just a number",
           "tags": [],
@@ -497,6 +508,7 @@
         {
           "entity_attribute": null,
           "name": "name",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a name",
           "tags": [],
@@ -513,6 +525,7 @@
         {
           "entity_attribute": null,
           "name": "last_name",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a last name",
           "tags": [],
@@ -529,6 +542,7 @@
         {
           "entity_attribute": null,
           "name": "country",
+          "source_column": "",
           "type": "varchar",
           "description": "Just a country",
           "tags": [],
@@ -545,6 +559,7 @@
         {
           "entity_attribute": null,
           "name": "created_at",
+          "source_column": "",
           "type": "timestamp",
           "description": "Just a timestamp",
           "tags": [],

--- a/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
@@ -197,6 +197,7 @@
         {
           "entity_attribute": null,
           "name": "total_games",
+          "source_column": "",
           "type": "integer",
           "description": "the games",
           "tags": [],

--- a/integration-tests/test-pipelines/run-seed-data/expectations/seed.asset.yml.json
+++ b/integration-tests/test-pipelines/run-seed-data/expectations/seed.asset.yml.json
@@ -34,6 +34,7 @@
       {
         "entity_attribute": null,
         "name": "name",
+        "source_column": "",
         "type": "varchar",
         "description": "Contact person's full name",
         "tags": [],
@@ -58,6 +59,7 @@
       {
         "entity_attribute": null,
         "name": "networking_through",
+        "source_column": "",
         "type": "varchar",
         "description": "Source or connection through which contact was made",
         "tags": [],
@@ -94,6 +96,7 @@
       {
         "entity_attribute": null,
         "name": "position",
+        "source_column": "",
         "type": "varchar",
         "description": "Contact's job position or title",
         "tags": [],
@@ -118,6 +121,7 @@
       {
         "entity_attribute": null,
         "name": "contact_date",
+        "source_column": "",
         "type": "varchar",
         "description": "Date when contact was established",
         "tags": [],

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -630,16 +630,10 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 		}
 
 		for _, column := range asset.Columns {
-			// When source_column is set, the column lives in the CSV under that
-			// name and the asset's `name` is the destination after rename.
-			lookup := column.Name
-			if column.SourceColumn != "" {
-				lookup = column.SourceColumn
-			}
-			if !columnMap[strings.ToLower(lookup)] {
+			if !columnMap[strings.ToLower(column.Name)] {
 				issues = append(issues, &Issue{
 					Task:        asset,
-					Description: fmt.Sprintf("Column '%s' is defined in the asset but does not exist in the CSV", lookup),
+					Description: fmt.Sprintf("Column '%s' is defined in the asset but does not exist in the CSV", column.Name),
 				})
 			}
 		}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -630,10 +630,16 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 		}
 
 		for _, column := range asset.Columns {
-			if !columnMap[strings.ToLower(column.Name)] {
+			// When source_column is set, the column lives in the CSV under that
+			// name and the asset's `name` is the destination after rename.
+			lookup := column.Name
+			if column.SourceColumn != "" {
+				lookup = column.SourceColumn
+			}
+			if !columnMap[strings.ToLower(lookup)] {
 				issues = append(issues, &Issue{
 					Task:        asset,
-					Description: fmt.Sprintf("Column '%s' is defined in the asset but does not exist in the CSV", column.Name),
+					Description: fmt.Sprintf("Column '%s' is defined in the asset but does not exist in the CSV", lookup),
 				})
 			}
 		}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -581,6 +581,7 @@ type UpstreamColumn struct {
 type Column struct {
 	EntityAttribute *EntityAttribute  `json:"entity_attribute" yaml:"-" mapstructure:"-"`
 	Name            string            `json:"name" yaml:"name,omitempty" mapstructure:"name"`
+	SourceColumn    string            `json:"source_column" yaml:"source_column,omitempty" mapstructure:"source_column"`
 	Type            string            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
 	Description     string            `json:"description" yaml:"description,omitempty" mapstructure:"description"`
 	Tags            EmptyStringArray  `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
@@ -178,6 +178,7 @@
                 {
                     "entity_attribute": null,
                     "name": "col1",
+                    "source_column": "",
                     "type": "string",
                     "description": "",
                     "tags": [],
@@ -216,6 +217,7 @@
                 {
                     "entity_attribute": null,
                     "name": "col2",
+                    "source_column": "",
                     "type": "string",
                     "description": "",
                     "tags": [],

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
@@ -186,6 +186,7 @@
                 {
                     "entity_attribute": null,
                     "name": "col1",
+                    "source_column": "",
                     "type": "string",
                     "description": "",
                     "tags": [],
@@ -224,6 +225,7 @@
                 {
                     "entity_attribute": null,
                     "name": "col2",
+                    "source_column": "",
                     "type": "string",
                     "description": "",
                     "tags": [],

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -391,6 +391,9 @@ func renderAssetStrings(render RenderFunc, a *Asset) error {
 		if c.Name, err = maybeRender(render, fmt.Sprintf("asset[%s].columns[%d].name", originalName, i), c.Name); err != nil {
 			return err
 		}
+		if c.SourceColumn, err = maybeRender(render, fmt.Sprintf("asset[%s].columns[%d].source_column", originalName, i), c.SourceColumn); err != nil {
+			return err
+		}
 		if c.Type, err = maybeRender(render, fmt.Sprintf("asset[%s].columns[%d].type", originalName, i), c.Type); err != nil {
 			return err
 		}

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -281,6 +281,7 @@ type columnUpstream struct {
 type column struct {
 	Extends       string            `yaml:"extends"`
 	Name          string            `yaml:"name"`
+	SourceColumn  string            `yaml:"source_column"`
 	Type          string            `yaml:"type"`
 	Description   string            `yaml:"description"`
 	Tests         []columnCheck     `yaml:"checks"`
@@ -480,6 +481,7 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 
 		columns[index] = Column{
 			Name:            column.Name,
+			SourceColumn:    column.SourceColumn,
 			Type:            strings.TrimSpace(column.Type),
 			Description:     column.Description,
 			Checks:          tests,

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -409,6 +409,26 @@ routing:
 	require.Equal(t, &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"}, task.Routing)
 }
 
+func TestConvertYamlToTask_SourceColumn(t *testing.T) {
+	t.Parallel()
+
+	task, err := pipeline.ConvertYamlToTask([]byte(strings.TrimSpace(`
+name: dataset.contacts
+type: ingestr
+columns:
+  - name: first_name
+    source_column: fname
+    type: string
+  - name: email
+    type: string
+`)))
+	require.NoError(t, err)
+	require.Len(t, task.Columns, 2)
+	require.Equal(t, "first_name", task.Columns[0].Name)
+	require.Equal(t, "fname", task.Columns[0].SourceColumn)
+	require.Empty(t, task.Columns[1].SourceColumn)
+}
+
 func TestCreateTaskFromFileComments_Routing(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -215,17 +215,25 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool) string {
 	hints := make([]string, 0)
 	for _, col := range cols {
 		typ := NormaliseColumnType(col.Type)
+		hint, typeKnown := TypeHintMapping[typ]
 
-		hint, exists := TypeHintMapping[typ]
-		if !exists {
+		if !typeKnown && col.SourceColumn == "" {
 			continue
 		}
+
 		name := col.Name
 		if normaliseNames {
 			name = NormalizeColumnName(name)
 		}
 
-		hints = append(hints, fmt.Sprintf("%s:%s", name, hint))
+		switch {
+		case col.SourceColumn != "" && typeKnown:
+			hints = append(hints, fmt.Sprintf("%s:%s:%s", name, hint, col.SourceColumn))
+		case col.SourceColumn != "":
+			hints = append(hints, fmt.Sprintf("%s::%s", name, col.SourceColumn))
+		default:
+			hints = append(hints, fmt.Sprintf("%s:%s", name, hint))
+		}
 	}
 	return strings.Join(hints, ",")
 }

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -101,6 +101,34 @@ func TestColumnHints(t *testing.T) {
 			normalizeNames: false,
 			expected:       "id:bigint,name:text",
 		},
+		{
+			name: "source_column adds dest:type:source triple",
+			columns: []pipeline.Column{
+				{Name: "id", SourceColumn: "sourceid", Type: "integer"},
+				{Name: "email", SourceColumn: "eml", Type: "string"},
+				{Name: "created_at", Type: "timestamp"},
+			},
+			normalizeNames: false,
+			expected:       "id:bigint:sourceid,email:text:eml,created_at:timestamp",
+		},
+		{
+			name: "source_column with name normalization normalizes dest name",
+			columns: []pipeline.Column{
+				{Name: "FirstName", SourceColumn: "fname", Type: "string"},
+			},
+			normalizeNames: true,
+			expected:       "first_name:text:fname",
+		},
+		{
+			name: "source_column without recognized type emits dest::source",
+			columns: []pipeline.Column{
+				{Name: "first_name", SourceColumn: "fname"},
+				{Name: "email", SourceColumn: "eml", Type: "string"},
+				{Name: "weird", SourceColumn: "wrd", Type: "unknown_type"},
+			},
+			normalizeNames: false,
+			expected:       "first_name::fname,email:text:eml,weird::wrd",
+		},
 	}
 
 	for _, tt := range tests {
@@ -262,6 +290,49 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 			assert.Equal(t, tt.wantColumn, hasColumns, "expected columns presence to be %v", tt.wantColumn)
 		})
 	}
+}
+
+func TestConsolidatedParameters_SourceColumn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("source_column with enforce_schema=true emits dest:type:source", func(t *testing.T) {
+		t.Parallel()
+		asset := &pipeline.Asset{
+			Parameters: map[string]string{
+				"enforce_schema": "true",
+			},
+			Columns: []pipeline.Column{
+				{Name: "id", SourceColumn: "sourceid", Type: "integer"},
+				{Name: "email", SourceColumn: "eml", Type: "string"},
+			},
+		}
+		result, err := ConsolidatedParameters(t.Context(), asset, []string{"--existing"}, &ColumnHintOptions{})
+		require.NoError(t, err)
+
+		var columnsValue string
+		for i, arg := range result {
+			if arg == "--columns" && i+1 < len(result) {
+				columnsValue = result[i+1]
+				break
+			}
+		}
+		assert.Equal(t, "id:bigint:sourceid,email:text:eml", columnsValue)
+	})
+
+	t.Run("source_column without enforce_schema does not emit --columns", func(t *testing.T) {
+		t.Parallel()
+		asset := &pipeline.Asset{
+			Parameters: map[string]string{},
+			Columns: []pipeline.Column{
+				{Name: "id", SourceColumn: "sourceid", Type: "integer"},
+			},
+		}
+		result, err := ConsolidatedParameters(t.Context(), asset, []string{"--existing"}, &ColumnHintOptions{})
+		require.NoError(t, err)
+		for _, arg := range result {
+			assert.NotEqual(t, "--columns", arg)
+		}
+	})
 }
 
 func TestColumnHints_Normalization(t *testing.T) {


### PR DESCRIPTION
This pair of PRs adds column name mapping for ingestr assets, allowing columns to be renamed as they move from a source to a destination. In an asset, name stays the destination column and source_column holds the name it has in the source; on ingestion the column is renamed accordingly, with optional type enforcement. The Bruin PR introduces the source_column field and passes the mapping through to ingestr, while the companion ingestr PR handles parsing and applying that mapping on its side. Together they provide a simple, declarative way to standardize column names at load time without post-processing. 