### PR TITLE
feat(ingestr): mask known credentials in debug output during cloud runs

### DIFF
--- a/pkg/ingestr/debug_mask.go
+++ b/pkg/ingestr/debug_mask.go
@@ -1,0 +1,99 @@
+package ingestr
+
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+// sensitiveQueryParams is the set of URI query-parameter names whose values
+// must be redacted from ingestr debug output during cloud runs. Names are
+// matched case-insensitively, after normalising underscores and hyphens.
+var sensitiveQueryParams = map[string]struct{}{
+	"apikey":               {},
+	"accesskey":            {},
+	"secretkey":            {},
+	"clientsecret":         {},
+	"password":             {},
+	"passwd":               {},
+	"pwd":                  {},
+	"secret":               {},
+	"token":                {},
+	"accesstoken":          {},
+	"refreshtoken":         {},
+	"idtoken":              {},
+	"bearer":               {},
+	"auth":                 {},
+	"authorization":        {},
+	"signature":            {},
+	"sig":                  {},
+	"xamzsignature":        {},
+	"xgoogsignature":       {},
+	"privatekey":           {},
+	"credentialsbase64":    {},
+	"credentialsjson":      {},
+	"awsaccesskeyid":       {},
+	"awssecretaccesskey":   {},
+}
+
+// isCloudRun returns true when bruin is running under the orchestrator
+// (BRUIN_RUN_ID is injected per cloud invocation). Local users never set
+// this, so local --debug runs stay unredacted.
+func isCloudRun() bool {
+	return os.Getenv("BRUIN_RUN_ID") != ""
+}
+
+// normaliseParamName strips characters that vary between equivalent param
+// names ("api_key", "api-key", "ApiKey" → "apikey").
+func normaliseParamName(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "_", "")
+	s = strings.ReplaceAll(s, "-", "")
+	return s
+}
+
+// collectURISecrets extracts the values that should be redacted in debug
+// output produced by a process given this URI. Currently: the password
+// component of userinfo, plus the values of known sensitive query
+// parameters. Unparseable URIs return nil.
+func collectURISecrets(uri string) []string {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil
+	}
+
+	var secrets []string
+	if parsed.User != nil {
+		if pwd, ok := parsed.User.Password(); ok && pwd != "" {
+			secrets = append(secrets, pwd)
+		}
+	}
+	for name, values := range parsed.Query() {
+		if _, sensitive := sensitiveQueryParams[normaliseParamName(name)]; !sensitive {
+			continue
+		}
+		for _, v := range values {
+			if v != "" {
+				secrets = append(secrets, v)
+			}
+		}
+	}
+	return secrets
+}
+
+// appendDebugMaskFlags appends one "--debug-mask <value>" pair per secret
+// extracted from the provided URIs. Caller is responsible for gating the
+// call on cloud-mode + debug-mode.
+func appendDebugMaskFlags(args []string, uris ...string) []string {
+	seen := make(map[string]struct{})
+	for _, uri := range uris {
+		for _, secret := range collectURISecrets(uri) {
+			if _, dup := seen[secret]; dup {
+				continue
+			}
+			seen[secret] = struct{}{}
+			args = append(args, "--debug-mask", secret)
+		}
+	}
+	return args
+}

--- a/pkg/ingestr/debug_mask_test.go
+++ b/pkg/ingestr/debug_mask_test.go
@@ -1,0 +1,93 @@
+package ingestr
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCollectURISecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want []string
+	}{
+		{
+			name: "postgres with password and sensitive query param",
+			uri:  "postgres://myuser:supersecretpass@db.example.com:5432/mydb?sslmode=require&api_key=sk_live_abc123",
+			want: []string{"supersecretpass", "sk_live_abc123"},
+		},
+		{
+			name: "bigquery credentials_base64",
+			uri:  "bigquery://my-project/dataset?credentials_base64=ZmFrZWNyZWRzMTIz",
+			want: []string{"ZmFrZWNyZWRzMTIz"},
+		},
+		{
+			name: "presigned s3 url",
+			uri:  "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123def456&X-Amz-Expires=3600",
+			want: []string{"abc123def456"},
+		},
+		{
+			name: "underscore vs hyphen vs case insensitivity",
+			uri:  "https://api.example.com/v1?API_KEY=v1&access-token=v2&ClientSecret=v3",
+			want: []string{"v1", "v2", "v3"},
+		},
+		{
+			name: "no secrets",
+			uri:  "duckdb:///path/to/db.duckdb",
+			want: nil,
+		},
+		{
+			name: "unparseable",
+			uri:  "::::not a uri::::",
+			want: nil,
+		},
+		{
+			name: "harmless params untouched",
+			uri:  "https://api.example.com/v1/users?limit=10&offset=20",
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectURISecrets(tc.uri)
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestAppendDebugMaskFlags_DeduplicatesAcrossURIs(t *testing.T) {
+	got := appendDebugMaskFlags(
+		nil,
+		"postgres://u:pw_shared_secret@a.example.com/db",
+		"postgres://u:pw_shared_secret@b.example.com/db",
+	)
+	want := []string{"--debug-mask", "pw_shared_secret"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestAppendDebugMaskFlags_EmptyURIs(t *testing.T) {
+	got := appendDebugMaskFlags([]string{"--debug"}, "", "")
+	want := []string{"--debug"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected unchanged args, got %v", got)
+	}
+}
+
+func TestIsCloudRun(t *testing.T) {
+	t.Setenv("BRUIN_RUN_ID", "")
+	if isCloudRun() {
+		t.Error("expected false when BRUIN_RUN_ID unset")
+	}
+	t.Setenv("BRUIN_RUN_ID", "run_abc")
+	if !isCloudRun() {
+		t.Error("expected true when BRUIN_RUN_ID set")
+	}
+}

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -326,6 +326,9 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 
 	if executor.IsDebugMode(ctx) {
 		baseArgs = append(baseArgs, "--debug")
+		if isCloudRun() {
+			baseArgs = appendDebugMaskFlags(baseArgs, sourceURI, destURI)
+		}
 	}
 
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
@@ -522,6 +525,9 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 
 	if executor.IsDebugMode(ctx) {
 		baseArgs = append(baseArgs, "--debug")
+		if isCloudRun() {
+			baseArgs = appendDebugMaskFlags(baseArgs, sourceURI, destURI)
+		}
 	}
 
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{

--- a/pkg/python/command_runner.go
+++ b/pkg/python/command_runner.go
@@ -29,12 +29,27 @@ type CommandInstance struct {
 
 type CommandRunner struct{}
 
+// redactArgsForLog joins args for debug printing, replacing any value
+// previously declared as a --debug-mask secret with ***. This prevents
+// bruin's own command_runner debug line from leaking credentials it is
+// asking ingestr to mask. Local runs that pass no --debug-mask flags are
+// unaffected.
+func redactArgsForLog(args []string) string {
+	joined := strings.Join(args, " ")
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--debug-mask" && args[i+1] != "" {
+			joined = strings.ReplaceAll(joined, args[i+1], "***")
+		}
+	}
+	return joined
+}
+
 func (l *CommandRunner) Run(ctx context.Context, repo *git.Repo, command *CommandInstance) error {
 	log := ctx.Value(executor.ContextLogger).(logger.Logger)
 	log.Debugf(
 		"%s %s",
 		command.Name,
-		strings.Join(command.Args, " "),
+		redactArgsForLog(command.Args),
 	)
 
 	cmd := exec.CommandContext(context.Background(), command.Name, command.Args...) //nolint:gosec,contextcheck

--- a/pkg/python/command_runner_test.go
+++ b/pkg/python/command_runner_test.go
@@ -1,0 +1,48 @@
+package python
+
+import "testing"
+
+func TestRedactArgsForLog(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "no debug-mask flags leaves args untouched",
+			args: []string{"ingest", "--source-uri", "duckdb:///x.db", "--yes"},
+			want: "ingest --source-uri duckdb:///x.db --yes",
+		},
+		{
+			name: "single debug-mask redacts everywhere",
+			args: []string{
+				"ingest",
+				"--source-uri", "postgres://u:SuperSecretPass987@h/d",
+				"--debug-mask", "SuperSecretPass987",
+			},
+			want: "ingest --source-uri postgres://u:***@h/d --debug-mask ***",
+		},
+		{
+			name: "multiple debug-masks each redacted",
+			args: []string{
+				"ingest",
+				"--source-uri", "https://api.example.com/v1?api_key=abcdef12345678&token=zzz_yyy_xxx",
+				"--debug-mask", "abcdef12345678",
+				"--debug-mask", "zzz_yyy_xxx",
+			},
+			want: "ingest --source-uri https://api.example.com/v1?api_key=***&token=*** --debug-mask *** --debug-mask ***",
+		},
+		{
+			name: "trailing --debug-mask without value ignored",
+			args: []string{"ingest", "--debug-mask"},
+			want: "ingest --debug-mask",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactArgsForLog(tc.args); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When bruin is invoked under the orchestrator (`BRUIN_RUN_ID` env set) with `--debug`, secrets extracted from source and destination URIs are now passed to ingestr as repeated `--debug-mask` flags. Ingestr replaces every occurrence with `***` before printing, so debug logs uploaded to S3 no longer contain credentials.

The same secret set is also used to redact bruin's own `command_runner.go` debug line, which previously leaked the full URI (including userinfo password) into its own logger output.

**Local runs (no `BRUIN_RUN_ID`)** are unaffected and see raw debug output — the user owns the credentials they pass, masking would just make debugging harder.

## Verified behaviour

| Mode | bruin's `command_runner` debug line | ingestr's debug output |
|---|---|---|
| Local (no `BRUIN_RUN_ID`) | `postgresql://pguser:SuperSecretPass987@…` | Raw |
| Cloud (`BRUIN_RUN_ID=…`) | `postgresql://pguser:***@…  …  --debug-mask ***` | Will be masked once ingestr-side PR ships |

## Secret extraction (`pkg/ingestr/debug_mask.go`)

For each URI we collect:
- **userinfo password** via `net/url` parsing
- **values of known sensitive query parameters**: `api_key`, `token`, `secret`, `signature`, `credentials_base64`, `aws_*_key*`, `X-Amz-Signature`, etc. Matched case-insensitively after stripping underscores and hyphens, so `api_key`, `API-KEY`, and `ApiKey` all match.

The `--debug-mask` flag is appended only when **both** `executor.IsDebugMode(ctx)` and `isCloudRun()` are true. `isCloudRun()` checks `BRUIN_RUN_ID`, the env var already used elsewhere in bruin (`cmd/helpers.go:139`, `cmd/lint.go:125`) to distinguish orchestrator-driven runs from local.

## Bruin-side leak fix (`pkg/python/command_runner.go`)

`redactArgsForLog` scans the arg list for `--debug-mask <value>` pairs and replaces each value with `***` in the joined string used for the debug log line. So bruin's own logger no longer leaks what ingestr is about to mask.

## Tests

- `pkg/ingestr/debug_mask_test.go` — URI parsing covers postgres/userinfo, BigQuery credentials_base64, presigned S3 URLs, multiple naming conventions for the same secret, dedup across multiple URIs, env-driven cloud-mode toggle
- `pkg/python/command_runner_test.go` — `redactArgsForLog` covers no-mask noop, single-mask redaction in both URI and `--debug-mask` arg, multiple-mask, malformed trailing `--debug-mask`

## End-to-end verification

Built bruin locally and ran an asset whose source is a postgres connection with password `SuperSecretPass987`:

```
# Cloud run
$ BRUIN_RUN_ID=test_run_123 bruin run --debug …
DEBUG  python/command_runner.go:49  uv tool run … ingestr ingest \
  --source-uri postgresql://pguser:***@db.example.invalid:5432/mydb?sslmode=require … \
  --debug --debug-mask *** …

# Local run
$ bruin run --debug …
DEBUG  python/command_runner.go:49  uv tool run … ingestr ingest \
  --source-uri postgresql://pguser:SuperSecretPass987@db.example.invalid:5432/mydb?sslmode=require … \
  --debug …
```

## Stacked on

This PR depends on bruin/pull/2138 (which adds `--debug` forwarding and `executor.IsDebugMode`). It targets that branch so the diff shown is just the masking change. When #2138 merges, GitHub will retarget this PR to `main`.

It also depends on **ingestr/pull/751** for the `--debug-mask` flag to do anything inside ingestr. Until that ships in a new ingestr release, this PR's effect is limited to redacting bruin's own `command_runner` debug line. Both halves together close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)