### PR TITLE
docs(monday): document items source, board scoping, and :linked mode

### DIFF
--- a/docs/ingestion/monday.md
+++ b/docs/ingestion/monday.md
@@ -91,8 +91,6 @@ parameters:
 
 > [!NOTE]
 > `:linked` discovers sub-boards by the convention that **an item on the master board has the same title as the sub-board's name**. So if your master board has an item called `Q1 Roadmap` and you also have a board called `Q1 Roadmap`, that board is treated as a linked sub-board and its items are included in the result.
->
-> This is a naming convention, not a real Monday-side relationship — so keep your master item titles and sub-board names in sync. If they ever drift apart (renames, typos, casing), the link is lost without any error and the sub-board's items are silently omitted. After a rename on either side, sanity-check the row count.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/monday.md
+++ b/docs/ingestion/monday.md
@@ -55,14 +55,44 @@ parameters:
 | `account_roles` | - | - | replace | Account roles with their types and permissions. Full reload on each run. |
 | `users` | - | - | replace | Users in your Monday.com account with their profiles and permissions. Full reload on each run. |
 | `boards` | id | updated_at | merge | Boards with their metadata, state, and configuration. Incrementally loads only updated boards. |
+| `items` | id | - | replace | Items (rows) across all boards, including each cell's raw values as a JSON array in `column_values`. Full reload on each run. |
 | `workspaces` | - | - | replace | Workspaces containing boards and their settings. Full reload on each run. |
 | `webhooks` | - | - | replace | Webhooks configured for boards with their events and configurations. Full reload on each run. |
-| `updates` | id | updated_at | merge | Updates (comments) on items with their content and metadata. Incrementally loads only updated entries. |
+| `updates` | id | updated_at | merge | Updates (comments) on items with their content and metadata, including the creator and item names. Incrementally loads only updated entries. |
 | `teams` | - | - | replace | Teams in your account with their members. Full reload on each run. |
 | `tags` | - | - | replace | Tags used across your account for organizing items. Full reload on each run. |
 | `custom_activities` | - | - | replace | Custom activity types defined in your account. Full reload on each run. |
 | `board_columns` | - | - | replace | Columns defined in all boards with their types and settings. Full reload on each run. |
 | `board_views` | - | - | replace | Views configured for boards with their filters and settings. Full reload on each run. |
+
+### Scoping to specific boards
+
+`items`, `boards`, `board_columns`, `board_views`, and `updates` accept an optional `:<board_id>[,<board_id>...]` suffix in `source_table` to restrict the result to the listed boards. Without a suffix they behave as before (every board in the account).
+
+```yaml
+parameters:
+  source_connection: my-monday
+  source_table: 'items:5091839751'                       # items on a single board
+  # source_table: 'board_columns:5091839751,5091841857'  # board_columns from two boards
+  # source_table: 'updates:5091841883'                   # updates on items of a single board
+  destination: postgres
+```
+
+### `items:<board_id>:linked`
+
+`items` additionally supports a `:linked` suffix that treats the given board as a "master" board and also pulls items from any **sub-boards whose name matches one of the master's item titles**. Useful for a "master board → linked sub-boards" fan-out pattern where the master's items name the sub-boards. Requires at least one master board id.
+
+```yaml
+parameters:
+  source_connection: my-monday
+  source_table: 'items:5091839751:linked'
+  destination: postgres
+```
+
+> [!NOTE]
+> `:linked` discovers sub-boards by the convention that **an item on the master board has the same title as the sub-board's name**. So if your master board has an item called `Q1 Roadmap` and you also have a board called `Q1 Roadmap`, that board is treated as a linked sub-board and its items are included in the result.
+>
+> This is a naming convention, not a real Monday-side relationship — so keep your master item titles and sub-board names in sync. If they ever drift apart (renames, typos, casing), the link is lost without any error and the sub-board's items are silently omitted. After a rename on either side, sanity-check the row count.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 


### PR DESCRIPTION
## Summary

Brings the Bruin Monday ingestion docs in line with what the ingestr source now supports