### PR TITLE
feat(ingestr): forward --debug flag to ingestr subprocess

### DIFF
--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -42,6 +42,13 @@ const (
 	stillRunningLogInterval = 120 * time.Second
 )
 
+// IsDebugMode reports whether the context carries a KeyIsDebug *bool set to true.
+// Safe against missing, wrong-typed, or nil-pointer values.
+func IsDebugMode(ctx context.Context) bool {
+	b, ok := ctx.Value(KeyIsDebug).(*bool)
+	return ok && b != nil && *b
+}
+
 type FormattingOptions struct {
 	DoNotLogTimestamp bool
 	DoNotLogTaskName  bool

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
 	duck "github.com/bruin-data/bruin/pkg/duckdb"
+	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -19,6 +20,15 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 )
+
+func isDebugMode(ctx context.Context) bool {
+	v := ctx.Value(executor.KeyIsDebug)
+	if v == nil {
+		return false
+	}
+	b, ok := v.(*bool)
+	return ok && b != nil && *b
+}
 
 // versionPattern matches the bare family marker (vMAJOR) or a fully-qualified
 // vMAJOR.MINOR.PATCH. MAJOR is any non-negative integer with no leading zero
@@ -323,6 +333,10 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		"log",
 	)
 
+	if isDebugMode(ctx) {
+		baseArgs = append(baseArgs, "--debug")
+	}
+
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
 		NormalizeColumnNames:   false,
 		EnforceSchemaByDefault: false,
@@ -500,7 +514,7 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 
 	extraPackages = python.AddExtraPackages(destURI, sourceURI, extraPackages)
 
-	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, []string{
+	baseArgs := []string{
 		"ingest",
 		"--source-uri",
 		sourceURI,
@@ -513,7 +527,13 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		"--yes",
 		"--progress",
 		"log",
-	}, &python.ColumnHintOptions{
+	}
+
+	if isDebugMode(ctx) {
+		baseArgs = append(baseArgs, "--debug")
+	}
+
+	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
 		NormalizeColumnNames:   true,
 		EnforceSchemaByDefault: true,
 	})

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -21,15 +21,6 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-func isDebugMode(ctx context.Context) bool {
-	v := ctx.Value(executor.KeyIsDebug)
-	if v == nil {
-		return false
-	}
-	b, ok := v.(*bool)
-	return ok && b != nil && *b
-}
-
 // versionPattern matches the bare family marker (vMAJOR) or a fully-qualified
 // vMAJOR.MINOR.PATCH. MAJOR is any non-negative integer with no leading zero
 // (other than the literal "0").
@@ -333,7 +324,7 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		"log",
 	)
 
-	if isDebugMode(ctx) {
+	if executor.IsDebugMode(ctx) {
 		baseArgs = append(baseArgs, "--debug")
 	}
 
@@ -529,7 +520,7 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		"log",
 	}
 
-	if isDebugMode(ctx) {
+	if executor.IsDebugMode(ctx) {
 		baseArgs = append(baseArgs, "--debug")
 	}
 

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -519,11 +519,8 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 
 	runArgs := u.ingestrRunCmd(ctx, extraPackages, cmdArgs)
 
-	if debug := ctx.Value(executor.KeyIsDebug); debug != nil {
-		boolVal := debug.(*bool)
-		if *boolVal {
-			_, _ = output.Write([]byte("Running CommandInstance: uv " + strings.Join(runArgs, " ") + "\n"))
-		}
+	if executor.IsDebugMode(ctx) {
+		_, _ = output.Write([]byte("Running CommandInstance: uv " + strings.Join(runArgs, " ") + "\n"))
 	}
 
 	err = u.Cmd.Run(ingestrCtx, execCtx.repo, &CommandInstance{


### PR DESCRIPTION
## Summary

When bruin is invoked with `--debug`, the flag now propagates to the `ingestr ingest` command spawned by both `BasicOperator.Run()` and `SeedOperator.Run()`.

Previously `--debug` only affected bruin's own Zap logger and was never appended to the subprocess args, so ingestr debug output was unavailable in cloud runs even when the parent invocation requested it.