### PR TITLE
feat(pipeline): make pipeline-level retries a *int (BRU-4817)

### DIFF
--- a/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
+++ b/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
@@ -150,7 +150,7 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null,
   "commit": "",

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
@@ -470,7 +470,7 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null
 }

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -283,7 +283,7 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null,
   "default": {

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
@@ -280,7 +280,7 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null,
   "commit": "",

--- a/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
@@ -597,7 +597,7 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null,
   "commit": "",

--- a/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
@@ -244,7 +244,7 @@
   "metadata_push": {
     "bigquery": false
   },
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null,
   "commit": "",

--- a/pkg/lint/policy_builtins.go
+++ b/pkg/lint/policy_builtins.go
@@ -461,7 +461,7 @@ var builtinRules = map[string]validators{
 	},
 	"pipeline-has-retries": {
 		Pipeline: func(ctx context.Context, pipeline *pipeline.Pipeline) ([]*Issue, error) {
-			if pipeline.Retries > 0 {
+			if pipeline.Retries != nil && *pipeline.Retries > 0 {
 				return nil, nil
 			}
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1620,7 +1620,7 @@ type Pipeline struct {
 	Catchup            bool                   `json:"catchup" yaml:"catchup,omitempty" mapstructure:"catchup"`
 	CatchupMode        string                 `json:"catchup_mode" yaml:"catchup_mode,omitempty" mapstructure:"catchup_mode"`
 	MetadataPush       MetadataPush           `json:"metadata_push" yaml:"metadata_push,omitempty" mapstructure:"metadata_push"`
-	Retries            int                    `json:"retries" yaml:"retries,omitempty" mapstructure:"retries"`
+	Retries            *int                   `json:"retries" yaml:"retries,omitempty" mapstructure:"retries"`
 	RetriesDelay       *int                   `json:"retries_delay,omitempty" yaml:"-" mapstructure:"-"`
 	Concurrency        int                    `json:"concurrency" yaml:"concurrency,omitempty" mapstructure:"concurrency"`
 	MaxActiveSteps     *int                   `json:"max_active_steps" yaml:"max_active_steps,omitempty" mapstructure:"max_active_steps"`

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -204,7 +204,7 @@ func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 			"slack":           "slack-connection",
 			"gcpConnectionId": "gcp-connection-id-here",
 		},
-		Retries: 3,
+		Retries: ptrInt(3),
 		Assets:  []*pipeline.Asset{asset1, asset2, asset3, asset4},
 	}
 	fs := afero.NewOsFs()
@@ -1204,7 +1204,7 @@ func TestPipeline_FormatContent_ErrorHandling(t *testing.T) {
 			Name:               "complex-test",
 			Schedule:           "daily",
 			StartDate:          "2024-01-01",
-			Retries:            3,
+			Retries:            ptrInt(3),
 			Concurrency:        5,
 			Catchup:            true,
 			Agent:              true,
@@ -2730,3 +2730,5 @@ func TestAsset_FormatContent_DeduplicatesTags(t *testing.T) {
 		})
 	}
 }
+
+func ptrInt(i int) *int { return &i }

--- a/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_unix.json
+++ b/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_unix.json
@@ -27,7 +27,7 @@
     "metadata_push": {
         "bigquery": false
     },
-    "retries": 0,
+    "retries": null,
     "concurrency": 1,
     "max_active_steps": null,
     "commit": "",

--- a/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_windows.json
+++ b/pkg/pipeline/testdata/pipeline/pipeline-with-no-assets_windows.json
@@ -33,7 +33,7 @@
   "catchup": false,
   "catchup_mode": "",
   "commit": "",
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null
 }

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_unix.json
@@ -284,7 +284,7 @@
     "metadata_push": {
         "bigquery": false
     },
-    "retries": 0,
+    "retries": null,
     "concurrency": 1,
     "max_active_steps": null,
     "commit": "",

--- a/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
+++ b/pkg/pipeline/testdata/pipeline/second-pipeline_windows.json
@@ -290,7 +290,7 @@
   "catchup": false,
   "catchup_mode": "",
   "commit": "",
-  "retries": 0,
+  "retries": null,
   "concurrency": 1,
   "max_active_steps": null
 }


### PR DESCRIPTION
## Problem

Pipeline-level `retries` was a plain `int`, so an unset value and an explicit `retries: 0` both serialized as `0`. Consumers (asset-service, orchestrator) couldn't tell "use the default" from "disable retries", so a pipeline that didn't configure `retries` got `0` and ran every task exactly once — contradicting the documented default of `2`. There was also no way to express "no retries pipeline-wide".

## Fix

Make `Pipeline.Retries` a `*int`, matching the existing shape of `Asset.Retries` / `ColumnCheck.Retries` / `CustomCheck.Retries` (which already serialize `null` when unset). Now:

- **unset** → `null` → consumers apply the default (the orchestrator already maps a nil pipeline retries to `2`; asset-service does the same in a follow-up).
- **explicit `0`** → `0` → honored as "no retries", at every level.

`pipeline-has-retries` lint policy is made nil-safe and keeps its prior behavior (unset/`0` fail, `>0` passes). Unix + Windows goldens and the parse/lineage integration expectations are refreshed where an unset pipeline `retries` flips from `0` to `null`.

This is the bruin half of the fix; asset-service will resolve `nil → 2` and bump to this version (replaces the interim asset-service workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)