### PR TITLE
feat(salesforce): add OAuth access_token auth method

### DIFF
--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -4,13 +4,18 @@
 
 Bruin supports Salesforce as a source for [ingestr assets](/assets/ingestr), and you can use it to ingest data from Salesforce into your data platform.
 
-To set up a Salesforce connection, you must add a configuration item in the `.bruin.yml` and `asset` file. You need `username`, `password`, `token` and `domain`. You can obtain your security token by logging into your Salesforce account and navigating to the user settings under "Reset My Security Token."
+To set up a Salesforce connection, you must add a configuration item in the `.bruin.yml` and `asset` file. Salesforce supports two authentication methods:
+
+- **Username, password, and security token**: classic SOAP-style login. You can obtain your security token by logging into your Salesforce account and navigating to the user settings under "Reset My Security Token."
+- **OAuth access token**: an access token minted by the Salesforce CLI (`sf org auth show-access-token`). Use this when you want to authenticate interactively in a browser.
 
 Follow the steps below to set up Salesforce correctly as a data source and run ingestion.
 
 ## Configuration
 
 ### Step 1: Add a connection to the .bruin.yml file
+
+Use either the username/password/token combination:
 
 ```yaml
 connections:
@@ -26,6 +31,21 @@ connections:
 - `password` is your Salesforce account password.
 - `token` is your Salesforce security token.
 - `domain` is your Salesforce domain (e.g., "your-company.my.salesforce.com").
+
+Or an OAuth access token:
+
+```yaml
+connections:
+      salesforce:
+            - name: "salesforce"
+              access_token: "00D...!AQ...your_oauth_access_token"
+              domain: "https://your-domain.my.salesforce.com"
+```
+
+- `access_token` is an OAuth access token for your Salesforce org. You can obtain one with `sf org auth show-access-token --target-org <salesforce-username>` after logging in via `sf org login web`.
+- `domain` is your Salesforce instance URL (e.g., the `Instance Url` shown by `sf org display`). For sandboxes, use the sandbox My Domain URL.
+
+When `access_token` is set it takes precedence over `username`/`password`/`token`.
 
 ### Step 2: Create an asset file for data ingestion
 

--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -39,11 +39,11 @@ connections:
       salesforce:
             - name: "salesforce"
               access_token: "00D...!AQ...your_oauth_access_token"
-              domain: "https://your-domain.my.salesforce.com"
+              domain: "your-domain.my.salesforce.com"
 ```
 
 - `access_token` is an OAuth access token for your Salesforce org. You can obtain one with `sf org auth show-access-token --target-org <salesforce-username>` after logging in via `sf org login web`.
-- `domain` is your Salesforce instance URL (e.g., the `Instance Url` shown by `sf org display`). For sandboxes, use the sandbox My Domain URL.
+- `domain` is your Salesforce instance domain — same field as above. You can pass it either as a host (e.g. `your-domain.my.salesforce.com`) or as a full URL (e.g. `https://your-domain.my.salesforce.com`); both are accepted. For sandboxes, use the sandbox My Domain URL.
 
 When `access_token` is set it takes precedence over `username`/`password`/`token`.
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -3498,9 +3498,6 @@
       "type": "object",
       "required": [
         "name",
-        "username",
-        "password",
-        "token",
         "domain"
       ]
     },

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -3487,6 +3487,9 @@
         "token": {
           "type": "string"
         },
+        "access_token": {
+          "type": "string"
+        },
         "domain": {
           "type": "string"
         }

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1330,11 +1330,12 @@ func (c FrankfurterConnection) GetName() string {
 }
 
 type SalesforceConnection struct {
-	Name     string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
-	Username string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
-	Password string `yaml:"password,omitempty" json:"password" mapstructure:"password"`
-	Token    string `yaml:"token,omitempty" json:"token" mapstructure:"token"`
-	Domain   string `yaml:"domain" json:"domain" mapstructure:"domain"`
+	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	Username    string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
+	Password    string `yaml:"password,omitempty" json:"password" mapstructure:"password"`
+	Token       string `yaml:"token,omitempty" json:"token" mapstructure:"token"`
+	AccessToken string `yaml:"access_token,omitempty" json:"access_token,omitempty" mapstructure:"access_token"`
+	Domain      string `yaml:"domain" json:"domain" mapstructure:"domain"`
 }
 
 func (c SalesforceConnection) GetName() string {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1331,9 +1331,9 @@ func (c FrankfurterConnection) GetName() string {
 
 type SalesforceConnection struct {
 	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
-	Username    string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
-	Password    string `yaml:"password,omitempty" json:"password" mapstructure:"password"`
-	Token       string `yaml:"token,omitempty" json:"token" mapstructure:"token"`
+	Username    string `yaml:"username,omitempty" json:"username,omitempty" mapstructure:"username"`
+	Password    string `yaml:"password,omitempty" json:"password,omitempty" mapstructure:"password"`
+	Token       string `yaml:"token,omitempty" json:"token,omitempty" mapstructure:"token"`
 	AccessToken string `yaml:"access_token,omitempty" json:"access_token,omitempty" mapstructure:"access_token"`
 	Domain      string `yaml:"domain" json:"domain" mapstructure:"domain"`
 }

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -620,11 +620,12 @@ func TestLoadFromFile(t *testing.T) {
 			},
 			Salesforce: []SalesforceConnection{
 				{
-					Name:     "salesforce-1",
-					Username: "username-123",
-					Password: "password-123",
-					Token:    "token-123",
-					Domain:   "mydomain.my.salesforce.com",
+					Name:        "salesforce-1",
+					Username:    "username-123",
+					Password:    "password-123",
+					Token:       "token-123",
+					AccessToken: "access-token-123",
+					Domain:      "mydomain.my.salesforce.com",
 				},
 			},
 			SQLite: []SQLiteConnection{

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -395,6 +395,7 @@ environments:
           username: "username-123"
           password: "password-123"
           token: "token-123"
+          access_token: "access-token-123"
           domain: "mydomain.my.salesforce.com"
       sqlite:
         - name: "sqlite-1"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -396,6 +396,7 @@ environments:
           username: "username-123"
           password: "password-123"
           token: "token-123"
+          access_token: "access-token-123"
           domain: "mydomain.my.salesforce.com"
       sqlite:
         - name: "sqlite-1"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -2651,10 +2651,11 @@ func (m *Manager) AddSalesforceConnectionFromConfig(connection *config.Salesforc
 	m.mutex.Unlock()
 
 	client, err := salesforce.NewClient(salesforce.Config{
-		Username: connection.Username,
-		Password: connection.Password,
-		Token:    connection.Token,
-		Domain:   connection.Domain,
+		Username:    connection.Username,
+		Password:    connection.Password,
+		Token:       connection.Token,
+		AccessToken: connection.AccessToken,
+		Domain:      connection.Domain,
 	})
 	if err != nil {
 		return err

--- a/pkg/salesforce/config.go
+++ b/pkg/salesforce/config.go
@@ -5,19 +5,23 @@ import (
 )
 
 type Config struct {
-	Username string
-	Password string
-	Token    string
-	Domain   string
+	Username    string
+	Password    string
+	Token       string
+	AccessToken string
+	Domain      string
 }
 
 func (c *Config) GetIngestrURI() string {
-	// salesforce://?username=<your_username>&password=<your_password>&token=<your_token>&domain=<your_domain>
 	baseURL := "salesforce://"
 	params := url.Values{}
-	params.Add("username", c.Username)
-	params.Add("password", c.Password)
-	params.Add("token", c.Token)
+	if c.AccessToken != "" {
+		params.Add("access_token", c.AccessToken)
+	} else {
+		params.Add("username", c.Username)
+		params.Add("password", c.Password)
+		params.Add("token", c.Token)
+	}
 	params.Add("domain", c.Domain)
 	return baseURL + "?" + params.Encode()
 }

--- a/pkg/salesforce/config_test.go
+++ b/pkg/salesforce/config_test.go
@@ -1,0 +1,89 @@
+package salesforce
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		config    Config
+		wantParam map[string]string
+		notParam  []string
+	}{
+		{
+			name: "access token takes precedence over username/password",
+			config: Config{
+				Username:    "user",
+				Password:    "pass",
+				Token:       "tok",
+				AccessToken: "atk",
+				Domain:      "company.my.salesforce.com",
+			},
+			wantParam: map[string]string{
+				"access_token": "atk",
+				"domain":       "company.my.salesforce.com",
+			},
+			notParam: []string{"username", "password", "token"},
+		},
+		{
+			name: "username/password path when no access token",
+			config: Config{
+				Username: "user",
+				Password: "pass",
+				Token:    "tok",
+				Domain:   "company.my.salesforce.com",
+			},
+			wantParam: map[string]string{
+				"username": "user",
+				"password": "pass",
+				"token":    "tok",
+				"domain":   "company.my.salesforce.com",
+			},
+			notParam: []string{"access_token"},
+		},
+		{
+			name:   "empty config falls back to username path with empty values",
+			config: Config{},
+			wantParam: map[string]string{
+				"username": "",
+				"password": "",
+				"token":    "",
+				"domain":   "",
+			},
+			notParam: []string{"access_token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uri := tt.config.GetIngestrURI()
+			if !strings.HasPrefix(uri, "salesforce://?") {
+				t.Fatalf("uri %q missing salesforce:// scheme", uri)
+			}
+
+			parsed, err := url.Parse(uri)
+			if err != nil {
+				t.Fatalf("failed to parse uri %q: %v", uri, err)
+			}
+			params := parsed.Query()
+
+			for k, want := range tt.wantParam {
+				if got := params.Get(k); got != want {
+					t.Errorf("param %q = %q, want %q", k, got, want)
+				}
+			}
+			for _, k := range tt.notParam {
+				if params.Has(k) {
+					t.Errorf("param %q should not be present, got %q", k, params.Get(k))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `access_token` field to Salesforce connection so users can pass an OAuth access token (e.g. from `sf org auth show-access-token`) instead of the username/password/security token combo.
-
Mirrors the matching ingestr change in https://github.com/bruin-data/ingestr/pull/820.
