### PR TITLE
Support resolving cloud agents by name

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -9,6 +9,7 @@ import (
 	path2 "path"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -91,6 +92,20 @@ func offsetFlag() *cli.IntFlag {
 	}
 }
 
+func agentIDFlag() *cli.IntFlag {
+	return &cli.IntFlag{
+		Name:  "agent-id",
+		Usage: "agent ID (see 'bruin cloud agents list' for available IDs)",
+	}
+}
+
+func agentNameFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:  "agent-name",
+		Usage: "agent name (resolved to an ID via 'bruin cloud agents list')",
+	}
+}
+
 func resolveAPIKey(c *cli.Command) (string, error) {
 	key := c.String("api-key")
 	if key != "" {
@@ -169,6 +184,43 @@ func resolveProjectID(projectID string, listProjects func() ([]bruincloud.Projec
 	default:
 		return "", errors.New("--project-id is required when your account has access to multiple projects")
 	}
+}
+
+func resolveAgentID(agentID int, agentIDSet bool, agentName string, listAgents func() ([]bruincloud.Agent, error)) (int, error) {
+	if agentIDSet {
+		return agentID, nil
+	}
+
+	if agentName == "" {
+		return 0, errors.New("either --agent-id or --agent-name is required")
+	}
+
+	agents, err := listAgents()
+	if err != nil {
+		return 0, fmt.Errorf("failed to list agents: %w", err)
+	}
+
+	var matches []bruincloud.Agent
+	for _, a := range agents {
+		if strings.EqualFold(a.Name, agentName) {
+			matches = append(matches, a)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return 0, fmt.Errorf("no agent found with name '%s'", agentName)
+	case 1:
+		return matches[0].ID, nil
+	default:
+		return 0, fmt.Errorf("multiple agents found with name '%s'; use --agent-id to disambiguate", agentName)
+	}
+}
+
+func resolveAgentIDFromCmd(ctx context.Context, c *cli.Command, client *bruincloud.APIClient) (int, error) {
+	return resolveAgentID(c.Int("agent-id"), c.IsSet("agent-id"), c.String("agent-name"), func() ([]bruincloud.Agent, error) {
+		return client.ListAgents(ctx)
+	})
 }
 
 func printFormattedLogs(result json.RawMessage) {
@@ -1972,11 +2024,8 @@ func cloudAgentsSend() *cli.Command {
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
-			&cli.IntFlag{
-				Name:     "agent-id",
-				Usage:    "agent ID",
-				Required: true,
-			},
+			agentIDFlag(),
+			agentNameFlag(),
 			&cli.StringFlag{
 				Name:     "message",
 				Usage:    "message to send",
@@ -1997,13 +2046,19 @@ func cloudAgentsSend() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
+			agentID, err := resolveAgentIDFromCmd(ctx, c, client)
+			if err != nil {
+				printError(err, output, "Failed to resolve agent")
+				return cli.Exit("", 1)
+			}
+
 			var threadID *int
 			if c.IsSet("thread-id") {
 				tid := c.Int("thread-id")
 				threadID = &tid
 			}
 
-			result, err := client.SendAgentMessage(ctx, c.Int("agent-id"), c.String("message"), threadID)
+			result, err := client.SendAgentMessage(ctx, agentID, c.String("message"), threadID)
 			if err != nil {
 				printError(err, output, "Failed to send message")
 				return cli.Exit("", 1)
@@ -2036,11 +2091,8 @@ func cloudAgentsStatus() *cli.Command {
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
-			&cli.IntFlag{
-				Name:     "agent-id",
-				Usage:    "agent ID",
-				Required: true,
-			},
+			agentIDFlag(),
+			agentNameFlag(),
 			&cli.IntFlag{
 				Name:     "thread-id",
 				Usage:    "thread ID",
@@ -2062,7 +2114,13 @@ func cloudAgentsStatus() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			msg, err := client.GetAgentMessageStatus(ctx, c.Int("agent-id"), c.Int("thread-id"), c.Int("message-id"))
+			agentID, err := resolveAgentIDFromCmd(ctx, c, client)
+			if err != nil {
+				printError(err, output, "Failed to resolve agent")
+				return cli.Exit("", 1)
+			}
+
+			msg, err := client.GetAgentMessageStatus(ctx, agentID, c.Int("thread-id"), c.Int("message-id"))
 			if err != nil {
 				printError(err, output, "Failed to get message status")
 				return cli.Exit("", 1)
@@ -2096,11 +2154,8 @@ func cloudAgentsThreads() *cli.Command {
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
-			&cli.IntFlag{
-				Name:     "agent-id",
-				Usage:    "agent ID",
-				Required: true,
-			},
+			agentIDFlag(),
+			agentNameFlag(),
 			limitFlag(),
 			offsetFlag(),
 		},
@@ -2114,7 +2169,13 @@ func cloudAgentsThreads() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			threads, err := client.ListAgentThreads(ctx, c.Int("agent-id"), c.Int("limit"), c.Int("offset"))
+			agentID, err := resolveAgentIDFromCmd(ctx, c, client)
+			if err != nil {
+				printError(err, output, "Failed to resolve agent")
+				return cli.Exit("", 1)
+			}
+
+			threads, err := client.ListAgentThreads(ctx, agentID, c.Int("limit"), c.Int("offset"))
 			if err != nil {
 				printError(err, output, "Failed to list threads")
 				return cli.Exit("", 1)
@@ -2145,11 +2206,8 @@ func cloudAgentsMessages() *cli.Command {
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
-			&cli.IntFlag{
-				Name:     "agent-id",
-				Usage:    "agent ID",
-				Required: true,
-			},
+			agentIDFlag(),
+			agentNameFlag(),
 			&cli.IntFlag{
 				Name:     "thread-id",
 				Usage:    "thread ID",
@@ -2168,7 +2226,13 @@ func cloudAgentsMessages() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			messages, err := client.ListAgentMessages(ctx, c.Int("agent-id"), c.Int("thread-id"), c.Int("limit"), c.Int("offset"))
+			agentID, err := resolveAgentIDFromCmd(ctx, c, client)
+			if err != nil {
+				printError(err, output, "Failed to resolve agent")
+				return cli.Exit("", 1)
+			}
+
+			messages, err := client.ListAgentMessages(ctx, agentID, c.Int("thread-id"), c.Int("limit"), c.Int("offset"))
 			if err != nil {
 				printError(err, output, "Failed to list messages")
 				return cli.Exit("", 1)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -137,6 +137,96 @@ func TestResolveProjectID_ListProjectsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
+func TestResolveAgentID_UsesExplicitID(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	agentID, err := resolveAgentID(42, true, "", func() ([]bruincloud.Agent, error) {
+		called = true
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, agentID)
+	assert.False(t, called)
+}
+
+func TestResolveAgentID_ResolvesByName(t *testing.T) {
+	t.Parallel()
+
+	agentID, err := resolveAgentID(0, false, "My Agent", func() ([]bruincloud.Agent, error) {
+		return []bruincloud.Agent{
+			{ID: 1, Name: "Other Agent"},
+			{ID: 7, Name: "My Agent"},
+		}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 7, agentID)
+}
+
+func TestResolveAgentID_NameIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	agentID, err := resolveAgentID(0, false, "my agent", func() ([]bruincloud.Agent, error) {
+		return []bruincloud.Agent{{ID: 7, Name: "My Agent"}}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 7, agentID)
+}
+
+func TestResolveAgentID_NoIdentifier(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	_, err := resolveAgentID(0, false, "", func() ([]bruincloud.Agent, error) {
+		called = true
+		return nil, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either --agent-id or --agent-name is required")
+	assert.False(t, called)
+}
+
+func TestResolveAgentID_NameNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveAgentID(0, false, "Missing", func() ([]bruincloud.Agent, error) {
+		return []bruincloud.Agent{{ID: 1, Name: "Other"}}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no agent found with name 'Missing'")
+}
+
+func TestResolveAgentID_MultipleMatches(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveAgentID(0, false, "Dup", func() ([]bruincloud.Agent, error) {
+		return []bruincloud.Agent{
+			{ID: 1, Name: "Dup"},
+			{ID: 2, Name: "Dup"},
+		}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple agents found with name 'Dup'")
+}
+
+func TestResolveAgentID_ListAgentsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveAgentID(0, false, "Any", func() ([]bruincloud.Agent, error) {
+		return nil, errors.New("boom")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list agents")
+	assert.Contains(t, err.Error(), "boom")
+}
+
 func TestCloudCommand_Help(t *testing.T) {
 	t.Parallel()
 	isDebug := false

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -352,11 +352,13 @@ Interact with Bruin Cloud AI agents from the terminal.
 
 #### `list`
 
-List available agents:
+List available agents. The output includes each agent's numeric **ID**, which the other `agents` commands accept via `--agent-id`:
 
 ```bash
 bruin cloud agents list --project-id <project-id>
 ```
+
+> Every command below accepts either `--agent-id <id>` or `--agent-name <name>`. When you pass `--agent-name`, the CLI resolves it to an ID by matching (case-insensitively) against `agents list`, so you don't need to look the ID up first. Names must be unique; if more than one agent shares a name, use `--agent-id` instead.
 
 #### `send`
 
@@ -366,6 +368,15 @@ Send a message to an agent:
 bruin cloud agents send \
   --project-id <project-id> \
   --agent-id <agent-id> \
+  --message "What pipelines failed today?"
+```
+
+Or reference the agent by name instead of ID:
+
+```bash
+bruin cloud agents send \
+  --project-id <project-id> \
+  --agent-name "My Agent" \
   --message "What pipelines failed today?"
 ```
 


### PR DESCRIPTION
## What

Adds `--agent-name` as an alternative to `--agent-id` for the `bruin cloud agents` subcommands (`send`, `status`, `threads`, `messages`). Previously `--agent-id` was required, forcing users to look the numeric ID up via `agents list` first.

When `--agent-name` is passed, the CLI resolves it to an ID by matching (case-insensitively) against `agents list`. Ambiguous names error out and ask the user to disambiguate with `--agent-id`. The `ListAgents` call is only made when a name actually needs resolving — passing `--agent-id` short-circuits before any network request.

## How

- `resolveAgentID(...)` holds the resolution logic, mirroring the existing `resolveProjectID` helper so it's unit-testable in isolation.
- `resolveAgentIDFromCmd(ctx, c, client)` is a thin cmd-aware wrapper following the existing `resolveRunID` convention, so the 4 call sites stay one-liners instead of repeating the lookup closure.
- New `agentIDFlag()` / `agentNameFlag()` flag helpers, consistent with the other flag helpers in the file.
- Docs updated in `docs/commands/cloud.md`.

## Testing

- `make format` — 0 issues
- `make test` (cmd package) — pass, including new `TestResolveAgentID_*` cases covering explicit ID, name resolution, case-insensitivity, missing identifier, not-found, multiple matches, and list error.