### PR TITLE
docs: document asset-level and per-check retries (BRU-4817)

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -220,6 +220,24 @@ See [interval modifiers](./interval-modifiers) for more details.
 
 - **Type:** `Object`
 
+## `retries`
+
+Number of times the asset is retried on failure before it is marked as failed. If not specified, the asset inherits the pipeline-level [`retries`](../pipelines/definition.md#retries).
+
+```yaml
+retries: 3
+```
+
+**Special values:**
+
+- unset: inherit the pipeline-level `retries`
+- `0`: no retries
+- `> 0`: retry the asset up to this many times
+
+The asset-level value is, in turn, the default for the asset's [quality checks](../quality/overview.md#retries), following the resolution chain **check → asset → pipeline**.
+
+- **Type:** `Integer`
+
 ## `rerun_cooldown`
 
 Set a delay (in seconds) between retry attempts for failed assets. This helps prevent overwhelming downstream systems during failures and allows for temporary issues to resolve. If not specified, the asset inherits the pipeline's `rerun_cooldown` setting.

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -333,6 +333,8 @@ retries: 2
 - **Type:** `Integer`
 - **Default:** `2`
 
+**Inheritance:** The pipeline-level `retries` is the default for every asset and every quality check in the pipeline. An [asset can override it](../assets/definition-schema.md#retries) with its own `retries`, and a [check can override it](../quality/overview.md#retries) again, following the resolution chain **check → asset → pipeline**. An explicit value (including `0`, meaning no retries) at any level wins over the inherited default.
+
 ### Rerun Cooldown
 
 Set a delay (in seconds) between retry attempts for failed assets. This helps prevent overwhelming downstream systems during failures and allows for temporary issues to resolve. When deploying to Airflow, this is automatically translated to `retries_delay` for compatibility.

--- a/docs/quality/custom.md
+++ b/docs/quality/custom.md
@@ -44,6 +44,7 @@ There are a few fields to configure the check behavior:
 - `count`: optional, expected number of rows returned by the query. When set,
   Bruin will automatically wrap the query with `SELECT count(*) FROM (<query>)`.
 - `blocking`: optional, whether the test should block running downstreams, default `true`.
+- `retries`: optional, how many times the check is retried on failure. If unset, it inherits the asset-level [`retries`](../assets/definition-schema.md#retries) (which falls back to the pipeline-level [`retries`](../pipelines/definition.md#retries)); `0` means no retries. See [retries](./overview.md#retries).
 
 ## Examples
 

--- a/docs/quality/overview.md
+++ b/docs/quality/overview.md
@@ -21,6 +21,28 @@ columns:
 
 If any of those checks fails the asset will be marked as failed and any downstream assets will not be executed.
 
+## retries
+
+Both column checks and [custom checks](./custom.md) accept an optional `retries` attribute that controls how many times the check is retried on failure before it is marked as failed. It can be configured independently of the asset- and pipeline-level retries.
+
+```yaml
+columns:
+  - name: id
+    type: integer
+    checks:
+      - name: unique
+        retries: 3   # retry this check up to 3 times
+      - name: not_null
+```
+
+**Special values:**
+
+- unset: inherit the asset-level [`retries`](../assets/definition-schema.md#retries) (which in turn falls back to the pipeline-level [`retries`](../pipelines/definition.md#retries))
+- `0`: no retries
+- `> 0`: retry the check up to this many times
+
+Retries are resolved through the chain **check → asset → pipeline**: a check without its own `retries` inherits the asset's, and an asset without its own inherits the pipeline's. An explicit value (including `0`) at any level wins over the inherited default.
+
 Quality checks can also be executed on their own without running the asset again:
 
 ```bash


### PR DESCRIPTION
Documents the asset-level and per-check `retries` fields and the `check → asset → pipeline` inheritance chain introduced in BRU-4817, which were previously undocumented (only pipeline-level retries was). Adds an inheritance note to the pipeline-level Retries section, a new `retries` field on the asset definition schema, a `retries` section in the quality-checks overview covering column and custom checks, and a `retries` entry in the custom-check field list. All four pages cross-link each other and explain the special values (unset inherits the parent level, `0` means no retries). Docs-only change — no runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)