### PR TITLE
feat(run): support interactive Python log output with carriage returns (BRU-4241)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1159,6 +1159,18 @@ func Run(isDebug *bool) *cli.Command {
 				runConfig.Output != "json" &&
 				!noColor
 
+			// Pass Python/child process output through verbatim (preserving carriage
+			// returns, no timestamp/task prefix) so progress bars like tqdm render in
+			// place. Only safe with a single sequential worker writing to a real
+			// terminal: with multiple workers or a log file the interleaved \r output
+			// would be unreadable. Detect the terminal here, before logOutput swaps
+			// os.Stdout for the tee writer below.
+			interactivePythonLogs := term.IsTerminal(int(os.Stdout.Fd())) && //nolint:gosec // G115: safe uintptr->int for terminal check
+				c.Int("workers") == 1 &&
+				!useTUI &&
+				runConfig.Output != "json" &&
+				!noColor
+
 			// Save the real terminal fd BEFORE logOutput replaces os.Stdout
 			var realTerminal *os.File
 			if useTUI {
@@ -1287,10 +1299,11 @@ func Run(isDebug *bool) *cli.Command {
 				return cli.Exit("", 1)
 			}
 			formatOpts := executor.FormattingOptions{
-				DoNotLogTimestamp: c.Bool("no-timestamp"),
-				DoNotLogTaskName:  preview.RunningForAnAsset,
-				NoColor:           noColor,
-				MinimalLogs:       minimalLogs,
+				DoNotLogTimestamp:     c.Bool("no-timestamp"),
+				DoNotLogTaskName:      preview.RunningForAnAsset,
+				NoColor:               noColor,
+				MinimalLogs:           minimalLogs,
+				InteractivePythonLogs: interactivePythonLogs,
 			}
 
 			// Create a context with timeout

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1153,23 +1153,28 @@ func Run(isDebug *bool) *cli.Command {
 			noColor := c.Bool("no-color")
 			minimalLogs := c.Bool("minimal-logs")
 
-			// Use the interactive TUI only when explicitly requested via --interactive flag
-			useTUI := c.Bool("interactive") &&
-				term.IsTerminal(int(os.Stdout.Fd())) && //nolint:gosec // G115: safe uintptr->int for terminal check
+			// Detect the real terminal here, before logOutput swaps os.Stdout for
+			// the tee writer below. Both interactive features below require a real
+			// terminal with colored, non-JSON output.
+			interactiveTerminal := term.IsTerminal(int(os.Stdout.Fd())) && //nolint:gosec // G115: safe uintptr->int for terminal check
 				runConfig.Output != "json" &&
 				!noColor
 
+			// Use the interactive TUI only when explicitly requested via --interactive flag
+			useTUI := c.Bool("interactive") && interactiveTerminal
+
 			// Pass Python/child process output through verbatim (preserving carriage
 			// returns, no timestamp/task prefix) so progress bars like tqdm render in
-			// place. Only safe with a single sequential worker writing to a real
-			// terminal: with multiple workers or a log file the interleaved \r output
-			// would be unreadable. Detect the terminal here, before logOutput swaps
-			// os.Stdout for the tee writer below.
-			interactivePythonLogs := term.IsTerminal(int(os.Stdout.Fd())) && //nolint:gosec // G115: safe uintptr->int for terminal check
+			// place. Only safe with a single sequential worker writing straight to a
+			// real terminal: with multiple workers the interleaved \r output would be
+			// unreadable, and with a log file the raw \r bytes pollute the log (the
+			// worker writes to the os.Stdout tee that logOutput installs below, and
+			// Clean() strips ANSI escapes but not carriage returns). So this is gated
+			// on !runConfig.NoLogFile to ensure os.Stdout is still the bare terminal.
+			interactivePythonLogs := interactiveTerminal &&
 				c.Int("workers") == 1 &&
 				!useTUI &&
-				runConfig.Output != "json" &&
-				!noColor
+				runConfig.NoLogFile
 
 			// Save the real terminal fd BEFORE logOutput replaces os.Stdout
 			var realTerminal *os.File

--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -58,6 +58,12 @@ type FormattingOptions struct {
 	LogOnlyWriter     io.Writer                                          // in TUI mode, worker output goes here (log file) instead of os.Stdout
 	OnTaskStart       func(scheduler.TaskInstance)                       // called when worker begins executing a task
 	OnTaskEnd         func(scheduler.TaskInstance, error, time.Duration) // called when worker finishes a task
+
+	// InteractivePythonLogs passes child process stdout/stderr through verbatim
+	// (preserving carriage returns, without the timestamp/task-name/">> " prefix)
+	// so progress bars like tqdm can update in place. Only safe for a single
+	// sequential worker writing to a real terminal.
+	InteractivePythonLogs bool
 }
 
 type Concurrent struct {
@@ -185,6 +191,7 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 			sprintfFunc:       w.printer.SprintfFunc(),
 			DoNotLogTimestamp: w.formatOpts.DoNotLogTimestamp,
 			DoNotLogTaskName:  w.formatOpts.DoNotLogTaskName,
+			Passthrough:       w.formatOpts.InteractivePythonLogs,
 		}
 
 		executionCtx := context.WithValue(ctx, KeyPrinter, printer)
@@ -247,9 +254,21 @@ type workerWriter struct {
 	sprintfFunc       func(format string, a ...interface{}) string
 	DoNotLogTimestamp bool
 	DoNotLogTaskName  bool
+	Passthrough       bool
+}
+
+// IsPassthrough reports whether this writer forwards child output verbatim.
+// consumePipe uses this to skip line buffering and the ">> " prefix so
+// carriage-return based progress bars render correctly.
+func (w *workerWriter) IsPassthrough() bool {
+	return w.Passthrough
 }
 
 func (w *workerWriter) Write(p []byte) (int, error) {
+	if w.Passthrough {
+		return w.w.Write(p)
+	}
+
 	var formatted string
 	timestampStr := whitePrinter("[%s]", time.Now().Format(timeFormat))
 

--- a/pkg/executor/concurrent_test.go
+++ b/pkg/executor/concurrent_test.go
@@ -178,6 +178,32 @@ func TestWorkerWriter_Write(t *testing.T) {
 	}
 }
 
+func TestWorkerWriter_Write_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	task := &pipeline.Asset{Name: "test-task"}
+
+	// In passthrough mode the writer forwards bytes verbatim: no timestamp,
+	// no task name, no ">> " prefix, and carriage returns are preserved so
+	// progress bars render in place.
+	input := []byte("\r 50%|#####     | 50/100")
+
+	var buf bytes.Buffer
+	w := &workerWriter{
+		w:           &buf,
+		task:        task,
+		sprintfFunc: fmt.Sprintf,
+		Passthrough: true,
+	}
+
+	n, err := w.Write(input)
+
+	require.NoError(t, err)
+	assert.Equal(t, len(input), n)
+	assert.Equal(t, string(input), buf.String())
+	assert.True(t, w.IsPassthrough())
+}
+
 func TestWorkerWriter_Write_WriteError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/python/command_runner.go
+++ b/pkg/python/command_runner.go
@@ -99,11 +99,19 @@ func (l *CommandRunner) RunAnyCommand(ctx context.Context, cmd *exec.Cmd) error 
 		return errors.Wrap(err, "failed to get stdout")
 	}
 
+	// When the output writer opts into passthrough (interactive terminal, single
+	// sequential worker), forward child output verbatim so carriage-return based
+	// progress bars (tqdm, etc.) can update in place.
+	passthrough := false
+	if pt, ok := output.(interface{ IsPassthrough() bool }); ok {
+		passthrough = pt.IsPassthrough()
+	}
+
 	// Start reading from pipes in goroutines before starting the command
 	// This prevents deadlock if the command generates a lot of output.
 	wg := new(errgroup.Group)
-	wg.Go(func() error { return consumePipe(stdout, output) })
-	wg.Go(func() error { return consumePipe(stderr, output) })
+	wg.Go(func() error { return consumePipe(stdout, output, passthrough) })
+	wg.Go(func() error { return consumePipe(stderr, output, passthrough) })
 
 	err = cmd.Start()
 	if err != nil {
@@ -130,7 +138,18 @@ func (l *CommandRunner) RunAnyCommand(ctx context.Context, cmd *exec.Cmd) error 
 	return nil
 }
 
-func consumePipe(pipe io.Reader, output io.Writer) error {
+func consumePipe(pipe io.Reader, output io.Writer, passthrough bool) error {
+	// In passthrough mode forward the raw byte stream untouched so carriage
+	// returns survive and progress bars render in place. No ">> " prefix is
+	// added; the writer is responsible for any formatting (none, in this case).
+	if passthrough {
+		_, err := io.Copy(output, pipe)
+		if err != nil && !stderrors.Is(err, io.EOF) {
+			return err
+		}
+		return nil
+	}
+
 	// Use bufio.Reader.ReadLine() instead of Scanner to handle unlimited line lengths.
 	reader := bufio.NewReaderSize(pipe, 64*1024) // 64KB buffer for efficient reading
 

--- a/pkg/python/command_runner.go
+++ b/pkg/python/command_runner.go
@@ -143,11 +143,9 @@ func consumePipe(pipe io.Reader, output io.Writer, passthrough bool) error {
 	// returns survive and progress bars render in place. No ">> " prefix is
 	// added; the writer is responsible for any formatting (none, in this case).
 	if passthrough {
+		// io.Copy returns nil on a clean EOF, so its error can be returned as-is.
 		_, err := io.Copy(output, pipe)
-		if err != nil && !stderrors.Is(err, io.EOF) {
-			return err
-		}
-		return nil
+		return err
 	}
 
 	// Use bufio.Reader.ReadLine() instead of Scanner to handle unlimited line lengths.

--- a/pkg/python/command_runner_test.go
+++ b/pkg/python/command_runner_test.go
@@ -1,0 +1,105 @@
+package python
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumePipe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		passthrough bool
+		expected    string
+	}{
+		{
+			name:     "simple newline gets prefix",
+			input:    "hello world\n",
+			expected: ">> hello world\n",
+		},
+		{
+			name:     "multiple lines each get prefix",
+			input:    "line1\nline2\n",
+			expected: ">> line1\n>> line2\n",
+		},
+		{
+			name:     "no trailing newline still flushes",
+			input:    "hello",
+			expected: ">> hello\n",
+		},
+		{
+			name:     "windows line endings collapse to newline",
+			input:    "hello\r\nworld\r\n",
+			expected: ">> hello\n>> world\n",
+		},
+		{
+			name:     "empty input produces nothing",
+			input:    "",
+			expected: "",
+		},
+		{
+			// Without passthrough, ReadLine only strips the carriage return
+			// directly before a newline; interior \r are kept but the whole
+			// thing is wrapped as one prefixed line ending in \n. The terminal
+			// never gets a chance to redraw progressively, which is why bars
+			// appear stalled until completion. This documents existing behavior.
+			name:     "carriage returns wrapped as single prefixed line without passthrough",
+			input:    "progress 0%\rprogress 50%\rprogress 100%\n",
+			expected: ">> progress 0%\rprogress 50%\rprogress 100%\n",
+		},
+		{
+			// A trailing \r before \n is stripped by ReadLine.
+			name:     "trailing carriage return before newline is stripped",
+			input:    "progress 100%\r\n",
+			expected: ">> progress 100%\n",
+		},
+		{
+			name:        "passthrough preserves bytes verbatim",
+			input:       "hello world\n",
+			passthrough: true,
+			expected:    "hello world\n",
+		},
+		{
+			name:        "passthrough preserves carriage returns",
+			input:       "progress 0%\rprogress 50%\rprogress 100%\n",
+			passthrough: true,
+			expected:    "progress 0%\rprogress 50%\rprogress 100%\n",
+		},
+		{
+			name:        "passthrough tqdm-style output untouched",
+			input:       "  0%|          | 0/100\r 50%|#####     | 50/100\r100%|##########| 100/100\n",
+			passthrough: true,
+			expected:    "  0%|          | 0/100\r 50%|#####     | 50/100\r100%|##########| 100/100\n",
+		},
+		{
+			name:        "passthrough adds no prefix and no trailing newline",
+			input:       "partial",
+			passthrough: true,
+			expected:    "partial",
+		},
+		{
+			name:        "passthrough empty input produces nothing",
+			input:       "",
+			passthrough: true,
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			reader := strings.NewReader(tt.input)
+
+			err := consumePipe(reader, &buf, tt.passthrough)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
## What

When running a pipeline with a **single sequential worker** on a **real terminal** (not TUI, not JSON output, color not disabled), Python/child process stdout and stderr are now passed through verbatim. This preserves carriage returns so progress bars like `tqdm` render and update in place, instead of being line-buffered and decorated with a timestamp / task-name / `>> ` prefix.

Linear: [BRU-4241](https://linear.app/bruin/issue/BRU-4241/support-interactive-python-log-output-with-carriage-returns)

## How

- **`cmd/run.go`**: detect the interactive terminal *before* `logOutput` swaps `os.Stdout` for the tee writer. Gated on `workers == 1 && !useTUI && output != "json" && !noColor`. Surfaced via `FormattingOptions.InteractivePythonLogs`.
- **`pkg/executor/concurrent.go`**: thread the flag into `workerWriter` as a `Passthrough` field with an `IsPassthrough()` accessor; in passthrough mode `Write` forwards bytes untouched.
- **`pkg/python/command_runner.go`**: `consumePipe` uses `io.Copy` to forward the raw byte stream when the writer opts into passthrough, instead of `bufio` line reads with a `>> ` prefix.

## Why the guards

Passthrough is only safe with one sequential worker writing to a real terminal. With multiple workers or a log file, interleaved `\r` output would be unreadable, so those cases keep the existing line-buffered formatting.

## Tests

- `pkg/python/command_runner_test.go` (new) and updates to `pkg/executor/concurrent_test.go`.
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)