### PR TITLE
fix(ingestr): preserve declared integer width and no-tz timestamps 

### DIFF
--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -247,7 +247,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 					{Name: "DateOfBirth", Type: "integer"},
 				},
 			},
-			want: []string{"ingest", "--source-uri", "duckdb:////some/path", "--source-table", "source-table", "--dest-uri", "bigquery://uri-here", "--dest-table", "asset-name", "--yes", "--progress", "log", "--columns", "id:bigint,name:text,DateOfBirth:bigint"},
+			want: []string{"ingest", "--source-uri", "duckdb:////some/path", "--source-table", "source-table", "--dest-uri", "bigquery://uri-here", "--dest-table", "asset-name", "--yes", "--progress", "log", "--columns", "id:int,name:text,DateOfBirth:int"},
 		},
 		{
 			name: "duck db dest, basic scenario",
@@ -588,7 +588,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				"--progress",
 				"log",
 				"--columns",
-				"id:bigint,load_date:timestamp,percent:double",
+				"id:int,load_date:timestamp,percent:double",
 			},
 		},
 		{

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -12,36 +12,44 @@ import (
 // TypeHintMapping maps different destination types to dlt types.
 // 'text' mappings are omitted, since they are the default.
 var TypeHintMapping = map[string]string{
-	// Integer types
-	"int":         "bigint",
-	"integer":     "bigint",
-	"bigint":      "bigint",
-	"smallint":    "bigint",
-	"tinyint":     "bigint",
-	"byteint":     "bigint",
-	"mediumint":   "bigint", // MySQL
-	"int2":        "bigint", // PostgreSQL alias
-	"int4":        "bigint", // PostgreSQL alias
-	"int8":        "bigint", // PostgreSQL alias
-	"int16":       "bigint", // ClickHouse
-	"int32":       "bigint", // ClickHouse
-	"int64":       "bigint", // ClickHouse
-	"int128":      "bigint", // ClickHouse
-	"int256":      "bigint", // ClickHouse
-	"uint8":       "bigint", // ClickHouse
-	"uint16":      "bigint", // ClickHouse
-	"uint32":      "bigint", // ClickHouse
-	"uint64":      "bigint", // ClickHouse
-	"uint128":     "bigint", // ClickHouse
-	"uint256":     "bigint", // ClickHouse
-	"serial":      "bigint", // PostgreSQL auto-increment
-	"bigserial":   "bigint", // PostgreSQL auto-increment
-	"smallserial": "bigint", // PostgreSQL auto-increment
-	"serial2":     "bigint", // PostgreSQL alias
-	"serial4":     "bigint", // PostgreSQL alias
-	"serial8":     "bigint", // PostgreSQL alias
-	"long":        "bigint", // Generic
-	"short":       "bigint", // Generic
+	// Integer types — mapped to the narrowest ingestr type that preserves the
+	// declared width, so a column the source detected as Int16/Int32 is not
+	// silently widened to Int64.
+	// 8-bit (-> Int16 in ingestr; ingestr has no Int8 type)
+	"tinyint": "tinyint",
+	"byte":    "tinyint", // Spark/Databricks ByteType (-128..127)
+	"uint8":   "tinyint", // ClickHouse (0..255)
+	// 16-bit
+	"smallint":    "smallint",
+	"int2":        "smallint", // PostgreSQL alias
+	"int16":       "smallint", // ClickHouse
+	"smallserial": "smallint", // PostgreSQL auto-increment
+	"serial2":     "smallint", // PostgreSQL alias
+	"short":       "smallint", // Generic
+	// 32-bit
+	"int":       "int",
+	"integer":   "int",
+	"int4":      "int", // PostgreSQL alias
+	"int32":     "int", // ClickHouse
+	"mediumint": "int", // MySQL (24-bit, fits Int32)
+	"serial":    "int", // PostgreSQL auto-increment
+	"serial4":   "int", // PostgreSQL alias
+	"uint16":    "int", // ClickHouse (0..65535, exceeds Int16)
+	"year":      "int", // MySQL
+	// 64-bit (and wider types clamped to Int64, the widest ingestr offers)
+	"bigint":    "bigint",
+	"int8":      "bigint", // PostgreSQL alias
+	"int64":     "bigint", // ClickHouse
+	"int128":    "bigint", // ClickHouse (no wider ingestr type)
+	"int256":    "bigint", // ClickHouse (no wider ingestr type)
+	"uint32":    "bigint", // ClickHouse (0..4.3B, exceeds Int32)
+	"uint64":    "bigint", // ClickHouse (best-effort; may exceed Int64)
+	"uint128":   "bigint", // ClickHouse
+	"uint256":   "bigint", // ClickHouse
+	"bigserial": "bigint", // PostgreSQL auto-increment
+	"serial8":   "bigint", // PostgreSQL alias
+	"long":      "bigint", // Generic
+	"byteint":   "bigint", // Snowflake (synonym for NUMBER(38,0))
 
 	// Floating point types
 	"float":            "double",
@@ -56,11 +64,11 @@ var TypeHintMapping = map[string]string{
 	// Decimal/Numeric types (with precision and scale)
 	"decimal":    "decimal",
 	"numeric":    "decimal",
-	"number":     "decimal",    // Oracle/Snowflake
-	"dec":        "decimal",    // Alias for decimal
-	"money":      "decimal",    // SQL Server/PostgreSQL
-	"smallmoney": "decimal",    // SQL Server
-	"bigdecimal": "bigdecimal", // High precision decimal (76,76) for BigQuery
+	"number":     "decimal", // Oracle/Snowflake
+	"dec":        "decimal", // Alias for decimal
+	"money":      "decimal", // SQL Server/PostgreSQL
+	"smallmoney": "decimal", // SQL Server
+	"bigdecimal": "decimal", // High precision decimal for BigQuery (ingestr has no separate bigdecimal type)
 
 	// Binary types
 	"binary":      "binary",
@@ -91,20 +99,23 @@ var TypeHintMapping = map[string]string{
 	"time without time zone": "time",
 	"timetz":                 "time", // PostgreSQL
 
-	// Timestamp/Datetime types
+	// Timestamp/Datetime types.
+	// ingestr maps "timestamp" to a timezone-aware type and "timestamp_ntz" to a
+	// naive (no time zone) type, so types that are unambiguously without a time
+	// zone are emitted as "timestamp_ntz" to avoid silently promoting them.
 	"datetime":                    "timestamp",
 	"timestamp":                   "timestamp",
-	"timestamp_ltz":               "timestamp", // Snowflake
-	"timestamp_ntz":               "timestamp", // Snowflake
-	"timestamp_tz":                "timestamp", // Snowflake
-	"timestamptz":                 "timestamp", // PostgreSQL
-	"timestamp with time zone":    "timestamp", // PostgreSQL/Standard SQL
-	"timestamp without time zone": "timestamp", // PostgreSQL/Standard SQL
-	"datetime2":                   "timestamp", // SQL Server
-	"datetimeoffset":              "timestamp", // SQL Server
-	"smalldatetime":               "timestamp", // SQL Server
-	"datetime64":                  "timestamp", // ClickHouse
-	"interval":                    "timestamp", // PostgreSQL (time interval)
+	"timestamp_ltz":               "timestamp",     // Snowflake (tz-aware local)
+	"timestamp_ntz":               "timestamp_ntz", // Snowflake (no time zone)
+	"timestamp_tz":                "timestamp",     // Snowflake
+	"timestamptz":                 "timestamp",     // PostgreSQL
+	"timestamp with time zone":    "timestamp",     // PostgreSQL/Standard SQL
+	"timestamp without time zone": "timestamp_ntz", // PostgreSQL/Standard SQL (no time zone)
+	"datetime2":                   "timestamp_ntz", // SQL Server (no time zone)
+	"datetimeoffset":              "timestamp",     // SQL Server (has offset)
+	"smalldatetime":               "timestamp_ntz", // SQL Server (no time zone)
+	"datetime64":                  "timestamp",     // ClickHouse
+	"interval":                    "interval",      // PostgreSQL (time interval)
 
 	// String/Text types
 	"string":            "text",
@@ -199,12 +210,8 @@ var TypeHintMapping = map[string]string{
 	"pg_lsn":   "text",
 
 	// Databricks/Spark types
-	"byte":             "bigint",
 	"void":             "text",
 	"calendarinterval": "text",
-
-	// Year type (MySQL)
-	"year": "bigint",
 }
 
 var multipleSpacePattern = regexp.MustCompile(`\s+`)

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -74,7 +74,7 @@ func TestColumnHints(t *testing.T) {
 				{Name: "created_at", Type: "timestamp"},
 			},
 			normalizeNames: false,
-			expected:       "id:bigint,name:text,created_at:timestamp",
+			expected:       "id:int,name:text,created_at:timestamp",
 		},
 		{
 			name: "column hints with name normalization",
@@ -99,7 +99,7 @@ func TestColumnHints(t *testing.T) {
 				{Name: "name", Type: "string"},
 			},
 			normalizeNames: false,
-			expected:       "id:bigint,name:text",
+			expected:       "id:int,name:text",
 		},
 		{
 			name: "source_column adds dest:type:source triple",
@@ -109,7 +109,7 @@ func TestColumnHints(t *testing.T) {
 				{Name: "created_at", Type: "timestamp"},
 			},
 			normalizeNames: false,
-			expected:       "id:bigint:sourceid,email:text:eml,created_at:timestamp",
+			expected:       "id:int:sourceid,email:text:eml,created_at:timestamp",
 		},
 		{
 			name: "source_column with name normalization normalizes dest name",
@@ -128,6 +128,52 @@ func TestColumnHints(t *testing.T) {
 			},
 			normalizeNames: false,
 			expected:       "first_name::fname,email:text:eml,weird::wrd",
+		},
+		{
+			name: "integer widths are preserved, not collapsed to bigint",
+			columns: []pipeline.Column{
+				{Name: "tiny", Type: "TINYINT"},
+				{Name: "small", Type: "SMALLINT"},
+				{Name: "regular", Type: "INT"},
+				{Name: "regular2", Type: "INTEGER"},
+				{Name: "big", Type: "BIGINT"},
+			},
+			normalizeNames: false,
+			expected:       "tiny:tinyint,small:smallint,regular:int,regular2:int,big:bigint",
+		},
+		{
+			name: "platform integer aliases map to the right width",
+			columns: []pipeline.Column{
+				{Name: "pg_small", Type: "int2"},
+				{Name: "pg_int", Type: "int4"},
+				{Name: "pg_big", Type: "int8"},
+				{Name: "ch_unsigned", Type: "uint16"},
+				{Name: "spark_byte", Type: "byte"},
+				{Name: "mysql_year", Type: "year"},
+			},
+			normalizeNames: false,
+			expected:       "pg_small:smallint,pg_int:int,pg_big:bigint,ch_unsigned:int,spark_byte:tinyint,mysql_year:int",
+		},
+		{
+			name: "no-tz timestamps map to timestamp_ntz while tz-aware stay timestamp",
+			columns: []pipeline.Column{
+				{Name: "naive", Type: "DATETIME2"},
+				{Name: "naive_ntz", Type: "timestamp_ntz"},
+				{Name: "small_dt", Type: "smalldatetime"},
+				{Name: "aware", Type: "timestamp"},
+				{Name: "aware_tz", Type: "timestamptz"},
+			},
+			normalizeNames: false,
+			expected:       "naive:timestamp_ntz,naive_ntz:timestamp_ntz,small_dt:timestamp_ntz,aware:timestamp,aware_tz:timestamp",
+		},
+		{
+			name: "interval and bigdecimal map to valid ingestr types",
+			columns: []pipeline.Column{
+				{Name: "span", Type: "interval"},
+				{Name: "huge", Type: "bigdecimal"},
+			},
+			normalizeNames: false,
+			expected:       "span:interval,huge:decimal",
 		},
 	}
 
@@ -316,7 +362,7 @@ func TestConsolidatedParameters_SourceColumn(t *testing.T) {
 				break
 			}
 		}
-		assert.Equal(t, "id:bigint:sourceid,email:text:eml", columnsValue)
+		assert.Equal(t, "id:int:sourceid,email:text:eml", columnsValue)
 	})
 
 	t.Run("source_column without enforce_schema does not emit --columns", func(t *testing.T) {

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -43,7 +43,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.24"
+	IngestrVersionV1 = "1.0.26"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION

TypeHintMapping collapsed every integer width to bigint, so ingestr widened source-detected Int16/Int32 columns up to Int64 (e.g. MSSQL SMALLINT/TINYINT -> Int64, INT -> Int32 lost). It also emitted "timestamp" for naive datetimes, which ingestr maps to a tz-aware type.

- Map integers to the narrowest ingestr type that preserves declared width: tinyint/smallint/int/bigint (per platform alias).
- Route unambiguously naive timestamps (datetime2, smalldatetime, timestamp_ntz, timestamp without time zone) to timestamp_ntz; leave tz-aware and ambiguous types as timestamp.
- Fix interval -> interval (was timestamp) and bigdecimal -> decimal (bigdecimal is not in ingestr's vocabulary and aborted ingestion).
- Update and extend ColumnHints unit tests.