### PR TITLE
Expose ESPN season and limit on EspnConnection

### DIFF
--- a/docs/ingestion/espn.md
+++ b/docs/ingestion/espn.md
@@ -23,12 +23,21 @@ ESPN's public endpoints are auth-less, so the connection is purely a routing tar
         - name: "espn_epl"
           sport: "soccer"
           league: "eng.1"
+        - name: "espn_nba_2025"
+          sport: "basketball"
+          league: "nba"
+          season: "2025"
+          limit: 50
 ```
 
 - `name`: Name of the connection.
 - `sport` (optional): ESPN sport slug. Defaults to `football`.
 - `league` (optional): ESPN league slug. Defaults to `nfl`.
+- `season` (optional): Season year, passed to scoreboard and standings requests. Useful for pinning a connection to a specific historical season.
+- `limit` (optional): Request limit for scoreboard and news. ESPN defaults to `100` when not set.
 - `base_url` (optional): Overrides the ESPN API base URL. Defaults to `https://site.api.espn.com`.
+
+The scoreboard window itself is taken from `--interval-start` / `--interval-end` on the run, which ingestr converts to ESPN's `dates=YYYYMMDD[-YYYYMMDD]` query parameter.
 
 ### Step 2: Create an asset file for data ingestion
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1785,6 +1785,12 @@
         "league": {
           "type": "string"
         },
+        "season": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer"
+        },
         "base_url": {
           "type": "string"
         }

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1798,6 +1798,8 @@ type EspnConnection struct {
 	Name    string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	Sport   string `yaml:"sport,omitempty" json:"sport,omitempty" mapstructure:"sport"`
 	League  string `yaml:"league,omitempty" json:"league,omitempty" mapstructure:"league"`
+	Season  string `yaml:"season,omitempty" json:"season,omitempty" mapstructure:"season"`
+	Limit   int    `yaml:"limit,omitempty" json:"limit,omitempty" mapstructure:"limit"`
 	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty" mapstructure:"base_url"`
 }
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -810,6 +810,8 @@ func TestLoadFromFile(t *testing.T) {
 					Name:   "espn-1",
 					Sport:  "football",
 					League: "nfl",
+					Season: "2026",
+					Limit:  50,
 				},
 			},
 		},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -509,6 +509,8 @@ environments:
         - name: "espn-1"
           sport: "football"
           league: "nfl"
+          season: "2026"
+          limit: 50
 
   prod:
     connections:

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -510,6 +510,8 @@ environments:
         - name: "espn-1"
           sport: "football"
           league: "nfl"
+          season: "2026"
+          limit: 50
 
   prod:
     connections:

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -3114,6 +3114,8 @@ func (m *Manager) AddEspnConnectionFromConfig(connection *config.EspnConnection)
 	client, err := espn.NewClient(espn.Config{
 		Sport:   connection.Sport,
 		League:  connection.League,
+		Season:  connection.Season,
+		Limit:   connection.Limit,
 		BaseURL: connection.BaseURL,
 	})
 	if err != nil {

--- a/pkg/espn/config.go
+++ b/pkg/espn/config.go
@@ -1,10 +1,15 @@
 package espn
 
-import "net/url"
+import (
+	"net/url"
+	"strconv"
+)
 
 type Config struct {
 	Sport   string
 	League  string
+	Season  string
+	Limit   int
 	BaseURL string
 }
 
@@ -15,6 +20,12 @@ func (c *Config) GetIngestrURI() string {
 	}
 	if c.League != "" {
 		params.Set("league", c.League)
+	}
+	if c.Season != "" {
+		params.Set("season", c.Season)
+	}
+	if c.Limit > 0 {
+		params.Set("limit", strconv.Itoa(c.Limit))
 	}
 	if c.BaseURL != "" {
 		params.Set("base_url", c.BaseURL)


### PR DESCRIPTION
## Summary

The ingestr ESPN source accepts `season` (passed to scoreboard and standings requests) and `limit` (request limit for scoreboard and news) as optional URI parameters. 