### PR TITLE
Support AWS default credential chain for secrets

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1126,7 +1126,7 @@ func Run(isDebug *bool) *cli.Command {
 					errs = append(errs, errors.Wrap(err, "failed to initialize doppler client"))
 				}
 			case "aws":
-				connectionManager, err = secrets.NewAWSSecretsManagerClientFromEnv(logger)
+				connectionManager, err = secrets.NewAWSSecretsManagerClientFromEnv(ctx, logger)
 				if err != nil {
 					errs = append(errs, errors.Wrap(err, "failed to initialize AWS Secrets Manager client"))
 				}

--- a/pkg/secrets/aws_secretsmanager.go
+++ b/pkg/secrets/aws_secretsmanager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -30,22 +31,35 @@ type AWSSecretsManagerClient struct {
 }
 
 // NewAWSSecretsManagerClientFromEnv creates a new AWS Secrets Manager client from environment variables.
-func NewAWSSecretsManagerClientFromEnv(logger logger.Logger) (*AWSSecretsManagerClient, error) {
+func NewAWSSecretsManagerClientFromEnv(ctx context.Context, logger logger.Logger) (*AWSSecretsManagerClient, error) {
 	accessKeyID := os.Getenv("BRUIN_AWS_ACCESS_KEY_ID")
-	if accessKeyID == "" {
-		return nil, errors.New("BRUIN_AWS_ACCESS_KEY_ID env variable not set")
-	}
 	secretAccessKey := os.Getenv("BRUIN_AWS_SECRET_ACCESS_KEY")
-	if secretAccessKey == "" {
+	if accessKeyID != "" && secretAccessKey == "" {
 		return nil, errors.New("BRUIN_AWS_SECRET_ACCESS_KEY env variable not set")
 	}
-	region := os.Getenv("BRUIN_AWS_REGION")
-	if region == "" {
-		return nil, errors.New("BRUIN_AWS_REGION env variable not set")
+	if accessKeyID == "" && secretAccessKey != "" {
+		return nil, errors.New("BRUIN_AWS_ACCESS_KEY_ID env variable not set")
 	}
-	sessionToken := os.Getenv("BRUIN_AWS_SESSION_TOKEN")
 
-	return NewAWSSecretsManagerClient(logger, accessKeyID, secretAccessKey, region, sessionToken)
+	region := os.Getenv("BRUIN_AWS_REGION")
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+
+	if accessKeyID != "" {
+		sessionToken := os.Getenv("BRUIN_AWS_SESSION_TOKEN")
+		opts = append(opts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken),
+		))
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load AWS config")
+	}
+
+	return newAWSSecretsManagerClientFromConfig(logger, cfg), nil
 }
 
 // NewAWSSecretsManagerClient creates a new AWS Secrets Manager client.
@@ -69,6 +83,10 @@ func NewAWSSecretsManagerClient(logger logger.Logger, accessKeyID, secretAccessK
 		),
 	}
 
+	return newAWSSecretsManagerClientFromConfig(logger, cfg), nil
+}
+
+func newAWSSecretsManagerClientFromConfig(logger logger.Logger, cfg aws.Config) *AWSSecretsManagerClient {
 	client := secretsmanager.NewFromConfig(cfg)
 
 	return &AWSSecretsManagerClient{
@@ -76,7 +94,7 @@ func NewAWSSecretsManagerClient(logger logger.Logger, accessKeyID, secretAccessK
 		logger:                  logger,
 		cacheConnections:        make(map[string]any),
 		cacheConnectionsDetails: make(map[string]any),
-	}, nil
+	}
 }
 
 // GetConnection retrieves a connection by name from AWS Secrets Manager.

--- a/pkg/secrets/aws_secretsmanager_test.go
+++ b/pkg/secrets/aws_secretsmanager_test.go
@@ -49,6 +49,113 @@ func TestNewAWSSecretsManagerClient(t *testing.T) {
 	})
 }
 
+func TestNewAWSSecretsManagerClientFromEnv(t *testing.T) {
+	log := &mockLogger{}
+
+	t.Run("falls back to default AWS config chain", func(t *testing.T) {
+		clearAWSSecretsManagerEnv(t)
+		t.Setenv("AWS_ACCESS_KEY_ID", "default-key")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "default-secret")
+		t.Setenv("AWS_SESSION_TOKEN", "default-token")
+		t.Setenv("AWS_REGION", "eu-west-1")
+
+		client, err := NewAWSSecretsManagerClientFromEnv(context.Background(), log)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		opts := requireSecretsManagerClientOptions(t, client)
+		require.Equal(t, "eu-west-1", opts.Region)
+
+		creds, err := opts.Credentials.Retrieve(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "default-key", creds.AccessKeyID)
+		require.Equal(t, "default-secret", creds.SecretAccessKey)
+		require.Equal(t, "default-token", creds.SessionToken)
+	})
+
+	t.Run("uses BRUIN static credentials as override", func(t *testing.T) {
+		clearAWSSecretsManagerEnv(t)
+		t.Setenv("AWS_ACCESS_KEY_ID", "default-key")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "default-secret")
+		t.Setenv("AWS_SESSION_TOKEN", "default-token")
+		t.Setenv("AWS_REGION", "eu-west-1")
+		t.Setenv("BRUIN_AWS_ACCESS_KEY_ID", "bruin-key")
+		t.Setenv("BRUIN_AWS_SECRET_ACCESS_KEY", "bruin-secret")
+		t.Setenv("BRUIN_AWS_SESSION_TOKEN", "bruin-token")
+		t.Setenv("BRUIN_AWS_REGION", "us-east-2")
+
+		client, err := NewAWSSecretsManagerClientFromEnv(context.Background(), log)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		opts := requireSecretsManagerClientOptions(t, client)
+		require.Equal(t, "us-east-2", opts.Region)
+
+		creds, err := opts.Credentials.Retrieve(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "bruin-key", creds.AccessKeyID)
+		require.Equal(t, "bruin-secret", creds.SecretAccessKey)
+		require.Equal(t, "bruin-token", creds.SessionToken)
+	})
+
+	t.Run("errors if BRUIN access key is missing for static credentials", func(t *testing.T) {
+		clearAWSSecretsManagerEnv(t)
+		t.Setenv("AWS_ACCESS_KEY_ID", "default-key")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "default-secret")
+		t.Setenv("AWS_REGION", "eu-west-1")
+		t.Setenv("BRUIN_AWS_SECRET_ACCESS_KEY", "bruin-secret")
+
+		client, err := NewAWSSecretsManagerClientFromEnv(context.Background(), log)
+		require.Error(t, err)
+		require.Nil(t, client)
+		require.Contains(t, err.Error(), "BRUIN_AWS_ACCESS_KEY_ID env variable not set")
+	})
+
+	t.Run("errors if BRUIN secret key is missing for static credentials", func(t *testing.T) {
+		clearAWSSecretsManagerEnv(t)
+		t.Setenv("AWS_ACCESS_KEY_ID", "default-key")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "default-secret")
+		t.Setenv("AWS_REGION", "eu-west-1")
+		t.Setenv("BRUIN_AWS_ACCESS_KEY_ID", "bruin-key")
+
+		client, err := NewAWSSecretsManagerClientFromEnv(context.Background(), log)
+		require.Error(t, err)
+		require.Nil(t, client)
+		require.Contains(t, err.Error(), "BRUIN_AWS_SECRET_ACCESS_KEY env variable not set")
+	})
+}
+
+func clearAWSSecretsManagerEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"BRUIN_AWS_ACCESS_KEY_ID",
+		"BRUIN_AWS_SECRET_ACCESS_KEY",
+		"BRUIN_AWS_SESSION_TOKEN",
+		"BRUIN_AWS_REGION",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+		"AWS_PROFILE",
+		"AWS_CONFIG_FILE",
+		"AWS_SHARED_CREDENTIALS_FILE",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+}
+
+func requireSecretsManagerClientOptions(t *testing.T, client *AWSSecretsManagerClient) secretsmanager.Options {
+	t.Helper()
+
+	secretsManagerClient, ok := client.client.(*secretsmanager.Client)
+	require.True(t, ok)
+
+	return secretsManagerClient.Options()
+}
+
 type mockAWSSecretsManagerClient struct {
 	response *secretsmanager.GetSecretValueOutput
 	err      error

--- a/pkg/secrets/aws_secretsmanager_test.go
+++ b/pkg/secrets/aws_secretsmanager_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -142,9 +143,31 @@ func clearAWSSecretsManagerEnv(t *testing.T) {
 		"AWS_CONFIG_FILE",
 		"AWS_SHARED_CREDENTIALS_FILE",
 	} {
-		t.Setenv(key, "")
+		unsetenv(t, key)
 	}
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+}
+
+//nolint:usetesting // testing.T has Setenv but no Unsetenv; this helper must restore after os.Unsetenv.
+func unsetenv(t *testing.T, key string) {
+	t.Helper()
+
+	value, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("failed to unset %s: %v", key, err)
+	}
+
+	t.Cleanup(func() {
+		if ok {
+			if err := os.Setenv(key, value); err != nil {
+				t.Fatalf("failed to restore %s: %v", key, err)
+			}
+			return
+		}
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("failed to restore unset %s: %v", key, err)
+		}
+	})
 }
 
 func requireSecretsManagerClientOptions(t *testing.T, client *AWSSecretsManagerClient) secretsmanager.Options {


### PR DESCRIPTION
Fixes #2152.

This lets the AWS Secrets Manager backend use the AWS SDK default credential and region chain when `BRUIN_AWS_*` static credentials are not provided. `BRUIN_AWS_ACCESS_KEY_ID` and `BRUIN_AWS_SECRET_ACCESS_KEY` still take precedence when both are set, and partial Bruin static credential config still errors.

Validated with `go test -tags="no_duckdb_arrow" ./pkg/secrets`, `make format`, `make test`, and `git diff --check`.