### PR TITLE
Emit column metadata into generated DDL

### DIFF
--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -103,6 +103,15 @@ columns:
     collation: en_US
 ```
 
+### DDL generation
+
+When an asset uses the `ddl` [materialization](./materialization.md) strategy, these fields
+are emitted into the generated `CREATE TABLE` statement: `precision`/`scale`/`length` become
+type modifiers (e.g. `decimal(10, 2)`, `varchar(255)`), and `collation`, `default`, and
+`foreign_key` become column/table clauses. Foreign keys are emitted as `NOT ENFORCED` on
+platforms that only store them as metadata (e.g. BigQuery). Support is currently available
+for PostgreSQL, BigQuery, and Snowflake, and is being extended to the other platforms.
+
 ### Quality Checks
 
 The structure of the quality checks is rather simple:

--- a/pkg/athena/materialization.go
+++ b/pkg/athena/materialization.go
@@ -198,7 +198,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string, location string
 func buildDDLQuery(asset *pipeline.Asset, query string, location string) ([]string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns))
 	for _, col := range asset.Columns {
-		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+		def := fmt.Sprintf("%s %s", col.Name, col.SQLType())
 		if col.Description != "" {
 			desc := strings.ReplaceAll(col.Description, `'`, `''`)
 			def += fmt.Sprintf(" COMMENT '%s'", desc)

--- a/pkg/athena/materialization_test.go
+++ b/pkg/athena/materialization_test.go
@@ -1314,3 +1314,23 @@ func TestBuildSCD2ByTimeFullRefreshQuery(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "decimal", Precision: intp(10), Scale: intp(2)},
+			{Name: "name", Type: "varchar", Length: intp(255)},
+		},
+	}
+	parts, err := NewMaterializer(false).Render(asset, "SELECT 1", "s3://bucket/loc")
+	require.NoError(t, err)
+	require.NotEmpty(t, parts)
+	createTable := parts[len(parts)-1]
+	require.Contains(t, createTable, "decimal(10, 2)")
+	require.Contains(t, createTable, "varchar(255)")
+}

--- a/pkg/bigquery/materialization.go
+++ b/pkg/bigquery/materialization.go
@@ -211,14 +211,28 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns))
 	primaryKeys := []string{}
 
-	for _, col := range asset.Columns {
-		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+	foreignKeys := []string{}
 
+	for _, col := range asset.Columns {
+		def := fmt.Sprintf("%s %s", col.Name, col.SQLType())
+
+		if col.Collation != "" {
+			def += fmt.Sprintf(" COLLATE %q", col.Collation)
+		}
+		if col.Default != "" {
+			def += " DEFAULT " + col.Default
+		}
 		if col.Description != "" {
 			def += fmt.Sprintf(` OPTIONS(description=%q)`, col.Description)
 		}
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, col.Name)
+		}
+		if col.ForeignKey != nil && col.ForeignKey.Table != "" && col.ForeignKey.Column != "" {
+			foreignKeys = append(foreignKeys, fmt.Sprintf(
+				"FOREIGN KEY (%s) REFERENCES %s(%s) NOT ENFORCED",
+				col.Name, col.ForeignKey.Table, col.ForeignKey.Column,
+			))
 		}
 		columnDefs = append(columnDefs, def)
 	}
@@ -227,6 +241,8 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 		primaryKeyClause := fmt.Sprintf("PRIMARY KEY (%s) NOT ENFORCED", strings.Join(primaryKeys, ", "))
 		columnDefs = append(columnDefs, primaryKeyClause)
 	}
+
+	columnDefs = append(columnDefs, foreignKeys...)
 
 	q := fmt.Sprintf(
 		"CREATE TABLE IF NOT EXISTS %s (\n  %s\n)",

--- a/pkg/bigquery/materialization_test.go
+++ b/pkg/bigquery/materialization_test.go
@@ -561,6 +561,21 @@ func TestBuildDDLQuery(t *testing.T) {
 			},
 			want: "CREATE TABLE IF NOT EXISTS my_table_with_multiple_pks (\n  id INT64,\n  category STRING,\n  name STRING OPTIONS(description=\"The name of the person\"),\n  PRIMARY KEY (id, category) NOT ENFORCED\n)",
 		},
+		{
+			name: "table with type detail, default, collation and foreign key",
+			asset: &pipeline.Asset{
+				Name: "orders",
+				Columns: []pipeline.Column{
+					{Name: "amount", Type: "NUMERIC", Precision: intp(10), Scale: intp(2), Default: "0"},
+					{Name: "name", Type: "STRING", Collation: "und:ci"},
+					{Name: "customer_id", Type: "INT64", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+				},
+				Materialization: pipeline.Materialization{
+					Type: pipeline.MaterializationTypeTable,
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS orders (\n  amount NUMERIC(10, 2) DEFAULT 0,\n  name STRING COLLATE \"und:ci\",\n  customer_id INT64,\n  FOREIGN KEY (customer_id) REFERENCES customers(id) NOT ENFORCED\n)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1081,3 +1096,5 @@ func TestBuildSCD2ByColumnQuery(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -169,8 +169,11 @@ func buildDDLQuery(asset *pipeline.Asset, query string) ([]string, error) {
 	primaryKeys := ""
 
 	for _, col := range asset.Columns {
-		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+		def := fmt.Sprintf("%s %s", col.Name, col.SQLType())
 
+		if col.Default != "" {
+			def += " DEFAULT " + col.Default
+		}
 		if col.Description != "" {
 			def += fmt.Sprintf(" COMMENT '%s'", col.Description)
 		}

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -391,3 +391,23 @@ func TestMaterializer_Render(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "Decimal", Precision: intp(10), Scale: intp(2), Default: "0"},
+		},
+	}
+	parts, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	require.NotEmpty(t, parts)
+	createTable := parts[len(parts)-1]
+	require.Contains(t, createTable, "Decimal(10, 2)")
+	require.Contains(t, createTable, "DEFAULT 0")
+	require.NotContains(t, createTable, "REFERENCES")
+}

--- a/pkg/databricks/materialization.go
+++ b/pkg/databricks/materialization.go
@@ -192,7 +192,7 @@ func buildDDLQuery(asset *pipeline.Asset, query string) ([]string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns))
 
 	for _, col := range asset.Columns {
-		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+		def := fmt.Sprintf("%s %s", col.Name, col.SQLType())
 		if col.PrimaryKey {
 			def += " PRIMARY KEY"
 		}

--- a/pkg/databricks/materialization_test.go
+++ b/pkg/databricks/materialization_test.go
@@ -706,3 +706,22 @@ func TestMaterializer_Render(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "decimal", Precision: intp(10), Scale: intp(2)},
+			{Name: "name", Type: "varchar", Length: intp(255)},
+		},
+	}
+	parts, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	rendered := strings.Join(parts, "\n")
+	require.Contains(t, rendered, "decimal(10, 2)")
+	require.Contains(t, rendered, "varchar(255)")
+}

--- a/pkg/duckdb/materialization.go
+++ b/pkg/duckdb/materialization.go
@@ -232,13 +232,24 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns))
 	primaryKeys := []string{}
+	foreignKeys := []string{}
 	columnComments := []string{}
 
 	for _, col := range asset.Columns {
-		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+		def := fmt.Sprintf("%s %s", col.Name, col.SQLType())
+		if col.Collation != "" {
+			def += " COLLATE " + col.Collation
+		}
+		if col.Default != "" {
+			def += " DEFAULT " + col.Default
+		}
 
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, col.Name)
+		}
+		if col.ForeignKey != nil && col.ForeignKey.Table != "" && col.ForeignKey.Column != "" {
+			foreignKeys = append(foreignKeys, fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s (%s)",
+				col.Name, col.ForeignKey.Table, col.ForeignKey.Column))
 		}
 
 		columnDefs = append(columnDefs, def)
@@ -253,6 +264,8 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 		primaryKeyClause := fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(primaryKeys, ", "))
 		columnDefs = append(columnDefs, primaryKeyClause)
 	}
+
+	columnDefs = append(columnDefs, foreignKeys...)
 
 	createTableStmt := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)", asset.Name, strings.Join(columnDefs, ",\n  "))
 

--- a/pkg/duckdb/materialization_test.go
+++ b/pkg/duckdb/materialization_test.go
@@ -1415,3 +1415,25 @@ func TestBuildSCD2ByTimeFullRefreshQuery(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0"},
+			{Name: "name", Type: "varchar", Length: intp(255), Collation: "en_US"},
+			{Name: "customer_id", Type: "integer", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+		},
+	}
+	render, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	assert.Contains(t, render, "numeric(10, 2)")
+	assert.Contains(t, render, "varchar(255)")
+	assert.Contains(t, render, "DEFAULT 0")
+	assert.Contains(t, render, "COLLATE")
+	assert.Contains(t, render, "REFERENCES")
+}

--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -124,7 +124,7 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
 		}
 
-		definition := fmt.Sprintf("    %s %s", QuoteIdentifier(col.Name), col.Type)
+		definition := fmt.Sprintf("    %s %s", QuoteIdentifier(col.Name), col.SQLType())
 		if col.PrimaryKey || !col.Nullable.Bool() {
 			definition += " NOT NULL"
 		}

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -128,3 +128,21 @@ func TestBuildDDLQuery(t *testing.T) {
 		"END;"
 	assert.Equal(t, expected, result)
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "decimal", Precision: intp(10), Scale: intp(2)},
+			{Name: "name", Type: "varchar", Length: intp(255)},
+		},
+	}
+	render, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	assert.Contains(t, render, "decimal(10, 2)")
+	assert.Contains(t, render, "varchar(255)")
+}

--- a/pkg/mssql/materialization.go
+++ b/pkg/mssql/materialization.go
@@ -202,25 +202,38 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 
 	columnDefs := make([]string, 0, len(asset.Columns)+1)
 	primaryKeys := make([]string, 0)
+	foreignKeys := make([]string, 0)
 	for _, col := range asset.Columns {
 		if col.Type == "" {
 			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
 		}
 
-		def := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.Type)
+		def := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.SQLType())
+		if col.Collation != "" {
+			def += " COLLATE " + col.Collation
+		}
 		if col.PrimaryKey || !col.Nullable.Bool() {
 			def += " NOT NULL"
+		}
+		if col.Default != "" {
+			def += " DEFAULT " + col.Default
 		}
 		columnDefs = append(columnDefs, def)
 
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, quoteIdentifier(col.Name))
 		}
+		if col.ForeignKey != nil && col.ForeignKey.Table != "" && col.ForeignKey.Column != "" {
+			foreignKeys = append(foreignKeys, fmt.Sprintf("    FOREIGN KEY (%s) REFERENCES %s (%s)",
+				quoteIdentifier(col.Name), quoteIdentifier(col.ForeignKey.Table), quoteIdentifier(col.ForeignKey.Column)))
+		}
 	}
 
 	if len(primaryKeys) > 0 {
 		columnDefs = append(columnDefs, fmt.Sprintf("    PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
 	}
+
+	columnDefs = append(columnDefs, foreignKeys...)
 
 	createTable := fmt.Sprintf(
 		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\nCREATE TABLE %s (\n%s\n)\nEND",

--- a/pkg/mssql/materialization_test.go
+++ b/pkg/mssql/materialization_test.go
@@ -382,3 +382,25 @@ func TestMaterializer_Render(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0"},
+			{Name: "name", Type: "varchar", Length: intp(255), Collation: "en_US"},
+			{Name: "customer_id", Type: "integer", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+		},
+	}
+	render, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	assert.Contains(t, render, "numeric(10, 2)")
+	assert.Contains(t, render, "varchar(255)")
+	assert.Contains(t, render, "DEFAULT 0")
+	assert.Contains(t, render, "COLLATE")
+	assert.Contains(t, render, "REFERENCES")
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -630,6 +630,30 @@ func (c *Column) HasCheck(check string) bool {
 	return false
 }
 
+// SQLType returns the column's SQL type, augmenting the declared Type with
+// precision/scale or length when those are provided as separate fields and the
+// type does not already encode them. For example, type "decimal" with precision
+// 10 and scale 2 becomes "decimal(10, 2)", and type "varchar" with length 255
+// becomes "varchar(255)". If Type is empty or already parameterized (contains a
+// parenthesis), it is returned unchanged.
+func (c *Column) SQLType() string {
+	t := strings.TrimSpace(c.Type)
+	if t == "" || strings.Contains(t, "(") {
+		return t
+	}
+
+	switch {
+	case c.Precision != nil && c.Scale != nil:
+		return fmt.Sprintf("%s(%d, %d)", t, *c.Precision, *c.Scale)
+	case c.Precision != nil:
+		return fmt.Sprintf("%s(%d)", t, *c.Precision)
+	case c.Length != nil:
+		return fmt.Sprintf("%s(%d)", t, *c.Length)
+	default:
+		return t
+	}
+}
+
 type AssetType string
 
 var AssetTypeConnectionMapping = map[AssetType]string{

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2757,3 +2757,28 @@ func TestAsset_FormatContent_DeduplicatesTags(t *testing.T) {
 }
 
 func ptrInt(i int) *int { return &i }
+
+func TestColumn_SQLType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		col  pipeline.Column
+		want string
+	}{
+		{name: "plain type", col: pipeline.Column{Type: "integer"}, want: "integer"},
+		{name: "empty type", col: pipeline.Column{Type: ""}, want: ""},
+		{name: "precision and scale", col: pipeline.Column{Type: "decimal", Precision: ptrInt(10), Scale: ptrInt(2)}, want: "decimal(10, 2)"},
+		{name: "precision only", col: pipeline.Column{Type: "number", Precision: ptrInt(38)}, want: "number(38)"},
+		{name: "length only", col: pipeline.Column{Type: "varchar", Length: ptrInt(255)}, want: "varchar(255)"},
+		{name: "already parameterized type is untouched", col: pipeline.Column{Type: "decimal(5,2)", Precision: ptrInt(10), Scale: ptrInt(2)}, want: "decimal(5,2)"},
+		{name: "no modifiers", col: pipeline.Column{Type: "timestamp"}, want: "timestamp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.col.SQLType())
+		})
+	}
+}

--- a/pkg/postgres/materialization.go
+++ b/pkg/postgres/materialization.go
@@ -289,14 +289,28 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns))
 	primaryKeys := []string{}
+	foreignKeys := []string{}
 	columnComments := []string{}
 
 	for _, col := range asset.Columns {
 		quotedColName := QuoteIdentifier(col.Name)
-		def := fmt.Sprintf("%s %s", quotedColName, col.Type)
+		def := fmt.Sprintf("%s %s", quotedColName, col.SQLType())
+
+		if col.Collation != "" {
+			def += " COLLATE " + QuoteIdentifier(col.Collation)
+		}
+		if col.Default != "" {
+			def += " DEFAULT " + col.Default
+		}
 
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, quotedColName)
+		}
+		if col.ForeignKey != nil && col.ForeignKey.Table != "" && col.ForeignKey.Column != "" {
+			foreignKeys = append(foreignKeys, fmt.Sprintf(
+				"foreign key (%s) references %s (%s)",
+				quotedColName, QuoteIdentifier(col.ForeignKey.Table), QuoteIdentifier(col.ForeignKey.Column),
+			))
 		}
 		columnDefs = append(columnDefs, def)
 
@@ -310,6 +324,8 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 		primaryKeyClause := fmt.Sprintf("primary key (%s)", strings.Join(primaryKeys, ", "))
 		columnDefs = append(columnDefs, primaryKeyClause)
 	}
+
+	columnDefs = append(columnDefs, foreignKeys...)
 
 	q := fmt.Sprintf(
 		"CREATE TABLE IF NOT EXISTS %s (\n"+

--- a/pkg/postgres/materialization_test.go
+++ b/pkg/postgres/materialization_test.go
@@ -424,6 +424,22 @@ WHEN NOT MATCHED THEN INSERT\("id", "col_a"\) VALUES\("id", "col_a"\);$`,
 			},
 			want: `CREATE TABLE IF NOT EXISTS "my_composite_primary_key_table" \(\s*"id" INT64,\s*"category" STRING,\s*primary key \("id", "category"\)\s*\);\s*COMMENT ON COLUMN "my_composite_primary_key_table"\."category" IS 'Category of the item';`,
 		},
+		{
+			name: "table with type detail, default, collation and foreign key",
+			task: &pipeline.Asset{
+				Name: "orders",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0"},
+					{Name: "name", Type: "varchar", Length: intp(255), Collation: "en_US"},
+					{Name: "customer_id", Type: "int", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+				},
+			},
+			want: `CREATE TABLE IF NOT EXISTS "orders" \(\s*"amount" numeric\(10, 2\) DEFAULT 0,\s*"name" varchar\(255\) COLLATE "en_US",\s*"customer_id" int,\s*foreign key \("customer_id"\) references "customers" \("id"\)\s*\)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1771,3 +1787,5 @@ func TestBuildRedshiftSCD2ByColumnQuery(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }

--- a/pkg/snowflake/materialization.go
+++ b/pkg/snowflake/materialization.go
@@ -174,10 +174,23 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns))
 	primaryKeys := make([]string, 0)
+	foreignKeys := make([]string, 0)
 	for _, col := range asset.Columns {
-		def := fmt.Sprintf("%s %s", col.Name, col.Type)
+		def := fmt.Sprintf("%s %s", col.Name, col.SQLType())
+		if col.Collation != "" {
+			def += fmt.Sprintf(" COLLATE '%s'", col.Collation)
+		}
+		if col.Default != "" {
+			def += " DEFAULT " + col.Default
+		}
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, col.Name)
+		}
+		if col.ForeignKey != nil && col.ForeignKey.Table != "" && col.ForeignKey.Column != "" {
+			foreignKeys = append(foreignKeys, fmt.Sprintf(
+				"foreign key (%s) references %s (%s)",
+				col.Name, col.ForeignKey.Table, col.ForeignKey.Column,
+			))
 		}
 		if col.Description != "" {
 			desc := strings.ReplaceAll(col.Description, `'`, `''`)
@@ -193,14 +206,19 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 	if len(primaryKeys) > 0 {
 		primaryKeyClause = fmt.Sprintf(",\nprimary key (%s)", strings.Join(primaryKeys, ", "))
 	}
+	foreignKeyClause := ""
+	if len(foreignKeys) > 0 {
+		foreignKeyClause = ",\n" + strings.Join(foreignKeys, ",\n")
+	}
 	ddl := fmt.Sprintf(
 		"CREATE TABLE IF NOT EXISTS %s %s(\n"+
-			"%s%s\n"+
+			"%s%s%s\n"+
 			")",
 		asset.Name,
 		clusterByClause,
 		strings.Join(columnDefs, ",\n"),
 		primaryKeyClause,
+		foreignKeyClause,
 	)
 
 	return ddl, nil

--- a/pkg/snowflake/materialization_test.go
+++ b/pkg/snowflake/materialization_test.go
@@ -399,6 +399,22 @@ func TestMaterializer_Render(t *testing.T) {
 				"primary key \\(id, category\\)\n" +
 				"\\)",
 		},
+		{
+			name: "table with type detail, default, collation and foreign key",
+			task: &pipeline.Asset{
+				Name: "orders",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyDDL,
+				},
+				Columns: []pipeline.Column{
+					{Name: "amount", Type: "NUMBER", Precision: intp(10), Scale: intp(2), Default: "0"},
+					{Name: "name", Type: "STRING", Collation: "en_US"},
+					{Name: "customer_id", Type: "INT64", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+				},
+			},
+			want: `CREATE TABLE IF NOT EXISTS orders \(\s*amount NUMBER\(10, 2\) DEFAULT 0,\s*name STRING COLLATE 'en_US',\s*customer_id INT64,\s*foreign key \(customer_id\) references customers \(id\)\s*\)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1040,3 +1056,5 @@ func TestBuildSCD2QueryByTime(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }

--- a/pkg/synapse/materialization.go
+++ b/pkg/synapse/materialization.go
@@ -222,9 +222,15 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) ([]string, error) {
 			return nil, fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
 		}
 
-		definition := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.Type)
+		definition := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.SQLType())
+		if col.Collation != "" {
+			definition += " COLLATE " + col.Collation
+		}
 		if col.PrimaryKey || !col.Nullable.Bool() {
 			definition += " NOT NULL"
+		}
+		if col.Default != "" {
+			definition += " DEFAULT " + col.Default
 		}
 		columnDefs = append(columnDefs, definition)
 

--- a/pkg/synapse/materialization_test.go
+++ b/pkg/synapse/materialization_test.go
@@ -284,3 +284,27 @@ func TestMaterializer_Render(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0"},
+			{Name: "name", Type: "varchar", Length: intp(255), Collation: "Latin1_General_CI_AS"},
+			{Name: "customer_id", Type: "int", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+		},
+	}
+	parts, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	require.NotEmpty(t, parts)
+	createTable := parts[len(parts)-1]
+	require.Contains(t, createTable, "numeric(10, 2)")
+	require.Contains(t, createTable, "varchar(255)")
+	require.Contains(t, createTable, "DEFAULT 0")
+	require.Contains(t, createTable, "COLLATE")
+	require.NotContains(t, createTable, "REFERENCES")
+}

--- a/pkg/trino/materialization.go
+++ b/pkg/trino/materialization.go
@@ -177,7 +177,7 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 
 	columnDefs := make([]string, 0, len(asset.Columns))
 	for _, col := range asset.Columns {
-		def := fmt.Sprintf("    %s %s", col.Name, col.Type)
+		def := fmt.Sprintf("    %s %s", col.Name, col.SQLType())
 		if col.Description != "" {
 			// Escape single quotes in descriptions
 			desc := strings.ReplaceAll(col.Description, `'`, `''`)

--- a/pkg/trino/materialization_test.go
+++ b/pkg/trino/materialization_test.go
@@ -1091,3 +1091,21 @@ func TestBuildDDLQuery_ErrorCases(t *testing.T) {
 		assert.Contains(t, err.Error(), string(pipeline.MaterializationStrategyDDL))
 	})
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "decimal", Precision: intp(10), Scale: intp(2)},
+			{Name: "name", Type: "varchar", Length: intp(255)},
+		},
+	}
+	render, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	assert.Contains(t, render, "decimal(10, 2)")
+	assert.Contains(t, render, "varchar(255)")
+}

--- a/pkg/vertica/materialization.go
+++ b/pkg/vertica/materialization.go
@@ -197,11 +197,11 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 		if col.Collation != "" {
 			definition += " COLLATE " + QuoteIdentifier(col.Collation)
 		}
-		if col.PrimaryKey || !col.Nullable.Bool() {
-			definition += " NOT NULL"
-		}
 		if col.Default != "" {
 			definition += " DEFAULT " + col.Default
+		}
+		if col.PrimaryKey || !col.Nullable.Bool() {
+			definition += " NOT NULL"
 		}
 		columnDefs = append(columnDefs, definition)
 

--- a/pkg/vertica/materialization.go
+++ b/pkg/vertica/materialization.go
@@ -185,6 +185,7 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 
 	columnDefs := make([]string, 0, len(asset.Columns)+1)
 	primaryKeys := make([]string, 0)
+	foreignKeys := make([]string, 0)
 	columnComments := make([]string, 0)
 	for _, col := range asset.Columns {
 		if col.Type == "" {
@@ -192,14 +193,24 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 		}
 
 		quotedColName := QuoteIdentifier(col.Name)
-		definition := fmt.Sprintf("%s %s", quotedColName, col.Type)
+		definition := fmt.Sprintf("%s %s", quotedColName, col.SQLType())
+		if col.Collation != "" {
+			definition += " COLLATE " + QuoteIdentifier(col.Collation)
+		}
 		if col.PrimaryKey || !col.Nullable.Bool() {
 			definition += " NOT NULL"
+		}
+		if col.Default != "" {
+			definition += " DEFAULT " + col.Default
 		}
 		columnDefs = append(columnDefs, definition)
 
 		if col.PrimaryKey {
 			primaryKeys = append(primaryKeys, quotedColName)
+		}
+		if col.ForeignKey != nil && col.ForeignKey.Table != "" && col.ForeignKey.Column != "" {
+			foreignKeys = append(foreignKeys, fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s (%s)",
+				quotedColName, QuoteIdentifier(col.ForeignKey.Table), QuoteIdentifier(col.ForeignKey.Column)))
 		}
 		if col.Description != "" {
 			columnComments = append(columnComments, fmt.Sprintf(
@@ -214,6 +225,8 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 	if len(primaryKeys) > 0 {
 		columnDefs = append(columnDefs, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(primaryKeys, ", ")))
 	}
+
+	columnDefs = append(columnDefs, foreignKeys...)
 
 	queries := make([]string, 0, 1+len(columnComments))
 	queries = append(queries, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n%s\n)", QuoteIdentifier(asset.Name), strings.Join(columnDefs, ",\n")))

--- a/pkg/vertica/materialization_test.go
+++ b/pkg/vertica/materialization_test.go
@@ -360,11 +360,13 @@ func intp(i int) *int { return &i }
 
 func TestColumnMetadataDDL(t *testing.T) {
 	t.Parallel()
+	notNull := false
 	asset := &pipeline.Asset{
 		Name:            "orders",
 		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
 		Columns: []pipeline.Column{
-			{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0"},
+			// non-nullable + default to assert Vertica's required `DEFAULT ... NOT NULL` order
+			{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0", Nullable: pipeline.DefaultTrueBool{Value: &notNull}},
 			{Name: "name", Type: "varchar", Length: intp(255), Collation: "en_US"},
 			{Name: "customer_id", Type: "integer", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
 		},
@@ -373,7 +375,7 @@ func TestColumnMetadataDDL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, render, "numeric(10, 2)")
 	assert.Contains(t, render, "varchar(255)")
-	assert.Contains(t, render, "DEFAULT 0")
+	assert.Contains(t, render, "DEFAULT 0 NOT NULL")
 	assert.Contains(t, render, "COLLATE")
 	assert.Contains(t, render, "REFERENCES")
 }

--- a/pkg/vertica/materialization_test.go
+++ b/pkg/vertica/materialization_test.go
@@ -355,3 +355,25 @@ func TestMaterializer_Render(t *testing.T) {
 		})
 	}
 }
+
+func intp(i int) *int { return &i }
+
+func TestColumnMetadataDDL(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name:            "orders",
+		Materialization: pipeline.Materialization{Type: pipeline.MaterializationTypeTable, Strategy: pipeline.MaterializationStrategyDDL},
+		Columns: []pipeline.Column{
+			{Name: "amount", Type: "numeric", Precision: intp(10), Scale: intp(2), Default: "0"},
+			{Name: "name", Type: "varchar", Length: intp(255), Collation: "en_US"},
+			{Name: "customer_id", Type: "integer", ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"}},
+		},
+	}
+	render, err := NewMaterializer(false).Render(asset, "SELECT 1")
+	require.NoError(t, err)
+	assert.Contains(t, render, "numeric(10, 2)")
+	assert.Contains(t, render, "varchar(255)")
+	assert.Contains(t, render, "DEFAULT 0")
+	assert.Contains(t, render, "COLLATE")
+	assert.Contains(t, render, "REFERENCES")
+}


### PR DESCRIPTION
Phase 2 of column metadata: use the new fields in the `ddl` materialization strategy. A shared `Column.SQLType()` helper augments the declared type with `precision`/`scale` or `length` (e.g. `decimal` → `decimal(10, 2)`, `varchar` → `varchar(255)`) without touching already-parameterized types, and is applied across every DDL platform.

PostgreSQL, BigQuery, Snowflake, MSSQL, Vertica, and DuckDB additionally emit `collation`, `default`, and `foreign_key` clauses (BigQuery foreign keys are `NOT ENFORCED`). Synapse emits collation/default but not foreign keys (unsupported on dedicated pools), ClickHouse emits defaults, and Databricks/Fabric/Trino/Athena get type modifiers only — matching each platform's `CREATE TABLE` capabilities.

This PR is stacked on #2193 (Phase 1); each platform has a new DDL test and `make format`/`make test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)