### PR TITLE
Expand pipeline asset defaults

### DIFF
--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -434,7 +434,6 @@ Fields:
 
 | Field              | Type                       | Default | Notes                            |
 |--------------------|----------------------------|---------|----------------------------------|
-| name               | String                     | —       | Default asset name when an asset has none |
 | type               | String                     | —       | Default asset type (e.g., "sql") |
 | description        | String                     | —       | Default asset description        |
 | start_date         | String                     | —       | Default asset start date         |
@@ -463,6 +462,9 @@ Fields:
 | rerun_cooldown     | Integer                    | —       | Default retry delay/cooldown     |
 | refresh_restricted | Boolean                    | —       | Default full-refresh restriction |
 | notifications      | Object                     | —       | Default asset notifications      |
+
+Asset identity/runtime fields such as `name`, `uri`, executable file metadata, definition file metadata, and `retries_delay`
+are not supported in pipeline defaults.
 
 Secrets item:
 

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -406,7 +406,12 @@ max_active_steps: 8
 ### Default (pipeline-level defaults)
 
 Set sensible defaults for all assets in the pipeline so you don't repeat yourself. Override at the asset level only when
-a task needs something different.
+a task needs something different. The `default` block accepts asset definition fields except file-derived/runtime-only
+fields such as `id`, `run`/executable file details, definition file details, and derived `retries_delay`.
+
+Scalar defaults fill only empty asset fields. Maps such as `parameters`, `meta`, and `metadata` are merged without
+overwriting asset keys. Repeated fields such as `tags`, `domains`, `depends`, `extends`, `columns`, `custom_checks`,
+and `notifications` are added when they are not already present.
 
 Example:
 
@@ -429,12 +434,35 @@ Fields:
 
 | Field              | Type                       | Default | Notes                            |
 |--------------------|----------------------------|---------|----------------------------------|
+| name               | String                     | —       | Default asset name when an asset has none |
 | type               | String                     | —       | Default asset type (e.g., "sql") |
+| description        | String                     | —       | Default asset description        |
+| start_date         | String                     | —       | Default asset start date         |
+| connection         | String                     | —       | Default connection name          |
+| image              | String                     | —       | Default container image          |
+| instance           | String                     | —       | Default Bruin Cloud instance type |
+| owner              | String                     | —       | Default owner                    |
+| tier               | Integer                    | —       | Default asset tier               |
+| tags               | Array of strings           | []      | Tags added to every asset        |
+| domains            | Array of strings           | []      | Domains added to every asset     |
+| meta               | Object (map[string]string) | {}      | Custom metadata defaults         |
+| metadata           | Object (map[string]string) | {}      | Additional metadata defaults     |
 | parameters         | Object (map[string]string) | {}      | Arbitrary key/value defaults     |
 | secrets            | Array of objects           | []      | See below                        |
+| depends            | Array/string/object        | []      | Default upstream dependencies    |
+| extends            | Array of strings           | []      | Default extensions               |
+| columns            | Array of objects           | []      | Default column metadata/checks   |
+| custom_checks      | Array of objects           | []      | Default custom checks            |
+| materialization    | Object                     | —       | Default materialization config   |
+| snowflake          | Object                     | —       | Snowflake-specific defaults      |
+| athena             | Object                     | —       | Athena-specific defaults         |
 | routing            | Object                     | —       | Runtime routing defaults for assets |
 | interval_modifiers | Object                     | —       | See [Interval Modifiers](/assets/interval-modifiers) |
 | hooks              | Object                     | —       | See [Hooks](/assets/definition-schema#hooks) |
+| retries            | Integer                    | —       | Default asset retries            |
+| rerun_cooldown     | Integer                    | —       | Default retry delay/cooldown     |
+| refresh_restricted | Boolean                    | —       | Default full-refresh restriction |
+| notifications      | Object                     | —       | Default asset notifications      |
 
 Secrets item:
 

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -4467,7 +4467,7 @@ func TestMacros(t *testing.T) {
 					ExitCode: 0,
 					Contains: []string{
 						// Pipeline default rerun_cooldown
-						`"default":{"type":"","parameters":null,"secrets":null,"hooks":{},"interval_modifiers":null,"rerun_cooldown":300}`, `"retries_delay":300`,
+						`"default":{"type":"","materialization":null,"parameters":null,"secrets":null,"hooks":{},"snowflake":null,"athena":null,"interval_modifiers":null,"rerun_cooldown":300}`, `"retries_delay":300`,
 						// Asset with explicit rerun_cooldown
 						`"name":"test_asset"`, `"rerun_cooldown":600`, `"retries_delay":600`,
 						// Asset that inherits from pipeline

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -293,6 +293,7 @@
   "max_active_steps": null,
   "default": {
     "type": "ingestr",
+    "materialization": null,
     "parameters": {
       "destination": "duckdb",
       "source_connection": "chess-run-default-option"
@@ -315,6 +316,8 @@
         }
       ]
     },
+    "snowflake": null,
+    "athena": null,
     "interval_modifiers": null
   },
   "commit": "",

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -807,7 +807,7 @@ type Upstream struct {
 }
 
 func (u Upstream) MarshalYAML() (interface{}, error) {
-	isAsset := u.Type == "" || u.Type == "asset"
+	isAsset := u.Type == "" || u.Type == selectorAssetDependencyType
 	if u.Mode == UpstreamModeFull && isAsset {
 		return u.Value, nil
 	}
@@ -815,7 +815,7 @@ func (u Upstream) MarshalYAML() (interface{}, error) {
 	val := map[string]any{}
 	id := "uri"
 	if isAsset {
-		id = "asset"
+		id = selectorAssetDependencyType
 	}
 	val[id] = u.Value
 
@@ -1068,7 +1068,7 @@ func (a *Asset) AddUpstream(asset *Asset) {
 	}
 
 	a.Upstreams = append(a.Upstreams, Upstream{
-		Type:  "asset",
+		Type:  selectorAssetDependencyType,
 		Value: asset.Name,
 		Mode:  UpstreamModeFull,
 	})
@@ -1091,7 +1091,7 @@ func (a *Asset) PrefixUpstreams(prefix string) {
 	}
 
 	for i, u := range a.Upstreams {
-		if u.Type != "asset" {
+		if u.Type != selectorAssetDependencyType {
 			continue
 		}
 
@@ -1766,13 +1766,81 @@ func (p *Pipeline) UnmarshalJSON(data []byte) error {
 }
 
 type DefaultValues struct {
+	Name              string            `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name"`
 	Type              string            `json:"type" yaml:"type" mapstructure:"type"`
+	Description       string            `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description"`
+	StartDate         string            `json:"start_date,omitempty" yaml:"start_date,omitempty" mapstructure:"start_date"`
+	Connection        string            `json:"connection,omitempty" yaml:"connection,omitempty" mapstructure:"connection"`
+	Tags              EmptyStringArray  `json:"tags,omitempty" yaml:"tags,omitempty" mapstructure:"tags"`
+	Domains           EmptyStringArray  `json:"domains,omitempty" yaml:"domains,omitempty" mapstructure:"domains"`
+	Meta              EmptyStringMap    `json:"meta,omitempty" yaml:"meta,omitempty" mapstructure:"meta"`
+	Materialization   Materialization   `json:"materialization,omitempty" yaml:"materialization,omitempty" mapstructure:"materialization"`
+	Upstreams         []Upstream        `json:"upstreams,omitempty" yaml:"depends,omitempty" mapstructure:"depends"`
+	Image             string            `json:"image,omitempty" yaml:"image,omitempty" mapstructure:"image"`
+	Instance          string            `json:"instance,omitempty" yaml:"instance,omitempty" mapstructure:"instance"`
+	Owner             string            `json:"owner,omitempty" yaml:"owner,omitempty" mapstructure:"owner"`
+	Tier              int               `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
 	Parameters        map[string]string `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
 	Secrets           []secretMapping   `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
+	Extends           []string          `json:"extends,omitempty" yaml:"extends,omitempty" mapstructure:"extends"`
+	Columns           []Column          `json:"columns,omitempty" yaml:"columns,omitempty" mapstructure:"columns"`
+	CustomChecks      []CustomCheck     `json:"custom_checks,omitempty" yaml:"custom_checks,omitempty" mapstructure:"custom_checks"`
 	Hooks             Hooks             `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
+	Metadata          EmptyStringMap    `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata"`
+	Snowflake         SnowflakeConfig   `json:"snowflake,omitempty" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
+	Athena            AthenaConfig      `json:"athena,omitempty" yaml:"athena,omitempty" mapstructure:"athena"`
 	Routing           *RoutingConfig    `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
 	IntervalModifiers IntervalModifiers `json:"interval_modifiers" yaml:"interval_modifiers" mapstructure:"interval_modifiers"`
 	RerunCooldown     *int              `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
+	Retries           *int              `json:"retries,omitempty" yaml:"retries,omitempty" mapstructure:"retries"`
+	RefreshRestricted *bool             `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
+	Notifications     *Notifications    `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+}
+
+func (d *DefaultValues) UnmarshalYAML(value *yaml.Node) error {
+	var definition taskDefinition
+	if err := value.Decode(&definition); err != nil {
+		return err
+	}
+
+	asset, err := taskDefinitionToAsset(definition)
+	if err != nil {
+		return err
+	}
+
+	*d = DefaultValues{
+		Name:              asset.Name,
+		Type:              string(asset.Type),
+		Description:       asset.Description,
+		StartDate:         asset.StartDate,
+		Connection:        asset.Connection,
+		Tags:              asset.Tags,
+		Domains:           asset.Domains,
+		Meta:              asset.Meta,
+		Materialization:   asset.Materialization,
+		Upstreams:         asset.Upstreams,
+		Image:             asset.Image,
+		Instance:          asset.Instance,
+		Owner:             asset.Owner,
+		Tier:              asset.Tier,
+		Parameters:        asset.Parameters,
+		Secrets:           definition.Secrets,
+		Extends:           asset.Extends,
+		Columns:           asset.Columns,
+		CustomChecks:      asset.CustomChecks,
+		Hooks:             asset.Hooks,
+		Metadata:          asset.Metadata,
+		Snowflake:         asset.Snowflake,
+		Athena:            asset.Athena,
+		Routing:           asset.Routing,
+		IntervalModifiers: asset.IntervalModifiers,
+		RerunCooldown:     asset.RerunCooldown,
+		Retries:           asset.Retries,
+		RefreshRestricted: asset.RefreshRestricted,
+		Notifications:     asset.Notifications,
+	}
+
+	return nil
 }
 
 func (p *Pipeline) GetCompatibilityHash() string {
@@ -2294,7 +2362,7 @@ func (b *Builder) CreatePipelineFromPath(ctx context.Context, pathToPipeline str
 				upstream.Mode = UpstreamModeFull
 			}
 
-			if upstream.Type != "asset" {
+			if upstream.Type != selectorAssetDependencyType {
 				continue
 			}
 			u, ok := pipeline.tasksByName[upstream.Value]
@@ -2525,7 +2593,8 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 		return asset, nil
 	}
 
-	if foundPipeline.DefaultValues == nil {
+	defaults := foundPipeline.DefaultValues
+	if defaults == nil {
 		return asset, nil
 	}
 
@@ -2533,8 +2602,21 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 		return asset, nil
 	}
 
-	if len(asset.Type) == 0 && len(foundPipeline.DefaultValues.Type) > 0 {
-		asset.Type = AssetType(foundPipeline.DefaultValues.Type)
+	if asset.Name == "" && defaults.Name != "" {
+		asset.Name = defaults.Name
+		asset.ID = hash(defaults.Name)
+	}
+	applyStringDefault(&asset.Description, defaults.Description)
+	applyStringDefault(&asset.StartDate, defaults.StartDate)
+	applyStringDefault(&asset.Connection, defaults.Connection)
+	applyStringDefault(&asset.Image, defaults.Image)
+	applyStringDefault(&asset.Instance, defaults.Instance)
+	applyStringDefault(&asset.Owner, defaults.Owner)
+	if asset.Tier == 0 && defaults.Tier != 0 {
+		asset.Tier = defaults.Tier
+	}
+	if len(asset.Type) == 0 && len(defaults.Type) > 0 {
+		asset.Type = AssetType(defaults.Type)
 	}
 
 	// merge parameters from the default values to asset parameters
@@ -2542,44 +2624,653 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 		asset.Parameters = EmptyStringMap{}
 	}
 
-	for key, value := range foundPipeline.DefaultValues.Parameters {
+	for key, value := range defaults.Parameters {
 		if _, exists := asset.Parameters[key]; !exists {
 			asset.Parameters[key] = value
 		}
 	}
+
+	mergeEmptyStringMapDefaults(&asset.Meta, defaults.Meta)
+	mergeEmptyStringMapDefaults(&asset.Metadata, defaults.Metadata)
+
+	asset.Tags = appendMissingStrings(asset.Tags, defaults.Tags)
+	asset.Domains = appendMissingStrings(asset.Domains, defaults.Domains)
+	asset.Extends = appendMissingPlainStrings(asset.Extends, defaults.Extends)
+	mergeMaterializationDefaults(&asset.Materialization, defaults.Materialization)
+	asset.Upstreams = appendMissingUpstreams(asset.Upstreams, defaults.Upstreams)
+	mergeColumnDefaults(asset, defaults.Columns)
+	mergeCustomCheckDefaults(asset, defaults.CustomChecks)
+	if asset.Name != "" {
+		refreshAssetCheckIDs(asset)
+	}
+
 	// merge secrets from the default values to asset secrets
 	existingSecrets := make(map[string]bool)
 	for _, secret := range asset.Secrets {
 		existingSecrets[secret.SecretKey] = true
 	}
-	for _, secret := range foundPipeline.DefaultValues.Secrets {
+	for _, secret := range defaults.Secrets {
 		secretMap := SecretMapping(secret)
 		if !existingSecrets[secretMap.SecretKey] {
 			asset.Secrets = append(asset.Secrets, secretMap)
 		}
 	}
 	if (asset.IntervalModifiers.Start == TimeModifier{}) {
-		asset.IntervalModifiers.Start = foundPipeline.DefaultValues.IntervalModifiers.Start
+		asset.IntervalModifiers.Start = defaults.IntervalModifiers.Start
 	}
 	if (asset.IntervalModifiers.End == TimeModifier{}) {
-		asset.IntervalModifiers.End = foundPipeline.DefaultValues.IntervalModifiers.End
+		asset.IntervalModifiers.End = defaults.IntervalModifiers.End
 	}
 	acceptsDefaultHooks := assetAcceptsDefaultHooks(asset)
 	if acceptsDefaultHooks && len(asset.Hooks.Pre) == 0 {
-		asset.Hooks.Pre = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Pre...)
+		asset.Hooks.Pre = append([]Hook(nil), defaults.Hooks.Pre...)
 	}
 	if acceptsDefaultHooks && len(asset.Hooks.Post) == 0 {
-		asset.Hooks.Post = append([]Hook(nil), foundPipeline.DefaultValues.Hooks.Post...)
+		asset.Hooks.Post = append([]Hook(nil), defaults.Hooks.Post...)
 	}
-	if !foundPipeline.DefaultValues.Routing.IsZero() {
+	if asset.Snowflake.Warehouse == "" {
+		asset.Snowflake.Warehouse = defaults.Snowflake.Warehouse
+	}
+	if asset.Athena.Location == "" {
+		asset.Athena.Location = defaults.Athena.Location
+	}
+	if !defaults.Routing.IsZero() {
 		if asset.Routing == nil {
-			asset.Routing = foundPipeline.DefaultValues.Routing.Clone()
+			asset.Routing = defaults.Routing.Clone()
 		} else if asset.Routing.EgressGateway == "" {
-			asset.Routing.EgressGateway = foundPipeline.DefaultValues.Routing.EgressGateway
+			asset.Routing.EgressGateway = defaults.Routing.EgressGateway
 		}
 	}
+	if asset.RerunCooldown == nil && defaults.RerunCooldown != nil {
+		asset.RerunCooldown = cloneIntPtr(defaults.RerunCooldown)
+	}
+	if asset.Retries == nil && defaults.Retries != nil {
+		asset.Retries = cloneIntPtr(defaults.Retries)
+	}
+	if asset.RefreshRestricted == nil && defaults.RefreshRestricted != nil {
+		asset.RefreshRestricted = cloneBoolPtr(defaults.RefreshRestricted)
+	}
+	asset.Notifications = mergeNotificationDefaults(asset.Notifications, defaults.Notifications)
 
 	return asset, nil
+}
+
+func applyStringDefault(target *string, defaultValue string) {
+	if *target == "" && defaultValue != "" {
+		*target = defaultValue
+	}
+}
+
+func mergeEmptyStringMapDefaults(target *EmptyStringMap, defaults EmptyStringMap) {
+	if len(defaults) == 0 {
+		return
+	}
+	if *target == nil {
+		*target = EmptyStringMap{}
+	}
+	for key, value := range defaults {
+		if _, exists := (*target)[key]; !exists {
+			(*target)[key] = value
+		}
+	}
+}
+
+func appendMissingStrings(target EmptyStringArray, defaults EmptyStringArray) EmptyStringArray {
+	if len(defaults) == 0 {
+		return target
+	}
+	merged := append(EmptyStringArray(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, value := range merged {
+		existing[value] = true
+	}
+	for _, value := range defaults {
+		if !existing[value] {
+			merged = append(merged, value)
+			existing[value] = true
+		}
+	}
+	return merged
+}
+
+func appendMissingPlainStrings(target []string, defaults []string) []string {
+	if len(defaults) == 0 {
+		return target
+	}
+	merged := append([]string(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, value := range merged {
+		existing[value] = true
+	}
+	for _, value := range defaults {
+		if !existing[value] {
+			merged = append(merged, value)
+			existing[value] = true
+		}
+	}
+	return merged
+}
+
+func mergeMaterializationDefaults(target *Materialization, defaults Materialization) {
+	if target.Type == "" {
+		target.Type = defaults.Type
+	}
+	if target.Strategy == "" {
+		target.Strategy = defaults.Strategy
+	}
+	if target.PartitionBy == "" {
+		target.PartitionBy = defaults.PartitionBy
+	}
+	if len(target.ClusterBy) == 0 && len(defaults.ClusterBy) > 0 {
+		target.ClusterBy = append([]string(nil), defaults.ClusterBy...)
+	}
+	if target.IncrementalKey == "" {
+		target.IncrementalKey = defaults.IncrementalKey
+	}
+	if target.TimeGranularity == "" {
+		target.TimeGranularity = defaults.TimeGranularity
+	}
+}
+
+func appendMissingUpstreams(target []Upstream, defaults []Upstream) []Upstream {
+	if len(defaults) == 0 {
+		return target
+	}
+	merged := append([]Upstream(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, upstream := range merged {
+		existing[upstreamIdentity(upstream)] = true
+	}
+	for _, upstream := range defaults {
+		key := upstreamIdentity(upstream)
+		if !existing[key] {
+			merged = append(merged, cloneUpstream(upstream))
+			existing[key] = true
+		}
+	}
+	return merged
+}
+
+func upstreamIdentity(upstream Upstream) string {
+	upstreamType := upstream.Type
+	if upstreamType == "" {
+		upstreamType = selectorAssetDependencyType
+	}
+	return upstreamType + "\x00" + upstream.Value
+}
+
+func cloneUpstream(upstream Upstream) Upstream {
+	clone := upstream
+	clone.Metadata = cloneEmptyStringMap(upstream.Metadata)
+	clone.Columns = append([]DependsColumn(nil), upstream.Columns...)
+	return clone
+}
+
+func mergeColumnDefaults(asset *Asset, defaults []Column) {
+	if len(defaults) == 0 {
+		return
+	}
+	for _, defaultColumn := range defaults {
+		index := findColumnIndex(asset.Columns, defaultColumn.Name)
+		if index == -1 {
+			asset.Columns = append(asset.Columns, cloneColumnForAsset(defaultColumn, asset.Name))
+			continue
+		}
+		mergeColumnDefault(&asset.Columns[index], defaultColumn, asset.Name)
+	}
+}
+
+func findColumnIndex(columns []Column, name string) int {
+	for index, column := range columns {
+		if strings.EqualFold(column.Name, name) {
+			return index
+		}
+	}
+	return -1
+}
+
+func mergeColumnDefault(target *Column, defaults Column, assetName string) {
+	if target.EntityAttribute == nil {
+		target.EntityAttribute = cloneEntityAttribute(defaults.EntityAttribute)
+	}
+	applyStringDefault(&target.Name, defaults.Name)
+	applyStringDefault(&target.SourceColumn, defaults.SourceColumn)
+	applyStringDefault(&target.Type, defaults.Type)
+	applyStringDefault(&target.Description, defaults.Description)
+	target.Tags = appendMissingStrings(target.Tags, defaults.Tags)
+	if !target.PrimaryKey && defaults.PrimaryKey {
+		target.PrimaryKey = true
+	}
+	if !target.UpdateOnMerge && defaults.UpdateOnMerge {
+		target.UpdateOnMerge = true
+	}
+	applyStringDefault(&target.MergeSQL, defaults.MergeSQL)
+	if target.Nullable.Value == nil && defaults.Nullable.Value != nil {
+		target.Nullable = DefaultTrueBool{Value: cloneBoolPtr(defaults.Nullable.Value)}
+	}
+	applyStringDefault(&target.Default, defaults.Default)
+	if target.Precision == nil {
+		target.Precision = cloneIntPtr(defaults.Precision)
+	}
+	if target.Scale == nil {
+		target.Scale = cloneIntPtr(defaults.Scale)
+	}
+	if target.Length == nil {
+		target.Length = cloneIntPtr(defaults.Length)
+	}
+	applyStringDefault(&target.Collation, defaults.Collation)
+	if target.ForeignKey == nil {
+		target.ForeignKey = cloneColumnReference(defaults.ForeignKey)
+	}
+	applyStringDefault(&target.Owner, defaults.Owner)
+	target.Domains = appendMissingStrings(target.Domains, defaults.Domains)
+	mergeEmptyStringMapDefaults(&target.Meta, defaults.Meta)
+	applyStringDefault(&target.Extends, defaults.Extends)
+	target.Checks = mergeColumnCheckDefaults(target.Checks, defaults.Checks, assetName, target.Name)
+	target.Upstreams = appendMissingColumnUpstreams(target.Upstreams, defaults.Upstreams)
+}
+
+func cloneColumnForAsset(column Column, assetName string) Column {
+	clone := column
+	clone.EntityAttribute = cloneEntityAttribute(column.EntityAttribute)
+	clone.Tags = append(EmptyStringArray(nil), column.Tags...)
+	clone.Nullable = cloneDefaultTrueBool(column.Nullable)
+	clone.Precision = cloneIntPtr(column.Precision)
+	clone.Scale = cloneIntPtr(column.Scale)
+	clone.Length = cloneIntPtr(column.Length)
+	clone.ForeignKey = cloneColumnReference(column.ForeignKey)
+	clone.Domains = append(EmptyStringArray(nil), column.Domains...)
+	clone.Meta = cloneEmptyStringMap(column.Meta)
+	clone.Checks = cloneColumnChecksForAsset(column.Checks, assetName, column.Name)
+	clone.Upstreams = cloneColumnUpstreams(column.Upstreams)
+	return clone
+}
+
+func cloneEntityAttribute(value *EntityAttribute) *EntityAttribute {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneColumnReference(value *ColumnReference) *ColumnReference {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func appendMissingColumnUpstreams(target []*UpstreamColumn, defaults []*UpstreamColumn) []*UpstreamColumn {
+	if len(defaults) == 0 {
+		return target
+	}
+	merged := cloneColumnUpstreams(target)
+	existing := make(map[string]bool, len(merged))
+	for _, upstream := range merged {
+		existing[columnUpstreamIdentity(upstream)] = true
+	}
+	for _, upstream := range defaults {
+		key := columnUpstreamIdentity(upstream)
+		if !existing[key] {
+			merged = append(merged, cloneColumnUpstream(upstream))
+			existing[key] = true
+		}
+	}
+	return merged
+}
+
+func columnUpstreamIdentity(upstream *UpstreamColumn) string {
+	if upstream == nil {
+		return ""
+	}
+	return upstream.Table + "\x00" + upstream.Column
+}
+
+func cloneColumnUpstreams(upstreams []*UpstreamColumn) []*UpstreamColumn {
+	if len(upstreams) == 0 {
+		return upstreams
+	}
+	clone := make([]*UpstreamColumn, 0, len(upstreams))
+	for _, upstream := range upstreams {
+		clone = append(clone, cloneColumnUpstream(upstream))
+	}
+	return clone
+}
+
+func cloneColumnUpstream(upstream *UpstreamColumn) *UpstreamColumn {
+	if upstream == nil {
+		return nil
+	}
+	clone := *upstream
+	return &clone
+}
+
+func mergeColumnCheckDefaults(target []ColumnCheck, defaults []ColumnCheck, assetName, columnName string) []ColumnCheck {
+	if len(defaults) == 0 {
+		return target
+	}
+	merged := append([]ColumnCheck(nil), target...)
+	for _, defaultCheck := range defaults {
+		index := findColumnCheckIndex(merged, defaultCheck.Name)
+		if index == -1 {
+			merged = append(merged, cloneColumnCheckForAsset(defaultCheck, assetName, columnName))
+			continue
+		}
+		mergeColumnCheckDefault(&merged[index], defaultCheck)
+	}
+	return merged
+}
+
+func findColumnCheckIndex(checks []ColumnCheck, name string) int {
+	for index, check := range checks {
+		if strings.EqualFold(check.Name, name) {
+			return index
+		}
+	}
+	return -1
+}
+
+func mergeColumnCheckDefault(target *ColumnCheck, defaults ColumnCheck) {
+	applyStringDefault(&target.Name, defaults.Name)
+	if isColumnCheckValueZero(target.Value) && !isColumnCheckValueZero(defaults.Value) {
+		target.Value = cloneColumnCheckValue(defaults.Value)
+	}
+	if target.Blocking.Value == nil && defaults.Blocking.Value != nil {
+		target.Blocking = cloneDefaultTrueBool(defaults.Blocking)
+	}
+	applyStringDefault(&target.Description, defaults.Description)
+	if target.Retries == nil {
+		target.Retries = cloneIntPtr(defaults.Retries)
+	}
+	if target.Notifications == nil {
+		target.Notifications = cloneNotifications(defaults.Notifications)
+	}
+}
+
+func cloneColumnChecksForAsset(checks []ColumnCheck, assetName, columnName string) []ColumnCheck {
+	if len(checks) == 0 {
+		return checks
+	}
+	clone := make([]ColumnCheck, 0, len(checks))
+	for _, check := range checks {
+		clone = append(clone, cloneColumnCheckForAsset(check, assetName, columnName))
+	}
+	return clone
+}
+
+func cloneColumnCheckForAsset(check ColumnCheck, assetName, columnName string) ColumnCheck {
+	clone := check
+	clone.ID = hash(fmt.Sprintf("%s-%s-%s", assetName, columnName, check.Name))
+	clone.Value = cloneColumnCheckValue(check.Value)
+	clone.Blocking = cloneDefaultTrueBool(check.Blocking)
+	clone.Retries = cloneIntPtr(check.Retries)
+	clone.Notifications = cloneNotifications(check.Notifications)
+	return clone
+}
+
+func mergeCustomCheckDefaults(asset *Asset, defaults []CustomCheck) {
+	if len(defaults) == 0 {
+		return
+	}
+	for _, defaultCheck := range defaults {
+		index := findCustomCheckIndex(asset.CustomChecks, defaultCheck.Name)
+		if index == -1 {
+			asset.CustomChecks = append(asset.CustomChecks, cloneCustomCheckForAsset(defaultCheck, asset.Name))
+			continue
+		}
+		mergeCustomCheckDefault(&asset.CustomChecks[index], defaultCheck)
+	}
+}
+
+func findCustomCheckIndex(checks []CustomCheck, name string) int {
+	for index, check := range checks {
+		if strings.EqualFold(check.Name, name) {
+			return index
+		}
+	}
+	return -1
+}
+
+func mergeCustomCheckDefault(target *CustomCheck, defaults CustomCheck) {
+	applyStringDefault(&target.Name, defaults.Name)
+	applyStringDefault(&target.Description, defaults.Description)
+	if target.Value == 0 && defaults.Value != 0 {
+		target.Value = defaults.Value
+	}
+	if target.Count == nil {
+		target.Count = cloneInt64Ptr(defaults.Count)
+	}
+	if target.Blocking.Value == nil && defaults.Blocking.Value != nil {
+		target.Blocking = cloneDefaultTrueBool(defaults.Blocking)
+	}
+	applyStringDefault(&target.Query, defaults.Query)
+	if target.Retries == nil {
+		target.Retries = cloneIntPtr(defaults.Retries)
+	}
+	if target.Notifications == nil {
+		target.Notifications = cloneNotifications(defaults.Notifications)
+	}
+}
+
+func cloneCustomCheckForAsset(check CustomCheck, assetName string) CustomCheck {
+	clone := check
+	clone.ID = hash(fmt.Sprintf("%s-%s", assetName, check.Name))
+	clone.Count = cloneInt64Ptr(check.Count)
+	clone.Blocking = cloneDefaultTrueBool(check.Blocking)
+	clone.Retries = cloneIntPtr(check.Retries)
+	clone.Notifications = cloneNotifications(check.Notifications)
+	return clone
+}
+
+func refreshAssetCheckIDs(asset *Asset) {
+	for columnIndex := range asset.Columns {
+		for checkIndex := range asset.Columns[columnIndex].Checks {
+			check := &asset.Columns[columnIndex].Checks[checkIndex]
+			check.ID = hash(fmt.Sprintf("%s-%s-%s", asset.Name, asset.Columns[columnIndex].Name, check.Name))
+		}
+	}
+	for checkIndex := range asset.CustomChecks {
+		check := &asset.CustomChecks[checkIndex]
+		check.ID = hash(fmt.Sprintf("%s-%s", asset.Name, check.Name))
+	}
+}
+
+func mergeNotificationDefaults(target *Notifications, defaults *Notifications) *Notifications {
+	if defaults == nil {
+		return target
+	}
+	if target == nil {
+		return cloneNotifications(defaults)
+	}
+	merged := cloneNotifications(target)
+	merged.Slack = appendMissingSlackNotifications(merged.Slack, defaults.Slack)
+	merged.MSTeams = appendMissingMSTeamsNotifications(merged.MSTeams, defaults.MSTeams)
+	merged.Discord = appendMissingDiscordNotifications(merged.Discord, defaults.Discord)
+	merged.Webhook = appendMissingWebhookNotifications(merged.Webhook, defaults.Webhook)
+	return merged
+}
+
+func appendMissingSlackNotifications(target []SlackNotification, defaults []SlackNotification) []SlackNotification {
+	merged := append([]SlackNotification(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, notification := range merged {
+		existing[notification.Channel] = true
+	}
+	for _, notification := range defaults {
+		if !existing[notification.Channel] {
+			merged = append(merged, cloneSlackNotification(notification))
+			existing[notification.Channel] = true
+		}
+	}
+	return merged
+}
+
+func appendMissingMSTeamsNotifications(target []MSTeamsNotification, defaults []MSTeamsNotification) []MSTeamsNotification {
+	merged := append([]MSTeamsNotification(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, notification := range merged {
+		existing[notification.Connection] = true
+	}
+	for _, notification := range defaults {
+		if !existing[notification.Connection] {
+			merged = append(merged, cloneMSTeamsNotification(notification))
+			existing[notification.Connection] = true
+		}
+	}
+	return merged
+}
+
+func appendMissingDiscordNotifications(target []DiscordNotification, defaults []DiscordNotification) []DiscordNotification {
+	merged := append([]DiscordNotification(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, notification := range merged {
+		existing[notification.Connection] = true
+	}
+	for _, notification := range defaults {
+		if !existing[notification.Connection] {
+			merged = append(merged, cloneDiscordNotification(notification))
+			existing[notification.Connection] = true
+		}
+	}
+	return merged
+}
+
+func appendMissingWebhookNotifications(target []WebhookNotification, defaults []WebhookNotification) []WebhookNotification {
+	merged := append([]WebhookNotification(nil), target...)
+	existing := make(map[string]bool, len(merged))
+	for _, notification := range merged {
+		existing[notification.Connection] = true
+	}
+	for _, notification := range defaults {
+		if !existing[notification.Connection] {
+			merged = append(merged, cloneWebhookNotification(notification))
+			existing[notification.Connection] = true
+		}
+	}
+	return merged
+}
+
+func cloneEmptyStringMap(value EmptyStringMap) EmptyStringMap {
+	if value == nil {
+		return nil
+	}
+	clone := make(EmptyStringMap, len(value))
+	for key, mapValue := range value {
+		clone[key] = mapValue
+	}
+	return clone
+}
+
+func cloneDefaultTrueBool(value DefaultTrueBool) DefaultTrueBool {
+	return DefaultTrueBool{Value: cloneBoolPtr(value.Value)}
+}
+
+func cloneColumnCheckValue(value ColumnCheckValue) ColumnCheckValue {
+	clone := ColumnCheckValue{}
+	if value.IntArray != nil {
+		clone.IntArray = ptrTo(append([]int(nil), (*value.IntArray)...))
+	}
+	if value.Int != nil {
+		clone.Int = cloneIntPtr(value.Int)
+	}
+	if value.Float != nil {
+		floatValue := *value.Float
+		clone.Float = &floatValue
+	}
+	if value.StringArray != nil {
+		clone.StringArray = ptrTo(append([]string(nil), (*value.StringArray)...))
+	}
+	if value.String != nil {
+		stringValue := *value.String
+		clone.String = &stringValue
+	}
+	if value.Bool != nil {
+		clone.Bool = cloneBoolPtr(value.Bool)
+	}
+	return clone
+}
+
+func isColumnCheckValueZero(value ColumnCheckValue) bool {
+	return value.IntArray == nil && value.Int == nil && value.Float == nil && value.StringArray == nil && value.String == nil && value.Bool == nil
+}
+
+func ptrTo[T any](value T) *T {
+	return &value
+}
+
+func cloneIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneInt64Ptr(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneNotifications(value *Notifications) *Notifications {
+	if value == nil {
+		return nil
+	}
+	clone := &Notifications{
+		Slack:   make([]SlackNotification, 0, len(value.Slack)),
+		MSTeams: make([]MSTeamsNotification, 0, len(value.MSTeams)),
+		Discord: make([]DiscordNotification, 0, len(value.Discord)),
+		Webhook: make([]WebhookNotification, 0, len(value.Webhook)),
+	}
+	for _, notification := range value.Slack {
+		clone.Slack = append(clone.Slack, cloneSlackNotification(notification))
+	}
+	for _, notification := range value.MSTeams {
+		clone.MSTeams = append(clone.MSTeams, cloneMSTeamsNotification(notification))
+	}
+	for _, notification := range value.Discord {
+		clone.Discord = append(clone.Discord, cloneDiscordNotification(notification))
+	}
+	for _, notification := range value.Webhook {
+		clone.Webhook = append(clone.Webhook, cloneWebhookNotification(notification))
+	}
+	return clone
+}
+
+func cloneSlackNotification(value SlackNotification) SlackNotification {
+	value.Success = cloneDefaultTrueBool(value.Success)
+	value.Failure = cloneDefaultTrueBool(value.Failure)
+	return value
+}
+
+func cloneMSTeamsNotification(value MSTeamsNotification) MSTeamsNotification {
+	value.Success = cloneDefaultTrueBool(value.Success)
+	value.Failure = cloneDefaultTrueBool(value.Failure)
+	return value
+}
+
+func cloneDiscordNotification(value DiscordNotification) DiscordNotification {
+	value.Success = cloneDefaultTrueBool(value.Success)
+	value.Failure = cloneDefaultTrueBool(value.Failure)
+	return value
+}
+
+func cloneWebhookNotification(value WebhookNotification) WebhookNotification {
+	value.Success = cloneDefaultTrueBool(value.Success)
+	value.Failure = cloneDefaultTrueBool(value.Failure)
+	return value
 }
 
 func assetAcceptsDefaultHooks(asset *Asset) bool {
@@ -2754,6 +3445,7 @@ func (b *Builder) SetNameFromPath(ctx context.Context, asset *Asset, foundPipeli
 
 	asset.Name = name
 	asset.ID = hash(name)
+	refreshAssetCheckIDs(asset)
 	return asset, nil
 }
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1766,7 +1766,6 @@ func (p *Pipeline) UnmarshalJSON(data []byte) error {
 }
 
 type DefaultValues struct {
-	Name              string            `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name"`
 	Type              string            `json:"type" yaml:"type" mapstructure:"type"`
 	Description       string            `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description"`
 	StartDate         string            `json:"start_date,omitempty" yaml:"start_date,omitempty" mapstructure:"start_date"`
@@ -1809,7 +1808,6 @@ func (d *DefaultValues) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	*d = DefaultValues{
-		Name:              asset.Name,
 		Type:              string(asset.Type),
 		Description:       asset.Description,
 		StartDate:         asset.StartDate,
@@ -2602,10 +2600,6 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 		return asset, nil
 	}
 
-	if asset.Name == "" && defaults.Name != "" {
-		asset.Name = defaults.Name
-		asset.ID = hash(defaults.Name)
-	}
 	applyStringDefault(&asset.Description, defaults.Description)
 	applyStringDefault(&asset.StartDate, defaults.StartDate)
 	applyStringDefault(&asset.Connection, defaults.Connection)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -417,7 +417,7 @@ type Materialization struct {
 }
 
 func (m Materialization) MarshalJSON() ([]byte, error) {
-	if m.Type == "" && m.Strategy == "" && m.PartitionBy == "" && len(m.ClusterBy) == 0 && m.IncrementalKey == "" {
+	if m.Type == "" && m.Strategy == "" && m.PartitionBy == "" && len(m.ClusterBy) == 0 && m.IncrementalKey == "" && m.TimeGranularity == "" {
 		return []byte("null"), nil
 	}
 
@@ -2633,9 +2633,9 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 	mergeEmptyStringMapDefaults(&asset.Meta, defaults.Meta)
 	mergeEmptyStringMapDefaults(&asset.Metadata, defaults.Metadata)
 
-	asset.Tags = appendMissingStrings(asset.Tags, defaults.Tags)
-	asset.Domains = appendMissingStrings(asset.Domains, defaults.Domains)
-	asset.Extends = appendMissingPlainStrings(asset.Extends, defaults.Extends)
+	appendMissingStringValues(&asset.Tags, defaults.Tags)
+	appendMissingStringValues(&asset.Domains, defaults.Domains)
+	appendMissingStringValues(&asset.Extends, defaults.Extends)
 	mergeMaterializationDefaults(&asset.Materialization, defaults.Materialization)
 	asset.Upstreams = appendMissingUpstreams(asset.Upstreams, defaults.Upstreams)
 	mergeColumnDefaults(asset, defaults.Columns)
@@ -2715,12 +2715,12 @@ func mergeEmptyStringMapDefaults(target *EmptyStringMap, defaults EmptyStringMap
 	}
 }
 
-func appendMissingStrings(target EmptyStringArray, defaults EmptyStringArray) EmptyStringArray {
+func appendMissingStringValues[S ~[]E, E ~string](target *S, defaults S) {
 	if len(defaults) == 0 {
-		return target
+		return
 	}
-	merged := append(EmptyStringArray(nil), target...)
-	existing := make(map[string]bool, len(merged))
+	merged := append(S(nil), (*target)...)
+	existing := make(map[E]bool, len(merged))
 	for _, value := range merged {
 		existing[value] = true
 	}
@@ -2730,25 +2730,7 @@ func appendMissingStrings(target EmptyStringArray, defaults EmptyStringArray) Em
 			existing[value] = true
 		}
 	}
-	return merged
-}
-
-func appendMissingPlainStrings(target []string, defaults []string) []string {
-	if len(defaults) == 0 {
-		return target
-	}
-	merged := append([]string(nil), target...)
-	existing := make(map[string]bool, len(merged))
-	for _, value := range merged {
-		existing[value] = true
-	}
-	for _, value := range defaults {
-		if !existing[value] {
-			merged = append(merged, value)
-			existing[value] = true
-		}
-	}
-	return merged
+	*target = merged
 }
 
 func mergeMaterializationDefaults(target *Materialization, defaults Materialization) {
@@ -2837,7 +2819,7 @@ func mergeColumnDefault(target *Column, defaults Column, assetName string) {
 	applyStringDefault(&target.SourceColumn, defaults.SourceColumn)
 	applyStringDefault(&target.Type, defaults.Type)
 	applyStringDefault(&target.Description, defaults.Description)
-	target.Tags = appendMissingStrings(target.Tags, defaults.Tags)
+	appendMissingStringValues(&target.Tags, defaults.Tags)
 	if !target.PrimaryKey && defaults.PrimaryKey {
 		target.PrimaryKey = true
 	}
@@ -2863,7 +2845,7 @@ func mergeColumnDefault(target *Column, defaults Column, assetName string) {
 		target.ForeignKey = cloneColumnReference(defaults.ForeignKey)
 	}
 	applyStringDefault(&target.Owner, defaults.Owner)
-	target.Domains = appendMissingStrings(target.Domains, defaults.Domains)
+	appendMissingStringValues(&target.Domains, defaults.Domains)
 	mergeEmptyStringMapDefaults(&target.Meta, defaults.Meta)
 	applyStringDefault(&target.Extends, defaults.Extends)
 	target.Checks = mergeColumnCheckDefaults(target.Checks, defaults.Checks, assetName, target.Name)

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -788,6 +788,38 @@ func TestColumnCheckValue_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestMaterialization_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		materialization pipeline.Materialization
+		want            string
+	}{
+		{
+			name: "empty materialization marshals to null",
+			want: "null",
+		},
+		{
+			name: "time granularity only materialization is preserved",
+			materialization: pipeline.Materialization{
+				TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+			},
+			want: `{"type":"","strategy":"","partition_by":"","cluster_by":null,"incremental_key":"","time_granularity":"date"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.materialization.MarshalJSON()
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(got))
+		})
+	}
+}
+
 func TestColumnCheckValue_MarshalJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -2254,6 +2255,191 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestDefaultValues_CoversAssetConfigFields(t *testing.T) {
+	t.Parallel()
+
+	assetType := reflect.TypeOf(pipeline.Asset{})
+	defaultType := reflect.TypeOf(pipeline.DefaultValues{})
+	defaultFields := make(map[string]bool, defaultType.NumField())
+	for i := range defaultType.NumField() {
+		defaultFields[defaultType.Field(i).Name] = true
+	}
+
+	nonDefaultable := map[string]bool{
+		"ID":             true,
+		"URI":            true,
+		"ExecutableFile": true,
+		"DefinitionFile": true,
+		"RetriesDelay":   true,
+	}
+
+	for i := range assetType.NumField() {
+		field := assetType.Field(i)
+		if !field.IsExported() || nonDefaultable[field.Name] {
+			continue
+		}
+
+		assert.Truef(t, defaultFields[field.Name], "Asset.%s should be represented in DefaultValues or explicitly marked non-defaultable", field.Name)
+	}
+}
+
+func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T) {
+	t.Parallel()
+
+	falseValue := false
+	retries := 3
+	rerunCooldown := 45
+	customCount := int64(1)
+
+	asset := &pipeline.Asset{
+		ID:          hash("asset"),
+		Name:        "asset",
+		Type:        pipeline.AssetTypeBigqueryQuery,
+		Description: "asset description",
+		Tags:        []string{"asset-tag"},
+		Domains:     []string{"asset-domain"},
+		Meta:        pipeline.EmptyStringMap{"shared": "asset", "asset": "yes"},
+		Materialization: pipeline.Materialization{
+			Strategy: pipeline.MaterializationStrategyAppend,
+		},
+		Upstreams: []pipeline.Upstream{{Type: "asset", Value: "asset-upstream"}},
+		Parameters: pipeline.EmptyStringMap{
+			"shared": "asset",
+		},
+		Extends: []string{"asset.extend"},
+		Columns: []pipeline.Column{
+			{
+				Name:        "id",
+				Description: "asset column",
+				Checks: []pipeline.ColumnCheck{
+					{Name: "not_null"},
+				},
+			},
+		},
+		CustomChecks: []pipeline.CustomCheck{
+			{Name: "row_count", Query: "select asset", Value: 1},
+		},
+		Notifications: &pipeline.Notifications{
+			Slack: []pipeline.SlackNotification{{Channel: "#asset"}},
+		},
+	}
+
+	defaults := &pipeline.DefaultValues{
+		Name:        "default-name",
+		Type:        string(pipeline.AssetTypeSnowflakeQuery),
+		Description: "default description",
+		StartDate:   "2024-01-01",
+		Connection:  "default-connection",
+		Tags:        []string{"default-tag", "asset-tag"},
+		Domains:     []string{"default-domain", "asset-domain"},
+		Meta:        pipeline.EmptyStringMap{"shared": "default", "default": "yes"},
+		Materialization: pipeline.Materialization{
+			Type:           pipeline.MaterializationTypeTable,
+			Strategy:       pipeline.MaterializationStrategyCreateReplace,
+			PartitionBy:    "dt",
+			ClusterBy:      []string{"tenant"},
+			IncrementalKey: "updated_at",
+		},
+		Upstreams: []pipeline.Upstream{
+			{Type: "asset", Value: "default-upstream"},
+			{Type: "asset", Value: "asset-upstream"},
+		},
+		Image:      "python:3.12",
+		Instance:   "b1.small",
+		Owner:      "data",
+		Tier:       2,
+		Parameters: map[string]string{"shared": "default", "default": "yes"},
+		Extends:    []string{"default.extend", "asset.extend"},
+		Columns: []pipeline.Column{
+			{
+				Name:        "id",
+				Type:        "integer",
+				Description: "default column",
+				Checks: []pipeline.ColumnCheck{
+					{Name: "unique"},
+					{Name: "not_null", Description: "default not null"},
+				},
+			},
+			{
+				Name: "loaded_at",
+				Type: "timestamp",
+			},
+		},
+		CustomChecks: []pipeline.CustomCheck{
+			{Name: "row_count", Description: "default row count", Query: "select default", Value: 2},
+			{Name: "freshness", Query: "select 0", Count: &customCount},
+		},
+		Metadata: pipeline.EmptyStringMap{"catalog": "default"},
+		Snowflake: pipeline.SnowflakeConfig{
+			Warehouse: "default-wh",
+		},
+		Athena: pipeline.AthenaConfig{
+			Location: "s3://default/results",
+		},
+		Routing: &pipeline.RoutingConfig{
+			EgressGateway: "default-gateway",
+		},
+		IntervalModifiers: pipeline.IntervalModifiers{
+			Start: pipeline.TimeModifier{Days: -1},
+			End:   pipeline.TimeModifier{Days: 1},
+		},
+		RerunCooldown:     &rerunCooldown,
+		Retries:           &retries,
+		RefreshRestricted: &falseValue,
+		Notifications: &pipeline.Notifications{
+			Slack: []pipeline.SlackNotification{{Channel: "#default"}},
+		},
+	}
+
+	builder := &pipeline.Builder{}
+	got, err := builder.SetupDefaultsFromPipeline(t.Context(), asset, &pipeline.Pipeline{DefaultValues: defaults})
+	require.NoError(t, err)
+
+	assert.Equal(t, "asset", got.Name)
+	assert.Empty(t, got.URI)
+	assert.Equal(t, pipeline.AssetTypeBigqueryQuery, got.Type)
+	assert.Equal(t, "asset description", got.Description)
+	assert.Equal(t, "2024-01-01", got.StartDate)
+	assert.Equal(t, "default-connection", got.Connection)
+	assert.Equal(t, []string{"asset-tag", "default-tag"}, []string(got.Tags))
+	assert.Equal(t, []string{"asset-domain", "default-domain"}, []string(got.Domains))
+	assert.Equal(t, pipeline.EmptyStringMap{"shared": "asset", "asset": "yes", "default": "yes"}, got.Meta)
+	assert.Equal(t, pipeline.MaterializationTypeTable, got.Materialization.Type)
+	assert.Equal(t, pipeline.MaterializationStrategyAppend, got.Materialization.Strategy)
+	assert.Equal(t, "dt", got.Materialization.PartitionBy)
+	assert.Equal(t, []string{"tenant"}, got.Materialization.ClusterBy)
+	assert.Equal(t, []pipeline.Upstream{
+		{Type: "asset", Value: "asset-upstream"},
+		{Type: "asset", Value: "default-upstream"},
+	}, got.Upstreams)
+	assert.Equal(t, "python:3.12", got.Image)
+	assert.Equal(t, "b1.small", got.Instance)
+	assert.Equal(t, "data", got.Owner)
+	assert.Equal(t, 2, got.Tier)
+	assert.Equal(t, pipeline.EmptyStringMap{"shared": "asset", "default": "yes"}, got.Parameters)
+	assert.Equal(t, []string{"asset.extend", "default.extend"}, got.Extends)
+	assert.Equal(t, pipeline.EmptyStringMap{"catalog": "default"}, got.Metadata)
+	assert.Equal(t, "default-wh", got.Snowflake.Warehouse)
+	assert.Equal(t, "s3://default/results", got.Athena.Location)
+	assert.Equal(t, &pipeline.RoutingConfig{EgressGateway: "default-gateway"}, got.Routing)
+	assert.Equal(t, &rerunCooldown, got.RerunCooldown)
+	assert.Equal(t, &retries, got.Retries)
+	assert.Equal(t, &falseValue, got.RefreshRestricted)
+	assert.Len(t, got.Columns, 2)
+	assert.Equal(t, "asset column", got.Columns[0].Description)
+	assert.Equal(t, "integer", got.Columns[0].Type)
+	assert.True(t, got.Columns[0].HasCheck("not_null"))
+	assert.True(t, got.Columns[0].HasCheck("unique"))
+	assert.Equal(t, "loaded_at", got.Columns[1].Name)
+	assert.Len(t, got.CustomChecks, 2)
+	assert.Equal(t, "select asset", got.CustomChecks[0].Query)
+	assert.Equal(t, "default row count", got.CustomChecks[0].Description)
+	assert.Equal(t, "freshness", got.CustomChecks[1].Name)
+	assert.Len(t, got.Notifications.Slack, 2)
+	assert.Equal(t, "#asset", got.Notifications.Slack[0].Channel)
+	assert.Equal(t, "#default", got.Notifications.Slack[1].Channel)
 }
 
 func TestBuilder_InjectConnectionAsSecret(t *testing.T) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2301,6 +2301,7 @@ func TestDefaultValues_CoversAssetConfigFields(t *testing.T) {
 
 	nonDefaultable := map[string]bool{
 		"ID":             true,
+		"Name":           true,
 		"URI":            true,
 		"ExecutableFile": true,
 		"DefinitionFile": true,
@@ -2315,6 +2316,28 @@ func TestDefaultValues_CoversAssetConfigFields(t *testing.T) {
 
 		assert.Truef(t, defaultFields[field.Name], "Asset.%s should be represented in DefaultValues or explicitly marked non-defaultable", field.Name)
 	}
+}
+
+func TestDefaultValues_UnmarshalYAMLDoesNotSupportName(t *testing.T) {
+	t.Parallel()
+
+	var p pipeline.Pipeline
+	err := yaml.Unmarshal([]byte(`
+name: test-pipeline
+default:
+  name: should-not-default
+  description: default description
+`), &p)
+	require.NoError(t, err)
+	require.NotNil(t, p.DefaultValues)
+
+	builder := &pipeline.Builder{}
+	got, err := builder.SetupDefaultsFromPipeline(t.Context(), &pipeline.Asset{}, &p)
+	require.NoError(t, err)
+
+	assert.Empty(t, got.Name)
+	assert.Empty(t, got.ID)
+	assert.Equal(t, "default description", got.Description)
 }
 
 func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T) {
@@ -2359,7 +2382,6 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 	}
 
 	defaults := &pipeline.DefaultValues{
-		Name:        "default-name",
 		Type:        string(pipeline.AssetTypeSnowflakeQuery),
 		Description: "default description",
 		StartDate:   "2024-01-01",

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -281,7 +281,6 @@ func assetFromDefaultValues(dv *DefaultValues) *Asset {
 	}
 
 	return &Asset{
-		Name:              dv.Name,
 		Type:              AssetType(dv.Type),
 		Description:       dv.Description,
 		StartDate:         dv.StartDate,
@@ -319,7 +318,6 @@ func copyAssetToDefaultValues(dv *DefaultValues, asset *Asset) {
 		secrets = append(secrets, secretMapping(secret))
 	}
 
-	dv.Name = asset.Name
 	dv.Type = string(asset.Type)
 	dv.Description = asset.Description
 	dv.StartDate = asset.StartDate

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -264,19 +264,90 @@ func renderDefaultValues(render RenderFunc, dv *DefaultValues) error {
 	if dv.Type, err = maybeRender(render, "default.type", dv.Type); err != nil {
 		return err
 	}
-	for i := range dv.Secrets {
-		s := &dv.Secrets[i]
-		if s.SecretKey, err = maybeRender(render, fmt.Sprintf("default.secrets[%d].key", i), s.SecretKey); err != nil {
-			return err
-		}
-		if s.InjectedKey, err = maybeRender(render, fmt.Sprintf("default.secrets[%d].inject_as", i), s.InjectedKey); err != nil {
-			return err
-		}
-	}
-	if err := renderRoutingConfig(render, "default.routing", dv.Routing); err != nil {
+
+	asset := assetFromDefaultValues(dv)
+	if err := renderAssetStrings(render, asset); err != nil {
 		return err
 	}
+	copyAssetToDefaultValues(dv, asset)
+
 	return nil
+}
+
+func assetFromDefaultValues(dv *DefaultValues) *Asset {
+	secrets := make([]SecretMapping, 0, len(dv.Secrets))
+	for _, secret := range dv.Secrets {
+		secrets = append(secrets, SecretMapping(secret))
+	}
+
+	return &Asset{
+		Name:              dv.Name,
+		Type:              AssetType(dv.Type),
+		Description:       dv.Description,
+		StartDate:         dv.StartDate,
+		Connection:        dv.Connection,
+		Tags:              dv.Tags,
+		Domains:           dv.Domains,
+		Meta:              dv.Meta,
+		Materialization:   dv.Materialization,
+		Upstreams:         dv.Upstreams,
+		Image:             dv.Image,
+		Instance:          dv.Instance,
+		Owner:             dv.Owner,
+		Tier:              dv.Tier,
+		Parameters:        EmptyStringMap(dv.Parameters),
+		Secrets:           secrets,
+		Extends:           dv.Extends,
+		Columns:           dv.Columns,
+		CustomChecks:      dv.CustomChecks,
+		Hooks:             dv.Hooks,
+		Metadata:          dv.Metadata,
+		Snowflake:         dv.Snowflake,
+		Athena:            dv.Athena,
+		Routing:           dv.Routing,
+		IntervalModifiers: dv.IntervalModifiers,
+		RerunCooldown:     dv.RerunCooldown,
+		Retries:           dv.Retries,
+		RefreshRestricted: dv.RefreshRestricted,
+		Notifications:     dv.Notifications,
+	}
+}
+
+func copyAssetToDefaultValues(dv *DefaultValues, asset *Asset) {
+	secrets := make([]secretMapping, 0, len(asset.Secrets))
+	for _, secret := range asset.Secrets {
+		secrets = append(secrets, secretMapping(secret))
+	}
+
+	dv.Name = asset.Name
+	dv.Type = string(asset.Type)
+	dv.Description = asset.Description
+	dv.StartDate = asset.StartDate
+	dv.Connection = asset.Connection
+	dv.Tags = asset.Tags
+	dv.Domains = asset.Domains
+	dv.Meta = asset.Meta
+	dv.Materialization = asset.Materialization
+	dv.Upstreams = asset.Upstreams
+	dv.Image = asset.Image
+	dv.Instance = asset.Instance
+	dv.Owner = asset.Owner
+	dv.Tier = asset.Tier
+	dv.Parameters = map[string]string(asset.Parameters)
+	dv.Secrets = secrets
+	dv.Extends = asset.Extends
+	dv.Columns = asset.Columns
+	dv.CustomChecks = asset.CustomChecks
+	dv.Hooks = asset.Hooks
+	dv.Metadata = asset.Metadata
+	dv.Snowflake = asset.Snowflake
+	dv.Athena = asset.Athena
+	dv.Routing = asset.Routing
+	dv.IntervalModifiers = asset.IntervalModifiers
+	dv.RerunCooldown = asset.RerunCooldown
+	dv.Retries = asset.Retries
+	dv.RefreshRestricted = asset.RefreshRestricted
+	dv.Notifications = asset.Notifications
 }
 
 func renderAssetStrings(render RenderFunc, a *Asset) error {

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -553,7 +553,6 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 		Meta:               map[string]string{"k": "v"},
 		DefaultConnections: map[string]string{"k": "v"},
 		DefaultValues: &pipeline.DefaultValues{
-			Name:        "n",
 			Type:        "type",
 			Description: "desc",
 			StartDate:   "start",

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // fakeRender is a minimal stand-in for jinja: replaces {{ var.<name> }} with
@@ -314,6 +315,35 @@ func TestPipeline_MaterializeVariant(t *testing.T) {
 		assert.Equal(t, "select '{{ end_date }}'", pl.DefaultValues.Hooks.Post[0].Query)
 	})
 
+	t.Run("renders default secrets", func(t *testing.T) {
+		t.Parallel()
+		var pl pipeline.Pipeline
+		require.NoError(t, yaml.Unmarshal([]byte(`
+name: p
+default:
+  secrets:
+    - key: "{{ var.secret_name }}"
+      inject_as: "{{ var.inject_as }}"
+variables:
+  secret_name:
+    type: string
+    default: raw_secret
+  inject_as:
+    type: string
+    default: RAW_SECRET
+variants:
+  only:
+    secret_name: rendered_secret
+    inject_as: RENDERED_SECRET
+`), &pl))
+
+		require.NoError(t, pl.MaterializeVariant("only", makeFakeRenderer))
+
+		require.Len(t, pl.DefaultValues.Secrets, 1)
+		assert.Equal(t, "rendered_secret", pl.DefaultValues.Secrets[0].SecretKey)
+		assert.Equal(t, "RENDERED_SECRET", pl.DefaultValues.Secrets[0].InjectedKey)
+	})
+
 	t.Run("merges variant overrides into Variables", func(t *testing.T) {
 		t.Parallel()
 		pl := build()
@@ -405,23 +435,36 @@ func TestVariantVisitorCoversStringFields(t *testing.T) {
 		"Pipeline.Assets[].Hooks.Post[].Query":     true,
 
 		// Enum-typed strings on Asset.
-		"Pipeline.Assets[].Materialization.Type":            true,
-		"Pipeline.Assets[].Materialization.Strategy":        true,
-		"Pipeline.Assets[].Materialization.TimeGranularity": true,
-		"Pipeline.Assets[].Upstreams[].Type":                true,
-		"Pipeline.Assets[].Upstreams[].Mode":                true,
+		"Pipeline.Assets[].Materialization.Type":                 true,
+		"Pipeline.Assets[].Materialization.Strategy":             true,
+		"Pipeline.Assets[].Materialization.TimeGranularity":      true,
+		"Pipeline.Assets[].Upstreams[].Type":                     true,
+		"Pipeline.Assets[].Upstreams[].Mode":                     true,
+		"Pipeline.DefaultValues.Materialization.Type":            true,
+		"Pipeline.DefaultValues.Materialization.Strategy":        true,
+		"Pipeline.DefaultValues.Materialization.TimeGranularity": true,
+		"Pipeline.DefaultValues.Upstreams[].Type":                true,
+		"Pipeline.DefaultValues.Upstreams[].Mode":                true,
 
 		// Column structural fields (parse-time linkage, lineage tracking).
-		"Pipeline.Assets[].Columns[].EntityAttribute.Entity":    true,
-		"Pipeline.Assets[].Columns[].EntityAttribute.Attribute": true,
-		"Pipeline.Assets[].Columns[].Extends":                   true,
-		"Pipeline.Assets[].Columns[].Upstreams[].Column":        true,
-		"Pipeline.Assets[].Columns[].Upstreams[].Table":         true,
-		"Pipeline.Assets[].Columns[].Checks[].ID":               true,
-		"Pipeline.Assets[].CustomChecks[].ID":                   true,
-		"Pipeline.Assets[].CustomChecks[].Query":                true,
-		"Pipeline.DefaultValues.Hooks.Pre[].Query":              true,
-		"Pipeline.DefaultValues.Hooks.Post[].Query":             true,
+		"Pipeline.Assets[].Columns[].EntityAttribute.Entity":         true,
+		"Pipeline.Assets[].Columns[].EntityAttribute.Attribute":      true,
+		"Pipeline.Assets[].Columns[].Extends":                        true,
+		"Pipeline.Assets[].Columns[].Upstreams[].Column":             true,
+		"Pipeline.Assets[].Columns[].Upstreams[].Table":              true,
+		"Pipeline.Assets[].Columns[].Checks[].ID":                    true,
+		"Pipeline.Assets[].CustomChecks[].ID":                        true,
+		"Pipeline.Assets[].CustomChecks[].Query":                     true,
+		"Pipeline.DefaultValues.Columns[].EntityAttribute.Entity":    true,
+		"Pipeline.DefaultValues.Columns[].EntityAttribute.Attribute": true,
+		"Pipeline.DefaultValues.Columns[].Extends":                   true,
+		"Pipeline.DefaultValues.Columns[].Upstreams[].Column":        true,
+		"Pipeline.DefaultValues.Columns[].Upstreams[].Table":         true,
+		"Pipeline.DefaultValues.Columns[].Checks[].ID":               true,
+		"Pipeline.DefaultValues.CustomChecks[].ID":                   true,
+		"Pipeline.DefaultValues.CustomChecks[].Query":                true,
+		"Pipeline.DefaultValues.Hooks.Pre[].Query":                   true,
+		"Pipeline.DefaultValues.Hooks.Post[].Query":                  true,
 
 		// Parameter values frequently embed runtime variables (e.g. {{ start_date }})
 		// and are resolved at execution time by the per-asset renderer.
@@ -435,10 +478,14 @@ func TestVariantVisitorCoversStringFields(t *testing.T) {
 		"Pipeline.DefaultValues.IntervalModifiers.End.Template":   true,
 
 		// Asset-level notifications mirror pipeline notifications.
-		"Pipeline.Assets[].Notifications.Slack[].Channel":      true,
-		"Pipeline.Assets[].Notifications.MSTeams[].Connection": true,
-		"Pipeline.Assets[].Notifications.Discord[].Connection": true,
-		"Pipeline.Assets[].Notifications.Webhook[].Connection": true,
+		"Pipeline.Assets[].Notifications.Slack[].Channel":           true,
+		"Pipeline.Assets[].Notifications.MSTeams[].Connection":      true,
+		"Pipeline.Assets[].Notifications.Discord[].Connection":      true,
+		"Pipeline.Assets[].Notifications.Webhook[].Connection":      true,
+		"Pipeline.DefaultValues.Notifications.Slack[].Channel":      true,
+		"Pipeline.DefaultValues.Notifications.MSTeams[].Connection": true,
+		"Pipeline.DefaultValues.Notifications.Discord[].Connection": true,
+		"Pipeline.DefaultValues.Notifications.Webhook[].Connection": true,
 	}
 
 	pl := buildFullyPopulatedPipelineForVisitorTest()
@@ -506,12 +553,51 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 		Meta:               map[string]string{"k": "v"},
 		DefaultConnections: map[string]string{"k": "v"},
 		DefaultValues: &pipeline.DefaultValues{
+			Name:        "n",
+			Type:        "type",
+			Description: "desc",
+			StartDate:   "start",
+			Connection:  "conn",
+			Tags:        []string{"a"},
+			Domains:     []string{"a"},
+			Meta:        map[string]string{"k": "v"},
+			Materialization: pipeline.Materialization{
+				ClusterBy:      []string{"a"},
+				PartitionBy:    "p",
+				IncrementalKey: "i",
+			},
+			Upstreams: []pipeline.Upstream{
+				{Type: "asset", Value: "x", Metadata: map[string]string{"k": "v"}, Columns: []pipeline.DependsColumn{{Name: "n", Usage: "u"}}},
+			},
+			Image:      "image",
+			Instance:   "instance",
+			Owner:      "owner",
 			Parameters: map[string]string{"k": "v"},
+			Extends:    []string{"x"},
+			Columns: []pipeline.Column{
+				{
+					Name:    "c",
+					Tags:    []string{"a"},
+					Domains: []string{"a"},
+					Meta:    map[string]string{"k": "v"},
+					Checks:  []pipeline.ColumnCheck{{Name: "ck"}},
+				},
+			},
+			CustomChecks: []pipeline.CustomCheck{{Name: "cc", Query: "q"}},
 			Hooks: pipeline.Hooks{
 				Pre:  []pipeline.Hook{{Query: "q"}},
 				Post: []pipeline.Hook{{Query: "q"}},
 			},
-			Routing: &pipeline.RoutingConfig{EgressGateway: "gw"},
+			Metadata:  map[string]string{"k": "v"},
+			Snowflake: pipeline.SnowflakeConfig{Warehouse: "wh"},
+			Athena:    pipeline.AthenaConfig{Location: "loc"},
+			Routing:   &pipeline.RoutingConfig{EgressGateway: "gw"},
+			Notifications: &pipeline.Notifications{
+				Slack:   []pipeline.SlackNotification{{Channel: "c"}},
+				MSTeams: []pipeline.MSTeamsNotification{{Connection: "c"}},
+				Discord: []pipeline.DiscordNotification{{Connection: "c"}},
+				Webhook: []pipeline.WebhookNotification{{Connection: "c"}},
+			},
 		},
 		Variables: pipeline.Variables{
 			"sentinel": map[string]any{"type": "string", "default": "RENDERED"},

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -354,6 +354,7 @@ type taskDefinition struct {
 	Instance              string            `yaml:"instance"`
 	Materialization       materialization   `yaml:"materialization"`
 	Owner                 string            `yaml:"owner"`
+	Tier                  int               `yaml:"tier"`
 	StartDate             string            `yaml:"start_date"`
 	Extends               []string          `yaml:"extends"`
 	Columns               []column          `yaml:"columns"`
@@ -366,6 +367,8 @@ type taskDefinition struct {
 	IntervalModifiers     IntervalModifiers `yaml:"interval_modifiers"`
 	Domains               []string          `yaml:"domains"`
 	Meta                  map[string]string `yaml:"meta"`
+	Metadata              map[string]string `yaml:"metadata"`
+	Retries               *int              `yaml:"retries"`
 	RerunCooldown         *int              `yaml:"rerun_cooldown"`
 	RefreshRestricted     *bool             `yaml:"refresh_restricted,omitempty"`
 	FullRefreshRestricted *bool             `yaml:"full_refresh_restricted,omitempty"`
@@ -565,6 +568,7 @@ func taskDefinitionToAsset(definition taskDefinition) (*Asset, error) {
 		Image:             definition.Image,
 		Instance:          definition.Instance,
 		Owner:             definition.Owner,
+		Tier:              definition.Tier,
 		StartDate:         definition.StartDate,
 		Tags:              definition.Tags,
 		Extends:           definition.Extends,
@@ -577,6 +581,8 @@ func taskDefinitionToAsset(definition taskDefinition) (*Asset, error) {
 		IntervalModifiers: definition.IntervalModifiers,
 		Domains:           definition.Domains,
 		Meta:              definition.Meta,
+		Metadata:          definition.Metadata,
+		Retries:           definition.Retries,
 		RerunCooldown:     definition.RerunCooldown,
 		RefreshRestricted: definition.refreshRestricted(),
 		Notifications:     notificationsOrNil(definition.Notifications),


### PR DESCRIPTION
Extends pipeline default handling to cover asset configuration fields such as instance, owner, tags, materialization, checks, routing, retries, and notifications while keeping URI and runtime-only fields out of defaults.

Updates variant rendering, parser support, docs, and parse expectations.

Validated with `make format` and `make test`.