### PR TITLE
Security: Patch GHSA-gv7w-rqvm-qjhr — upgrade esbuild to ^0.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "vitepress-plugin-mermaid": "^2.0.17"
   },
   "dependencies": {
-    "esbuild": "^0.27.1",
+    "esbuild": "^0.28.1",
     "highlight.js": "^11.10.0",
     "markdown-it": "^14.1.0",
     "vite": "^6.4.1",
     "vue": "^3.5.16"
   },
   "overrides": {
-    "esbuild": "^0.27.1",
+    "esbuild": "^0.28.1",
     "vite": "^6.4.1"
   }
 }


### PR DESCRIPTION
## Security Patch — esbuild vulnerability

### Change
Bumps `esbuild` from `^0.27.1` to `^0.28.1` in both `dependencies` and `overrides`.

| Package | Old | New | Advisory | Severity |
|---------|-----|-----|----------|----------|
| esbuild | ^0.27.1 | **^0.28.1** | [GHSA-gv7w-rqvm-qjhr](https://github.com/advisories/GHSA-gv7w-rqvm-qjhr) | High |

### Note
`package-lock.json` needs regeneration — run `npm install` locally or let CI handle it.

### Linear Ticket
- [BRU-4956](https://linear.app/bruin/issue/BRU-4956)

**Reviewer:** Burak Karakan