### PR TITLE
fix(lint): resolve cross-pipeline URI deps against repo root for single-asset validate

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -308,7 +308,15 @@ func Lint(isDebug *bool) *cli.Command {
 				filteredRules = append(filteredRules, crossPipelineRules...)
 				linter := lint.NewLinter(pipelineFinder, DefaultPipelineBuilder, filteredRules, logger, parser)
 				logger.Debugf("running %d rules for asset-only validation", len(filteredRules))
-				result, errr = linter.LintAsset(lintCtx, rootPath, PipelineDefinitionFiles, asset, c)
+
+				// Repo root lets cross-pipeline URI deps resolve against sibling pipelines.
+				crossPipelineRoot := ""
+				if repoRoot, repoErr := git.FindRepoFromPath(rootPath); repoErr != nil {
+					logger.Debugf("could not find repo root for cross-pipeline resolution, falling back to '%s': %v", rootPath, repoErr)
+				} else {
+					crossPipelineRoot = repoRoot.Path
+				}
+				result, errr = linter.LintAsset(lintCtx, rootPath, PipelineDefinitionFiles, asset, c, crossPipelineRoot)
 			}
 
 			printer := lint.Printer{RootCheckPath: rootPath}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -231,18 +231,20 @@ func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinit
 
 	// Resolve URI deps against every repo pipeline, not just the asset's own.
 	// Keep assetPipeline so the pointer-based issue match below still works.
+	// A broken sibling pipeline must not fail an otherwise-valid asset validate,
+	// so on error we log and fall back to the asset's own pipeline.
 	crossPipelines := pipelines
 	if hasURIDeps && crossPipelineRootPath != "" && crossPipelineRootPath != rootPath {
 		repoPipelines, err := l.extractPipelinesFromPath(ctx, crossPipelineRootPath, pipelineDefinitionFileName)
 		if err != nil {
-			return nil, err
-		}
-
-		crossPipelines = make([]*pipeline.Pipeline, 0, len(repoPipelines))
-		crossPipelines = append(crossPipelines, assetPipeline)
-		for _, p := range repoPipelines {
-			if p.DefinitionFile.Path != assetPipeline.DefinitionFile.Path {
-				crossPipelines = append(crossPipelines, p)
+			l.logger.Debugf("could not load repo pipelines for cross-pipeline URI resolution, falling back to the asset's pipeline: %v", err)
+		} else {
+			crossPipelines = make([]*pipeline.Pipeline, 0, len(repoPipelines))
+			crossPipelines = append(crossPipelines, assetPipeline)
+			for _, p := range repoPipelines {
+				if p.DefinitionFile.Path != assetPipeline.DefinitionFile.Path {
+					crossPipelines = append(crossPipelines, p)
+				}
 			}
 		}
 	}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -154,7 +154,10 @@ func (l *Linter) Lint(ctx context.Context, rootPath string, pipelineDefinitionFi
 	return l.LintPipelines(ctx, pipelines)
 }
 
-func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinitionFileName []string, assetNameOrPath string, c *cli.Command) (*PipelineAnalysisResult, error) {
+// LintAsset validates a single asset found under rootPath. When set,
+// crossPipelineRootPath (typically the repo root) widens the pipeline set used
+// to resolve cross-pipeline URI dependencies.
+func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinitionFileName []string, assetNameOrPath string, c *cli.Command, crossPipelineRootPath string) (*PipelineAnalysisResult, error) {
 	pipelines, err := l.extractPipelinesFromPath(ctx, rootPath, pipelineDefinitionFileName)
 	if err != nil {
 		return nil, err
@@ -226,12 +229,30 @@ func (l *Linter) LintAsset(ctx context.Context, rootPath string, pipelineDefinit
 		}
 	}
 
+	// Resolve URI deps against every repo pipeline, not just the asset's own.
+	// Keep assetPipeline so the pointer-based issue match below still works.
+	crossPipelines := pipelines
+	if hasURIDeps && crossPipelineRootPath != "" && crossPipelineRootPath != rootPath {
+		repoPipelines, err := l.extractPipelinesFromPath(ctx, crossPipelineRootPath, pipelineDefinitionFileName)
+		if err != nil {
+			return nil, err
+		}
+
+		crossPipelines = make([]*pipeline.Pipeline, 0, len(repoPipelines))
+		crossPipelines = append(crossPipelines, assetPipeline)
+		for _, p := range repoPipelines {
+			if p.DefinitionFile.Path != assetPipeline.DefinitionFile.Path {
+				crossPipelines = append(crossPipelines, p)
+			}
+		}
+	}
+
 	// now the actual validation starts
 	for _, rule := range rules {
 		levels := rule.GetApplicableLevels()
 		if hasURIDeps && slices.Contains(levels, LevelCrossPipeline) {
 			// Cross-pipeline rules are only included when asset has URI dependencies
-			issues, err := rule.ValidateCrossPipeline(ctx, pipelines)
+			issues, err := rule.ValidateCrossPipeline(ctx, crossPipelines)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -480,7 +480,7 @@ func TestLinter_LintAsset(t *testing.T) {
 				logger:        logger.Sugar(),
 			}
 
-			_, err := l.LintAsset(ctx, tt.args.rootPath, tt.args.pipelineDefinitionFileName, "my-asset", nil)
+			_, err := l.LintAsset(ctx, tt.args.rootPath, tt.args.pipelineDefinitionFileName, "my-asset", nil, "")
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Equal(t, tt.errorMessage, err.Error())
@@ -614,7 +614,7 @@ func TestLinter_LintAsset_WithURIDependencies(t *testing.T) {
 				sqlParser: nil,
 			}
 
-			result, err := l.LintAsset(t.Context(), "some-root-path", []string{"pipeline.yml"}, "my-asset", nil)
+			result, err := l.LintAsset(t.Context(), "some-root-path", []string{"pipeline.yml"}, "my-asset", nil, "")
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			require.Len(t, result.Pipelines, 1)
@@ -639,6 +639,92 @@ func TestLinter_LintAsset_WithURIDependencies(t *testing.T) {
 			m.AssertExpectations(t)
 		})
 	}
+}
+
+func TestLinter_LintAsset_CrossPipelineURIResolvesAgainstRepoRoot(t *testing.T) {
+	t.Parallel()
+
+	// downstream asset depends on an upstream that lives in a *sibling* pipeline
+	// via a cross-pipeline URI.
+	downstreamAsset := &pipeline.Asset{
+		Name: "my-asset",
+		Upstreams: []pipeline.Upstream{
+			{Type: "uri", Value: "external://repro_seed/upstream_seed"},
+		},
+	}
+	downstreamPipeline := &pipeline.Pipeline{
+		Name:           "downstream",
+		Assets:         []*pipeline.Asset{downstreamAsset},
+		DefinitionFile: pipeline.DefinitionFile{Path: "repo/downstream/pipeline.yml"},
+	}
+
+	upstreamPipeline := &pipeline.Pipeline{
+		Name: "upstream",
+		Assets: []*pipeline.Asset{
+			{Name: "upstream_seed", URI: "external://repro_seed/upstream_seed"},
+		},
+		DefinitionFile: pipeline.DefinitionFile{Path: "repo/upstream/pipeline.yml"},
+	}
+
+	const (
+		downstreamRoot = "repo/downstream"
+		repoRoot       = "repo"
+	)
+
+	newLinter := func() *Linter {
+		m := new(mockPipelineBuilder)
+		m.On("CreatePipelineFromPath", mock.Anything, "repo/downstream", mock.FunctionalOptions(pipeline.WithMutate())).
+			Return(downstreamPipeline, nil)
+		m.On("CreatePipelineFromPath", mock.Anything, "repo/upstream", mock.FunctionalOptions(pipeline.WithMutate())).
+			Return(upstreamPipeline, nil)
+
+		return &Linter{
+			// The asset's own pipeline root only sees the downstream pipeline,
+			// whereas the repo root sees both pipelines.
+			findPipelines: func(root string, _ []string) ([]string, error) {
+				if root == repoRoot {
+					return []string{"repo/downstream", "repo/upstream"}, nil
+				}
+				return []string{"repo/downstream"}, nil
+			},
+			builder: m,
+			rules: []Rule{
+				&SimpleRule{
+					Identifier:             "cross-pipeline-uri-dependencies",
+					CrossPipelineValidator: ValidateCrossPipelineURIDependencies,
+					ApplicableLevels:       []Level{LevelCrossPipeline},
+				},
+			},
+			logger:    zap.NewNop().Sugar(),
+			sqlParser: nil,
+		}
+	}
+
+	countURIIssues := func(result *PipelineAnalysisResult) int {
+		count := 0
+		for _, p := range result.Pipelines {
+			for _, issues := range p.Issues {
+				count += len(issues)
+			}
+		}
+		return count
+	}
+
+	t.Run("scoped to the asset's pipeline the sibling URI is unresolved", func(t *testing.T) {
+		t.Parallel()
+		l := newLinter()
+		result, err := l.LintAsset(t.Context(), downstreamRoot, []string{"pipeline.yml"}, "my-asset", nil, "")
+		require.NoError(t, err)
+		require.Equal(t, 1, countURIIssues(result), "expected the cross-pipeline URI to look unresolved when scoped to a single pipeline")
+	})
+
+	t.Run("resolving against the repo root finds the sibling URI", func(t *testing.T) {
+		t.Parallel()
+		l := newLinter()
+		result, err := l.LintAsset(t.Context(), downstreamRoot, []string{"pipeline.yml"}, "my-asset", nil, repoRoot)
+		require.NoError(t, err)
+		require.Equal(t, 0, countURIIssues(result), "expected the cross-pipeline URI to resolve when validating against the repo root")
+	})
 }
 
 func TestPipelineAnalysisResult_ErrorCount(t *testing.T) {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -644,34 +644,36 @@ func TestLinter_LintAsset_WithURIDependencies(t *testing.T) {
 func TestLinter_LintAsset_CrossPipelineURIResolvesAgainstRepoRoot(t *testing.T) {
 	t.Parallel()
 
-	// downstream asset depends on an upstream that lives in a *sibling* pipeline
-	// via a cross-pipeline URI.
-	downstreamAsset := &pipeline.Asset{
-		Name: "my-asset",
-		Upstreams: []pipeline.Upstream{
-			{Type: "uri", Value: "external://repro_seed/upstream_seed"},
-		},
-	}
-	downstreamPipeline := &pipeline.Pipeline{
-		Name:           "downstream",
-		Assets:         []*pipeline.Asset{downstreamAsset},
-		DefinitionFile: pipeline.DefinitionFile{Path: "repo/downstream/pipeline.yml"},
-	}
-
-	upstreamPipeline := &pipeline.Pipeline{
-		Name: "upstream",
-		Assets: []*pipeline.Asset{
-			{Name: "upstream_seed", URI: "external://repro_seed/upstream_seed"},
-		},
-		DefinitionFile: pipeline.DefinitionFile{Path: "repo/upstream/pipeline.yml"},
-	}
-
 	const (
 		downstreamRoot = "repo/downstream"
 		repoRoot       = "repo"
 	)
 
-	newLinter := func() *Linter {
+	// newLinter builds a linter with fresh pipeline objects on every call so
+	// parallel subtests never share mutable pipeline state. When repoRootBroken
+	// is true, loading the wider repo root fails (e.g. a malformed sibling
+	// pipeline) while the asset's own pipeline root still resolves.
+	newLinter := func(repoRootBroken bool) *Linter {
+		// downstream asset depends on an upstream that lives in a *sibling*
+		// pipeline via a cross-pipeline URI.
+		downstreamPipeline := &pipeline.Pipeline{
+			Name: "downstream",
+			Assets: []*pipeline.Asset{
+				{
+					Name:      "my-asset",
+					Upstreams: []pipeline.Upstream{{Type: "uri", Value: "external://repro_seed/upstream_seed"}},
+				},
+			},
+			DefinitionFile: pipeline.DefinitionFile{Path: "repo/downstream/pipeline.yml"},
+		}
+		upstreamPipeline := &pipeline.Pipeline{
+			Name: "upstream",
+			Assets: []*pipeline.Asset{
+				{Name: "upstream_seed", URI: "external://repro_seed/upstream_seed"},
+			},
+			DefinitionFile: pipeline.DefinitionFile{Path: "repo/upstream/pipeline.yml"},
+		}
+
 		m := new(mockPipelineBuilder)
 		m.On("CreatePipelineFromPath", mock.Anything, "repo/downstream", mock.FunctionalOptions(pipeline.WithMutate())).
 			Return(downstreamPipeline, nil)
@@ -683,6 +685,9 @@ func TestLinter_LintAsset_CrossPipelineURIResolvesAgainstRepoRoot(t *testing.T) 
 			// whereas the repo root sees both pipelines.
 			findPipelines: func(root string, _ []string) ([]string, error) {
 				if root == repoRoot {
+					if repoRootBroken {
+						return nil, errors.New("nested pipelines found")
+					}
 					return []string{"repo/downstream", "repo/upstream"}, nil
 				}
 				return []string{"repo/downstream"}, nil
@@ -712,7 +717,7 @@ func TestLinter_LintAsset_CrossPipelineURIResolvesAgainstRepoRoot(t *testing.T) 
 
 	t.Run("scoped to the asset's pipeline the sibling URI is unresolved", func(t *testing.T) {
 		t.Parallel()
-		l := newLinter()
+		l := newLinter(false)
 		result, err := l.LintAsset(t.Context(), downstreamRoot, []string{"pipeline.yml"}, "my-asset", nil, "")
 		require.NoError(t, err)
 		require.Equal(t, 1, countURIIssues(result), "expected the cross-pipeline URI to look unresolved when scoped to a single pipeline")
@@ -720,10 +725,18 @@ func TestLinter_LintAsset_CrossPipelineURIResolvesAgainstRepoRoot(t *testing.T) 
 
 	t.Run("resolving against the repo root finds the sibling URI", func(t *testing.T) {
 		t.Parallel()
-		l := newLinter()
+		l := newLinter(false)
 		result, err := l.LintAsset(t.Context(), downstreamRoot, []string{"pipeline.yml"}, "my-asset", nil, repoRoot)
 		require.NoError(t, err)
 		require.Equal(t, 0, countURIIssues(result), "expected the cross-pipeline URI to resolve when validating against the repo root")
+	})
+
+	t.Run("a broken repo root falls back to the asset's pipeline instead of failing", func(t *testing.T) {
+		t.Parallel()
+		l := newLinter(true)
+		result, err := l.LintAsset(t.Context(), downstreamRoot, []string{"pipeline.yml"}, "my-asset", nil, repoRoot)
+		require.NoError(t, err, "a broken sibling pipeline must not fail an otherwise-valid asset validate")
+		require.Equal(t, 1, countURIIssues(result), "falling back to the asset's pipeline leaves the sibling URI unresolved")
 	})
 }
 


### PR DESCRIPTION
Validating a single asset with `bruin validate <asset>` only loaded that asset's own pipeline, so a cross-pipeline `external://` dependency pointing to an asset in a sibling pipeline always raised a false-positive `not found in any available pipeline` warning. `LintAsset` now accepts a wider root (the repo root, resolved via git in `cmd/lint.go`) and builds the URI availability set from every pipeline in the repo, while keeping the asset's own pipeline object so pointer-based issue matching still works. Behavior is unchanged for full-repo validation, and genuinely missing URIs still warn. Verified against a real repro project: the warning disappears for valid sibling-pipeline URIs and persists for non-existent ones. Added `TestLinter_LintAsset_CrossPipelineURIResolvesAgainstRepoRoot` covering both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)