### PR TITLE
Add Microsoft OneLake as an ingestr destination connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -323,6 +323,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Mailchimp", link: "/ingestion/mailchimp"},
                                     {text: "Linear", link: "/ingestion/linear"},
                                     {text: "Mixpanel", link: "/ingestion/mixpanel"},
+                                    {text: "Microsoft OneLake", link: "/ingestion/onelake"},
                                     {text: "MongoDB", link: "/ingestion/mongo"},
                                     {text: "MySQL", link: "/ingestion/mysql"},
                                     {text: "Notion", link: "/ingestion/notion"},

--- a/docs/ingestion/onelake.md
+++ b/docs/ingestion/onelake.md
@@ -1,0 +1,80 @@
+# Microsoft OneLake
+
+[Microsoft OneLake](https://learn.microsoft.com/en-us/fabric/onelake/onelake-overview) is the single, unified, logical data lake for Microsoft Fabric. Every Fabric tenant gets one OneLake, and data is organized into workspaces and lakehouses backed by Azure Data Lake Storage Gen2.
+
+Bruin supports OneLake as a destination for [Ingestr assets](/assets/ingestr), so you can move data from any supported source into a Fabric lakehouse.
+
+In order to set up the OneLake connection, you need to add a configuration item in the `.bruin.yml` file and in the `asset` file. You will need the workspace and lakehouse names along with credentials for Microsoft Entra ID authentication. For details on how to obtain these credentials, please refer [here](https://getbruin.com/docs/ingestr/supported-sources/onelake.html#microsoft-onelake).
+
+## Writing to OneLake
+
+Follow the steps below to correctly set up OneLake as a destination and run ingestion.
+
+### Step 1: Add a connection to .bruin.yml file
+
+To connect to OneLake, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+    connections:
+      onelake:
+        - name: "my-onelake"
+          workspace_name: "myworkspace"
+          lakehouse_name: "mylakehouse"
+          # Authentication — provide ONE of the options below.
+          # Option 1: Service principal (Microsoft Entra ID)
+          tenant_id: "tenant-id"
+          client_id: "client-id"
+          client_secret: "client-secret"
+          # Option 2: SAS token
+          # sas_token: "sv=..."
+          # Option 3: DefaultAzureCredential (env vars, managed identity, or Azure CLI login)
+          # use_azure_default_credential: true
+```
+
+- `workspace_name`: The Fabric workspace name or GUID.
+- `lakehouse_name`: The lakehouse name or GUID (the `.Lakehouse` suffix is added automatically).
+
+OneLake requires Microsoft Entra ID authentication — shared account keys are not accepted. Provide **one** of the following authentication methods:
+
+- **Service principal**: `tenant_id`, `client_id`, and `client_secret`. The service principal needs Contributor access to the workspace.
+- **SAS token**: `sas_token`.
+- **DefaultAzureCredential**: set `use_azure_default_credential: true` to let ingestr authenticate via environment variables, a managed identity, or the Azure CLI login.
+
+### Step 2: Create an asset file for data ingestion
+
+To ingest data to OneLake, you need to create an [asset configuration](/assets/ingestr.html#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., `stripe_onelake.yml`) inside the assets folder and add the following content:
+
+```yaml
+name: Tables/events
+type: ingestr
+connection: my-onelake
+
+parameters:
+  source_connection: stripe
+  source_table: 'event'
+
+  destination: onelake
+```
+
+- `name`: The name of the asset. This is also used as the destination table (`--dest-table`) in the lakehouse — see [Storage modes](#storage-modes) below.
+- `type`: Specifies the type of the asset. Set this to `ingestr` to use the ingestr data pipeline.
+- `connection`: This is the destination connection, which defines where the data should be stored. Here `my-onelake` points at the OneLake connection defined in `.bruin.yml`.
+- `source_connection`: The name of the source connection defined in `.bruin.yml`.
+- `source_table`: The table to ingest from the source.
+- `destination`: Set to `onelake`.
+
+### Storage modes
+
+The asset name is passed to ingestr as the destination table, and its prefix determines how data is stored in the lakehouse:
+
+- `Tables/<name>` → a Delta Lake table that is queryable in Fabric.
+- `Files/<path>` → raw Parquet files.
+- A bare name (e.g. `events`) defaults to `Tables/`.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/stripe_onelake.yml
+```
+
+As a result of this command, Bruin will ingest data from the given source into your Microsoft OneLake lakehouse.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -537,6 +537,12 @@
           },
           "type": "array"
         },
+        "onelake": {
+          "items": {
+            "$ref": "#/$defs/OneLakeConnection"
+          },
+          "type": "array"
+        },
         "mongo": {
           "items": {
             "$ref": "#/$defs/MongoConnection"
@@ -1529,6 +1535,41 @@
         "host",
         "port",
         "database"
+      ]
+    },
+    "OneLakeConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "workspace_name": {
+          "type": "string"
+        },
+        "lakehouse_name": {
+          "type": "string"
+        },
+        "tenant_id": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "sas_token": {
+          "type": "string"
+        },
+        "use_azure_default_credential": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "workspace_name",
+        "lakehouse_name"
       ]
     },
     "FacebookAdsConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -230,6 +230,21 @@ func (c FabricConnection) GetName() string {
 	return c.Name
 }
 
+type OneLakeConnection struct {
+	Name                      string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	WorkspaceName             string `yaml:"workspace_name,omitempty" json:"workspace_name" mapstructure:"workspace_name"`
+	LakehouseName             string `yaml:"lakehouse_name,omitempty" json:"lakehouse_name" mapstructure:"lakehouse_name"`
+	TenantID                  string `yaml:"tenant_id,omitempty" json:"tenant_id,omitempty" mapstructure:"tenant_id"`
+	ClientID                  string `yaml:"client_id,omitempty" json:"client_id,omitempty" mapstructure:"client_id"`
+	ClientSecret              string `yaml:"client_secret,omitempty" json:"client_secret,omitempty" mapstructure:"client_secret"`
+	SASToken                  string `yaml:"sas_token,omitempty" json:"sas_token,omitempty" mapstructure:"sas_token"`
+	UseAzureDefaultCredential bool   `yaml:"use_azure_default_credential,omitempty" json:"use_azure_default_credential,omitempty" mapstructure:"use_azure_default_credential"`
+}
+
+func (c OneLakeConnection) GetName() string {
+	return c.Name
+}
+
 type DatabricksConnection struct {
 	Name         string `yaml:"name,omitempty"  json:"name" mapstructure:"name"`
 	Token        string `yaml:"token,omitempty" json:"token,omitempty" mapstructure:"token" jsonschema:"oneof_required=token"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -33,6 +33,7 @@ type Connections struct {
 	Databricks          []DatabricksConnection          `yaml:"databricks,omitempty" json:"databricks,omitempty" mapstructure:"databricks"`
 	Synapse             []SynapseConnection             `yaml:"synapse,omitempty" json:"synapse,omitempty" mapstructure:"synapse"`
 	Fabric              []FabricConnection              `yaml:"fabric,omitempty" json:"fabric,omitempty" mapstructure:"fabric"`
+	OneLake             []OneLakeConnection             `yaml:"onelake,omitempty" json:"onelake,omitempty" mapstructure:"onelake"`
 	Mongo               []MongoConnection               `yaml:"mongo,omitempty" json:"mongo,omitempty" mapstructure:"mongo"`
 	Couchbase           []CouchbaseConnection           `yaml:"couchbase,omitempty" json:"couchbase,omitempty" mapstructure:"couchbase"`
 	Cursor              []CursorConnection              `yaml:"cursor,omitempty" json:"cursor,omitempty" mapstructure:"cursor"`
@@ -556,6 +557,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Fabric = append(env.Connections.Fabric, conn)
+	case "onelake":
+		var conn OneLakeConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.OneLake = append(env.Connections.OneLake, conn)
 	case "mongo":
 		var conn MongoConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1262,6 +1270,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Synapse = removeConnection(env.Connections.Synapse, connectionName)
 	case "fabric":
 		env.Connections.Fabric = removeConnection(env.Connections.Fabric, connectionName)
+	case "onelake":
+		env.Connections.OneLake = removeConnection(env.Connections.OneLake, connectionName)
 	case "gorgias":
 		env.Connections.Gorgias = removeConnection(env.Connections.Gorgias, connectionName)
 	case "g2":
@@ -1491,6 +1501,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Databricks, source.Databricks)
 	mergeConnectionList(&c.Synapse, source.Synapse)
 	mergeConnectionList(&c.Fabric, source.Fabric)
+	mergeConnectionList(&c.OneLake, source.OneLake)
 	mergeConnectionList(&c.Mongo, source.Mongo)
 	mergeConnectionList(&c.Couchbase, source.Couchbase)
 	mergeConnectionList(&c.Cursor, source.Cursor)

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -76,6 +76,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/mysql"
 	"github.com/bruin-data/bruin/pkg/notion"
+	"github.com/bruin-data/bruin/pkg/onelake"
 	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/personio"
 	"github.com/bruin-data/bruin/pkg/phantombuster"
@@ -124,6 +125,7 @@ type Manager struct {
 	MsSQL                map[string]*mssql.DB
 	Databricks           map[string]*databricks.DB
 	Fabric               map[string]*fabric.DB
+	OneLake              map[string]*onelake.Client
 	Mongo                map[string]*mongo.DB
 	Couchbase            map[string]*couchbase.DB
 	Cursor               map[string]*cursor.Client
@@ -621,6 +623,35 @@ func (m *Manager) AddFabricConnectionFromConfig(connection *config.FabricConnect
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.Fabric[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
+func (m *Manager) AddOneLakeConnectionFromConfig(connection *config.OneLakeConnection) error {
+	m.mutex.Lock()
+	if m.OneLake == nil {
+		m.OneLake = make(map[string]*onelake.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := onelake.NewClient(onelake.Config{
+		WorkspaceName:             connection.WorkspaceName,
+		LakehouseName:             connection.LakehouseName,
+		TenantID:                  connection.TenantID,
+		ClientID:                  connection.ClientID,
+		ClientSecret:              connection.ClientSecret,
+		SASToken:                  connection.SASToken,
+		UseAzureDefaultCredential: connection.UseAzureDefaultCredential,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.OneLake[connection.Name] = client
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection
 
@@ -2958,6 +2989,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.MsSQL, connectionManager.AddMsSQLConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Synapse, connectionManager.AddSynapseSQLConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Fabric, connectionManager.AddFabricConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.OneLake, connectionManager.AddOneLakeConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Databricks, connectionManager.AddDatabricksConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Mongo, connectionManager.AddMongoConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Couchbase, connectionManager.AddCouchbaseConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/onelake/client.go
+++ b/pkg/onelake/client.go
@@ -1,0 +1,13 @@
+package onelake
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{c}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}

--- a/pkg/onelake/config.go
+++ b/pkg/onelake/config.go
@@ -2,6 +2,7 @@ package onelake
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -17,11 +18,16 @@ type Config struct {
 }
 
 // GetIngestrURI builds the URI ingestr expects for a Microsoft OneLake
-// destination. OneLake requires Microsoft Entra ID authentication, so one of
-// the following must be provided: a service principal (client_id/client_secret,
-// optionally tenant_id), a SAS token, or use_azure_default_credential which lets
-// ingestr fall back to DefaultAzureCredential (env vars, managed identity, or
-// Azure CLI login).
+// destination. OneLake requires Microsoft Entra ID authentication, so exactly
+// one of the following authentication modes must be fully configured:
+//   - Service principal: tenant_id + client_id + client_secret (all three).
+//   - SAS token: sas_token.
+//   - DefaultAzureCredential: use_azure_default_credential, which lets ingestr
+//     authenticate via env vars, a managed identity, or the Azure CLI login.
+//
+// Partially configured modes (e.g. client_id without client_secret) and
+// combinations of more than one mode are rejected so misconfigurations surface
+// as clear errors instead of silently producing an unusable URI.
 //
 //	onelake://<workspace>/<lakehouse>?tenant_id=<tenant_id>&client_id=<client_id>&client_secret=<client_secret>
 func (c Config) GetIngestrURI() (string, error) {
@@ -31,22 +37,48 @@ func (c Config) GetIngestrURI() (string, error) {
 		return "", errors.New("onelake: both workspace_name and lakehouse_name must be provided")
 	}
 
+	// Detect which auth modes have any field set so we can reject partial or
+	// ambiguous configurations.
+	servicePrincipalSet := c.TenantID != "" || c.ClientID != "" || c.ClientSecret != ""
+	sasSet := c.SASToken != ""
+
+	modesConfigured := 0
+	for _, set := range []bool{servicePrincipalSet, sasSet, c.UseAzureDefaultCredential} {
+		if set {
+			modesConfigured++
+		}
+	}
+
+	switch {
+	case modesConfigured == 0:
+		return "", errors.New("onelake: authentication required: set service principal (tenant_id + client_id + client_secret), sas_token, or use_azure_default_credential")
+	case modesConfigured > 1:
+		return "", errors.New("onelake: multiple authentication methods configured; provide exactly one of service principal (tenant_id + client_id + client_secret), sas_token, or use_azure_default_credential")
+	}
+
 	query := url.Values{}
 	switch {
-	case c.ClientID != "":
+	case servicePrincipalSet:
+		var missing []string
+		if c.TenantID == "" {
+			missing = append(missing, "tenant_id")
+		}
+		if c.ClientID == "" {
+			missing = append(missing, "client_id")
+		}
+		if c.ClientSecret == "" {
+			missing = append(missing, "client_secret")
+		}
+		if len(missing) > 0 {
+			return "", fmt.Errorf("onelake: service principal authentication requires %s", strings.Join(missing, ", "))
+		}
+		query.Set("tenant_id", c.TenantID)
 		query.Set("client_id", c.ClientID)
-		if c.ClientSecret != "" {
-			query.Set("client_secret", c.ClientSecret)
-		}
-		if c.TenantID != "" {
-			query.Set("tenant_id", c.TenantID)
-		}
-	case c.SASToken != "":
+		query.Set("client_secret", c.ClientSecret)
+	case sasSet:
 		query.Set("sas_token", c.SASToken)
 	case c.UseAzureDefaultCredential:
 		// No auth params: ingestr falls back to DefaultAzureCredential.
-	default:
-		return "", errors.New("onelake: authentication required: set client_id/client_secret/tenant_id, sas_token, or use_azure_default_credential")
 	}
 
 	u := url.URL{

--- a/pkg/onelake/config.go
+++ b/pkg/onelake/config.go
@@ -1,0 +1,60 @@
+package onelake
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+type Config struct {
+	WorkspaceName             string
+	LakehouseName             string
+	TenantID                  string
+	ClientID                  string
+	ClientSecret              string
+	SASToken                  string
+	UseAzureDefaultCredential bool
+}
+
+// GetIngestrURI builds the URI ingestr expects for a Microsoft OneLake
+// destination. OneLake requires Microsoft Entra ID authentication, so one of
+// the following must be provided: a service principal (client_id/client_secret,
+// optionally tenant_id), a SAS token, or use_azure_default_credential which lets
+// ingestr fall back to DefaultAzureCredential (env vars, managed identity, or
+// Azure CLI login).
+//
+//	onelake://<workspace>/<lakehouse>?tenant_id=<tenant_id>&client_id=<client_id>&client_secret=<client_secret>
+func (c Config) GetIngestrURI() (string, error) {
+	workspace := strings.TrimSpace(c.WorkspaceName)
+	lakehouse := strings.TrimSpace(c.LakehouseName)
+	if workspace == "" || lakehouse == "" {
+		return "", errors.New("onelake: both workspace_name and lakehouse_name must be provided")
+	}
+
+	query := url.Values{}
+	switch {
+	case c.ClientID != "":
+		query.Set("client_id", c.ClientID)
+		if c.ClientSecret != "" {
+			query.Set("client_secret", c.ClientSecret)
+		}
+		if c.TenantID != "" {
+			query.Set("tenant_id", c.TenantID)
+		}
+	case c.SASToken != "":
+		query.Set("sas_token", c.SASToken)
+	case c.UseAzureDefaultCredential:
+		// No auth params: ingestr falls back to DefaultAzureCredential.
+	default:
+		return "", errors.New("onelake: authentication required: set client_id/client_secret/tenant_id, sas_token, or use_azure_default_credential")
+	}
+
+	u := url.URL{
+		Scheme:   "onelake",
+		Host:     workspace,
+		Path:     "/" + lakehouse,
+		RawQuery: query.Encode(),
+	}
+
+	return u.String(), nil
+}

--- a/pkg/onelake/config_test.go
+++ b/pkg/onelake/config_test.go
@@ -67,18 +67,98 @@ func TestConfig_GetIngestrURI_ServicePrincipal_ReturnsURI(t *testing.T) {
 	require.Contains(t, got, "client_secret=secret")
 }
 
-func TestConfig_GetIngestrURI_ServicePrincipalWithoutTenant_ReturnsURI(t *testing.T) {
+func TestConfig_GetIngestrURI_PartialServicePrincipal_ReturnsError(t *testing.T) {
 	t.Parallel()
-	config := Config{
-		WorkspaceName: "ws",
-		LakehouseName: "lh",
-		ClientID:      "client",
-		ClientSecret:  "secret",
+
+	tests := []struct {
+		name        string
+		config      Config
+		wantMissing []string
+	}{
+		{
+			name:        "only client_id",
+			config:      Config{WorkspaceName: "ws", LakehouseName: "lh", ClientID: "client"},
+			wantMissing: []string{"tenant_id", "client_secret"},
+		},
+		{
+			name:        "client_id and client_secret without tenant",
+			config:      Config{WorkspaceName: "ws", LakehouseName: "lh", ClientID: "client", ClientSecret: "secret"},
+			wantMissing: []string{"tenant_id"},
+		},
+		{
+			name:        "tenant and client_id without secret",
+			config:      Config{WorkspaceName: "ws", LakehouseName: "lh", TenantID: "tenant", ClientID: "client"},
+			wantMissing: []string{"client_secret"},
+		},
+		{
+			name:        "only tenant_id",
+			config:      Config{WorkspaceName: "ws", LakehouseName: "lh", TenantID: "tenant"},
+			wantMissing: []string{"client_id", "client_secret"},
+		},
 	}
-	got, err := config.GetIngestrURI()
-	require.NoError(t, err)
-	require.Contains(t, got, "client_id=client")
-	require.NotContains(t, got, "tenant_id=")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.config.GetIngestrURI()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "service principal authentication requires")
+			for _, field := range tt.wantMissing {
+				require.Contains(t, err.Error(), field)
+			}
+		})
+	}
+}
+
+func TestConfig_GetIngestrURI_MultipleAuthMethods_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name: "service principal and sas token",
+			config: Config{
+				WorkspaceName: "ws", LakehouseName: "lh",
+				TenantID: "tenant", ClientID: "client", ClientSecret: "secret",
+				SASToken: "sv=token",
+			},
+		},
+		{
+			name: "service principal and default credential",
+			config: Config{
+				WorkspaceName: "ws", LakehouseName: "lh",
+				TenantID: "tenant", ClientID: "client", ClientSecret: "secret",
+				UseAzureDefaultCredential: true,
+			},
+		},
+		{
+			name: "sas token and default credential",
+			config: Config{
+				WorkspaceName: "ws", LakehouseName: "lh",
+				SASToken:                  "sv=token",
+				UseAzureDefaultCredential: true,
+			},
+		},
+		{
+			name: "partial service principal and sas token",
+			config: Config{
+				WorkspaceName: "ws", LakehouseName: "lh",
+				ClientID: "client",
+				SASToken: "sv=token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.config.GetIngestrURI()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "multiple authentication methods configured")
+		})
+	}
 }
 
 func TestConfig_GetIngestrURI_SASToken_ReturnsURI(t *testing.T) {
@@ -105,21 +185,6 @@ func TestConfig_GetIngestrURI_DefaultAzureCredential_ReturnsURIWithoutAuthParams
 	got, err := config.GetIngestrURI()
 	require.NoError(t, err)
 	require.Equal(t, "onelake://ws/lh", got)
-}
-
-func TestConfig_GetIngestrURI_ServicePrincipalTakesPrecedenceOverSAS(t *testing.T) {
-	t.Parallel()
-	config := Config{
-		WorkspaceName: "ws",
-		LakehouseName: "lh",
-		ClientID:      "client",
-		ClientSecret:  "secret",
-		SASToken:      "sv=token",
-	}
-	got, err := config.GetIngestrURI()
-	require.NoError(t, err)
-	require.Contains(t, got, "client_id=client")
-	require.NotContains(t, got, "sas_token=")
 }
 
 func TestConfig_GetIngestrURI_TrimsWorkspaceAndLakehouse(t *testing.T) {

--- a/pkg/onelake/config_test.go
+++ b/pkg/onelake/config_test.go
@@ -1,0 +1,148 @@
+package onelake
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI_MissingWorkspaceOrLakehouse_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name:   "missing both",
+			config: Config{ClientID: "client"},
+		},
+		{
+			name:   "missing lakehouse",
+			config: Config{WorkspaceName: "ws", ClientID: "client"},
+		},
+		{
+			name:   "missing workspace",
+			config: Config{LakehouseName: "lh", ClientID: "client"},
+		},
+		{
+			name:   "whitespace only",
+			config: Config{WorkspaceName: "  ", LakehouseName: "   ", ClientID: "client"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.config.GetIngestrURI()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "workspace_name and lakehouse_name")
+		})
+	}
+}
+
+func TestConfig_GetIngestrURI_NoAuth_ReturnsError(t *testing.T) {
+	t.Parallel()
+	config := Config{WorkspaceName: "ws", LakehouseName: "lh"}
+	_, err := config.GetIngestrURI()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "authentication required")
+}
+
+func TestConfig_GetIngestrURI_ServicePrincipal_ReturnsURI(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		WorkspaceName: "myworkspace",
+		LakehouseName: "mylakehouse",
+		TenantID:      "tenant",
+		ClientID:      "client",
+		ClientSecret:  "secret",
+	}
+	got, err := config.GetIngestrURI()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(got, "onelake://myworkspace/mylakehouse?"), "want onelake://myworkspace/mylakehouse prefix, got %s", got)
+	require.Contains(t, got, "tenant_id=tenant")
+	require.Contains(t, got, "client_id=client")
+	require.Contains(t, got, "client_secret=secret")
+}
+
+func TestConfig_GetIngestrURI_ServicePrincipalWithoutTenant_ReturnsURI(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		WorkspaceName: "ws",
+		LakehouseName: "lh",
+		ClientID:      "client",
+		ClientSecret:  "secret",
+	}
+	got, err := config.GetIngestrURI()
+	require.NoError(t, err)
+	require.Contains(t, got, "client_id=client")
+	require.NotContains(t, got, "tenant_id=")
+}
+
+func TestConfig_GetIngestrURI_SASToken_ReturnsURI(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		WorkspaceName: "ws",
+		LakehouseName: "lh",
+		SASToken:      "sv=token",
+	}
+	got, err := config.GetIngestrURI()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(got, "onelake://ws/lh?"), "got %s", got)
+	require.Contains(t, got, "sas_token=")
+	require.NotContains(t, got, "client_id=")
+}
+
+func TestConfig_GetIngestrURI_DefaultAzureCredential_ReturnsURIWithoutAuthParams(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		WorkspaceName:             "ws",
+		LakehouseName:             "lh",
+		UseAzureDefaultCredential: true,
+	}
+	got, err := config.GetIngestrURI()
+	require.NoError(t, err)
+	require.Equal(t, "onelake://ws/lh", got)
+}
+
+func TestConfig_GetIngestrURI_ServicePrincipalTakesPrecedenceOverSAS(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		WorkspaceName: "ws",
+		LakehouseName: "lh",
+		ClientID:      "client",
+		ClientSecret:  "secret",
+		SASToken:      "sv=token",
+	}
+	got, err := config.GetIngestrURI()
+	require.NoError(t, err)
+	require.Contains(t, got, "client_id=client")
+	require.NotContains(t, got, "sas_token=")
+}
+
+func TestConfig_GetIngestrURI_TrimsWorkspaceAndLakehouse(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		WorkspaceName: "  myworkspace  ",
+		LakehouseName: "  mylakehouse  ",
+		SASToken:      "token",
+	}
+	got, err := config.GetIngestrURI()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(got, "onelake://myworkspace/mylakehouse"), "got %s", got)
+}
+
+func TestClient_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+	client, err := NewClient(Config{
+		WorkspaceName: "ws",
+		LakehouseName: "lh",
+		SASToken:      "token",
+	})
+	require.NoError(t, err)
+	got, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(got, "onelake://ws/lh"), "got %s", got)
+}

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -43,7 +43,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.12"
+	IngestrVersionV1 = "1.0.13"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
Add connection handling for Microsoft OneLake (Fabric) as an ingestr destination, plus user-facing docs.

- New pkg/onelake package (Config/Client) building the ingestr URI onelake://<workspace>/<lakehouse>?<auth>, supporting service principal, SAS token, and DefaultAzureCredential auth.
- Wire OneLakeConnection through config (struct, AddConnection, delete, merge) and the connection manager.
- Docs at docs/ingestion/onelake.md and sidebar entry.
- Update connections schema integration expectation.