### PR TITLE
[codex] Fix Snowflake diff stat count parsing

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -594,6 +594,13 @@ func calculatePercentageDiffInt(val1, val2 int64, tolerance float64) string {
 	return calculatePercentageDiff(float64(val1), float64(val2), tolerance)
 }
 
+func calculateFillRate(count, nullCount int64) float64 {
+	if count == 0 {
+		return 0
+	}
+	return float64(count-nullCount) / float64(count) * 100
+}
+
 func abs(x float64) float64 {
 	if x < 0 {
 		return -x
@@ -676,8 +683,8 @@ func tableStatsToTable(stats1 diff.ColumnStatistics, stats2 diff.ColumnStatistic
 		t.AppendRow(table.Row{"Null Count", numStats1.NullCount, numStats2.NullCount, nullDiffStr, nullDiffPercent})
 
 		// Calculate fill rates
-		fillRate1 := float64(numStats1.Count-numStats1.NullCount) / float64(numStats1.Count) * 100
-		fillRate2 := float64(numStats2.Count-numStats2.NullCount) / float64(numStats2.Count) * 100
+		fillRate1 := calculateFillRate(numStats1.Count, numStats1.NullCount)
+		fillRate2 := calculateFillRate(numStats2.Count, numStats2.NullCount)
 		fillRateDiff := fillRate1 - fillRate2
 		fillRateDiffPercent := calculatePercentageDiff(fillRate1, fillRate2, tolerance)
 		fillRateDiffStr := formatDiffValue(fillRateDiff, fillRateDiffPercent)
@@ -734,8 +741,8 @@ func tableStatsToTable(stats1 diff.ColumnStatistics, stats2 diff.ColumnStatistic
 		t.AppendRow(table.Row{"Null Count", strStats1.NullCount, strStats2.NullCount, nullDiffStr, nullDiffPercent})
 
 		// Calculate fill rates using proper count
-		fillRate1 := float64(strStats1.Count-strStats1.NullCount) / float64(strStats1.Count) * 100
-		fillRate2 := float64(strStats2.Count-strStats2.NullCount) / float64(strStats2.Count) * 100
+		fillRate1 := calculateFillRate(strStats1.Count, strStats1.NullCount)
+		fillRate2 := calculateFillRate(strStats2.Count, strStats2.NullCount)
 		fillRateDiff := fillRate1 - fillRate2
 		fillRateDiffPercent := calculatePercentageDiff(fillRate1, fillRate2, tolerance)
 		fillRateDiffStr := formatDiffValue(fillRateDiff, fillRateDiffPercent)
@@ -787,8 +794,8 @@ func tableStatsToTable(stats1 diff.ColumnStatistics, stats2 diff.ColumnStatistic
 		t.AppendRow(table.Row{"Null Count", boolStats1.NullCount, boolStats2.NullCount, nullDiffStr, nullDiffPercent})
 
 		// Calculate fill rates
-		fillRate1 := float64(boolStats1.Count-boolStats1.NullCount) / float64(boolStats1.Count) * 100
-		fillRate2 := float64(boolStats2.Count-boolStats2.NullCount) / float64(boolStats2.Count) * 100
+		fillRate1 := calculateFillRate(boolStats1.Count, boolStats1.NullCount)
+		fillRate2 := calculateFillRate(boolStats2.Count, boolStats2.NullCount)
 		fillRateDiff := fillRate1 - fillRate2
 		fillRateDiffPercent := calculatePercentageDiff(fillRate1, fillRate2, tolerance)
 		fillRateDiffStr := formatDiffValue(fillRateDiff, fillRateDiffPercent)
@@ -824,8 +831,8 @@ func tableStatsToTable(stats1 diff.ColumnStatistics, stats2 diff.ColumnStatistic
 		t.AppendRow(table.Row{"Null Count", dtStats1.NullCount, dtStats2.NullCount, nullDiffStr, nullDiffPercent})
 
 		// Calculate fill rates
-		fillRate1 := float64(dtStats1.Count-dtStats1.NullCount) / float64(dtStats1.Count) * 100
-		fillRate2 := float64(dtStats2.Count-dtStats2.NullCount) / float64(dtStats2.Count) * 100
+		fillRate1 := calculateFillRate(dtStats1.Count, dtStats1.NullCount)
+		fillRate2 := calculateFillRate(dtStats2.Count, dtStats2.NullCount)
 		fillRateDiff := fillRate1 - fillRate2
 		fillRateDiffPercent := calculatePercentageDiff(fillRate1, fillRate2, tolerance)
 		fillRateDiffStr := formatDiffValue(fillRateDiff, fillRateDiffPercent)
@@ -873,8 +880,8 @@ func tableStatsToTable(stats1 diff.ColumnStatistics, stats2 diff.ColumnStatistic
 		t.AppendRow(table.Row{"Null Count", jsonStats1.NullCount, jsonStats2.NullCount, nullDiffStr, nullDiffPercent})
 
 		// Calculate fill rates
-		fillRate1 := float64(jsonStats1.Count-jsonStats1.NullCount) / float64(jsonStats1.Count) * 100
-		fillRate2 := float64(jsonStats2.Count-jsonStats2.NullCount) / float64(jsonStats2.Count) * 100
+		fillRate1 := calculateFillRate(jsonStats1.Count, jsonStats1.NullCount)
+		fillRate2 := calculateFillRate(jsonStats2.Count, jsonStats2.NullCount)
 		fillRateDiff := fillRate1 - fillRate2
 		fillRateDiffPercent := calculatePercentageDiff(fillRate1, fillRate2, tolerance)
 		fillRateDiffStr := formatDiffValue(fillRateDiff, fillRateDiffPercent)
@@ -1232,8 +1239,8 @@ func buildColumnStatistics(t1Col, t2Col *diff.Column, tolerance float64) JSONCol
 		stats.Statistics = append(stats.Statistics, buildStatRow("Count", numStats1.Count, numStats2.Count, tolerance))
 		stats.Statistics = append(stats.Statistics, buildStatRow("Null Count", numStats1.NullCount, numStats2.NullCount, tolerance))
 
-		fillRate1 := float64(numStats1.Count-numStats1.NullCount) / float64(numStats1.Count) * 100
-		fillRate2 := float64(numStats2.Count-numStats2.NullCount) / float64(numStats2.Count) * 100
+		fillRate1 := calculateFillRate(numStats1.Count, numStats1.NullCount)
+		fillRate2 := calculateFillRate(numStats2.Count, numStats2.NullCount)
 		stats.Statistics = append(stats.Statistics, buildStatRowFloat("Fill Rate", fillRate1, fillRate2, tolerance, "%"))
 
 		if numStats1.Avg != nil && numStats2.Avg != nil {
@@ -1259,8 +1266,8 @@ func buildColumnStatistics(t1Col, t2Col *diff.Column, tolerance float64) JSONCol
 		stats.Statistics = append(stats.Statistics, buildStatRow("Count", strStats1.Count, strStats2.Count, tolerance))
 		stats.Statistics = append(stats.Statistics, buildStatRow("Null Count", strStats1.NullCount, strStats2.NullCount, tolerance))
 
-		fillRate1 := float64(strStats1.Count-strStats1.NullCount) / float64(strStats1.Count) * 100
-		fillRate2 := float64(strStats2.Count-strStats2.NullCount) / float64(strStats2.Count) * 100
+		fillRate1 := calculateFillRate(strStats1.Count, strStats1.NullCount)
+		fillRate2 := calculateFillRate(strStats2.Count, strStats2.NullCount)
 		stats.Statistics = append(stats.Statistics, buildStatRowFloat("Fill Rate", fillRate1, fillRate2, tolerance, "%"))
 
 		stats.Statistics = append(stats.Statistics, buildStatRow("Distinct Count", strStats1.DistinctCount, strStats2.DistinctCount, tolerance))

--- a/cmd/datadiff_test.go
+++ b/cmd/datadiff_test.go
@@ -181,6 +181,44 @@ func TestCalculatePercentageDiffInt(t *testing.T) {
 	}
 }
 
+func TestCalculateFillRate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		count     int64
+		nullCount int64
+		want      float64
+	}{
+		{
+			name:      "full column",
+			count:     100,
+			nullCount: 0,
+			want:      100,
+		},
+		{
+			name:      "partially null column",
+			count:     100,
+			nullCount: 25,
+			want:      75,
+		},
+		{
+			name:      "empty column stats",
+			count:     0,
+			nullCount: 0,
+			want:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.InDelta(t, tt.want, calculateFillRate(tt.count, tt.nullCount), 0)
+		})
+	}
+}
+
 func TestCalculatePercentageDiffEdgeCases(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -359,6 +397,47 @@ func TestFormatDiffValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTableStatsToTableDoesNotRenderNaNFillRateForEmptyCounts(t *testing.T) {
+	t.Parallel()
+
+	output := tableStatsToTable(
+		&diff.NumericalStatistics{},
+		&diff.NumericalStatistics{},
+		"source",
+		"target",
+		0.001,
+	)
+
+	assert.NotContains(t, output, "NaN")
+	assert.Contains(t, output, "0%")
+}
+
+func TestBuildColumnStatisticsDoesNotRenderNaNFillRateForEmptyCounts(t *testing.T) {
+	t.Parallel()
+
+	stats := buildColumnStatistics(
+		&diff.Column{
+			Name:  "amount",
+			Type:  "NUMBER",
+			Stats: &diff.NumericalStatistics{},
+		},
+		&diff.Column{
+			Name:  "amount",
+			Type:  "NUMBER",
+			Stats: &diff.NumericalStatistics{},
+		},
+		0.001,
+	)
+
+	require.Len(t, stats.Statistics, 3)
+	fillRate := stats.Statistics[2]
+	assert.Equal(t, "Fill Rate", fillRate.Name)
+	assert.Equal(t, "0%", fillRate.Source)
+	assert.Equal(t, "0%", fillRate.Target)
+	assert.NotContains(t, fillRate.Diff, "NaN")
+	assert.NotContains(t, fillRate.DiffPercent, "NaN")
 }
 
 func TestGenerateAlterStatements(t *testing.T) {

--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -667,25 +667,11 @@ func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly 
 		}
 
 		if len(countResult) > 0 && len(countResult[0]) > 0 {
-			switch val := countResult[0][0].(type) {
-			case int64:
-				rowCount = val
-			case int:
-				rowCount = int64(val)
-			case int32:
-				rowCount = int64(val)
-			case float64:
-				rowCount = int64(val)
-			case string:
-				// Handle string representation of numbers (common with Snowflake)
-				parsed, err := strconv.ParseInt(val, 10, 64)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse row count string '%s' for table '%s': %w", val, tableName, err)
-				}
-				rowCount = parsed
-			default:
-				return nil, fmt.Errorf("unexpected row count type for table '%s': got %T with value %v", tableName, val, val)
+			parsedRowCount, err := parseSnowflakeInt64(countResult[0][0], "row count")
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse row count for table '%s': %w", tableName, err)
 			}
+			rowCount = parsedRowCount
 		}
 	}
 
@@ -851,6 +837,27 @@ func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly 
 	}, nil
 }
 
+func parseSnowflakeInt64(value interface{}, fieldName string) (int64, error) {
+	switch val := value.(type) {
+	case int64:
+		return val, nil
+	case int:
+		return int64(val), nil
+	case int32:
+		return int64(val), nil
+	case float64:
+		return int64(val), nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(val), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse %s string %q: %w", fieldName, val, err)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("unexpected %s type: got %T with value %v", fieldName, val, val)
+	}
+}
+
 func (db *DB) fetchNumericalStats(ctx context.Context, tableName, columnName string) (*diff.NumericalStatistics, error) {
 	stats := &diff.NumericalStatistics{}
 	queryStr := fmt.Sprintf(`
@@ -873,11 +880,14 @@ func (db *DB) fetchNumericalStats(ctx context.Context, tableName, columnName str
 	if len(result) > 0 && len(result[0]) >= 7 { //nolint:nestif
 		row := result[0]
 
-		if val, ok := row[0].(int64); ok {
-			stats.Count = val
+		var err error
+		stats.Count, err = parseSnowflakeInt64(row[0], "count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[1].(int64); ok {
-			stats.NullCount = val
+		stats.NullCount, err = parseSnowflakeInt64(row[1], "null count")
+		if err != nil {
+			return nil, err
 		}
 
 		// Handle nullable numeric fields
@@ -933,23 +943,36 @@ func (db *DB) fetchStringStats(ctx context.Context, tableName, columnName string
 	if len(result) > 0 && len(result[0]) >= 7 {
 		row := result[0]
 
-		if val, ok := row[0].(int64); ok {
-			stats.Count = val
+		var err error
+		stats.Count, err = parseSnowflakeInt64(row[0], "count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[1].(int64); ok {
-			stats.NullCount = val
+		stats.NullCount, err = parseSnowflakeInt64(row[1], "null count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[2].(int64); ok {
-			stats.DistinctCount = val
+		stats.DistinctCount, err = parseSnowflakeInt64(row[2], "distinct count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[3].(int64); ok {
-			stats.EmptyCount = val
+		stats.EmptyCount, err = parseSnowflakeInt64(row[3], "empty count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[4].(int64); ok {
-			stats.MinLength = int(val)
+		if row[4] != nil {
+			minLength, err := parseSnowflakeInt64(row[4], "min length")
+			if err != nil {
+				return nil, err
+			}
+			stats.MinLength = int(minLength)
 		}
-		if val, ok := row[5].(int64); ok {
-			stats.MaxLength = int(val)
+		if row[5] != nil {
+			maxLength, err := parseSnowflakeInt64(row[5], "max length")
+			if err != nil {
+				return nil, err
+			}
+			stats.MaxLength = int(maxLength)
 		}
 		if val, ok := row[6].(float64); ok {
 			stats.AvgLength = val
@@ -978,17 +1001,22 @@ func (db *DB) fetchBooleanStats(ctx context.Context, tableName, columnName strin
 	if len(result) > 0 && len(result[0]) >= 4 {
 		row := result[0]
 
-		if val, ok := row[0].(int64); ok {
-			stats.Count = val
+		var err error
+		stats.Count, err = parseSnowflakeInt64(row[0], "count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[1].(int64); ok {
-			stats.NullCount = val
+		stats.NullCount, err = parseSnowflakeInt64(row[1], "null count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[2].(int64); ok {
-			stats.TrueCount = val
+		stats.TrueCount, err = parseSnowflakeInt64(row[2], "true count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[3].(int64); ok {
-			stats.FalseCount = val
+		stats.FalseCount, err = parseSnowflakeInt64(row[3], "false count")
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -1015,14 +1043,18 @@ func (db *DB) fetchDateTimeStats(ctx context.Context, tableName, columnName stri
 	if len(result) > 0 && len(result[0]) >= 5 {
 		row := result[0]
 
-		if val, ok := row[0].(int64); ok {
-			stats.Count = val
+		var err error
+		stats.Count, err = parseSnowflakeInt64(row[0], "count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[1].(int64); ok {
-			stats.NullCount = val
+		stats.NullCount, err = parseSnowflakeInt64(row[1], "null count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[2].(int64); ok {
-			stats.UniqueCount = val
+		stats.UniqueCount, err = parseSnowflakeInt64(row[2], "unique count")
+		if err != nil {
+			return nil, err
 		}
 		// Handle datetime values - convert to proper time.Time objects
 		if row[3] != nil {
@@ -1058,11 +1090,14 @@ func (db *DB) fetchJSONStats(ctx context.Context, tableName, columnName string) 
 	if len(result) > 0 && len(result[0]) >= 2 {
 		row := result[0]
 
-		if val, ok := row[0].(int64); ok {
-			stats.Count = val
+		var err error
+		stats.Count, err = parseSnowflakeInt64(row[0], "count")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := row[1].(int64); ok {
-			stats.NullCount = val
+		stats.NullCount, err = parseSnowflakeInt64(row[1], "null count")
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/snowflake/db_test.go
+++ b/pkg/snowflake/db_test.go
@@ -187,6 +187,213 @@ func TestDB_Select(t *testing.T) {
 	}
 }
 
+func TestParseSnowflakeInt64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		want    int64
+		wantErr string
+	}{
+		{
+			name:  "int64",
+			value: int64(42),
+			want:  42,
+		},
+		{
+			name:  "int",
+			value: 42,
+			want:  42,
+		},
+		{
+			name:  "int32",
+			value: int32(42),
+			want:  42,
+		},
+		{
+			name:  "float64",
+			value: 42.0,
+			want:  42,
+		},
+		{
+			name:  "string",
+			value: "42",
+			want:  42,
+		},
+		{
+			name:  "string with whitespace",
+			value: " 42 ",
+			want:  42,
+		},
+		{
+			name:    "invalid string",
+			value:   "not-a-number",
+			wantErr: "failed to parse count string",
+		},
+		{
+			name:    "unexpected type",
+			value:   true,
+			wantErr: "unexpected count type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseSnowflakeInt64(tt.value, "count")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDBFetchStatsParsesSnowflakeStringAggregates(t *testing.T) {
+	t.Parallel()
+
+	const (
+		statsQueryPattern = `(?s)SELECT.*COUNT\(\*\) as count.*FROM SCHEMA\.TABLE`
+		statsTableName    = "SCHEMA.TABLE"
+		statsColumnName   = "COL"
+	)
+
+	t.Run("numerical stats", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		require.NoError(t, err)
+		defer mockDB.Close()
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		db := DB{conn: sqlxDB}
+
+		mock.ExpectQuery(statsQueryPattern).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "null_count", "min_val", "max_val", "avg_val", "sum_val", "stddev_val"}).
+				AddRow("42", "3", 1.0, 10.0, 5.5, 100.0, 2.5))
+
+		stats, err := db.fetchNumericalStats(t.Context(), statsTableName, statsColumnName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), stats.Count)
+		assert.Equal(t, int64(3), stats.NullCount)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("string stats", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		require.NoError(t, err)
+		defer mockDB.Close()
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		db := DB{conn: sqlxDB}
+
+		mock.ExpectQuery(statsQueryPattern).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "null_count", "distinct_count", "empty_count", "min_length", "max_length", "avg_length"}).
+				AddRow("42", "3", "12", "2", "1", "25", 8.5))
+
+		stats, err := db.fetchStringStats(t.Context(), statsTableName, statsColumnName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), stats.Count)
+		assert.Equal(t, int64(3), stats.NullCount)
+		assert.Equal(t, int64(12), stats.DistinctCount)
+		assert.Equal(t, int64(2), stats.EmptyCount)
+		assert.Equal(t, 1, stats.MinLength)
+		assert.Equal(t, 25, stats.MaxLength)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("string stats with null lengths", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		require.NoError(t, err)
+		defer mockDB.Close()
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		db := DB{conn: sqlxDB}
+
+		mock.ExpectQuery(statsQueryPattern).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "null_count", "distinct_count", "empty_count", "min_length", "max_length", "avg_length"}).
+				AddRow("42", "42", "0", "0", nil, nil, nil))
+
+		stats, err := db.fetchStringStats(t.Context(), statsTableName, statsColumnName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), stats.Count)
+		assert.Equal(t, int64(42), stats.NullCount)
+		assert.Zero(t, stats.MinLength)
+		assert.Zero(t, stats.MaxLength)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("boolean stats", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		require.NoError(t, err)
+		defer mockDB.Close()
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		db := DB{conn: sqlxDB}
+
+		mock.ExpectQuery(statsQueryPattern).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "null_count", "true_count", "false_count"}).
+				AddRow("42", "3", "20", "19"))
+
+		stats, err := db.fetchBooleanStats(t.Context(), statsTableName, statsColumnName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), stats.Count)
+		assert.Equal(t, int64(3), stats.NullCount)
+		assert.Equal(t, int64(20), stats.TrueCount)
+		assert.Equal(t, int64(19), stats.FalseCount)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("datetime stats", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		require.NoError(t, err)
+		defer mockDB.Close()
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		db := DB{conn: sqlxDB}
+
+		mock.ExpectQuery(statsQueryPattern).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "null_count", "unique_count", "earliest_date", "latest_date"}).
+				AddRow("42", "3", "12", "2024-01-01 00:00:00", "2024-01-02 00:00:00"))
+
+		stats, err := db.fetchDateTimeStats(t.Context(), statsTableName, statsColumnName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), stats.Count)
+		assert.Equal(t, int64(3), stats.NullCount)
+		assert.Equal(t, int64(12), stats.UniqueCount)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("json stats", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		require.NoError(t, err)
+		defer mockDB.Close()
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		db := DB{conn: sqlxDB}
+
+		mock.ExpectQuery(statsQueryPattern).
+			WillReturnRows(sqlmock.NewRows([]string{"count", "null_count"}).
+				AddRow("42", "3"))
+
+		stats, err := db.fetchJSONStats(t.Context(), statsTableName, statsColumnName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), stats.Count)
+		assert.Equal(t, int64(3), stats.NullCount)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestDB_SelectRetriesTransientConnectError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #2169.

- Parse Snowflake aggregate counts from `int64`, `int`, `int32`, `float64`, and numeric strings instead of silently ignoring non-`int64` values.
- Apply the shared parser to Snowflake row counts and all diff stat fetchers.
- Guard fill-rate calculation so empty stats render as `0%` instead of `NaN%`.

## Root cause

Snowflake diff stat fetchers asserted aggregate values as `int64` only. When the Snowflake driver returned `COUNT(*)` or related aggregates as strings, Bruin left count fields at zero and later divided `0 / 0` for fill rate.

## Validation

- `make format`
- `make test`