### PR TITLE
Add run options to bruin cloud runs trigger

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	path2 "path"
 	"regexp"
+	"slices"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -728,10 +732,250 @@ func cloudRunsGet() *cli.Command {
 	}
 }
 
+// maxTriggerIntervals caps how many runs a single split can create.
+const maxTriggerIntervals = 250
+
+var validSplitUnits = map[string]bool{
+	"minute": true, "hour": true, "day": true,
+	"week": true, "month": true, "year": true,
+}
+
+// parseRunDate accepts the common date/datetime formats the trigger endpoint allows.
+func parseRunDate(s string) (time.Time, error) {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05", "2006-01-02"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid date %q (use RFC3339 like 2026-05-01T00:00:00Z or YYYY-MM-DD)", s)
+}
+
+// addRunInterval advances t by n units.
+func addRunInterval(t time.Time, unit string, n int) time.Time {
+	switch unit {
+	case "minute":
+		return t.Add(time.Duration(n) * time.Minute)
+	case "hour":
+		return t.Add(time.Duration(n) * time.Hour)
+	case "day":
+		return t.AddDate(0, 0, n)
+	case "week":
+		return t.AddDate(0, 0, 7*n)
+	case "month":
+		return t.AddDate(0, n, 0)
+	case "year":
+		return t.AddDate(n, 0, 0)
+	}
+	return t
+}
+
+// splitRunIntervals chunks [start, end] into windows of chunkSize units.
+func splitRunIntervals(start, end time.Time, split string, chunkSize int) []bruincloud.RunInterval {
+	var intervals []bruincloud.RunInterval
+	cur := start
+	for cur.Before(end) {
+		next := addRunInterval(cur, split, chunkSize)
+		ivEnd := next.Add(-time.Millisecond)
+		if ivEnd.After(end) {
+			ivEnd = end
+		}
+		intervals = append(intervals, bruincloud.RunInterval{
+			StartDate: cur.Format("2006-01-02T15:04:05.000Z"),
+			EndDate:   ivEnd.Format("2006-01-02T15:04:05.000Z"),
+		})
+		cur = next
+	}
+	return intervals
+}
+
+func buildTriggerIntervals(split string, chunkSizeSet bool, chunkSize int, startDate, endDate string) ([]bruincloud.RunInterval, error) {
+	if split == "" {
+		if chunkSizeSet {
+			return nil, errors.New("--chunk-size requires --split")
+		}
+		return []bruincloud.RunInterval{{StartDate: startDate, EndDate: endDate}}, nil
+	}
+
+	if !validSplitUnits[split] {
+		return nil, fmt.Errorf("invalid --split %q (valid: minute, hour, day, week, month, year)", split)
+	}
+	if chunkSize < 1 {
+		return nil, errors.New("--chunk-size must be at least 1")
+	}
+	start, err := parseRunDate(startDate)
+	if err != nil {
+		return nil, err
+	}
+	end, err := parseRunDate(endDate)
+	if err != nil {
+		return nil, err
+	}
+	if !start.Before(end) {
+		return nil, errors.New("start date must be before end date")
+	}
+	intervals := splitRunIntervals(start, end, split, chunkSize)
+	if len(intervals) == 0 {
+		return nil, errors.New("no intervals generated from the given date range")
+	}
+	if len(intervals) > maxTriggerIntervals {
+		return nil, fmt.Errorf("split produces %d runs, which exceeds the limit of %d; use a larger --chunk-size or a smaller range", len(intervals), maxTriggerIntervals)
+	}
+	return intervals, nil
+}
+
+// matchTriggerAsset finds an asset by full name, bare name, or filename.
+func matchTriggerAsset(assets []bruincloud.Asset, in string) *bruincloud.Asset {
+	query := strings.TrimSuffix(strings.TrimSuffix(in, ".sql"), ".py")
+	for i := range assets {
+		a := &assets[i]
+		if a.Name == in || a.Name == query || strings.HasSuffix(a.Name, "."+query) {
+			return a
+		}
+	}
+	return nil
+}
+
+// assetStringList decodes a json.RawMessage that holds a []string (tags, downstream).
+func assetStringList(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var list []string
+	_ = json.Unmarshal(raw, &list)
+	return list
+}
+
+// triggerAssetSelection holds the asset-selection flags. The Cloud trigger API
+// only understands an explicit whitelist of asset IDs, so tag/exclude-tag/
+// downstream are resolved client-side into that whitelist.
+type triggerAssetSelection struct {
+	assetInputs []string
+	tag         string
+	excludeTags []string
+	downstream  bool
+}
+
+func (s triggerAssetSelection) active() bool {
+	return len(s.assetInputs) > 0 || s.tag != "" || len(s.excludeTags) > 0 || s.downstream
+}
+
+// selectTriggerAssets resolves the selection flags into a concrete asset set.
+func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) ([]*bruincloud.Asset, error) {
+	if !sel.active() {
+		return nil, nil
+	}
+
+	selected := make(map[string]*bruincloud.Asset)
+	for _, in := range sel.assetInputs {
+		m := matchTriggerAsset(assets, in)
+		if m == nil {
+			return nil, fmt.Errorf("asset %q not found in pipeline; run 'bruin cloud assets list' to see available names", in)
+		}
+		selected[m.Name] = m
+	}
+	if sel.tag != "" {
+		matched := false
+		for i := range assets {
+			if slices.Contains(assetStringList(assets[i].Tags), sel.tag) {
+				selected[assets[i].Name] = &assets[i]
+				matched = true
+			}
+		}
+		if !matched && len(sel.assetInputs) == 0 {
+			return nil, fmt.Errorf("no assets found with tag %q", sel.tag)
+		}
+	}
+
+	// With only exclude-tag/downstream given, start from the full pipeline.
+	if len(sel.assetInputs) == 0 && sel.tag == "" {
+		for i := range assets {
+			selected[assets[i].Name] = &assets[i]
+		}
+	}
+
+	// Transitively pull in downstream assets.
+	if sel.downstream {
+		byName := make(map[string]*bruincloud.Asset, len(assets))
+		for i := range assets {
+			byName[assets[i].Name] = &assets[i]
+		}
+		queue := make([]string, 0, len(selected))
+		for name := range selected {
+			queue = append(queue, name)
+		}
+		for len(queue) > 0 {
+			name := queue[0]
+			queue = queue[1:]
+			a := byName[name]
+			if a == nil {
+				continue
+			}
+			for _, d := range assetStringList(a.Downstream) {
+				if _, seen := selected[d]; seen {
+					continue
+				}
+				if da := byName[d]; da != nil {
+					selected[d] = da
+					queue = append(queue, d)
+				}
+			}
+		}
+	}
+
+	for _, ex := range sel.excludeTags {
+		for name, a := range selected {
+			if slices.Contains(assetStringList(a.Tags), ex) {
+				delete(selected, name)
+			}
+		}
+	}
+
+	return slices.SortedFunc(maps.Values(selected), func(a, b *bruincloud.Asset) int {
+		return strings.Compare(a.Name, b.Name)
+	}), nil
+}
+
+// applyAssetSelection translates a resolved selection into the trigger options
+func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fullRefresh bool) {
+	if fullRefresh {
+		opts.AssetOverrides = map[string]map[string]any{}
+	}
+	if selected != nil {
+		for _, a := range selected {
+			opts.Whitelist = append(opts.Whitelist, a.ID)
+			if fullRefresh {
+				opts.AssetOverrides[a.Name] = map[string]any{"FULL_REFRESH": 1}
+			}
+		}
+	} else if fullRefresh {
+		for i := range assets {
+			opts.AssetOverrides[assets[i].Name] = map[string]any{"FULL_REFRESH": 1}
+		}
+	}
+}
+
+func parseRunVariables(pairs []string) (map[string]any, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	vars := make(map[string]any, len(pairs))
+	for _, variable := range pairs {
+		parsed, err := parseVariable(variable)
+		if err != nil {
+			return nil, fmt.Errorf("invalid variable override %q: %w", variable, err)
+		}
+		for key, value := range parsed {
+			vars[key] = value
+		}
+	}
+	return vars, nil
+}
+
 func cloudRunsTrigger() *cli.Command {
 	return &cli.Command{
-		Name:  "trigger",
-		Usage: "Trigger a new pipeline run",
+		Name:      "trigger",
+		Usage:     "Trigger a new pipeline run",
+		ArgsUsage: "[path to the task file]",
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
@@ -746,6 +990,38 @@ func cloudRunsTrigger() *cli.Command {
 				Name:     "end-date",
 				Usage:    "end date for the run (e.g. 2026-01-02T00:00:00Z)",
 				Required: true,
+			},
+			&cli.BoolFlag{
+				Name:  "downstream",
+				Usage: "pass this flag if you'd like to run all the downstream tasks as well",
+			},
+			&cli.StringFlag{
+				Name:    "tag",
+				Aliases: []string{"t"},
+				Usage:   "pick assets with the given tag",
+			},
+			&cli.StringSliceFlag{
+				Name:    "exclude-tag",
+				Aliases: []string{"x"},
+				Usage:   "exclude assets with the given tag",
+			},
+			&cli.BoolFlag{
+				Name:    "full-refresh",
+				Aliases: []string{"r"},
+				Usage:   "truncate the table before running",
+			},
+			&cli.StringSliceFlag{
+				Name:  "var",
+				Usage: "override pipeline variables with custom values (key=value)",
+			},
+			&cli.StringFlag{
+				Name:  "split",
+				Usage: "split the date range into batches by unit: minute, hour, day, week, month, year (one run per batch)",
+			},
+			&cli.IntFlag{
+				Name:  "chunk-size",
+				Usage: "number of split units per batch (used with --split)",
+				Value: 1,
 			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
@@ -765,13 +1041,55 @@ func cloudRunsTrigger() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			err = client.TriggerRun(ctx, project, pipeline, c.String("start-date"), c.String("end-date"))
+			// Build the run intervals
+			intervals, err := buildTriggerIntervals(c.String("split"), c.IsSet("chunk-size"), c.Int("chunk-size"), c.String("start-date"), c.String("end-date"))
 			if err != nil {
+				printError(err, output, "Invalid flags")
+				return cli.Exit("", 1)
+			}
+
+			vars, err := parseRunVariables(c.StringSlice("var"))
+			if err != nil {
+				printError(err, output, "Invalid flag")
+				return cli.Exit("", 1)
+			}
+
+			opts := bruincloud.TriggerRunOptions{Variables: vars}
+
+			// Asset selection
+			sel := triggerAssetSelection{
+				assetInputs: c.Args().Slice(),
+				tag:         c.String("tag"),
+				excludeTags: c.StringSlice("exclude-tag"),
+				downstream:  c.Bool("downstream"),
+			}
+			fullRefresh := c.Bool("full-refresh")
+			if sel.active() || fullRefresh {
+				assets, err := client.ListAssets(ctx, project, pipeline)
+				if err != nil {
+					printError(err, output, "Failed to list assets")
+					return cli.Exit("", 1)
+				}
+
+				selected, err := selectTriggerAssets(assets, sel)
+				if err != nil {
+					printError(err, output, "Failed to resolve assets")
+					return cli.Exit("", 1)
+				}
+
+				applyAssetSelection(&opts, selected, assets, fullRefresh)
+			}
+
+			if err := client.TriggerRun(ctx, project, pipeline, intervals, opts); err != nil {
 				printError(err, output, "Failed to trigger run")
 				return cli.Exit("", 1)
 			}
 
-			printSuccessForOutput(output, fmt.Sprintf("Successfully triggered run for pipeline '%s' in project '%s'", pipeline, project))
+			msg := fmt.Sprintf("Successfully triggered run for pipeline '%s' in project '%s'", pipeline, project)
+			if len(intervals) > 1 {
+				msg = fmt.Sprintf("Successfully triggered %d runs for pipeline '%s' in project '%s'", len(intervals), pipeline, project)
+			}
+			printSuccessForOutput(output, msg)
 			return nil
 		},
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -753,7 +753,7 @@ func validateSplitFlags(split string, chunkSizeSet bool, chunkSize int) error {
 	return nil
 }
 
-// matchTriggerAsset finds an asset by full name, bare name, or filename. 
+// matchTriggerAsset finds an asset by full name, bare name, or filename.
 func matchTriggerAsset(assets []bruincloud.Asset, in string) (*bruincloud.Asset, error) {
 	query := strings.TrimSuffix(strings.TrimSuffix(in, ".sql"), ".py")
 
@@ -796,7 +796,7 @@ func assetStringList(raw json.RawMessage) []string {
 	return list
 }
 
-// triggerAssetSelection holds the asset-selection flags. 
+// triggerAssetSelection holds the asset-selection flags.
 type triggerAssetSelection struct {
 	assetInputs []string
 	downstream  bool

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -823,16 +823,40 @@ func buildTriggerIntervals(split string, chunkSizeSet bool, chunkSize int, start
 	return intervals, nil
 }
 
-// matchTriggerAsset finds an asset by full name, bare name, or filename.
-func matchTriggerAsset(assets []bruincloud.Asset, in string) *bruincloud.Asset {
+// matchTriggerAsset finds an asset by full name, bare name, or filename. An exact
+// full-name match always wins. Otherwise it matches by leaf name (schema-qualified
+// suffix); if that leaf name is shared by multiple assets it returns an ambiguity
+// error rather than silently picking one. Returns (nil, nil) when nothing matches.
+func matchTriggerAsset(assets []bruincloud.Asset, in string) (*bruincloud.Asset, error) {
 	query := strings.TrimSuffix(strings.TrimSuffix(in, ".sql"), ".py")
+
+	// An exact full-name match is unambiguous and takes precedence.
 	for i := range assets {
-		a := &assets[i]
-		if a.Name == in || a.Name == query || strings.HasSuffix(a.Name, "."+query) {
-			return a
+		if assets[i].Name == in || assets[i].Name == query {
+			return &assets[i], nil
 		}
 	}
-	return nil
+
+	// Otherwise match by leaf name, detecting ambiguity across schemas.
+	var matches []*bruincloud.Asset
+	for i := range assets {
+		if strings.HasSuffix(assets[i].Name, "."+query) {
+			matches = append(matches, &assets[i])
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, nil
+	case 1:
+		return matches[0], nil
+	default:
+		names := make([]string, len(matches))
+		for i, a := range matches {
+			names[i] = a.Name
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("asset %q is ambiguous; it matches %s — use the fully-qualified name", in, strings.Join(names, ", "))
+	}
 }
 
 // assetStringList decodes a json.RawMessage that holds a []string (tags, downstream).
@@ -856,7 +880,7 @@ type triggerAssetSelection struct {
 }
 
 func (s triggerAssetSelection) active() bool {
-	return len(s.assetInputs) > 0 || s.tag != "" || len(s.excludeTags) > 0 || s.downstream
+	return len(s.assetInputs) > 0 || s.tag != "" || len(s.excludeTags) > 0
 }
 
 // selectTriggerAssets resolves the selection flags into a concrete asset set.
@@ -867,7 +891,10 @@ func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) (
 
 	selected := make(map[string]*bruincloud.Asset)
 	for _, in := range sel.assetInputs {
-		m := matchTriggerAsset(assets, in)
+		m, err := matchTriggerAsset(assets, in)
+		if err != nil {
+			return nil, err
+		}
 		if m == nil {
 			return nil, fmt.Errorf("asset %q not found in pipeline; run 'bruin cloud assets list' to see available names", in)
 		}
@@ -930,12 +957,18 @@ func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) (
 		}
 	}
 
+	// An active selection that resolves to nothing must not fall back to running
+	// the whole pipeline (empty whitelist)
+	if len(selected) == 0 {
+		return nil, errors.New("no assets matched the selection; check the asset arguments, --tag, and --exclude-tag")
+	}
+
 	return slices.SortedFunc(maps.Values(selected), func(a, b *bruincloud.Asset) int {
 		return strings.Compare(a.Name, b.Name)
 	}), nil
 }
 
-// applyAssetSelection translates a resolved selection into the trigger options
+// applyAssetSelection sets the whitelist (asset IDs) and, when fullRefresh is set, the FULL_REFRESH overrides; a nil selection runs the whole pipeline.
 func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fullRefresh bool) {
 	if fullRefresh {
 		opts.AssetOverrides = map[string]map[string]any{}
@@ -993,7 +1026,7 @@ func cloudRunsTrigger() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "downstream",
-				Usage: "pass this flag if you'd like to run all the downstream tasks as well",
+				Usage: "also run assets downstream of the selected ones (used with an asset/--tag selection; no effect on its own)",
 			},
 			&cli.StringFlag{
 				Name:    "tag",

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -732,95 +731,28 @@ func cloudRunsGet() *cli.Command {
 	}
 }
 
-// maxTriggerIntervals caps how many runs a single split can create.
-const maxTriggerIntervals = 250
-
 var validSplitUnits = map[string]bool{
 	"minute": true, "hour": true, "day": true,
 	"week": true, "month": true, "year": true,
 }
 
-// parseRunDate accepts the common date/datetime formats the trigger endpoint allows.
-func parseRunDate(s string) (time.Time, error) {
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05", "2006-01-02"} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t.UTC(), nil
-		}
-	}
-	return time.Time{}, fmt.Errorf("invalid date %q (use RFC3339 like 2026-05-01T00:00:00Z or YYYY-MM-DD)", s)
-}
-
-// addRunInterval advances t by n units.
-func addRunInterval(t time.Time, unit string, n int) time.Time {
-	switch unit {
-	case "minute":
-		return t.Add(time.Duration(n) * time.Minute)
-	case "hour":
-		return t.Add(time.Duration(n) * time.Hour)
-	case "day":
-		return t.AddDate(0, 0, n)
-	case "week":
-		return t.AddDate(0, 0, 7*n)
-	case "month":
-		return t.AddDate(0, n, 0)
-	case "year":
-		return t.AddDate(n, 0, 0)
-	}
-	return t
-}
-
-// splitRunIntervals chunks [start, end] into windows of chunkSize units.
-func splitRunIntervals(start, end time.Time, split string, chunkSize int) []bruincloud.RunInterval {
-	var intervals []bruincloud.RunInterval
-	cur := start
-	for cur.Before(end) {
-		next := addRunInterval(cur, split, chunkSize)
-		ivEnd := next.Add(-time.Millisecond)
-		if ivEnd.After(end) {
-			ivEnd = end
-		}
-		intervals = append(intervals, bruincloud.RunInterval{
-			StartDate: cur.Format("2006-01-02T15:04:05.000Z"),
-			EndDate:   ivEnd.Format("2006-01-02T15:04:05.000Z"),
-		})
-		cur = next
-	}
-	return intervals
-}
-
-func buildTriggerIntervals(split string, chunkSizeSet bool, chunkSize int, startDate, endDate string) ([]bruincloud.RunInterval, error) {
+// validateSplitFlags checks the --split / --chunk-size combination. The actual
+// splitting happens server-side (the backfill endpoint), so this only validates
+// the flags locally for a clear error before the request.
+func validateSplitFlags(split string, chunkSizeSet bool, chunkSize int) error {
 	if split == "" {
 		if chunkSizeSet {
-			return nil, errors.New("--chunk-size requires --split")
+			return errors.New("--chunk-size requires --split")
 		}
-		return []bruincloud.RunInterval{{StartDate: startDate, EndDate: endDate}}, nil
+		return nil
 	}
-
 	if !validSplitUnits[split] {
-		return nil, fmt.Errorf("invalid --split %q (valid: minute, hour, day, week, month, year)", split)
+		return fmt.Errorf("invalid --split %q (valid: minute, hour, day, week, month, year)", split)
 	}
 	if chunkSize < 1 {
-		return nil, errors.New("--chunk-size must be at least 1")
+		return errors.New("--chunk-size must be at least 1")
 	}
-	start, err := parseRunDate(startDate)
-	if err != nil {
-		return nil, err
-	}
-	end, err := parseRunDate(endDate)
-	if err != nil {
-		return nil, err
-	}
-	if !start.Before(end) {
-		return nil, errors.New("start date must be before end date")
-	}
-	intervals := splitRunIntervals(start, end, split, chunkSize)
-	if len(intervals) == 0 {
-		return nil, errors.New("no intervals generated from the given date range")
-	}
-	if len(intervals) > maxTriggerIntervals {
-		return nil, fmt.Errorf("split produces %d runs, which exceeds the limit of %d; use a larger --chunk-size or a smaller range", len(intervals), maxTriggerIntervals)
-	}
-	return intervals, nil
+	return nil
 }
 
 // matchTriggerAsset finds an asset by full name, bare name, or filename. An exact
@@ -870,17 +802,16 @@ func assetStringList(raw json.RawMessage) []string {
 }
 
 // triggerAssetSelection holds the asset-selection flags. The Cloud trigger API
-// only understands an explicit whitelist of asset IDs, so tag/exclude-tag/
-// downstream are resolved client-side into that whitelist.
+// only understands an explicit whitelist of asset IDs, so the selection (asset
+// names, optionally expanded by --downstream) is resolved client-side into that
+// whitelist. (--tag is run-level metadata, not an asset filter.)
 type triggerAssetSelection struct {
 	assetInputs []string
-	tag         string
-	excludeTags []string
 	downstream  bool
 }
 
 func (s triggerAssetSelection) active() bool {
-	return len(s.assetInputs) > 0 || s.tag != "" || len(s.excludeTags) > 0
+	return len(s.assetInputs) > 0
 }
 
 // selectTriggerAssets resolves the selection flags into a concrete asset set.
@@ -899,25 +830,6 @@ func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) (
 			return nil, fmt.Errorf("asset %q not found in pipeline; run 'bruin cloud assets list' to see available names", in)
 		}
 		selected[m.Name] = m
-	}
-	if sel.tag != "" {
-		matched := false
-		for i := range assets {
-			if slices.Contains(assetStringList(assets[i].Tags), sel.tag) {
-				selected[assets[i].Name] = &assets[i]
-				matched = true
-			}
-		}
-		if !matched && len(sel.assetInputs) == 0 {
-			return nil, fmt.Errorf("no assets found with tag %q", sel.tag)
-		}
-	}
-
-	// With only exclude-tag/downstream given, start from the full pipeline.
-	if len(sel.assetInputs) == 0 && sel.tag == "" {
-		for i := range assets {
-			selected[assets[i].Name] = &assets[i]
-		}
 	}
 
 	// Transitively pull in downstream assets.
@@ -947,20 +859,6 @@ func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) (
 				}
 			}
 		}
-	}
-
-	for _, ex := range sel.excludeTags {
-		for name, a := range selected {
-			if slices.Contains(assetStringList(a.Tags), ex) {
-				delete(selected, name)
-			}
-		}
-	}
-
-	// An active selection that resolves to nothing must not fall back to running
-	// the whole pipeline (empty whitelist)
-	if len(selected) == 0 {
-		return nil, errors.New("no assets matched the selection; check the asset arguments, --tag, and --exclude-tag")
 	}
 
 	return slices.SortedFunc(maps.Values(selected), func(a, b *bruincloud.Asset) int {
@@ -1026,17 +924,12 @@ func cloudRunsTrigger() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "downstream",
-				Usage: "also run assets downstream of the selected ones (used with an asset/--tag selection; no effect on its own)",
-			},
-			&cli.StringFlag{
-				Name:    "tag",
-				Aliases: []string{"t"},
-				Usage:   "pick assets with the given tag",
+				Usage: "also run assets downstream of the selected ones (used with a positional asset selection; no effect on its own)",
 			},
 			&cli.StringSliceFlag{
-				Name:    "exclude-tag",
-				Aliases: []string{"x"},
-				Usage:   "exclude assets with the given tag",
+				Name:    "tag",
+				Aliases: []string{"t"},
+				Usage:   "tag the run; repeat for multiple.",
 			},
 			&cli.BoolFlag{
 				Name:    "full-refresh",
@@ -1046,6 +939,10 @@ func cloudRunsTrigger() *cli.Command {
 			&cli.StringSliceFlag{
 				Name:  "var",
 				Usage: "override pipeline variables with custom values (key=value)",
+			},
+			&cli.StringFlag{
+				Name:  "note",
+				Usage: "attach a note to the run.",
 			},
 			&cli.StringFlag{
 				Name:  "split",
@@ -1074,9 +971,11 @@ func cloudRunsTrigger() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			// Build the run intervals
-			intervals, err := buildTriggerIntervals(c.String("split"), c.IsSet("chunk-size"), c.Int("chunk-size"), c.String("start-date"), c.String("end-date"))
-			if err != nil {
+			// --split routes to the backfill endpoint;
+			// without it we trigger a single run.
+			split := c.String("split")
+			chunkSize := c.Int("chunk-size")
+			if err := validateSplitFlags(split, c.IsSet("chunk-size"), chunkSize); err != nil {
 				printError(err, output, "Invalid flags")
 				return cli.Exit("", 1)
 			}
@@ -1087,13 +986,11 @@ func cloudRunsTrigger() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			opts := bruincloud.TriggerRunOptions{Variables: vars}
+			opts := bruincloud.TriggerRunOptions{Variables: vars, Note: c.String("note"), Tags: c.StringSlice("tag")}
 
 			// Asset selection
 			sel := triggerAssetSelection{
 				assetInputs: c.Args().Slice(),
-				tag:         c.String("tag"),
-				excludeTags: c.StringSlice("exclude-tag"),
 				downstream:  c.Bool("downstream"),
 			}
 			fullRefresh := c.Bool("full-refresh")
@@ -1113,16 +1010,21 @@ func cloudRunsTrigger() *cli.Command {
 				applyAssetSelection(&opts, selected, assets, fullRefresh)
 			}
 
-			if err := client.TriggerRun(ctx, project, pipeline, intervals, opts); err != nil {
-				printError(err, output, "Failed to trigger run")
-				return cli.Exit("", 1)
+			startDate, endDate := c.String("start-date"), c.String("end-date")
+			if split == "" {
+				if err := client.TriggerRun(ctx, project, pipeline, startDate, endDate, opts); err != nil {
+					printError(err, output, "Failed to trigger run")
+					return cli.Exit("", 1)
+				}
+				printSuccessForOutput(output, fmt.Sprintf("Successfully triggered run for pipeline '%s' in project '%s'", pipeline, project))
+				return nil
 			}
 
-			msg := fmt.Sprintf("Successfully triggered run for pipeline '%s' in project '%s'", pipeline, project)
-			if len(intervals) > 1 {
-				msg = fmt.Sprintf("Successfully triggered %d runs for pipeline '%s' in project '%s'", len(intervals), pipeline, project)
+			if err := client.TriggerBackfill(ctx, project, pipeline, startDate, endDate, split, chunkSize, opts); err != nil {
+				printError(err, output, "Failed to trigger backfill")
+				return cli.Exit("", 1)
 			}
-			printSuccessForOutput(output, msg)
+			printSuccessForOutput(output, fmt.Sprintf("Successfully triggered backfill (split by %s, chunk size %d) for pipeline '%s' in project '%s'", split, chunkSize, pipeline, project))
 			return nil
 		},
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -736,9 +736,7 @@ var validSplitUnits = map[string]bool{
 	"week": true, "month": true, "year": true,
 }
 
-// validateSplitFlags checks the --split / --chunk-size combination. The actual
-// splitting happens server-side (the backfill endpoint), so this only validates
-// the flags locally for a clear error before the request.
+// validateSplitFlags checks the --split / --chunk-size combination.
 func validateSplitFlags(split string, chunkSizeSet bool, chunkSize int) error {
 	if split == "" {
 		if chunkSizeSet {
@@ -755,10 +753,7 @@ func validateSplitFlags(split string, chunkSizeSet bool, chunkSize int) error {
 	return nil
 }
 
-// matchTriggerAsset finds an asset by full name, bare name, or filename. An exact
-// full-name match always wins. Otherwise it matches by leaf name (schema-qualified
-// suffix); if that leaf name is shared by multiple assets it returns an ambiguity
-// error rather than silently picking one. Returns (nil, nil) when nothing matches.
+// matchTriggerAsset finds an asset by full name, bare name, or filename. 
 func matchTriggerAsset(assets []bruincloud.Asset, in string) (*bruincloud.Asset, error) {
 	query := strings.TrimSuffix(strings.TrimSuffix(in, ".sql"), ".py")
 
@@ -801,10 +796,7 @@ func assetStringList(raw json.RawMessage) []string {
 	return list
 }
 
-// triggerAssetSelection holds the asset-selection flags. The Cloud trigger API
-// only understands an explicit whitelist of asset IDs, so the selection (asset
-// names, optionally expanded by --downstream) is resolved client-side into that
-// whitelist. (--tag is run-level metadata, not an asset filter.)
+// triggerAssetSelection holds the asset-selection flags. 
 type triggerAssetSelection struct {
 	assetInputs []string
 	downstream  bool

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -810,13 +810,10 @@ type triggerAssetSelection struct {
 	downstream  bool
 }
 
-func (s triggerAssetSelection) active() bool {
-	return len(s.assetInputs) > 0
-}
-
 // selectTriggerAssets resolves the selection flags into a concrete asset set.
 func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) ([]*bruincloud.Asset, error) {
-	if !sel.active() {
+	// A selection is active only when assets are named; --downstream alone is a no-op.
+	if len(sel.assetInputs) == 0 {
 		return nil, nil
 	}
 
@@ -866,22 +863,88 @@ func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) (
 	}), nil
 }
 
-// applyAssetSelection sets the whitelist (asset IDs) and, when fullRefresh is set, the FULL_REFRESH overrides; a nil selection runs the whole pipeline.
-func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fullRefresh bool) {
-	if fullRefresh {
-		opts.AssetOverrides = map[string]map[string]any{}
+type fullRefreshSpec struct {
+	all    bool
+	assets []string
+}
+
+// resolveFullRefresh interprets the --full-refresh flag values.
+func resolveFullRefresh(fullrefreshs []string, assets []bruincloud.Asset, selected []*bruincloud.Asset) (fullRefreshSpec, error) {
+	var spec fullRefreshSpec
+	if len(fullrefreshs) == 0 {
+		return spec, nil
 	}
+
+	var names []string
+	for _, fr := range fullrefreshs {
+		if fr == "all" {
+			spec.all = true
+			continue
+		}
+		names = append(names, fr)
+	}
+	if spec.all {
+		if len(names) > 0 {
+			return spec, errors.New(`--full-refresh "all" cannot be combined with specific asset names`)
+		}
+		return spec, nil
+	}
+
+	inSelection := make(map[string]bool, len(selected))
+	for _, a := range selected {
+		inSelection[a.Name] = true
+	}
+	for _, in := range names {
+		m, err := matchTriggerAsset(assets, in)
+		if err != nil {
+			return spec, err
+		}
+		if m == nil {
+			return spec, fmt.Errorf("asset %q not found in pipeline; run 'bruin cloud assets list' to see available names", in)
+		}
+		if len(selected) > 0 && !inSelection[m.Name] {
+			return spec, fmt.Errorf("cannot full-refresh %q because it is not in the selected assets", in)
+		}
+		spec.assets = append(spec.assets, m.Name)
+	}
+	return spec, nil
+}
+
+// applyAssetSelection sets the whitelist (asset IDs) from the selection and the
+// FULL_REFRESH overrides from the full-refresh spec. A nil selection runs the whole
+// pipeline; an "all" full-refresh covers the selection if there is one, otherwise the
+// whole pipeline.
+func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fr fullRefreshSpec) {
+	for _, a := range selected {
+		opts.Whitelist = append(opts.Whitelist, a.ID)
+	}
+
+	// 1. Nothing to refresh → return early so AssetOverrides stays nil
+	if !fr.all && len(fr.assets) == 0 {
+		return
+	}
+	opts.AssetOverrides = map[string]map[string]any{}
+
+	// 2. Named subset → refresh exactly the assets the user listed.
+	if !fr.all {
+		for _, name := range fr.assets {
+			opts.AssetOverrides[name] = map[string]any{"FULL_REFRESH": 1}
+		}
+		return
+	}
+
+	// 3. "all" → but "all" means different things:
+	// 3a. with --asset: refresh only the selected assets
 	if selected != nil {
 		for _, a := range selected {
-			opts.Whitelist = append(opts.Whitelist, a.ID)
-			if fullRefresh {
-				opts.AssetOverrides[a.Name] = map[string]any{"FULL_REFRESH": 1}
-			}
+			opts.AssetOverrides[a.Name] = map[string]any{"FULL_REFRESH": 1}
 		}
-	} else if fullRefresh {
-		for i := range assets {
-			opts.AssetOverrides[assets[i].Name] = map[string]any{"FULL_REFRESH": 1}
-		}
+		return
+	}
+
+	// 3b. without --asset: refresh every asset in the pipeline
+	for i := range assets {
+		opts.AssetOverrides[assets[i].Name] = map[string]any{"FULL_REFRESH": 1}
 	}
 }
 
@@ -904,9 +967,8 @@ func parseRunVariables(pairs []string) (map[string]any, error) {
 
 func cloudRunsTrigger() *cli.Command {
 	return &cli.Command{
-		Name:      "trigger",
-		Usage:     "Trigger a new pipeline run",
-		ArgsUsage: "[path to the task file]",
+		Name:  "trigger",
+		Usage: "Trigger a new pipeline run",
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
@@ -922,19 +984,24 @@ func cloudRunsTrigger() *cli.Command {
 				Usage:    "end date for the run (e.g. 2026-01-02T00:00:00Z)",
 				Required: true,
 			},
+			&cli.StringSliceFlag{
+				Name:    "asset",
+				Aliases: []string{"assets"},
+				Usage:   "select specific assets to run by name; repeat or comma-separate for multiple",
+			},
 			&cli.BoolFlag{
 				Name:  "downstream",
-				Usage: "also run assets downstream of the selected ones (used with a positional asset selection; no effect on its own)",
+				Usage: "also run assets downstream of the selected ones (used with --asset; no effect on its own)",
 			},
 			&cli.StringSliceFlag{
 				Name:    "tag",
 				Aliases: []string{"t"},
 				Usage:   "tag the run; repeat for multiple.",
 			},
-			&cli.BoolFlag{
+			&cli.StringSliceFlag{
 				Name:    "full-refresh",
 				Aliases: []string{"r"},
-				Usage:   "truncate the table before running",
+				Usage:   `full-refresh (truncate before running): "all" for every asset in the run, or asset name(s) to refresh only those`,
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",
@@ -988,13 +1055,18 @@ func cloudRunsTrigger() *cli.Command {
 
 			opts := bruincloud.TriggerRunOptions{Variables: vars, Note: c.String("note"), Tags: c.StringSlice("tag")}
 
-			// Asset selection
+			if c.Args().Len() > 0 {
+				printError(fmt.Errorf("unexpected argument(s): %s", strings.Join(c.Args().Slice(), " ")), output, "Invalid arguments")
+				return cli.Exit("", 1)
+			}
+
+			// Asset selection comes from --asset.
 			sel := triggerAssetSelection{
-				assetInputs: c.Args().Slice(),
+				assetInputs: c.StringSlice("asset"),
 				downstream:  c.Bool("downstream"),
 			}
-			fullRefresh := c.Bool("full-refresh")
-			if sel.active() || fullRefresh {
+			fullRefresh := c.StringSlice("full-refresh")
+			if len(sel.assetInputs) > 0 || len(fullRefresh) > 0 {
 				assets, err := client.ListAssets(ctx, project, pipeline)
 				if err != nil {
 					printError(err, output, "Failed to list assets")
@@ -1007,7 +1079,13 @@ func cloudRunsTrigger() *cli.Command {
 					return cli.Exit("", 1)
 				}
 
-				applyAssetSelection(&opts, selected, assets, fullRefresh)
+				fr, err := resolveFullRefresh(fullRefresh, assets, selected)
+				if err != nil {
+					printError(err, output, "Failed to resolve full refresh")
+					return cli.Exit("", 1)
+				}
+
+				applyAssetSelection(&opts, selected, assets, fr)
 			}
 
 			startDate, endDate := c.String("start-date"), c.String("end-date")

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -809,72 +809,26 @@ func selectTriggerAssets(assets []bruincloud.Asset, assetInputs []string) ([]*br
 	}), nil
 }
 
-type fullRefreshSpec struct {
-	all    bool
-	assets []string
-}
-
-// resolveFullRefresh builds the full-refresh spec from --full-refresh (every asset in
-// the run) and --full-refresh-asset (specific asset names).
-func resolveFullRefresh(names []string, all bool, assets []bruincloud.Asset, selected []*bruincloud.Asset) (fullRefreshSpec, error) {
-	spec := fullRefreshSpec{all: all}
-	if all && len(names) > 0 {
-		return spec, errors.New("--full-refresh cannot be combined with specific --full-refresh-asset names")
-	}
-
-	inSelection := make(map[string]bool, len(selected))
-	for _, a := range selected {
-		inSelection[a.Name] = true
-	}
-	for _, in := range names {
-		m, err := matchTriggerAsset(assets, in)
-		if err != nil {
-			return spec, err
-		}
-		if m == nil {
-			return spec, fmt.Errorf("asset %q not found in pipeline; run 'bruin cloud assets list' to see available names", in)
-		}
-		if len(selected) > 0 && !inSelection[m.Name] {
-			return spec, fmt.Errorf("cannot full-refresh %q because it is not in the selected assets", in)
-		}
-		spec.assets = append(spec.assets, m.Name)
-	}
-	return spec, nil
-}
-
-// applyAssetSelection sets the whitelist (asset IDs) from the selection and the
-// FULL_REFRESH overrides from the full-refresh spec. With "all" set, full refresh covers
-// the selected assets when an --asset selection is given, otherwise every asset in the
-// pipeline; otherwise it covers exactly the named assets.
-func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fr fullRefreshSpec) {
+// applyAssetSelection sets the whitelist (asset IDs) from the selection and, when
+// fullRefresh is set, the FULL_REFRESH overrides. Full refresh covers the selected
+// assets when an --asset selection is given, otherwise every asset in the pipeline.
+func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fullRefresh bool) {
 	for _, a := range selected {
 		opts.Whitelist = append(opts.Whitelist, a.ID)
 	}
 
-	// 1. Nothing to refresh → return early so AssetOverrides stays nil
-	if !fr.all && len(fr.assets) == 0 {
+	if !fullRefresh {
 		return
 	}
 	opts.AssetOverrides = map[string]map[string]any{}
 
-	// 2. Named subset → refresh exactly the assets the user listed.
-	if !fr.all {
-		for _, name := range fr.assets {
-			opts.AssetOverrides[name] = map[string]any{"FULL_REFRESH": 1}
-		}
-		return
-	}
-
-	// 3. "all" → but "all" means different things:
-	// 3a. with --asset: refresh only the selected assets
+	// With an --asset selection, refresh only those; otherwise the whole pipeline.
 	if selected != nil {
 		for _, a := range selected {
 			opts.AssetOverrides[a.Name] = map[string]any{"FULL_REFRESH": 1}
 		}
 		return
 	}
-
-	// 3b. without --asset: refresh every asset in the pipeline
 	for i := range assets {
 		opts.AssetOverrides[assets[i].Name] = map[string]any{"FULL_REFRESH": 1}
 	}
@@ -929,11 +883,7 @@ func cloudRunsTrigger() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "full-refresh",
 				Aliases: []string{"r"},
-				Usage:   "full-refresh every asset in the run (the --asset selection if given, otherwise all)",
-			},
-			&cli.StringSliceFlag{
-				Name:  "full-refresh-asset",
-				Usage: "full-refresh only the named asset(s); repeat or comma-separate. Mutually exclusive with --full-refresh.",
+				Usage:   "full-refresh the assets in the run: the --asset selection if given, otherwise every asset",
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",
@@ -992,12 +942,11 @@ func cloudRunsTrigger() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			// Asset selection comes from --asset; full refresh from --full-refresh (all)
-			// or --full-refresh-asset (specific names).
+			// Asset selection comes from --asset; --full-refresh truncates the assets in
+			// the run (the selection if given, otherwise every asset).
 			assetInputs := c.StringSlice("asset")
-			fullRefreshAssets := c.StringSlice("full-refresh-asset")
-			fullRefreshAll := c.Bool("full-refresh")
-			if len(assetInputs) > 0 || len(fullRefreshAssets) > 0 || fullRefreshAll {
+			fullRefresh := c.Bool("full-refresh")
+			if len(assetInputs) > 0 || fullRefresh {
 				assets, err := client.ListAssets(ctx, project, pipeline)
 				if err != nil {
 					printError(err, output, "Failed to list assets")
@@ -1010,13 +959,7 @@ func cloudRunsTrigger() *cli.Command {
 					return cli.Exit("", 1)
 				}
 
-				fr, err := resolveFullRefresh(fullRefreshAssets, fullRefreshAll, assets, selected)
-				if err != nil {
-					printError(err, output, "Failed to resolve full refresh")
-					return cli.Exit("", 1)
-				}
-
-				applyAssetSelection(&opts, selected, assets, fr)
+				applyAssetSelection(&opts, selected, assets, fullRefresh)
 			}
 
 			startDate, endDate := c.String("start-date"), c.String("end-date")

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -786,31 +786,14 @@ func matchTriggerAsset(assets []bruincloud.Asset, in string) (*bruincloud.Asset,
 	}
 }
 
-// assetStringList decodes a json.RawMessage that holds a []string (tags, downstream).
-func assetStringList(raw json.RawMessage) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	var list []string
-	_ = json.Unmarshal(raw, &list)
-	return list
-}
-
-// triggerAssetSelection holds the asset-selection flags.
-type triggerAssetSelection struct {
-	assetInputs []string
-	downstream  bool
-}
-
-// selectTriggerAssets resolves the selection flags into a concrete asset set.
-func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) ([]*bruincloud.Asset, error) {
-	// A selection is active only when assets are named; --downstream alone is a no-op.
-	if len(sel.assetInputs) == 0 {
+// selectTriggerAssets resolves the named asset inputs into a concrete asset set.
+func selectTriggerAssets(assets []bruincloud.Asset, assetInputs []string) ([]*bruincloud.Asset, error) {
+	if len(assetInputs) == 0 {
 		return nil, nil
 	}
 
 	selected := make(map[string]*bruincloud.Asset)
-	for _, in := range sel.assetInputs {
+	for _, in := range assetInputs {
 		m, err := matchTriggerAsset(assets, in)
 		if err != nil {
 			return nil, err
@@ -819,35 +802,6 @@ func selectTriggerAssets(assets []bruincloud.Asset, sel triggerAssetSelection) (
 			return nil, fmt.Errorf("asset %q not found in pipeline; run 'bruin cloud assets list' to see available names", in)
 		}
 		selected[m.Name] = m
-	}
-
-	// Transitively pull in downstream assets.
-	if sel.downstream {
-		byName := make(map[string]*bruincloud.Asset, len(assets))
-		for i := range assets {
-			byName[assets[i].Name] = &assets[i]
-		}
-		queue := make([]string, 0, len(selected))
-		for name := range selected {
-			queue = append(queue, name)
-		}
-		for len(queue) > 0 {
-			name := queue[0]
-			queue = queue[1:]
-			a := byName[name]
-			if a == nil {
-				continue
-			}
-			for _, d := range assetStringList(a.Downstream) {
-				if _, seen := selected[d]; seen {
-					continue
-				}
-				if da := byName[d]; da != nil {
-					selected[d] = da
-					queue = append(queue, d)
-				}
-			}
-		}
 	}
 
 	return slices.SortedFunc(maps.Values(selected), func(a, b *bruincloud.Asset) int {
@@ -860,26 +814,12 @@ type fullRefreshSpec struct {
 	assets []string
 }
 
-// resolveFullRefresh interprets the --full-refresh flag values.
-func resolveFullRefresh(fullrefreshs []string, assets []bruincloud.Asset, selected []*bruincloud.Asset) (fullRefreshSpec, error) {
-	var spec fullRefreshSpec
-	if len(fullrefreshs) == 0 {
-		return spec, nil
-	}
-
-	var names []string
-	for _, fr := range fullrefreshs {
-		if fr == "all" {
-			spec.all = true
-			continue
-		}
-		names = append(names, fr)
-	}
-	if spec.all {
-		if len(names) > 0 {
-			return spec, errors.New(`--full-refresh "all" cannot be combined with specific asset names`)
-		}
-		return spec, nil
+// resolveFullRefresh builds the full-refresh spec from --full-refresh (every asset in
+// the run) and --full-refresh-asset (specific asset names).
+func resolveFullRefresh(names []string, all bool, assets []bruincloud.Asset, selected []*bruincloud.Asset) (fullRefreshSpec, error) {
+	spec := fullRefreshSpec{all: all}
+	if all && len(names) > 0 {
+		return spec, errors.New("--full-refresh cannot be combined with specific --full-refresh-asset names")
 	}
 
 	inSelection := make(map[string]bool, len(selected))
@@ -903,9 +843,9 @@ func resolveFullRefresh(fullrefreshs []string, assets []bruincloud.Asset, select
 }
 
 // applyAssetSelection sets the whitelist (asset IDs) from the selection and the
-// FULL_REFRESH overrides from the full-refresh spec. A nil selection runs the whole
-// pipeline; an "all" full-refresh covers the selection if there is one, otherwise the
-// whole pipeline.
+// FULL_REFRESH overrides from the full-refresh spec. With "all" set, full refresh covers
+// the selected assets when an --asset selection is given, otherwise every asset in the
+// pipeline; otherwise it covers exactly the named assets.
 func applyAssetSelection(opts *bruincloud.TriggerRunOptions, selected []*bruincloud.Asset, assets []bruincloud.Asset, fr fullRefreshSpec) {
 	for _, a := range selected {
 		opts.Whitelist = append(opts.Whitelist, a.ID)
@@ -981,19 +921,19 @@ func cloudRunsTrigger() *cli.Command {
 				Aliases: []string{"assets"},
 				Usage:   "select specific assets to run by name; repeat or comma-separate for multiple",
 			},
-			&cli.BoolFlag{
-				Name:  "downstream",
-				Usage: "also run assets downstream of the selected ones (used with --asset; no effect on its own)",
-			},
 			&cli.StringSliceFlag{
 				Name:    "tag",
 				Aliases: []string{"t"},
 				Usage:   "tag the run; repeat for multiple.",
 			},
-			&cli.StringSliceFlag{
+			&cli.BoolFlag{
 				Name:    "full-refresh",
 				Aliases: []string{"r"},
-				Usage:   `full-refresh (truncate before running): "all" for every asset in the run, or asset name(s) to refresh only those`,
+				Usage:   "full-refresh every asset in the run (the --asset selection if given, otherwise all)",
+			},
+			&cli.StringSliceFlag{
+				Name:  "full-refresh-asset",
+				Usage: "full-refresh only the named asset(s); repeat or comma-separate. Mutually exclusive with --full-refresh.",
 			},
 			&cli.StringSliceFlag{
 				Name:  "var",
@@ -1052,26 +992,25 @@ func cloudRunsTrigger() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			// Asset selection comes from --asset.
-			sel := triggerAssetSelection{
-				assetInputs: c.StringSlice("asset"),
-				downstream:  c.Bool("downstream"),
-			}
-			fullRefresh := c.StringSlice("full-refresh")
-			if len(sel.assetInputs) > 0 || len(fullRefresh) > 0 {
+			// Asset selection comes from --asset; full refresh from --full-refresh (all)
+			// or --full-refresh-asset (specific names).
+			assetInputs := c.StringSlice("asset")
+			fullRefreshAssets := c.StringSlice("full-refresh-asset")
+			fullRefreshAll := c.Bool("full-refresh")
+			if len(assetInputs) > 0 || len(fullRefreshAssets) > 0 || fullRefreshAll {
 				assets, err := client.ListAssets(ctx, project, pipeline)
 				if err != nil {
 					printError(err, output, "Failed to list assets")
 					return cli.Exit("", 1)
 				}
 
-				selected, err := selectTriggerAssets(assets, sel)
+				selected, err := selectTriggerAssets(assets, assetInputs)
 				if err != nil {
 					printError(err, output, "Failed to resolve assets")
 					return cli.Exit("", 1)
 				}
 
-				fr, err := resolveFullRefresh(fullRefresh, assets, selected)
+				fr, err := resolveFullRefresh(fullRefreshAssets, fullRefreshAll, assets, selected)
 				if err != nil {
 					printError(err, output, "Failed to resolve full refresh")
 					return cli.Exit("", 1)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -483,7 +483,7 @@ func TestApplyAssetSelection(t *testing.T) {
 	t.Run("no selection no full refresh leaves opts empty", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, nil, assets, fullRefreshSpec{})
+		applyAssetSelection(&opts, nil, assets, false)
 		assert.Nil(t, opts.Whitelist)
 		assert.Nil(t, opts.AssetOverrides)
 	})
@@ -491,15 +491,15 @@ func TestApplyAssetSelection(t *testing.T) {
 	t.Run("selection sets whitelist by id without overrides", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, selected, assets, fullRefreshSpec{})
+		applyAssetSelection(&opts, selected, assets, false)
 		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
 		assert.Nil(t, opts.AssetOverrides)
 	})
 
-	t.Run("full refresh all without selection covers whole pipeline", func(t *testing.T) {
+	t.Run("full refresh without selection covers whole pipeline", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, nil, assets, fullRefreshSpec{all: true})
+		applyAssetSelection(&opts, nil, assets, true)
 		assert.Nil(t, opts.Whitelist) // empty whitelist => whole pipeline
 		assert.Len(t, opts.AssetOverrides, 3)
 		for _, a := range assets {
@@ -507,105 +507,15 @@ func TestApplyAssetSelection(t *testing.T) {
 		}
 	})
 
-	t.Run("full refresh all with selection covers only selected", func(t *testing.T) {
+	t.Run("full refresh with selection covers only selected", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, selected, assets, fullRefreshSpec{all: true})
+		applyAssetSelection(&opts, selected, assets, true)
 		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
 		assert.Len(t, opts.AssetOverrides, 2)
 		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.raw"])
 		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.report"])
-	})
-
-	t.Run("full refresh subset overrides only named assets", func(t *testing.T) {
-		t.Parallel()
-		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, selected, assets, fullRefreshSpec{assets: []string{"s.report"}})
-		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
-		assert.Len(t, opts.AssetOverrides, 1)
-		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.report"])
-		assert.NotContains(t, opts.AssetOverrides, "s.raw")
-	})
-
-	t.Run("full refresh names without selection runs whole pipeline", func(t *testing.T) {
-		t.Parallel()
-		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, nil, assets, fullRefreshSpec{assets: []string{"s.summary"}})
-		assert.Nil(t, opts.Whitelist) // empty whitelist => whole pipeline
-		assert.Len(t, opts.AssetOverrides, 1)
-		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.summary"])
-	})
-}
-
-func TestResolveFullRefresh(t *testing.T) {
-	t.Parallel()
-
-	assets := []bruincloud.Asset{
-		mkTriggerAsset(t, "s.raw", "id-raw", nil, nil),
-		mkTriggerAsset(t, "s.summary", "id-summary", nil, nil),
-		mkTriggerAsset(t, "s.report", "id-report", nil, nil),
-	}
-	selected := []*bruincloud.Asset{&assets[0], &assets[2]} // raw + report
-
-	t.Run("nothing requested returns empty spec", func(t *testing.T) {
-		t.Parallel()
-		spec, err := resolveFullRefresh(nil, false, assets, nil)
-		require.NoError(t, err)
-		assert.False(t, spec.all)
-		assert.Empty(t, spec.assets)
-	})
-
-	t.Run("full-refresh-all sets all", func(t *testing.T) {
-		t.Parallel()
-		spec, err := resolveFullRefresh(nil, true, assets, nil)
-		require.NoError(t, err)
-		assert.True(t, spec.all)
-		assert.Empty(t, spec.assets)
-	})
-
-	t.Run("all combined with names errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := resolveFullRefresh([]string{"s.raw"}, true, assets, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot be combined")
-	})
-
-	t.Run("names resolved to canonical form", func(t *testing.T) {
-		t.Parallel()
-		spec, err := resolveFullRefresh([]string{"report", "raw.sql"}, false, assets, nil)
-		require.NoError(t, err)
-		assert.False(t, spec.all)
-		assert.Equal(t, []string{"s.report", "s.raw"}, spec.assets)
-	})
-
-	t.Run("asset literally named all is matched, not treated as keyword", func(t *testing.T) {
-		t.Parallel()
-		withAll := append([]bruincloud.Asset{mkTriggerAsset(t, "all", "id-all", nil, nil)}, assets...)
-		spec, err := resolveFullRefresh([]string{"all"}, false, withAll, nil)
-		require.NoError(t, err)
-		assert.False(t, spec.all)
-		assert.Equal(t, []string{"all"}, spec.assets)
-	})
-
-	t.Run("unknown asset errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := resolveFullRefresh([]string{"nope"}, false, assets, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not found")
-	})
-
-	t.Run("name within selection is allowed", func(t *testing.T) {
-		t.Parallel()
-		spec, err := resolveFullRefresh([]string{"s.report"}, false, assets, selected)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"s.report"}, spec.assets)
-	})
-
-	t.Run("name outside selection errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := resolveFullRefresh([]string{"s.summary"}, false, assets, selected)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not in the selected assets")
+		assert.NotContains(t, opts.AssetOverrides, "s.summary")
 	})
 }
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -353,30 +353,26 @@ func TestSelectTriggerAssets(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		sel     triggerAssetSelection
-		want    []string
-		wantErr bool
-		wantNil bool
+		name        string
+		assetInputs []string
+		want        []string
+		wantErr     bool
+		wantNil     bool
 	}{
-		{name: "no selection runs whole pipeline", sel: triggerAssetSelection{}, wantNil: true},
-		{name: "downstream alone is not a selection", sel: triggerAssetSelection{downstream: true}, wantNil: true},
-		{name: "by asset name", sel: triggerAssetSelection{assetInputs: []string{"s.summary"}}, want: []string{"s.summary"}},
-		{name: "by bare/file name", sel: triggerAssetSelection{assetInputs: []string{"raw.sql"}}, want: []string{"s.raw"}},
-		{name: "by bare name without prefix", sel: triggerAssetSelection{assetInputs: []string{"report"}}, want: []string{"s.report"}},
-		{name: "multiple assets", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "s.report"}}, want: []string{"s.raw", "s.report"}},
-		{name: "duplicate asset deduped", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "raw.sql"}}, want: []string{"s.raw"}},
-		{name: "unknown asset errors", sel: triggerAssetSelection{assetInputs: []string{"nope"}}, wantErr: true},
-		{name: "one unknown among valid errors", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "nope"}}, wantErr: true},
-		{name: "downstream expansion transitive", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, downstream: true}, want: []string{"s.raw", "s.report", "s.summary"}},
-		{name: "downstream on leaf asset", sel: triggerAssetSelection{assetInputs: []string{"s.standalone"}, downstream: true}, want: []string{"s.standalone"}},
-		{name: "downstream mid-chain", sel: triggerAssetSelection{assetInputs: []string{"s.summary"}, downstream: true}, want: []string{"s.report", "s.summary"}},
+		{name: "no selection runs whole pipeline", assetInputs: nil, wantNil: true},
+		{name: "by asset name", assetInputs: []string{"s.summary"}, want: []string{"s.summary"}},
+		{name: "by bare/file name", assetInputs: []string{"raw.sql"}, want: []string{"s.raw"}},
+		{name: "by bare name without prefix", assetInputs: []string{"report"}, want: []string{"s.report"}},
+		{name: "multiple assets", assetInputs: []string{"s.raw", "s.report"}, want: []string{"s.raw", "s.report"}},
+		{name: "duplicate asset deduped", assetInputs: []string{"s.raw", "raw.sql"}, want: []string{"s.raw"}},
+		{name: "unknown asset errors", assetInputs: []string{"nope"}, wantErr: true},
+		{name: "one unknown among valid errors", assetInputs: []string{"s.raw", "nope"}, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := selectTriggerAssets(assets, tt.sel)
+			got, err := selectTriggerAssets(assets, tt.assetInputs)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -551,17 +547,17 @@ func TestResolveFullRefresh(t *testing.T) {
 	}
 	selected := []*bruincloud.Asset{&assets[0], &assets[2]} // raw + report
 
-	t.Run("empty values returns empty spec", func(t *testing.T) {
+	t.Run("nothing requested returns empty spec", func(t *testing.T) {
 		t.Parallel()
-		spec, err := resolveFullRefresh(nil, assets, nil)
+		spec, err := resolveFullRefresh(nil, false, assets, nil)
 		require.NoError(t, err)
 		assert.False(t, spec.all)
 		assert.Empty(t, spec.assets)
 	})
 
-	t.Run("all keyword sets all", func(t *testing.T) {
+	t.Run("full-refresh-all sets all", func(t *testing.T) {
 		t.Parallel()
-		spec, err := resolveFullRefresh([]string{"all"}, assets, nil)
+		spec, err := resolveFullRefresh(nil, true, assets, nil)
 		require.NoError(t, err)
 		assert.True(t, spec.all)
 		assert.Empty(t, spec.assets)
@@ -569,36 +565,45 @@ func TestResolveFullRefresh(t *testing.T) {
 
 	t.Run("all combined with names errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := resolveFullRefresh([]string{"all", "s.raw"}, assets, nil)
+		_, err := resolveFullRefresh([]string{"s.raw"}, true, assets, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be combined")
 	})
 
 	t.Run("names resolved to canonical form", func(t *testing.T) {
 		t.Parallel()
-		spec, err := resolveFullRefresh([]string{"report", "raw.sql"}, assets, nil)
+		spec, err := resolveFullRefresh([]string{"report", "raw.sql"}, false, assets, nil)
 		require.NoError(t, err)
 		assert.False(t, spec.all)
 		assert.Equal(t, []string{"s.report", "s.raw"}, spec.assets)
 	})
 
+	t.Run("asset literally named all is matched, not treated as keyword", func(t *testing.T) {
+		t.Parallel()
+		withAll := append([]bruincloud.Asset{mkTriggerAsset(t, "all", "id-all", nil, nil)}, assets...)
+		spec, err := resolveFullRefresh([]string{"all"}, false, withAll, nil)
+		require.NoError(t, err)
+		assert.False(t, spec.all)
+		assert.Equal(t, []string{"all"}, spec.assets)
+	})
+
 	t.Run("unknown asset errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := resolveFullRefresh([]string{"nope"}, assets, nil)
+		_, err := resolveFullRefresh([]string{"nope"}, false, assets, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("name within selection is allowed", func(t *testing.T) {
 		t.Parallel()
-		spec, err := resolveFullRefresh([]string{"s.report"}, assets, selected)
+		spec, err := resolveFullRefresh([]string{"s.report"}, false, assets, selected)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"s.report"}, spec.assets)
 	})
 
 	t.Run("name outside selection errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := resolveFullRefresh([]string{"s.summary"}, assets, selected)
+		_, err := resolveFullRefresh([]string{"s.summary"}, false, assets, selected)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the selected assets")
 	})

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/stretchr/testify/assert"
@@ -369,19 +368,9 @@ func TestSelectTriggerAssets(t *testing.T) {
 		{name: "duplicate asset deduped", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "raw.sql"}}, want: []string{"s.raw"}},
 		{name: "unknown asset errors", sel: triggerAssetSelection{assetInputs: []string{"nope"}}, wantErr: true},
 		{name: "one unknown among valid errors", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "nope"}}, wantErr: true},
-		{name: "by tag", sel: triggerAssetSelection{tag: "report"}, want: []string{"s.report", "s.standalone"}},
-		{name: "unknown tag errors", sel: triggerAssetSelection{tag: "ghost"}, wantErr: true},
-		{name: "asset and tag union", sel: triggerAssetSelection{assetInputs: []string{"s.standalone"}, tag: "source"}, want: []string{"s.raw", "s.standalone"}},
 		{name: "downstream expansion transitive", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, downstream: true}, want: []string{"s.raw", "s.report", "s.summary"}},
 		{name: "downstream on leaf asset", sel: triggerAssetSelection{assetInputs: []string{"s.standalone"}, downstream: true}, want: []string{"s.standalone"}},
 		{name: "downstream mid-chain", sel: triggerAssetSelection{assetInputs: []string{"s.summary"}, downstream: true}, want: []string{"s.report", "s.summary"}},
-		{name: "tag with downstream", sel: triggerAssetSelection{tag: "source", downstream: true}, want: []string{"s.raw", "s.report", "s.summary"}},
-		{name: "exclude tag from all", sel: triggerAssetSelection{excludeTags: []string{"report"}}, want: []string{"s.raw", "s.summary"}},
-		{name: "multiple exclude tags", sel: triggerAssetSelection{excludeTags: []string{"source", "report"}}, want: []string{"s.summary"}},
-		{name: "exclude all tags errors", sel: triggerAssetSelection{excludeTags: []string{"source", "summary", "report"}}, wantErr: true},
-		{name: "downstream then exclude tag", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, downstream: true, excludeTags: []string{"report"}}, want: []string{"s.raw", "s.summary"}},
-		{name: "tag then exclude same tag errors", sel: triggerAssetSelection{tag: "report", excludeTags: []string{"report"}}, wantErr: true},
-		{name: "asset survives unmatched exclude tag", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, excludeTags: []string{"report"}}, want: []string{"s.raw"}},
 	}
 
 	for _, tt := range tests {
@@ -402,38 +391,38 @@ func TestSelectTriggerAssets(t *testing.T) {
 	}
 }
 
-func TestSplitRunIntervals(t *testing.T) {
+func TestValidateSplitFlags(t *testing.T) {
 	t.Parallel()
 
-	mustParse := func(s string) time.Time {
-		ts, err := parseRunDate(s)
-		require.NoError(t, err)
-		return ts
-	}
-
-	t.Run("monthly split of a quarter yields three runs", func(t *testing.T) {
+	t.Run("no split, no chunk-size is valid", func(t *testing.T) {
 		t.Parallel()
-		got := splitRunIntervals(mustParse("2026-01-01"), mustParse("2026-04-01"), "month", 1)
-		require.Len(t, got, 3)
-		assert.Equal(t, "2026-01-01T00:00:00.000Z", got[0].StartDate)
-		assert.Equal(t, "2026-01-31T23:59:59.999Z", got[0].EndDate)
-		assert.Equal(t, "2026-02-01T00:00:00.000Z", got[1].StartDate)
-		assert.Equal(t, "2026-03-01T00:00:00.000Z", got[2].StartDate)
+		require.NoError(t, validateSplitFlags("", false, 1))
 	})
 
-	t.Run("chunk size groups units per batch", func(t *testing.T) {
+	t.Run("chunk-size without split errors", func(t *testing.T) {
 		t.Parallel()
-		got := splitRunIntervals(mustParse("2026-01-01"), mustParse("2026-01-11"), "day", 5)
-		require.Len(t, got, 2)
-		assert.Equal(t, "2026-01-01T00:00:00.000Z", got[0].StartDate)
-		assert.Equal(t, "2026-01-06T00:00:00.000Z", got[1].StartDate)
+		err := validateSplitFlags("", true, 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--chunk-size requires --split")
 	})
 
-	t.Run("final interval is clamped to end", func(t *testing.T) {
+	t.Run("valid split unit", func(t *testing.T) {
 		t.Parallel()
-		got := splitRunIntervals(mustParse("2026-01-01"), mustParse("2026-01-10"), "week", 1)
-		require.Len(t, got, 2)
-		assert.Equal(t, "2026-01-10T00:00:00.000Z", got[1].EndDate)
+		require.NoError(t, validateSplitFlags("month", true, 2))
+	})
+
+	t.Run("invalid split unit errors", func(t *testing.T) {
+		t.Parallel()
+		err := validateSplitFlags("fortnight", false, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --split")
+	})
+
+	t.Run("chunk-size below one errors", func(t *testing.T) {
+		t.Parallel()
+		err := validateSplitFlags("day", true, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least 1")
 	})
 }
 
@@ -531,66 +520,6 @@ func TestApplyAssetSelection(t *testing.T) {
 		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.raw"])
 		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.report"])
 		assert.NotContains(t, opts.AssetOverrides, "s.summary")
-	})
-}
-
-func TestBuildTriggerIntervals(t *testing.T) {
-	t.Parallel()
-
-	t.Run("no split is a single passthrough interval", func(t *testing.T) {
-		t.Parallel()
-		got, err := buildTriggerIntervals("", false, 1, "2024-01-01", "2024-01-31")
-		require.NoError(t, err)
-		assert.Equal(t, []bruincloud.RunInterval{{StartDate: "2024-01-01", EndDate: "2024-01-31"}}, got)
-	})
-
-	t.Run("chunk-size without split errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := buildTriggerIntervals("", true, 7, "2024-01-01", "2024-01-31")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--chunk-size requires --split")
-	})
-
-	t.Run("monthly split produces one interval per month", func(t *testing.T) {
-		t.Parallel()
-		got, err := buildTriggerIntervals("month", false, 1, "2024-01-01", "2024-04-01")
-		require.NoError(t, err)
-		require.Len(t, got, 3)
-		assert.Equal(t, "2024-01-01T00:00:00.000Z", got[0].StartDate)
-	})
-
-	t.Run("invalid split unit errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := buildTriggerIntervals("fortnight", false, 1, "2024-01-01", "2024-04-01")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid --split")
-	})
-
-	t.Run("chunk-size below one errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := buildTriggerIntervals("day", true, 0, "2024-01-01", "2024-01-31")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "at least 1")
-	})
-
-	t.Run("invalid date errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := buildTriggerIntervals("day", false, 1, "not-a-date", "2024-01-31")
-		require.Error(t, err)
-	})
-
-	t.Run("start not before end errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := buildTriggerIntervals("day", false, 1, "2024-02-01", "2024-01-01")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "before")
-	})
-
-	t.Run("exceeding the run cap errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := buildTriggerIntervals("day", false, 1, "2024-01-01", "2025-01-01") // 366 daily runs
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeds the limit")
 	})
 }
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/stretchr/testify/assert"
@@ -323,4 +324,271 @@ func TestCloudRunsDiagnoseCommand_Flags(t *testing.T) {
 	assert.Contains(t, flagNames, "pipeline")
 	assert.Contains(t, flagNames, "run-id")
 	assert.Contains(t, flagNames, "latest")
+}
+
+func mkTriggerAsset(t *testing.T, name, id string, tags, downstream []string) bruincloud.Asset {
+	t.Helper()
+	tagsRaw, err := json.Marshal(tags)
+	require.NoError(t, err)
+	dsRaw, err := json.Marshal(downstream)
+	require.NoError(t, err)
+	return bruincloud.Asset{Name: name, ID: id, Tags: tagsRaw, Downstream: dsRaw}
+}
+
+func triggerAssetNames(selected []*bruincloud.Asset) []string {
+	names := make([]string, 0, len(selected))
+	for _, a := range selected {
+		names = append(names, a.Name)
+	}
+	return names
+}
+
+func TestSelectTriggerAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := []bruincloud.Asset{
+		mkTriggerAsset(t, "s.raw", "id-raw", []string{"source"}, []string{"s.summary"}),
+		mkTriggerAsset(t, "s.summary", "id-summary", []string{"summary"}, []string{"s.report"}),
+		mkTriggerAsset(t, "s.report", "id-report", []string{"report"}, nil),
+		mkTriggerAsset(t, "s.standalone", "id-standalone", []string{"report"}, nil),
+	}
+
+	tests := []struct {
+		name    string
+		sel     triggerAssetSelection
+		want    []string
+		wantErr bool
+		wantNil bool
+	}{
+		{name: "no selection runs whole pipeline", sel: triggerAssetSelection{}, wantNil: true},
+		{name: "by asset name", sel: triggerAssetSelection{assetInputs: []string{"s.summary"}}, want: []string{"s.summary"}},
+		{name: "by bare/file name", sel: triggerAssetSelection{assetInputs: []string{"raw.sql"}}, want: []string{"s.raw"}},
+		{name: "by bare name without prefix", sel: triggerAssetSelection{assetInputs: []string{"report"}}, want: []string{"s.report"}},
+		{name: "multiple assets", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "s.report"}}, want: []string{"s.raw", "s.report"}},
+		{name: "duplicate asset deduped", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "raw.sql"}}, want: []string{"s.raw"}},
+		{name: "unknown asset errors", sel: triggerAssetSelection{assetInputs: []string{"nope"}}, wantErr: true},
+		{name: "one unknown among valid errors", sel: triggerAssetSelection{assetInputs: []string{"s.raw", "nope"}}, wantErr: true},
+		{name: "by tag", sel: triggerAssetSelection{tag: "report"}, want: []string{"s.report", "s.standalone"}},
+		{name: "unknown tag errors", sel: triggerAssetSelection{tag: "ghost"}, wantErr: true},
+		{name: "asset and tag union", sel: triggerAssetSelection{assetInputs: []string{"s.standalone"}, tag: "source"}, want: []string{"s.raw", "s.standalone"}},
+		{name: "downstream expansion transitive", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, downstream: true}, want: []string{"s.raw", "s.report", "s.summary"}},
+		{name: "downstream on leaf asset", sel: triggerAssetSelection{assetInputs: []string{"s.standalone"}, downstream: true}, want: []string{"s.standalone"}},
+		{name: "downstream mid-chain", sel: triggerAssetSelection{assetInputs: []string{"s.summary"}, downstream: true}, want: []string{"s.report", "s.summary"}},
+		{name: "tag with downstream", sel: triggerAssetSelection{tag: "source", downstream: true}, want: []string{"s.raw", "s.report", "s.summary"}},
+		{name: "exclude tag from all", sel: triggerAssetSelection{excludeTags: []string{"report"}}, want: []string{"s.raw", "s.summary"}},
+		{name: "multiple exclude tags", sel: triggerAssetSelection{excludeTags: []string{"source", "report"}}, want: []string{"s.summary"}},
+		{name: "exclude all tags yields empty", sel: triggerAssetSelection{excludeTags: []string{"source", "summary", "report"}}, want: []string{}},
+		{name: "downstream then exclude tag", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, downstream: true, excludeTags: []string{"report"}}, want: []string{"s.raw", "s.summary"}},
+		{name: "tag then exclude same tag", sel: triggerAssetSelection{tag: "report", excludeTags: []string{"report"}}, want: []string{}},
+		{name: "asset survives unmatched exclude tag", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, excludeTags: []string{"report"}}, want: []string{"s.raw"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := selectTriggerAssets(assets, tt.sel)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, triggerAssetNames(got))
+		})
+	}
+}
+
+func TestSplitRunIntervals(t *testing.T) {
+	t.Parallel()
+
+	mustParse := func(s string) time.Time {
+		ts, err := parseRunDate(s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	t.Run("monthly split of a quarter yields three runs", func(t *testing.T) {
+		t.Parallel()
+		got := splitRunIntervals(mustParse("2026-01-01"), mustParse("2026-04-01"), "month", 1)
+		require.Len(t, got, 3)
+		assert.Equal(t, "2026-01-01T00:00:00.000Z", got[0].StartDate)
+		assert.Equal(t, "2026-01-31T23:59:59.999Z", got[0].EndDate)
+		assert.Equal(t, "2026-02-01T00:00:00.000Z", got[1].StartDate)
+		assert.Equal(t, "2026-03-01T00:00:00.000Z", got[2].StartDate)
+	})
+
+	t.Run("chunk size groups units per batch", func(t *testing.T) {
+		t.Parallel()
+		got := splitRunIntervals(mustParse("2026-01-01"), mustParse("2026-01-11"), "day", 5)
+		require.Len(t, got, 2)
+		assert.Equal(t, "2026-01-01T00:00:00.000Z", got[0].StartDate)
+		assert.Equal(t, "2026-01-06T00:00:00.000Z", got[1].StartDate)
+	})
+
+	t.Run("final interval is clamped to end", func(t *testing.T) {
+		t.Parallel()
+		got := splitRunIntervals(mustParse("2026-01-01"), mustParse("2026-01-10"), "week", 1)
+		require.Len(t, got, 2)
+		assert.Equal(t, "2026-01-10T00:00:00.000Z", got[1].EndDate)
+	})
+}
+
+func TestParseRunVariables(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseRunVariables(nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("quoted string value", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseRunVariables([]string{`env="prod"`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"env": "prod"}, got)
+	})
+
+	t.Run("boolean value", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseRunVariables([]string{"debug=true"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"debug": true}, got)
+	})
+
+	t.Run("json object form sets multiple keys", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseRunVariables([]string{`{"region":"eu","retries":3}`})
+		require.NoError(t, err)
+		assert.Equal(t, "eu", got["region"])
+		assert.EqualValues(t, 3, got["retries"])
+	})
+
+	t.Run("multiple flags are merged", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseRunVariables([]string{`a="x"`, "b=true"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"a": "x", "b": true}, got)
+	})
+
+	t.Run("unquoted bareword value errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseRunVariables([]string{"env=prod"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid variable override")
+	})
+}
+
+func TestApplyAssetSelection(t *testing.T) {
+	t.Parallel()
+
+	assets := []bruincloud.Asset{
+		mkTriggerAsset(t, "s.raw", "id-raw", nil, nil),
+		mkTriggerAsset(t, "s.summary", "id-summary", nil, nil),
+		mkTriggerAsset(t, "s.report", "id-report", nil, nil),
+	}
+	// A concrete selection (as selectTriggerAssets would return): raw + report.
+	selected := []*bruincloud.Asset{&assets[0], &assets[2]}
+
+	t.Run("no selection no full refresh leaves opts empty", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, nil, assets, false)
+		assert.Nil(t, opts.Whitelist)
+		assert.Nil(t, opts.AssetOverrides)
+	})
+
+	t.Run("no selection with full refresh overrides every asset", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, nil, assets, true)
+		assert.Nil(t, opts.Whitelist) // empty whitelist => whole pipeline
+		assert.Len(t, opts.AssetOverrides, 3)
+		for _, a := range assets {
+			assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides[a.Name])
+		}
+	})
+
+	t.Run("selection sets whitelist by id without overrides", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, selected, assets, false)
+		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
+		assert.Nil(t, opts.AssetOverrides)
+	})
+
+	t.Run("selection with full refresh overrides only selected", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, selected, assets, true)
+		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
+		assert.Len(t, opts.AssetOverrides, 2)
+		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.raw"])
+		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.report"])
+		assert.NotContains(t, opts.AssetOverrides, "s.summary")
+	})
+}
+
+func TestBuildTriggerIntervals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no split is a single passthrough interval", func(t *testing.T) {
+		t.Parallel()
+		got, err := buildTriggerIntervals("", false, 1, "2024-01-01", "2024-01-31")
+		require.NoError(t, err)
+		assert.Equal(t, []bruincloud.RunInterval{{StartDate: "2024-01-01", EndDate: "2024-01-31"}}, got)
+	})
+
+	t.Run("chunk-size without split errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildTriggerIntervals("", true, 7, "2024-01-01", "2024-01-31")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--chunk-size requires --split")
+	})
+
+	t.Run("monthly split produces one interval per month", func(t *testing.T) {
+		t.Parallel()
+		got, err := buildTriggerIntervals("month", false, 1, "2024-01-01", "2024-04-01")
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		assert.Equal(t, "2024-01-01T00:00:00.000Z", got[0].StartDate)
+	})
+
+	t.Run("invalid split unit errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildTriggerIntervals("fortnight", false, 1, "2024-01-01", "2024-04-01")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --split")
+	})
+
+	t.Run("chunk-size below one errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildTriggerIntervals("day", true, 0, "2024-01-01", "2024-01-31")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least 1")
+	})
+
+	t.Run("invalid date errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildTriggerIntervals("day", false, 1, "not-a-date", "2024-01-31")
+		require.Error(t, err)
+	})
+
+	t.Run("start not before end errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildTriggerIntervals("day", false, 1, "2024-02-01", "2024-01-01")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "before")
+	})
+
+	t.Run("exceeding the run cap errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildTriggerIntervals("day", false, 1, "2024-01-01", "2025-01-01") // 366 daily runs
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds the limit")
+	})
 }

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -487,15 +487,23 @@ func TestApplyAssetSelection(t *testing.T) {
 	t.Run("no selection no full refresh leaves opts empty", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, nil, assets, false)
+		applyAssetSelection(&opts, nil, assets, fullRefreshSpec{})
 		assert.Nil(t, opts.Whitelist)
 		assert.Nil(t, opts.AssetOverrides)
 	})
 
-	t.Run("no selection with full refresh overrides every asset", func(t *testing.T) {
+	t.Run("selection sets whitelist by id without overrides", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, nil, assets, true)
+		applyAssetSelection(&opts, selected, assets, fullRefreshSpec{})
+		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
+		assert.Nil(t, opts.AssetOverrides)
+	})
+
+	t.Run("full refresh all without selection covers whole pipeline", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, nil, assets, fullRefreshSpec{all: true})
 		assert.Nil(t, opts.Whitelist) // empty whitelist => whole pipeline
 		assert.Len(t, opts.AssetOverrides, 3)
 		for _, a := range assets {
@@ -503,23 +511,96 @@ func TestApplyAssetSelection(t *testing.T) {
 		}
 	})
 
-	t.Run("selection sets whitelist by id without overrides", func(t *testing.T) {
+	t.Run("full refresh all with selection covers only selected", func(t *testing.T) {
 		t.Parallel()
 		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, selected, assets, false)
-		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
-		assert.Nil(t, opts.AssetOverrides)
-	})
-
-	t.Run("selection with full refresh overrides only selected", func(t *testing.T) {
-		t.Parallel()
-		var opts bruincloud.TriggerRunOptions
-		applyAssetSelection(&opts, selected, assets, true)
+		applyAssetSelection(&opts, selected, assets, fullRefreshSpec{all: true})
 		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
 		assert.Len(t, opts.AssetOverrides, 2)
 		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.raw"])
 		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.report"])
-		assert.NotContains(t, opts.AssetOverrides, "s.summary")
+	})
+
+	t.Run("full refresh subset overrides only named assets", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, selected, assets, fullRefreshSpec{assets: []string{"s.report"}})
+		assert.Equal(t, []string{"id-raw", "id-report"}, opts.Whitelist)
+		assert.Len(t, opts.AssetOverrides, 1)
+		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.report"])
+		assert.NotContains(t, opts.AssetOverrides, "s.raw")
+	})
+
+	t.Run("full refresh names without selection runs whole pipeline", func(t *testing.T) {
+		t.Parallel()
+		var opts bruincloud.TriggerRunOptions
+		applyAssetSelection(&opts, nil, assets, fullRefreshSpec{assets: []string{"s.summary"}})
+		assert.Nil(t, opts.Whitelist) // empty whitelist => whole pipeline
+		assert.Len(t, opts.AssetOverrides, 1)
+		assert.Equal(t, map[string]any{"FULL_REFRESH": 1}, opts.AssetOverrides["s.summary"])
+	})
+}
+
+func TestResolveFullRefresh(t *testing.T) {
+	t.Parallel()
+
+	assets := []bruincloud.Asset{
+		mkTriggerAsset(t, "s.raw", "id-raw", nil, nil),
+		mkTriggerAsset(t, "s.summary", "id-summary", nil, nil),
+		mkTriggerAsset(t, "s.report", "id-report", nil, nil),
+	}
+	selected := []*bruincloud.Asset{&assets[0], &assets[2]} // raw + report
+
+	t.Run("empty values returns empty spec", func(t *testing.T) {
+		t.Parallel()
+		spec, err := resolveFullRefresh(nil, assets, nil)
+		require.NoError(t, err)
+		assert.False(t, spec.all)
+		assert.Empty(t, spec.assets)
+	})
+
+	t.Run("all keyword sets all", func(t *testing.T) {
+		t.Parallel()
+		spec, err := resolveFullRefresh([]string{"all"}, assets, nil)
+		require.NoError(t, err)
+		assert.True(t, spec.all)
+		assert.Empty(t, spec.assets)
+	})
+
+	t.Run("all combined with names errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveFullRefresh([]string{"all", "s.raw"}, assets, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be combined")
+	})
+
+	t.Run("names resolved to canonical form", func(t *testing.T) {
+		t.Parallel()
+		spec, err := resolveFullRefresh([]string{"report", "raw.sql"}, assets, nil)
+		require.NoError(t, err)
+		assert.False(t, spec.all)
+		assert.Equal(t, []string{"s.report", "s.raw"}, spec.assets)
+	})
+
+	t.Run("unknown asset errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveFullRefresh([]string{"nope"}, assets, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("name within selection is allowed", func(t *testing.T) {
+		t.Parallel()
+		spec, err := resolveFullRefresh([]string{"s.report"}, assets, selected)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"s.report"}, spec.assets)
+	})
+
+	t.Run("name outside selection errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveFullRefresh([]string{"s.summary"}, assets, selected)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not in the selected assets")
 	})
 }
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -361,6 +361,7 @@ func TestSelectTriggerAssets(t *testing.T) {
 		wantNil bool
 	}{
 		{name: "no selection runs whole pipeline", sel: triggerAssetSelection{}, wantNil: true},
+		{name: "downstream alone is not a selection", sel: triggerAssetSelection{downstream: true}, wantNil: true},
 		{name: "by asset name", sel: triggerAssetSelection{assetInputs: []string{"s.summary"}}, want: []string{"s.summary"}},
 		{name: "by bare/file name", sel: triggerAssetSelection{assetInputs: []string{"raw.sql"}}, want: []string{"s.raw"}},
 		{name: "by bare name without prefix", sel: triggerAssetSelection{assetInputs: []string{"report"}}, want: []string{"s.report"}},
@@ -377,9 +378,9 @@ func TestSelectTriggerAssets(t *testing.T) {
 		{name: "tag with downstream", sel: triggerAssetSelection{tag: "source", downstream: true}, want: []string{"s.raw", "s.report", "s.summary"}},
 		{name: "exclude tag from all", sel: triggerAssetSelection{excludeTags: []string{"report"}}, want: []string{"s.raw", "s.summary"}},
 		{name: "multiple exclude tags", sel: triggerAssetSelection{excludeTags: []string{"source", "report"}}, want: []string{"s.summary"}},
-		{name: "exclude all tags yields empty", sel: triggerAssetSelection{excludeTags: []string{"source", "summary", "report"}}, want: []string{}},
+		{name: "exclude all tags errors", sel: triggerAssetSelection{excludeTags: []string{"source", "summary", "report"}}, wantErr: true},
 		{name: "downstream then exclude tag", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, downstream: true, excludeTags: []string{"report"}}, want: []string{"s.raw", "s.summary"}},
-		{name: "tag then exclude same tag", sel: triggerAssetSelection{tag: "report", excludeTags: []string{"report"}}, want: []string{}},
+		{name: "tag then exclude same tag errors", sel: triggerAssetSelection{tag: "report", excludeTags: []string{"report"}}, wantErr: true},
 		{name: "asset survives unmatched exclude tag", sel: triggerAssetSelection{assetInputs: []string{"s.raw"}, excludeTags: []string{"report"}}, want: []string{"s.raw"}},
 	}
 
@@ -590,5 +591,64 @@ func TestBuildTriggerIntervals(t *testing.T) {
 		_, err := buildTriggerIntervals("day", false, 1, "2024-01-01", "2025-01-01") // 366 daily runs
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exceeds the limit")
+	})
+}
+
+func TestMatchTriggerAsset(t *testing.T) {
+	t.Parallel()
+
+	assets := []bruincloud.Asset{
+		mkTriggerAsset(t, "marketing.report", "id-mkt", nil, nil),
+		mkTriggerAsset(t, "finance.report", "id-fin", nil, nil),
+		mkTriggerAsset(t, "core.events", "id-events", nil, nil),
+	}
+
+	t.Run("exact full name", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTriggerAsset(assets, "finance.report")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "id-fin", got.ID)
+	})
+
+	t.Run("unique leaf name", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTriggerAsset(assets, "events")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "id-events", got.ID)
+	})
+
+	t.Run("filename extension stripped", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTriggerAsset(assets, "events.sql")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "id-events", got.ID)
+	})
+
+	t.Run("ambiguous leaf name errors", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTriggerAsset(assets, "report")
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "ambiguous")
+		assert.Contains(t, err.Error(), "marketing.report")
+		assert.Contains(t, err.Error(), "finance.report")
+	})
+
+	t.Run("exact name wins over ambiguous leaf", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTriggerAsset(assets, "marketing.report")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "id-mkt", got.ID)
+	})
+
+	t.Run("no match returns nil without error", func(t *testing.T) {
+		t.Parallel()
+		got, err := matchTriggerAsset(assets, "nope")
+		require.NoError(t, err)
+		assert.Nil(t, got)
 	})
 }

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -179,15 +179,15 @@ The flags mirror `bruin run` for the options the Cloud trigger API supports.
 | `--start-date` | str | - | Start date for the run (YYYY-MM-DD) |
 | `--end-date` | str | - | End date for the run (YYYY-MM-DD) |
 | `--downstream` | bool | `false` | Also run all assets downstream of the selected ones. |
-| `--tag`, `-t` | str | - | Run only assets with the given tag. |
-| `--exclude-tag`, `-x` | []str | - | Exclude assets with the given tag. Can be used multiple times. |
+| `--tag`, `-t` | []str | - | Tag the run (repeatable). A run-level label shown in the Cloud activity log — **not** an asset filter. |
 | `--full-refresh`, `-r` | bool | `false` | Run the selected assets (or whole pipeline) as a full refresh. |
 | `--var` | []str | - | Override pipeline variables, as `key=value`. Can be used multiple times. |
-| `--split` | str | - | Split the date range into batches by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. One run is created per batch. |
+| `--note` | str | - | Attach a note to the run; shown in the Cloud activity log. |
+| `--split` | str | - | Trigger a backfill, splitting the date range into one run per interval by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. |
 | `--chunk-size` | int | `1` | Number of split units per batch (used with `--split`). |
 
-**Run only selected assets.** Pass an asset path/name as a positional argument, or
-filter with `--tag`/`--exclude-tag`. 
+**Run only selected assets.** Pass an asset path/name as a positional argument
+(repeatable), optionally with `--downstream` to include their downstream assets.
 
 ```bash
 # Run a single asset
@@ -196,16 +196,21 @@ bruin cloud runs trigger \
   --start-date 2024-01-01 --end-date 2024-01-31 \
   my_asset
 
-# Run everything tagged "daily", plus their downstream assets
+# Run an asset plus its downstream, and tag the run
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  --tag daily --downstream
+  my_asset --downstream --tag nightly --tag manual
 ```
 
-**Split a range into batches (monthly, weekly, …).** With `--split`, the CLI breaks
-the date range into intervals and triggers one run per interval (up to 250). This is
-how you start a backfill of selected assets with monthly batches:
+> [!NOTE]
+> `--tag` labels the run (it shows in the Cloud activity log); it does **not** select
+> assets. Select assets by name (positional) and expand with `--downstream`.
+
+**Split a range into batches (monthly, weekly, …).** With `--split`, the trigger
+becomes a **backfill**: The date range is splitted into one run per interval
+(by unit and chunk size) as a single backfill. This is
+how you backfill selected assets with monthly batches:
 
 ```bash
 # One run per month across the quarter, for a single asset
@@ -234,8 +239,8 @@ bruin cloud runs trigger \
 ```
 
 > [!NOTE]
-> Split runs are created as separate runs, one per interval. They are not grouped
-> into a single "Backfill" view in the Cloud UI.
+> `--split` creates a backfill.
+> Without `--split`, the command triggers a single normal run.
 
 #### `rerun`
 
@@ -509,18 +514,18 @@ bruin cloud runs trigger \
 ```
 
 To reprocess in batches — one run per month, week, or day — add `--split` (and
-optionally `--chunk-size`). Combine it with asset selection to backfill just part of
-the pipeline:
+optionally `--chunk-size`). Combine it with a positional asset selection to backfill
+just part of the pipeline:
 
 ```bash
-# One run per month across the year, for assets tagged "reporting"
+# One run per month across the year, for a single asset
 bruin cloud runs trigger \
   --project-id my-project \
   --pipeline my-pipeline \
   --start-date 2024-01-01 \
   --end-date 2025-01-01 \
   --split month \
-  --tag reporting
+  reporting_summary
 ```
 
 ### Script it with JSON output

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -172,10 +172,70 @@ bruin cloud runs trigger \
   --end-date 2024-01-31
 ```
 
+The flags mirror `bruin run` for the options the Cloud trigger API supports.
+
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--start-date` | str | - | Start date for the run (YYYY-MM-DD) |
 | `--end-date` | str | - | End date for the run (YYYY-MM-DD) |
+| `--downstream` | bool | `false` | Also run all assets downstream of the selected ones. |
+| `--tag`, `-t` | str | - | Run only assets with the given tag. |
+| `--exclude-tag`, `-x` | []str | - | Exclude assets with the given tag. Can be used multiple times. |
+| `--full-refresh`, `-r` | bool | `false` | Run the selected assets (or whole pipeline) as a full refresh. |
+| `--var` | []str | - | Override pipeline variables, as `key=value`. Can be used multiple times. |
+| `--split` | str | - | Split the date range into batches by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. One run is created per batch. |
+| `--chunk-size` | int | `1` | Number of split units per batch (used with `--split`). |
+
+**Run only selected assets.** Pass an asset path/name as a positional argument, or
+filter with `--tag`/`--exclude-tag`. 
+
+```bash
+# Run a single asset
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  my_asset
+
+# Run everything tagged "daily", plus their downstream assets
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --tag daily --downstream
+```
+
+**Split a range into batches (monthly, weekly, …).** With `--split`, the CLI breaks
+the date range into intervals and triggers one run per interval (up to 250). This is
+how you start a backfill of selected assets with monthly batches:
+
+```bash
+# One run per month across the quarter, for a single asset
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-04-01 \
+  --split month \
+  my_asset
+```
+
+Use `--chunk-size` to group several split units into each batch. For example weekly
+batches via 7-day chunks, or two-month batches:
+
+```bash
+# One run per week (7-day chunks)
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-02-12 \
+  --split day --chunk-size 7
+
+# One run per two months across the year
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2025-01-01 \
+  --split month --chunk-size 2
+```
+
+> [!NOTE]
+> Split runs are created as separate runs, one per interval. They are not grouped
+> into a single "Backfill" view in the Cloud UI.
 
 #### `rerun`
 
@@ -446,6 +506,21 @@ bruin cloud runs trigger \
   --pipeline my-pipeline \
   --start-date 2024-01-01 \
   --end-date 2024-01-31
+```
+
+To reprocess in batches — one run per month, week, or day — add `--split` (and
+optionally `--chunk-size`). Combine it with asset selection to backfill just part of
+the pipeline:
+
+```bash
+# One run per month across the year, for assets tagged "reporting"
+bruin cloud runs trigger \
+  --project-id my-project \
+  --pipeline my-pipeline \
+  --start-date 2024-01-01 \
+  --end-date 2025-01-01 \
+  --split month \
+  --tag reporting
 ```
 
 ### Script it with JSON output

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -180,8 +180,7 @@ The flags mirror `bruin run` for the options the Cloud trigger API supports.
 | `--end-date` | str | - | End date for the run (YYYY-MM-DD) |
 | `--asset`, `--assets` | []str | - | Select assets to run by name (repeatable or comma-separated). |
 | `--tag`, `-t` | []str | - | Tag the run (repeatable). A run-level label shown in the Cloud activity log — **not** an asset filter. |
-| `--full-refresh`, `-r` | bool | `false` | Full-refresh every asset in the run. |
-| `--full-refresh-asset` | []str | - | Full-refresh only the named asset(s); repeatable or comma-separated. Combine with `--asset` to refresh a subset. Mutually exclusive with `--full-refresh`. |
+| `--full-refresh`, `-r` | bool | `false` | Full-refresh the assets in the run: the `--asset` selection if given, otherwise every asset. |
 | `--var` | []str | - | Override pipeline variables, as `key=value` where the value is JSON (strings need quotes, e.g. `'env="prod"'`). Can be used multiple times, or pass one JSON object. |
 | `--note` | str | - | Attach a note to the run; shown in the Cloud activity log. |
 | `--split` | str | - | Trigger a backfill, splitting the date range into one run per interval by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. |
@@ -208,11 +207,9 @@ bruin cloud runs trigger \
 > `--tag` labels the run (it shows in the Cloud activity log); it does **not** select
 > assets. Select assets by name with `--asset`.
 
-**Full refresh.** Pass `--full-refresh` (bare, no value) to truncate **every** asset in
-the run before running, or `--full-refresh-asset <name>` to truncate only specific
-assets (repeatable or comma-separated, e.g. `--full-refresh-asset asset_a,asset_b`).
-`--full-refresh-asset` can be combined with `--asset` to refresh a subset of the selected
-assets while the rest run normally; the two full-refresh flags are mutually exclusive.
+**Full refresh.** Pass `--full-refresh` (bare, no value) to truncate assets before
+running. It covers the `--asset` selection when you give one, otherwise every asset in
+the pipeline.
 
 ```bash
 # Full-refresh the whole pipeline (every asset)
@@ -221,25 +218,13 @@ bruin cloud runs trigger \
   --start-date 2024-01-01 --end-date 2024-01-31 \
   --full-refresh
 
-# Run the whole pipeline, but full-refresh only standalone_report
+# Run only standalone_report, with full refresh
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  --full-refresh-asset standalone_report
+  --asset standalone_report --full-refresh
 
-# Full-refresh a couple of specific assets (runs the whole pipeline, refreshing those two)
-bruin cloud runs trigger \
-  --project-id <project-id> --pipeline <pipeline-name> \
-  --start-date 2024-01-01 --end-date 2024-01-31 \
-  --full-refresh-asset raw_events,daily_summary
-
-# Run raw_events + daily_summary, but full-refresh only raw_events
-bruin cloud runs trigger \
-  --project-id <project-id> --pipeline <pipeline-name> \
-  --start-date 2024-01-01 --end-date 2024-01-31 \
-  --asset raw_events,daily_summary --full-refresh-asset raw_events
-
-# Run raw_events + daily_summary and full-refresh both (--full-refresh covers the selection)
+# Run raw_events + daily_summary and full-refresh both (the selection)
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
@@ -247,9 +232,8 @@ bruin cloud runs trigger \
 ```
 
 > [!NOTE]
-> `--full-refresh-asset` without `--asset` still runs the **whole pipeline** — it only
-> changes which assets are truncated first. When you narrow the run with `--asset`, each
-> named `--full-refresh-asset` has to be part of that selection.
+> `--full-refresh` truncates whatever the run covers: with `--asset` it refreshes only
+> the selected assets, without it the whole pipeline.
 
 **Override pipeline variables.** Each `--var` is `key=value`, where the **value is parsed
 as JSON**. So a string must be quoted (`"prod"`), while numbers and booleans are written

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -182,7 +182,7 @@ The flags mirror `bruin run` for the options the Cloud trigger API supports.
 | `--downstream` | bool | `false` | Also run all assets downstream of the selected ones. |
 | `--tag`, `-t` | []str | - | Tag the run (repeatable). A run-level label shown in the Cloud activity log — **not** an asset filter. |
 | `--full-refresh`, `-r` | []str | - | Full-refresh. Pass `all` for every asset in the run, or asset name(s) to refresh only those. Combine with `--asset` to refresh a subset of the selected assets. |
-| `--var` | []str | - | Override pipeline variables, as `key=value`. Can be used multiple times. |
+| `--var` | []str | - | Override pipeline variables, as `key=value` where the value is JSON (strings need quotes, e.g. `'env="prod"'`). Can be used multiple times, or pass one JSON object. |
 | `--note` | str | - | Attach a note to the run; shown in the Cloud activity log. |
 | `--split` | str | - | Trigger a backfill, splitting the date range into one run per interval by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. |
 | `--chunk-size` | int | `1` | Number of split units per batch (used with `--split`). |
@@ -245,6 +245,30 @@ bruin cloud runs trigger \
 > A `--full-refresh` asset name must be part of the run. When you narrow the run with
 > `--asset`, each named `--full-refresh` asset has to be in that selection. (`--full-refresh`
 > can't be used bare; pass `all` to refresh everything.)
+
+**Override pipeline variables.** Each `--var` is `key=value`, where the **value is parsed
+as JSON**. So a string must be quoted (`"prod"`), while numbers and booleans are written
+bare. Repeat `--var` for multiple keys, or pass a whole JSON object at once.
+
+```bash
+# String value — note the JSON quotes (wrapped in single quotes for the shell)
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --var 'env="prod"'
+
+# Several variables of different types
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --var 'env="prod"' --var retries=3 --var debug=true
+
+# Or pass them all as one JSON object
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --var '{"env":"prod","retries":3}'
+```
 
 **Split a range into batches (monthly, weekly, …).** With `--split`, the trigger
 becomes a **backfill**: The date range is splitted into one run per interval

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -178,34 +178,73 @@ The flags mirror `bruin run` for the options the Cloud trigger API supports.
 |------|------|---------|-------------|
 | `--start-date` | str | - | Start date for the run (YYYY-MM-DD) |
 | `--end-date` | str | - | End date for the run (YYYY-MM-DD) |
+| `--asset`, `--assets` | []str | - | Select assets to run by name (repeatable or comma-separated). |
 | `--downstream` | bool | `false` | Also run all assets downstream of the selected ones. |
 | `--tag`, `-t` | []str | - | Tag the run (repeatable). A run-level label shown in the Cloud activity log — **not** an asset filter. |
-| `--full-refresh`, `-r` | bool | `false` | Run the selected assets (or whole pipeline) as a full refresh. |
+| `--full-refresh`, `-r` | []str | - | Full-refresh. Pass `all` for every asset in the run, or asset name(s) to refresh only those. Combine with `--asset` to refresh a subset of the selected assets. |
 | `--var` | []str | - | Override pipeline variables, as `key=value`. Can be used multiple times. |
 | `--note` | str | - | Attach a note to the run; shown in the Cloud activity log. |
 | `--split` | str | - | Trigger a backfill, splitting the date range into one run per interval by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. |
 | `--chunk-size` | int | `1` | Number of split units per batch (used with `--split`). |
 
-**Run only selected assets.** Pass an asset path/name as a positional argument
-(repeatable), optionally with `--downstream` to include their downstream assets.
+**Run only selected assets.** Select assets by name with `--asset` (repeatable or
+comma-separated), optionally with `--downstream` to include their downstream assets.
+Without a selection, the whole pipeline runs.
 
 ```bash
 # Run a single asset
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  my_asset
+  --asset my_asset
 
 # Run an asset plus its downstream, and tag the run
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  my_asset --downstream --tag nightly --tag manual
+  --asset my_asset --downstream --tag nightly --tag manual
+
+# Select several assets at once (comma-separated or repeated --asset)
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --asset raw_events,daily_summary
 ```
 
 > [!NOTE]
 > `--tag` labels the run (it shows in the Cloud activity log); it does **not** select
-> assets. Select assets by name (positional) and expand with `--downstream`.
+> assets. Select assets by name with `--asset` and expand with `--downstream`.
+
+**Full refresh.** `--full-refresh` truncates tables before running. Pass `all` to
+refresh every asset in the run, or asset name(s) to refresh only those. It can be
+combined with `--asset` to refresh a subset of the selected assets while the rest run
+normally.
+
+```bash
+# Full-refresh the whole pipeline
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --full-refresh all
+
+# Run raw_events + daily_summary, but full-refresh only raw_events
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --asset raw_events,daily_summary --full-refresh raw_events
+
+# Run raw_events + daily_summary and full-refresh both ("all" covers every asset in the
+# run, which here is the selection)
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --asset raw_events,daily_summary --full-refresh all
+```
+
+> [!NOTE]
+> A `--full-refresh` asset name must be part of the run. When you narrow the run with
+> `--asset`, each named `--full-refresh` asset has to be in that selection. (`--full-refresh`
+> can't be used bare; pass `all` to refresh everything.)
 
 **Split a range into batches (monthly, weekly, …).** With `--split`, the trigger
 becomes a **backfill**: The date range is splitted into one run per interval
@@ -218,7 +257,7 @@ bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-04-01 \
   --split month \
-  my_asset
+  --asset my_asset
 ```
 
 Use `--chunk-size` to group several split units into each batch. For example weekly
@@ -514,8 +553,8 @@ bruin cloud runs trigger \
 ```
 
 To reprocess in batches — one run per month, week, or day — add `--split` (and
-optionally `--chunk-size`). Combine it with a positional asset selection to backfill
-just part of the pipeline:
+optionally `--chunk-size`). Combine it with an `--asset` selection to backfill just
+part of the pipeline:
 
 ```bash
 # One run per month across the year, for a single asset
@@ -525,7 +564,7 @@ bruin cloud runs trigger \
   --start-date 2024-01-01 \
   --end-date 2025-01-01 \
   --split month \
-  reporting_summary
+  --asset reporting_summary
 ```
 
 ### Script it with JSON output

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -179,17 +179,16 @@ The flags mirror `bruin run` for the options the Cloud trigger API supports.
 | `--start-date` | str | - | Start date for the run (YYYY-MM-DD) |
 | `--end-date` | str | - | End date for the run (YYYY-MM-DD) |
 | `--asset`, `--assets` | []str | - | Select assets to run by name (repeatable or comma-separated). |
-| `--downstream` | bool | `false` | Also run all assets downstream of the selected ones. |
 | `--tag`, `-t` | []str | - | Tag the run (repeatable). A run-level label shown in the Cloud activity log — **not** an asset filter. |
-| `--full-refresh`, `-r` | []str | - | Full-refresh. Pass `all` for every asset in the run, or asset name(s) to refresh only those. Combine with `--asset` to refresh a subset of the selected assets. |
+| `--full-refresh`, `-r` | bool | `false` | Full-refresh every asset in the run. |
+| `--full-refresh-asset` | []str | - | Full-refresh only the named asset(s); repeatable or comma-separated. Combine with `--asset` to refresh a subset. Mutually exclusive with `--full-refresh`. |
 | `--var` | []str | - | Override pipeline variables, as `key=value` where the value is JSON (strings need quotes, e.g. `'env="prod"'`). Can be used multiple times, or pass one JSON object. |
 | `--note` | str | - | Attach a note to the run; shown in the Cloud activity log. |
 | `--split` | str | - | Trigger a backfill, splitting the date range into one run per interval by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. |
 | `--chunk-size` | int | `1` | Number of split units per batch (used with `--split`). |
 
 **Run only selected assets.** Select assets by name with `--asset` (repeatable or
-comma-separated), optionally with `--downstream` to include their downstream assets.
-Without a selection, the whole pipeline runs.
+comma-separated). Without a selection, the whole pipeline runs.
 
 ```bash
 # Run a single asset
@@ -197,12 +196,6 @@ bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
   --asset my_asset
-
-# Run an asset plus its downstream, and tag the run
-bruin cloud runs trigger \
-  --project-id <project-id> --pipeline <pipeline-name> \
-  --start-date 2024-01-01 --end-date 2024-01-31 \
-  --asset my_asset --downstream --tag nightly --tag manual
 
 # Select several assets at once (comma-separated or repeated --asset)
 bruin cloud runs trigger \
@@ -213,53 +206,50 @@ bruin cloud runs trigger \
 
 > [!NOTE]
 > `--tag` labels the run (it shows in the Cloud activity log); it does **not** select
-> assets. Select assets by name with `--asset` and expand with `--downstream`.
+> assets. Select assets by name with `--asset`.
 
-**Include downstream assets.** `--downstream` expands the selection to everything that
-depends on the chosen assets, transitively. It only has an effect alongside `--asset` —
-on its own it does nothing (the whole pipeline already runs).
+**Full refresh.** Pass `--full-refresh` (bare, no value) to truncate **every** asset in
+the run before running, or `--full-refresh-asset <name>` to truncate only specific
+assets (repeatable or comma-separated, e.g. `--full-refresh-asset asset_a,asset_b`).
+`--full-refresh-asset` can be combined with `--asset` to refresh a subset of the selected
+assets while the rest run normally; the two full-refresh flags are mutually exclusive.
 
 ```bash
-# Run raw_events and every asset downstream of it
+# Full-refresh the whole pipeline (every asset)
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  --asset raw_events --downstream
-```
+  --full-refresh
 
-For example, if `raw_events → daily_summary → weekly_rollup`, that single command runs
-all three. Without `--downstream`, only `raw_events` runs.
-
-**Full refresh.** `--full-refresh` truncates tables before running. Pass `all` to
-refresh every asset in the run, or asset name(s) to refresh only those. It can be
-combined with `--asset` to refresh a subset of the selected assets while the rest run
-normally.
-
-```bash
-# Full-refresh the whole pipeline
+# Run the whole pipeline, but full-refresh only standalone_report
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  --full-refresh all
+  --full-refresh-asset standalone_report
+
+# Full-refresh a couple of specific assets (runs the whole pipeline, refreshing those two)
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --full-refresh-asset raw_events,daily_summary
 
 # Run raw_events + daily_summary, but full-refresh only raw_events
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  --asset raw_events,daily_summary --full-refresh raw_events
+  --asset raw_events,daily_summary --full-refresh-asset raw_events
 
-# Run raw_events + daily_summary and full-refresh both ("all" covers every asset in the
-# run, which here is the selection)
+# Run raw_events + daily_summary and full-refresh both (--full-refresh covers the selection)
 bruin cloud runs trigger \
   --project-id <project-id> --pipeline <pipeline-name> \
   --start-date 2024-01-01 --end-date 2024-01-31 \
-  --asset raw_events,daily_summary --full-refresh all
+  --asset raw_events,daily_summary --full-refresh
 ```
 
 > [!NOTE]
-> A `--full-refresh` asset name must be part of the run. When you narrow the run with
-> `--asset`, each named `--full-refresh` asset has to be in that selection. (`--full-refresh`
-> can't be used bare; pass `all` to refresh everything.)
+> `--full-refresh-asset` without `--asset` still runs the **whole pipeline** — it only
+> changes which assets are truncated first. When you narrow the run with `--asset`, each
+> named `--full-refresh-asset` has to be part of that selection.
 
 **Override pipeline variables.** Each `--var` is `key=value`, where the **value is parsed
 as JSON**. So a string must be quoted (`"prod"`), while numbers and booleans are written

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -281,6 +281,12 @@ bruin cloud runs trigger \
 > `--split` creates a backfill.
 > Without `--split`, the command triggers a single normal run.
 
+> [!NOTE]
+> For a backfill, `--end-date` is **exclusive**: the range is split as
+> `[start-date, end-date)`, so the last interval ends just before `--end-date`. To
+> include a final period, pass the date one period past it — e.g. `--end-date 2024-01-04`
+> to cover `2024-01-03` with `--split day`.
+
 #### `rerun`
 
 Re-run a previous pipeline run. Useful when a transient issue caused a failure:

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -215,6 +215,21 @@ bruin cloud runs trigger \
 > `--tag` labels the run (it shows in the Cloud activity log); it does **not** select
 > assets. Select assets by name with `--asset` and expand with `--downstream`.
 
+**Include downstream assets.** `--downstream` expands the selection to everything that
+depends on the chosen assets, transitively. It only has an effect alongside `--asset` —
+on its own it does nothing (the whole pipeline already runs).
+
+```bash
+# Run raw_events and every asset downstream of it
+bruin cloud runs trigger \
+  --project-id <project-id> --pipeline <pipeline-name> \
+  --start-date 2024-01-01 --end-date 2024-01-31 \
+  --asset raw_events --downstream
+```
+
+For example, if `raw_events → daily_summary → weekly_rollup`, that single command runs
+all three. Without `--downstream`, only `raw_events` runs.
+
 **Full refresh.** `--full-refresh` truncates tables before running. Pass `all` to
 refresh every asset in the run, or asset name(s) to refresh only those. It can be
 combined with `--asset` to refresh a subset of the selected assets while the rest run

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -212,11 +212,11 @@ type TriggerRunOptions struct {
 	Whitelist      []string
 	AssetOverrides map[string]map[string]any
 	Variables      map[string]any
-	Note string
-	Tags []string
+	Note           string
+	Tags           []string
 }
 
-// encodeRunNote serializes the run note and tags into the single note field the Cloud expects
+// encodeRunNote serializes the run note and tags into the single note field the Cloud expects.
 func encodeRunNote(note string, tags []string) string {
 	if note == "" && len(tags) == 0 {
 		return ""

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -207,18 +207,50 @@ func (c *APIClient) GetRun(ctx context.Context, project, pipeline, runID string)
 	return &resp.Data, nil
 }
 
-func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline, startDate, endDate string) error {
-	body := map[string]any{
-		"pipelines": []map[string]string{
-			{
-				"project":    project,
-				"pipeline":   pipeline,
-				"start_date": startDate,
-				"end_date":   endDate,
-			},
-		},
+// RunInterval is a single [start, end] window for a triggered run.
+type RunInterval struct {
+	StartDate string
+	EndDate   string
+}
+
+// TriggerRunOptions holds the optional parameters the trigger endpoint accepts.
+type TriggerRunOptions struct {
+	Whitelist      []string
+	AssetOverrides map[string]map[string]any
+	Variables      map[string]any
+}
+
+// TriggerRun triggers one run per interval. Each interval is sent as its own
+// single-entry request: the trigger endpoint reliably creates a run when given
+// one pipeline entry, but repeating the same pipeline across multiple entries in
+// one request fails server-side, so batches (e.g. one run per month) are issued
+// sequentially. On a partial failure the error reports how many runs succeeded.
+func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline string, intervals []RunInterval, opts TriggerRunOptions) error {
+	for i, iv := range intervals {
+		entry := map[string]any{
+			"project":    project,
+			"pipeline":   pipeline,
+			"start_date": iv.StartDate,
+			"end_date":   iv.EndDate,
+		}
+		if len(opts.Whitelist) > 0 {
+			entry["whitelist"] = opts.Whitelist
+		}
+		if len(opts.AssetOverrides) > 0 {
+			entry["asset_overrides"] = opts.AssetOverrides
+		}
+		if len(opts.Variables) > 0 {
+			entry["variables"] = opts.Variables
+		}
+		body := map[string]any{"pipelines": []map[string]any{entry}}
+		if err := c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-runs", body, nil); err != nil {
+			if len(intervals) > 1 {
+				return fmt.Errorf("triggered %d of %d runs; interval %s..%s failed: %w", i, len(intervals), iv.StartDate, iv.EndDate, err)
+			}
+			return err
+		}
 	}
-	return c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-runs", body, nil)
+	return nil
 }
 
 func (c *APIClient) RerunRun(ctx context.Context, project, pipeline, runID string, onlyFailed bool) error {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -221,9 +221,9 @@ type TriggerRunOptions struct {
 }
 
 // TriggerRun triggers one run per interval. Each interval is sent as its own
-// single-entry request: the trigger endpoint reliably creates a run when given
-// one pipeline entry, but repeating the same pipeline across multiple entries in
-// one request fails server-side, so batches (e.g. one run per month) are issued
+// single-entry request: a single-entry request reliably creates a run, whereas
+// repeating the same pipeline across multiple entries in one request was observed
+// to fail server-side (HTTP 500), so batches (e.g. one run per month) are issued
 // sequentially. On a partial failure the error reports how many runs succeeded.
 func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline string, intervals []RunInterval, opts TriggerRunOptions) error {
 	for i, iv := range intervals {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -207,50 +207,72 @@ func (c *APIClient) GetRun(ctx context.Context, project, pipeline, runID string)
 	return &resp.Data, nil
 }
 
-// RunInterval is a single [start, end] window for a triggered run.
-type RunInterval struct {
-	StartDate string
-	EndDate   string
-}
-
-// TriggerRunOptions holds the optional parameters the trigger endpoint accepts.
+// TriggerRunOptions holds the optional parameters the trigger endpoints accept.
 type TriggerRunOptions struct {
 	Whitelist      []string
 	AssetOverrides map[string]map[string]any
 	Variables      map[string]any
+	Note string
+	Tags []string
 }
 
-// TriggerRun triggers one run per interval. Each interval is sent as its own
-// single-entry request: a single-entry request reliably creates a run, whereas
-// repeating the same pipeline across multiple entries in one request was observed
-// to fail server-side (HTTP 500), so batches (e.g. one run per month) are issued
-// sequentially. On a partial failure the error reports how many runs succeeded.
-func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline string, intervals []RunInterval, opts TriggerRunOptions) error {
-	for i, iv := range intervals {
-		entry := map[string]any{
-			"project":    project,
-			"pipeline":   pipeline,
-			"start_date": iv.StartDate,
-			"end_date":   iv.EndDate,
-		}
-		if len(opts.Whitelist) > 0 {
-			entry["whitelist"] = opts.Whitelist
-		}
-		if len(opts.AssetOverrides) > 0 {
-			entry["asset_overrides"] = opts.AssetOverrides
-		}
-		if len(opts.Variables) > 0 {
-			entry["variables"] = opts.Variables
-		}
-		body := map[string]any{"pipelines": []map[string]any{entry}}
-		if err := c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-runs", body, nil); err != nil {
-			if len(intervals) > 1 {
-				return fmt.Errorf("triggered %d of %d runs; interval %s..%s failed: %w", i, len(intervals), iv.StartDate, iv.EndDate, err)
-			}
-			return err
-		}
+// encodeRunNote serializes the run note and tags into the single note field the Cloud expects
+func encodeRunNote(note string, tags []string) string {
+	if note == "" && len(tags) == 0 {
+		return ""
 	}
-	return nil
+	if tags == nil {
+		tags = []string{}
+	}
+	b, err := json.Marshal(struct {
+		Note string   `json:"note"`
+		Tags []string `json:"tags"`
+	}{Note: note, Tags: tags})
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// triggerEntry builds the fields shared by the run and backfill request bodies:
+// the pipeline target, the date range, and the run options.
+func triggerEntry(project, pipeline, startDate, endDate string, opts TriggerRunOptions) map[string]any {
+	entry := map[string]any{
+		"project":    project,
+		"pipeline":   pipeline,
+		"start_date": startDate,
+		"end_date":   endDate,
+	}
+	if len(opts.Whitelist) > 0 {
+		entry["whitelist"] = opts.Whitelist
+	}
+	if len(opts.AssetOverrides) > 0 {
+		entry["asset_overrides"] = opts.AssetOverrides
+	}
+	if len(opts.Variables) > 0 {
+		entry["variables"] = opts.Variables
+	}
+	if note := encodeRunNote(opts.Note, opts.Tags); note != "" {
+		entry["note"] = note
+	}
+	return entry
+}
+
+// TriggerRun triggers a single pipeline run for the given date range.
+func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline, startDate, endDate string, opts TriggerRunOptions) error {
+	entry := triggerEntry(project, pipeline, startDate, endDate, opts)
+	body := map[string]any{"pipelines": []map[string]any{entry}}
+	return c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-runs", body, nil)
+}
+
+// TriggerBackfill triggers a backfill: the Cloud splits the date range into one run
+// per interval (by split unit + chunk size) server-side and groups them as a single
+// backfill.
+func (c *APIClient) TriggerBackfill(ctx context.Context, project, pipeline, startDate, endDate, split string, chunkSize int, opts TriggerRunOptions) error {
+	body := triggerEntry(project, pipeline, startDate, endDate, opts)
+	body["split"] = split
+	body["chunk_size"] = chunkSize
+	return c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-backfill", body, nil)
 }
 
 func (c *APIClient) RerunRun(ctx context.Context, project, pipeline, runID string, onlyFailed bool) error {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -314,41 +314,31 @@ func TestTriggerRun(t *testing.T) {
 		_, _ = w.Write([]byte(`200`))
 	})
 
-	intervals := []RunInterval{{StartDate: "2026-01-01", EndDate: "2026-01-02"}}
-	err := client.TriggerRun(t.Context(), "proj", "pipe", intervals, TriggerRunOptions{})
+	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-02", TriggerRunOptions{})
 	require.NoError(t, err)
 }
 
-func TestTriggerRunSplitIntervals(t *testing.T) {
+func TestTriggerBackfill(t *testing.T) {
 	t.Parallel()
-	var requestCount int
-	var seenStarts []string
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		assert.Equal(t, "/trigger-pipeline-backfill", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
 		body := readJSON(t, r)
-		// Each interval is its own request with a single-entry pipelines array.
-		pipelines := body["pipelines"].([]any)
-		assert.Len(t, pipelines, 1)
-		entry := pipelines[0].(map[string]any)
-		assert.Equal(t, []any{"asset-id-1"}, entry["whitelist"]) // shared options on every request
-		seenStarts = append(seenStarts, entry["start_date"].(string))
+		assert.Equal(t, "proj", body["project"])
+		assert.Equal(t, "pipe", body["pipeline"])
+		assert.Equal(t, "2026-01-01", body["start_date"])
+		assert.Equal(t, "2026-04-01", body["end_date"])
+		assert.Equal(t, "month", body["split"])
+		assert.EqualValues(t, 2, body["chunk_size"])
+		assert.Equal(t, []any{"asset-id-1"}, body["whitelist"])
+
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`200`))
 	})
 
-	intervals := []RunInterval{
-		{StartDate: "2026-01-01T00:00:00.000Z", EndDate: "2026-01-31T23:59:59.999Z"},
-		{StartDate: "2026-02-01T00:00:00.000Z", EndDate: "2026-02-28T23:59:59.999Z"},
-		{StartDate: "2026-03-01T00:00:00.000Z", EndDate: "2026-03-31T23:59:59.999Z"},
-	}
-	err := client.TriggerRun(t.Context(), "proj", "pipe", intervals, TriggerRunOptions{Whitelist: []string{"asset-id-1"}})
+	err := client.TriggerBackfill(t.Context(), "proj", "pipe", "2026-01-01", "2026-04-01", "month", 2, TriggerRunOptions{Whitelist: []string{"asset-id-1"}})
 	require.NoError(t, err)
-	assert.Equal(t, 3, requestCount)
-	assert.Equal(t, []string{
-		"2026-01-01T00:00:00.000Z",
-		"2026-02-01T00:00:00.000Z",
-		"2026-03-01T00:00:00.000Z",
-	}, seenStarts)
 }
 
 func TestTriggerRunWithOptions(t *testing.T) {
@@ -377,8 +367,7 @@ func TestTriggerRunWithOptions(t *testing.T) {
 		AssetOverrides: map[string]map[string]any{"schema.asset": {"FULL_REFRESH": 1}},
 		Variables:      map[string]any{"foo": "bar"},
 	}
-	intervals := []RunInterval{{StartDate: "2026-01-01", EndDate: "2026-01-31"}}
-	err := client.TriggerRun(t.Context(), "proj", "pipe", intervals, opts)
+	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-31", opts)
 	require.NoError(t, err)
 }
 
@@ -631,4 +620,28 @@ func TestSendAgentMessage_WithThreadID(t *testing.T) {
 	result, err := client.SendAgentMessage(t.Context(), 1, "hello", &threadID)
 	require.NoError(t, err)
 	assert.Contains(t, string(result), "message_id")
+}
+
+func TestEncodeRunNote(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, encodeRunNote("", nil))
+	assert.JSONEq(t, `{"note":"hi","tags":[]}`, encodeRunNote("hi", nil))
+	assert.JSONEq(t, `{"note":"","tags":["a","b"]}`, encodeRunNote("", []string{"a", "b"}))
+	assert.JSONEq(t, `{"note":"hi","tags":["a"]}`, encodeRunNote("hi", []string{"a"}))
+}
+
+func TestTriggerRunWithTags(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body := readJSON(t, r)
+		entry := body["pipelines"].([]any)[0].(map[string]any)
+		// Note + tags are carried together inside the note field as JSON (the Cloud RunNote format).
+		assert.JSONEq(t, `{"note":"Q1 backfill","tags":["nightly","manual"]}`, entry["note"].(string))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`200`))
+	})
+
+	err := client.TriggerRun(t.Context(), "p", "pipe", "2026-01-01", "2026-01-02",
+		TriggerRunOptions{Note: "Q1 backfill", Tags: []string{"nightly", "manual"}})
+	require.NoError(t, err)
 }

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -304,12 +304,81 @@ func TestTriggerRun(t *testing.T) {
 		body := readJSON(t, r)
 		pipelines := body["pipelines"].([]any)
 		assert.Len(t, pipelines, 1)
+		entry := pipelines[0].(map[string]any)
+		assert.Equal(t, "proj", entry["project"])
+		assert.Equal(t, "pipe", entry["pipeline"])
+		assert.Equal(t, "2026-01-01", entry["start_date"])
+		assert.Equal(t, "2026-01-02", entry["end_date"])
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`200`))
 	})
 
-	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-02")
+	intervals := []RunInterval{{StartDate: "2026-01-01", EndDate: "2026-01-02"}}
+	err := client.TriggerRun(t.Context(), "proj", "pipe", intervals, TriggerRunOptions{})
+	require.NoError(t, err)
+}
+
+func TestTriggerRunSplitIntervals(t *testing.T) {
+	t.Parallel()
+	var requestCount int
+	var seenStarts []string
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		body := readJSON(t, r)
+		// Each interval is its own request with a single-entry pipelines array.
+		pipelines := body["pipelines"].([]any)
+		assert.Len(t, pipelines, 1)
+		entry := pipelines[0].(map[string]any)
+		assert.Equal(t, []any{"asset-id-1"}, entry["whitelist"]) // shared options on every request
+		seenStarts = append(seenStarts, entry["start_date"].(string))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`200`))
+	})
+
+	intervals := []RunInterval{
+		{StartDate: "2026-01-01T00:00:00.000Z", EndDate: "2026-01-31T23:59:59.999Z"},
+		{StartDate: "2026-02-01T00:00:00.000Z", EndDate: "2026-02-28T23:59:59.999Z"},
+		{StartDate: "2026-03-01T00:00:00.000Z", EndDate: "2026-03-31T23:59:59.999Z"},
+	}
+	err := client.TriggerRun(t.Context(), "proj", "pipe", intervals, TriggerRunOptions{Whitelist: []string{"asset-id-1"}})
+	require.NoError(t, err)
+	assert.Equal(t, 3, requestCount)
+	assert.Equal(t, []string{
+		"2026-01-01T00:00:00.000Z",
+		"2026-02-01T00:00:00.000Z",
+		"2026-03-01T00:00:00.000Z",
+	}, seenStarts)
+}
+
+func TestTriggerRunWithOptions(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/trigger-pipeline-runs", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		body := readJSON(t, r)
+		pipelines := body["pipelines"].([]any)
+		assert.Len(t, pipelines, 1)
+
+		entry := pipelines[0].(map[string]any)
+		assert.Equal(t, []any{"asset-id-1"}, entry["whitelist"])
+		overrides := entry["asset_overrides"].(map[string]any)
+		assert.Contains(t, overrides, "schema.asset")
+		vars := entry["variables"].(map[string]any)
+		assert.Equal(t, "bar", vars["foo"])
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`200`))
+	})
+
+	opts := TriggerRunOptions{
+		Whitelist:      []string{"asset-id-1"},
+		AssetOverrides: map[string]map[string]any{"schema.asset": {"FULL_REFRESH": 1}},
+		Variables:      map[string]any{"foo": "bar"},
+	}
+	intervals := []RunInterval{{StartDate: "2026-01-01", EndDate: "2026-01-31"}}
+	err := client.TriggerRun(t.Context(), "proj", "pipe", intervals, opts)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
`bruin cloud runs trigger` only accepted `--start-date`/`--end-date`. This pr adds the run options the Cloud trigger API actually supports
flag names:
- **Asset selection**
- **`--full-refresh`** 
- **`--var`**
- **`--split` / `--chunk-size`**
