### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,4 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "set -eu; root=\"${CONDUCTOR_ROOT_PATH:-}\"; src=\"$root/pkg/sqlparser/rustffi/target\"; dst=\"pkg/sqlparser/rustffi/target\"; if [ -n \"$root\" ] && [ \"$root\" != \"$PWD\" ] && [ -d \"$src\" ]; then if command -v rsync >/dev/null 2>&1; then mkdir -p \"$dst\"; rsync -a \"$src/\" \"$dst/\"; else rm -rf \"$dst\"; mkdir -p \"$(dirname \"$dst\")\"; cp -Rp \"$src\" \"$dst\"; fi; fi"

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,0 @@
-{
-  "scripts": {
-    "setup": "set -eu; root=\"${CONDUCTOR_ROOT_PATH:-}\"; src=\"$root/pkg/sqlparser/rustffi/target\"; dst=\"pkg/sqlparser/rustffi/target\"; if [ -n \"$root\" ] && [ \"$root\" != \"$PWD\" ] && [ -d \"$src\" ]; then if command -v rsync >/dev/null 2>&1; then mkdir -p \"$dst\"; rsync -a \"$src/\" \"$dst/\"; else rm -rf \"$dst\"; mkdir -p \"$(dirname \"$dst\")\"; cp -Rp \"$src\" \"$dst\"; fi; fi"
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.