### PR TITLE
[codex] serialize asset routing in JSON

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -4350,7 +4350,7 @@ func TestMacros(t *testing.T) {
 					ExitCode: 0,
 					Contains: []string{
 						// Pipeline default rerun_cooldown
-						`"default":{"type":"","parameters":null,"secrets":null,"hooks":{},"interval_modifiers":null,"rerun_cooldown":300}`, `"retries_delay":300`,
+						`"default":{"type":"","parameters":null,"secrets":null,"hooks":{},"routing":null,"interval_modifiers":null,"rerun_cooldown":300}`, `"retries_delay":300`,
 						// Asset with explicit rerun_cooldown
 						`"name":"test_asset"`, `"rerun_cooldown":600`, `"retries_delay":600`,
 						// Asset that inherits from pipeline

--- a/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
+++ b/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
@@ -135,6 +135,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     }
   ],

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage-asset.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage-asset.json
@@ -169,6 +169,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-default-option/expectations/asset.py.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/asset.py.json
@@ -53,6 +53,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-default-option/expectations/chess_games.asset.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/chess_games.asset.yml.json
@@ -43,6 +43,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -70,6 +70,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -116,6 +117,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -162,6 +164,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -264,6 +267,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     }
   ],
@@ -305,6 +309,7 @@
         }
       ]
     },
+    "routing": null,
     "interval_modifiers": null
   },
   "commit": "",

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/asset.py.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/asset.py.json
@@ -57,6 +57,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/chess_games.asset.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/chess_games.asset.yml.json
@@ -49,6 +49,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/chess_profiles.asset.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/chess_profiles.asset.yml.json
@@ -38,6 +38,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
@@ -71,6 +71,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -123,6 +124,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -164,6 +166,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -261,6 +264,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     }
   ],

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/player_summary.sql.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/player_summary.sql.json
@@ -94,6 +94,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
@@ -116,6 +116,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -288,6 +289,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -449,6 +451,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -579,6 +582,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     }
   ],

--- a/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
@@ -60,6 +60,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -101,6 +102,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -142,6 +144,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     },
     {
@@ -225,6 +228,7 @@
       "metadata": {},
       "snowflake": null,
       "athena": null,
+      "routing": null,
       "interval_modifiers": null
     }
   ],

--- a/integration-tests/test-pipelines/run-seed-data/expectations/seed.asset.yml.json
+++ b/integration-tests/test-pipelines/run-seed-data/expectations/seed.asset.yml.json
@@ -141,6 +141,7 @@
     "metadata": {},
     "snowflake": null,
     "athena": null,
+    "routing": null,
     "interval_modifiers": null
   },
   "pipeline": {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -869,7 +869,7 @@ type Asset struct { //nolint:recvcheck
 	Metadata          EmptyStringMap     `json:"metadata" yaml:"metadata,omitempty" mapstructure:"metadata"`
 	Snowflake         SnowflakeConfig    `json:"snowflake" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
 	Athena            AthenaConfig       `json:"athena" yaml:"athena,omitempty" mapstructure:"athena"`
-	Routing           *RoutingConfig     `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
+	Routing           *RoutingConfig     `json:"routing" yaml:"routing,omitempty" mapstructure:"routing"`
 	IntervalModifiers IntervalModifiers  `json:"interval_modifiers" yaml:"interval_modifiers,omitempty" mapstructure:"interval_modifiers"`
 	RerunCooldown     *int               `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 	RetriesDelay      *int               `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
@@ -1696,7 +1696,7 @@ type DefaultValues struct {
 	Parameters        map[string]string `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
 	Secrets           []secretMapping   `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
 	Hooks             Hooks             `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
-	Routing           *RoutingConfig    `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
+	Routing           *RoutingConfig    `json:"routing" yaml:"routing,omitempty" mapstructure:"routing"`
 	IntervalModifiers IntervalModifiers `json:"interval_modifiers" yaml:"interval_modifiers" mapstructure:"interval_modifiers"`
 	RerunCooldown     *int              `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
 }

--- a/pkg/pipeline/testdata/pipeline/first-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/first-pipeline_unix.json
@@ -66,6 +66,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -107,6 +108,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -190,6 +192,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -272,6 +275,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         }
     ],

--- a/pkg/pipeline/testdata/pipeline/first-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/first-pipeline_windows.json
@@ -74,6 +74,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -115,6 +116,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -198,6 +200,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -280,6 +283,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         }
     ],

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
@@ -55,6 +55,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -96,6 +97,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -261,6 +263,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         }
     ],

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
@@ -63,6 +63,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -104,6 +105,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         },
         {
@@ -269,6 +271,7 @@
             "metadata": {},
             "snowflake": null,
             "athena": null,
+            "routing": null,
             "interval_modifiers": null
         }
     ],


### PR DESCRIPTION
## Summary

- Serialize `routing` in pipeline asset JSON even when it is nil.
- Serialize `default.routing` in pipeline JSON even when it is nil.
- Update unit and integration JSON expectations to include `"routing": null` for unrouted assets/defaults.

## Validation

- `go test -tags="no_duckdb_arrow" ./pkg/pipeline -run TestPipeline_JsonMarshal`
- `make format`
- `make test`
- `go test -tags="no_duckdb_arrow" -v -count=1 -run "^(TestIndividualTasks|TestMacros)$" ./integration-tests`
- `make integration-test`
