### PR TITLE
Merge catchup and catchup_mode into a single field

### DIFF
--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -290,13 +290,21 @@ notifications:
 Backfill any missed intervals between start_date and now. Turn this on when you need to automatically recover historical
 runs after downtime or late onboarding.
 
+`catchup` accepts either a boolean or a string mode:
+
+- `false` (or omitted): no catchup
+- `true` or `"active"`: catch up only active assets
+- `"all"`: catch up every asset
+
+Any other string is treated as `false`. The value is always serialized as a string (`""`, `"active"`, or `"all"`).
+
 Example:
 
 ```yaml
-catchup: true
+catchup: active
 ```
 
-- **Type:** `Boolean`
+- **Type:** `Boolean` or one of `"active"`, `"all"`
 - **Default:** `false`
 
 ### Metadata push

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -293,8 +293,8 @@ runs after downtime or late onboarding.
 `catchup` accepts either a boolean or a string mode:
 
 - `false` (or omitted): no catchup
-- `true` or `"active"`: catch up only active assets
-- `"all"`: catch up every asset
+- `true` or `"active"`: catch up only the runs that should have happened while the pipeline was active
+- `"all"`: catch up every run regardless of the pipeline's active state at the time
 
 Any other string is treated as `false`. The value is always serialized as a string (`""`, `"active"`, or `"all"`).
 

--- a/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
+++ b/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
@@ -145,8 +145,7 @@
     "discord": [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "metadata_push": {
     "bigquery": false
   },

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
@@ -466,7 +466,7 @@
     "ms_teams": [],
     "discord": []
   },
-  "catchup": false, "catchup_mode": "",
+  "catchup": "",
   "metadata_push": {
     "bigquery": false
   },

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -278,8 +278,7 @@
     "discord": [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "metadata_push": {
     "bigquery": false
   },

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
@@ -275,8 +275,7 @@
     "discord": [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "metadata_push": {
     "bigquery": false
   },

--- a/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
@@ -592,8 +592,7 @@
     "discord": [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "metadata_push": {
     "bigquery": false
   },

--- a/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
@@ -239,8 +239,7 @@
     "discord": [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "metadata_push": {
     "bigquery": false
   },

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1598,6 +1598,60 @@ func (mp *MetadataPush) HasAnyEnabled() bool {
 
 type Macro string
 
+type CatchupMode string
+
+const (
+	CatchupNone   CatchupMode = ""
+	CatchupActive CatchupMode = "active"
+	CatchupAll    CatchupMode = "all"
+)
+
+func (c *CatchupMode) UnmarshalYAML(node *yaml.Node) error {
+	var b bool
+	if err := node.Decode(&b); err == nil {
+		*c = boolToCatchup(b)
+		return nil
+	}
+	var s string
+	if err := node.Decode(&s); err == nil {
+		*c = normalizeCatchupString(s)
+		return nil
+	}
+	*c = CatchupNone
+	return nil
+}
+
+func (c *CatchupMode) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		*c = boolToCatchup(b)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*c = normalizeCatchupString(s)
+		return nil
+	}
+	*c = CatchupNone
+	return nil
+}
+
+func boolToCatchup(b bool) CatchupMode {
+	if b {
+		return CatchupActive
+	}
+	return CatchupNone
+}
+
+func normalizeCatchupString(s string) CatchupMode {
+	switch CatchupMode(s) {
+	case CatchupActive, CatchupAll:
+		return CatchupMode(s)
+	default:
+		return CatchupNone
+	}
+}
+
 // Pipeline is the in-memory representation of a pipeline.yml plus its loaded
 // assets. When adding a new exported field that may legitimately contain Jinja
 // (`{{ var.X }}`) — typically string-valued metadata fields — extend the
@@ -1617,8 +1671,7 @@ type Pipeline struct {
 	DefaultConnections EmptyStringMap         `json:"default_connections" yaml:"default_connections,omitempty" mapstructure:"default_connections"`
 	Assets             []*Asset               `json:"assets" yaml:"assets,omitempty"`
 	Notifications      Notifications          `json:"notifications" yaml:"notifications,omitempty" mapstructure:"notifications"`
-	Catchup            bool                   `json:"catchup" yaml:"catchup,omitempty" mapstructure:"catchup"`
-	CatchupMode        string                 `json:"catchup_mode" yaml:"catchup_mode,omitempty" mapstructure:"catchup_mode"`
+	Catchup            CatchupMode            `json:"catchup" yaml:"catchup,omitempty" mapstructure:"catchup"`
 	MetadataPush       MetadataPush           `json:"metadata_push" yaml:"metadata_push,omitempty" mapstructure:"metadata_push"`
 	Retries            *int                   `json:"retries" yaml:"retries,omitempty" mapstructure:"retries"`
 	RetriesDelay       *int                   `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
@@ -1637,15 +1690,6 @@ type Pipeline struct {
 	Macros             []Macro                `json:"macros" yaml:"macros,omitempty" mapstructure:"macros"`
 }
 
-func validateCatchupMode(mode string) error {
-	switch mode {
-	case "", "active", "all":
-		return nil
-	default:
-		return fmt.Errorf("invalid catchup_mode %q, must be one of: 'active', 'all'", mode)
-	}
-}
-
 func (p *Pipeline) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type pipelineAlias Pipeline
 	aux := (*pipelineAlias)(p)
@@ -1656,10 +1700,6 @@ func (p *Pipeline) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if p.Concurrency == 0 {
 		p.Concurrency = 1
-	}
-
-	if err := validateCatchupMode(p.CatchupMode); err != nil {
-		return err
 	}
 
 	if err := p.Variants.Validate(p.Variables); err != nil {
@@ -1679,10 +1719,6 @@ func (p *Pipeline) UnmarshalJSON(data []byte) error {
 
 	if p.Concurrency == 0 {
 		p.Concurrency = 1
-	}
-
-	if err := validateCatchupMode(p.CatchupMode); err != nil {
-		return err
 	}
 
 	if err := p.Variants.Validate(p.Variables); err != nil {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1206,7 +1206,7 @@ func TestPipeline_FormatContent_ErrorHandling(t *testing.T) {
 			StartDate:          "2024-01-01",
 			Retries:            ptrInt(3),
 			Concurrency:        5,
-			Catchup:            true,
+			Catchup:            pipeline.CatchupActive,
 			Agent:              true,
 			Tags:               pipeline.EmptyStringArray{"production", "critical"},
 			Domains:            pipeline.EmptyStringArray{"analytics"},
@@ -1233,7 +1233,7 @@ func TestPipeline_FormatContent_ErrorHandling(t *testing.T) {
 		assert.Contains(t, contentStr, "schedule: daily")
 		assert.Contains(t, contentStr, "retries: 3")
 		assert.Contains(t, contentStr, "concurrency: 5")
-		assert.Contains(t, contentStr, "catchup: true")
+		assert.Contains(t, contentStr, "catchup: active")
 		assert.Contains(t, contentStr, "agent: true")
 		assert.Contains(t, contentStr, "tags:")
 		assert.Contains(t, contentStr, "- production")
@@ -2618,18 +2618,20 @@ func TestIntervalModifiers_JSON_Integration(t *testing.T) {
 	assert.Equal(t, modifiers, result)
 }
 
-func TestPipeline_ValidateCatchupMode(t *testing.T) {
+func TestPipeline_CatchupNormalization(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		yaml    string
-		wantErr bool
+		name string
+		yaml string
+		want pipeline.CatchupMode
 	}{
-		{name: "empty is valid", yaml: "name: test\n", wantErr: false},
-		{name: "active is valid", yaml: "name: test\ncatchup_mode: active\n", wantErr: false},
-		{name: "all is valid", yaml: "name: test\ncatchup_mode: all\n", wantErr: false},
-		{name: "invalid value", yaml: "name: test\ncatchup_mode: invalid\n", wantErr: true},
+		{name: "missing is none", yaml: "name: test\n", want: pipeline.CatchupNone},
+		{name: "bool true is active", yaml: "name: test\ncatchup: true\n", want: pipeline.CatchupActive},
+		{name: "bool false is none", yaml: "name: test\ncatchup: false\n", want: pipeline.CatchupNone},
+		{name: "string active stays active", yaml: "name: test\ncatchup: active\n", want: pipeline.CatchupActive},
+		{name: "string all stays all", yaml: "name: test\ncatchup: all\n", want: pipeline.CatchupAll},
+		{name: "unknown string collapses to none", yaml: "name: test\ncatchup: invalid\n", want: pipeline.CatchupNone},
 	}
 
 	for _, tt := range tests {
@@ -2637,11 +2639,34 @@ func TestPipeline_ValidateCatchupMode(t *testing.T) {
 			t.Parallel()
 			var p pipeline.Pipeline
 			err := yaml.Unmarshal([]byte(tt.yaml), &p)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, p.Catchup)
+		})
+	}
+}
+
+func TestPipeline_CatchupJSONNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		json string
+		want pipeline.CatchupMode
+	}{
+		{name: "bool true is active", json: `{"name":"t","catchup":true}`, want: pipeline.CatchupActive},
+		{name: "bool false is none", json: `{"name":"t","catchup":false}`, want: pipeline.CatchupNone},
+		{name: "string active", json: `{"name":"t","catchup":"active"}`, want: pipeline.CatchupActive},
+		{name: "string all", json: `{"name":"t","catchup":"all"}`, want: pipeline.CatchupAll},
+		{name: "unknown string collapses to none", json: `{"name":"t","catchup":"weird"}`, want: pipeline.CatchupNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var p pipeline.Pipeline
+			err := json.Unmarshal([]byte(tt.json), &p)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, p.Catchup)
 		})
 	}
 }

--- a/pkg/pipeline/testdata/persist/complex-pipeline.expected.yml
+++ b/pkg/pipeline/testdata/persist/complex-pipeline.expected.yml
@@ -14,7 +14,7 @@ start_date: "2024-01-01"
 default_connections:
   gcp: prod-connection
   snowflake: snow-connection
-catchup: true
+catchup: active
 retries: 3
 concurrency: 5
 agent: true

--- a/pkg/pipeline/testdata/pipeline/first-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/first-pipeline_unix.json
@@ -303,8 +303,7 @@
         ],
         "webhook": []
     },
-    "catchup": false,
-    "catchup_mode": "",
+    "catchup": "",
     "metadata_push": {
         "bigquery": false
     },

--- a/pkg/pipeline/testdata/pipeline/first-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/first-pipeline_windows.json
@@ -311,8 +311,7 @@
     ],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "commit": "",
   "retries": 3,
   "concurrency": 1,

--- a/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_unix.json
+++ b/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_unix.json
@@ -22,8 +22,7 @@
         "discord": [],
         "webhook": []
     },
-    "catchup": false,
-    "catchup_mode": "",
+    "catchup": "",
     "metadata_push": {
         "bigquery": false
     },

--- a/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_windows.json
+++ b/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_windows.json
@@ -30,8 +30,7 @@
     "ms_teams" : [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "commit": "",
   "retries": null,
   "concurrency": 1,

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
@@ -279,8 +279,7 @@
         "discord": [],
         "webhook": []
     },
-    "catchup": false,
-    "catchup_mode": "",
+    "catchup": "",
     "metadata_push": {
         "bigquery": false
     },

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
@@ -287,8 +287,7 @@
     "ms_teams": [],
     "webhook": []
   },
-  "catchup": false,
-  "catchup_mode": "",
+  "catchup": "",
   "commit": "",
   "retries": null,
   "concurrency": 1,

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -375,7 +375,7 @@ func TestVariantVisitorCoversStringFields(t *testing.T) {
 	skipFields := map[string]bool{
 		// Pipeline metadata set internally or validated against an enum.
 		"Pipeline.LegacyID":            true,
-		"Pipeline.CatchupMode":         true,
+		"Pipeline.Catchup":             true,
 		"Pipeline.MacrosPath":          true,
 		"Pipeline.Commit":              true,
 		"Pipeline.Snapshot":            true,


### PR DESCRIPTION
## Summary

- Replaces `Pipeline.Catchup` (bool) + `Pipeline.CatchupMode` (string) with a single `Catchup` field backed by a new `CatchupMode` string type.
- The unmarshalers accept either a bool or a string on both YAML and JSON: `false`/missing/unknown → `""`, `true`/`"active"` → `"active"`, `"all"` → `"all"`.
- The value always serializes as a string (`""`, `"active"`, or `"all"`) on both encoders.
- Removes the now-unnecessary `validateCatchupMode` helper; invalid strings silently collapse to none instead of erroring.
- Updates the unit-test, persist, and integration-test expectation fixtures to the new shape.
- Expands the `Catchup` section in `docs/pipelines/definition.md` to document the new bool-or-string semantics.

## Test plan

- [x] `make format`
- [x] `make test`
- [ ] `make integration-test-light`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)