### PR TITLE
Accept ingestr flags as asset parameters

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -46,8 +46,24 @@ parameters:
   version: v0 | v1 | v1.x.y
   incremental_strategy: replace | append | merge | delete+insert
   incremental_key: string
+  schema_contract: evolve | freeze | discard_row | discard_value
+  schema_naming: auto | direct | snake_case
   sql_backend: pyarrow | sqlalchemy
+  page_size: integer
   loader_file_format: jsonl | csv | parquet
+  loader_file_size: integer
+  extract_parallelism: integer
+  sql_limit: integer
+  sql_exclude_columns: string
+  no_inference: true|false
+  mask: string
+  trim_whitespace: true|false
+  pipelines_dir: string
+  staging_bucket: string
+  staging_dataset: string
+  stream: true|false
+  flush_interval: string
+  flush_records: integer
   enforce_schema: true|false # Will ensure that the columns defined in the asset are present in the destination and with the desired types (see https://getbruin.com/docs/bruin/assets/columns.html)
 ```
 
@@ -66,15 +82,25 @@ parameters:
 | `incremental_key` | No | `--incremental-key` | Column that determines incremental progress. When the column is defined with type `date`, Bruin also forwards it through the `--columns` option so Ingestr treats it as a date field. |
 | `partition_by` | No | `--partition-by` | Comma-separated list of destination columns to partition by. |
 | `cluster_by` | No | `--cluster-by` | Comma-separated list of destination clustering keys. |
+| `schema_contract` | No | `--schema-contract` | Controls how Ingestr handles schema changes (`evolve`, `freeze`, `discard_row`, `discard_value`). |
 | `loader_file_format` | No | `--loader-file-format` | Overrides the loader file format (`jsonl`, `csv`, `parquet`). |
 | `loader_file_size` | No | `--loader-file-size` | Sets the maximum loader file size accepted by Ingestr. |
 | `sql_backend` | No | `--sql-backend` | Selects the SQL backend Ingestr should use (`pyarrow` or `sqlalchemy`). |
 | `schema_naming` | No | `--schema-naming` | Controls how Ingestr normalizes schema names. Accepted values match the [Ingestr CLI.](https://getbruin.com/docs/ingestr/commands/ingest.html#optional-flags) |
+| `page_size` | No | `--page-size` | Sets the fetch page size for SQL sources. |
 | `extract_parallelism` | No | `--extract-parallelism` | Limits the number of concurrent extraction workers. |
 | `sql_reflection_level` | No | `--sql-reflection-level` | Tunes the amount of schema reflection performed against the source. |
 | `sql_limit` | No | `--sql-limit` | Applies a `LIMIT` clause when extracting from the source. |
 | `sql_exclude_columns` | No | `--sql-exclude-columns` | List of columns to skip during extraction. |
+| `no_inference` | No | `--no-inference` | Uses `columns` as the source schema for schema-less sources instead of inferring types. |
+| `mask` | No | `--mask` | Adds a column masking rule such as `email:hash`. |
+| `pipelines_dir` | No | `--pipelines-dir` | Directory where Ingestr stores pipeline metadata. |
 | `staging_bucket` | No | `--staging-bucket` | Overrides the staging bucket that Ingestr uses for intermediate files. |
+| `staging_dataset` | No | `--staging-dataset` | Dataset/schema to use for staging tables. |
+| `trim_whitespace` | No | `--trim-whitespace` | Trims leading and trailing whitespace from extracted string values when set to `true`. |
+| `stream` | No | `--stream` | Enables continuous ingestion for CDC and message-broker sources. |
+| `flush_interval` | No | `--flush-interval` | Flush interval for streaming mode, such as `30s`. |
+| `flush_records` | No | `--flush-records` | Number of buffered records that triggers a flush in streaming mode. |
 | `enforce_schema` | No | `--columns` | When set to `true`, enforces the column types defined in the asset's `columns` section. Ingestr will create or update the destination table with the specified schema. |
 
 ### Column metadata

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -231,6 +231,20 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			want: []string{"ingest", "--source-uri", "snowflake://uri-here", "--source-table", "source-table", "--dest-uri", "bigquery://uri-here", "--dest-table", "asset-name", "--yes", "--progress", "log"},
 		},
 		{
+			name: "trim whitespace",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "bq",
+				Parameters: map[string]string{
+					"source_connection": "sf",
+					"source_table":      "source-table",
+					"destination":       "bigquery",
+					"trim_whitespace":   "true",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "snowflake://uri-here", "--source-table", "source-table", "--dest-uri", "bigquery://uri-here", "--dest-table", "asset-name", "--yes", "--progress", "log", "--trim-whitespace"},
+		},
+		{
 			name: "duck db source, basic scenario",
 			asset: &pipeline.Asset{
 				Name:       "asset-name",

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -8,64 +8,45 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
-func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs []string, columnOpts *ColumnHintOptions) ([]string, error) {
-	if value, exists := asset.Parameters["incremental_key"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--incremental-key", value)
+var ingestrValueParameterFlags = []string{
+	"incremental_key",
+	"incremental_strategy",
+	"partition_by",
+	"cluster_by",
+	"schema_contract",
+	"schema_naming",
+	"page_size",
+	"loader_file_size",
+	"extract_parallelism",
+	"sql_reflection_level",
+	"sql_limit",
+	"sql_exclude_columns",
+	"mask",
+	"pipelines_dir",
+	"staging_bucket",
+	"staging_dataset",
+	"flush_interval",
+	"flush_records",
+	"sql_backend",
+	"loader_file_format",
+}
 
+var ingestrBoolParameterFlags = []string{
+	"no_inference",
+	"trim_whitespace",
+	"stream",
+}
+
+func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs []string, columnOpts *ColumnHintOptions) ([]string, error) {
+	cmdArgs = appendIngestrParameterFlags(asset.Parameters, cmdArgs)
+
+	if value, exists := asset.Parameters["incremental_key"]; exists && value != "" {
 		// Check if the incremental key column exists and is of date type
 		for _, column := range asset.Columns {
 			if column.Name == value && strings.ToLower(column.Type) == "date" {
 				cmdArgs = append(cmdArgs, "--columns", column.Name+":"+column.Type)
 			}
 		}
-	}
-
-	if value, exists := asset.Parameters["incremental_strategy"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--incremental-strategy", value)
-	}
-
-	if value, exists := asset.Parameters["loader_file_format"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--loader-file-format", value)
-	}
-
-	if value, exists := asset.Parameters["partition_by"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--partition-by", value)
-	}
-
-	if value, exists := asset.Parameters["cluster_by"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--cluster-by", value)
-	}
-
-	if value, exists := asset.Parameters["sql_backend"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--sql-backend", value)
-	}
-
-	if value, exists := asset.Parameters["loader_file_size"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--loader-file-size", value)
-	}
-
-	if value, exists := asset.Parameters["schema_naming"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--schema-naming", value)
-	}
-
-	if value, exists := asset.Parameters["extract_parallelism"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--extract-parallelism", value)
-	}
-
-	if value, exists := asset.Parameters["sql_reflection_level"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--sql-reflection-level", value)
-	}
-
-	if value, exists := asset.Parameters["sql_limit"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--sql-limit", value)
-	}
-
-	if value, exists := asset.Parameters["sql_exclude_columns"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--sql-exclude-columns", value)
-	}
-
-	if value, exists := asset.Parameters["staging_bucket"]; exists && value != "" {
-		cmdArgs = append(cmdArgs, "--staging-bucket", value)
 	}
 
 	// Handle primary keys
@@ -131,6 +112,22 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 	}
 
 	return cmdArgs, nil
+}
+
+func appendIngestrParameterFlags(params map[string]string, cmdArgs []string) []string {
+	for _, param := range ingestrValueParameterFlags {
+		if value, exists := params[param]; exists && value != "" {
+			cmdArgs = append(cmdArgs, "--"+strings.ReplaceAll(param, "_", "-"), value)
+		}
+	}
+
+	for _, param := range ingestrBoolParameterFlags {
+		if value, exists := params[param]; exists && value == "true" {
+			cmdArgs = append(cmdArgs, "--"+strings.ReplaceAll(param, "_", "-"))
+		}
+	}
+
+	return cmdArgs
 }
 
 func AddExtraPackages(destURI, sourceURI string, extraPackages []string) []string {

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -57,6 +57,106 @@ func Test_uvPythonRunner_ingestrLoaderFileFormat(t *testing.T) {
 	}
 }
 
+func TestConsolidatedParameters_IngestrFlagPassthrough(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Parameters: map[string]string{
+			"incremental_key":      "updated_at",
+			"incremental_strategy": "merge",
+			"partition_by":         "event_date",
+			"cluster_by":           "account_id",
+			"schema_contract":      "freeze",
+			"schema_naming":        "snake_case",
+			"page_size":            "1000",
+			"loader_file_size":     "2000",
+			"extract_parallelism":  "7",
+			"sql_reflection_level": "full",
+			"sql_limit":            "500",
+			"sql_exclude_columns":  "internal_notes",
+			"mask":                 "email:hash",
+			"pipelines_dir":        ".ingestr",
+			"staging_bucket":       "gs://bucket/path",
+			"staging_dataset":      "scratch",
+			"flush_interval":       "10s",
+			"flush_records":        "10000",
+			"sql_backend":          "sqlalchemy",
+			"loader_file_format":   "parquet",
+			"no_inference":         "true",
+			"trim_whitespace":      "true",
+			"stream":               "true",
+		},
+	}
+
+	result, err := ConsolidatedParameters(t.Context(), asset, []string{"--existing"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--existing",
+		"--incremental-key", "updated_at",
+		"--incremental-strategy", "merge",
+		"--partition-by", "event_date",
+		"--cluster-by", "account_id",
+		"--schema-contract", "freeze",
+		"--schema-naming", "snake_case",
+		"--page-size", "1000",
+		"--loader-file-size", "2000",
+		"--extract-parallelism", "7",
+		"--sql-reflection-level", "full",
+		"--sql-limit", "500",
+		"--sql-exclude-columns", "internal_notes",
+		"--mask", "email:hash",
+		"--pipelines-dir", ".ingestr",
+		"--staging-bucket", "gs://bucket/path",
+		"--staging-dataset", "scratch",
+		"--flush-interval", "10s",
+		"--flush-records", "10000",
+		"--sql-backend", "sqlalchemy",
+		"--loader-file-format", "parquet",
+		"--no-inference",
+		"--trim-whitespace",
+		"--stream",
+	}, result)
+}
+
+func TestConsolidatedParameters_TrimWhitespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		params   map[string]string
+		expected []string
+	}{
+		{
+			name: "true appends trim whitespace flag",
+			params: map[string]string{
+				"trim_whitespace": "true",
+			},
+			expected: []string{"--existing", "--trim-whitespace"},
+		},
+		{
+			name: "false does not append trim whitespace flag",
+			params: map[string]string{
+				"trim_whitespace": "false",
+			},
+			expected: []string{"--existing"},
+		},
+		{
+			name:     "missing does not append trim whitespace flag",
+			params:   map[string]string{},
+			expected: []string{"--existing"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := ConsolidatedParameters(t.Context(), &pipeline.Asset{Parameters: tt.params}, []string{"--existing"}, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestColumnHints(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds snake_case ingestr asset parameters for supported ingest flags and maps them to the matching CLI flags.

Keeps Bruin-managed flags under existing control and updates docs/tests for the new passthrough behavior.

Checks: make format; make test.