### PR TITLE
Add SharePoint ingestr connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -346,6 +346,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "S3", link: "/ingestion/s3"},
                                     {text: "SendGrid", link: "/ingestion/sendgrid"},
                                     {text: "SFTP", link: "/ingestion/sftp"},
+                                    {text: "SharePoint", link: "/ingestion/sharepoint"},
                                     {text: "Shopify", link: "/ingestion/shopify"},
                                     {text: "Smartsheet", link: "/ingestion/smartsheet"},
                                     {text: "Snapchat Ads", link: "/ingestion/snapchat-ads"},

--- a/docs/ingestion/sharepoint.md
+++ b/docs/ingestion/sharepoint.md
@@ -1,0 +1,168 @@
+# SharePoint
+
+[SharePoint Online](https://www.microsoft.com/microsoft-365/sharepoint/collaboration) is Microsoft's document management platform.
+
+Bruin supports SharePoint as a source for [Ingestr assets](/assets/ingestr). You can ingest Excel and CSV files from a SharePoint Online document library into a destination supported by ingestr.
+
+## Configuration
+
+### Step 1: Add a connection to `.bruin.yml`
+
+```yaml
+connections:
+  sharepoint:
+    - name: my-sharepoint
+      tenant_id: your-tenant-id
+      client_id: your-client-id
+      client_secret: your-client-secret
+      hostname: example.sharepoint.com
+      site: sites/Example
+      library: Documents # optional
+      max_file_size: 104857600 # optional, bytes
+      max_files: 10000 # optional, use 0 for unlimited
+```
+
+- `tenant_id`: Azure AD tenant ID for the app registration.
+- `client_id`: app registration client ID.
+- `client_secret`: app registration client secret.
+- `hostname`: SharePoint tenant hostname, such as `example.sharepoint.com`.
+- `site`: server-relative site path, such as `sites/Example`.
+- `library`: optional document library name. If omitted, ingestr uses the site's default Documents library.
+- `max_file_size`: optional maximum bytes for a single downloaded file. Use `0` for unlimited.
+- `max_files`: optional maximum number of files a glob may match. Defaults to `10000`; use `0` for unlimited.
+
+Authentication uses the OAuth2 client-credentials flow. The app registration needs application permission to read the site's files, such as `Sites.Read.All` or `Files.Read.All`, granted with admin consent.
+
+### Step 2: Create an ingestr asset
+
+```yaml
+name: raw.sharepoint_budget
+type: ingestr
+connection: duckdb
+
+parameters:
+  source_connection: my-sharepoint
+  source_table: "Reports/budget.xlsx#sheet=North,date_cols=Date"
+  destination: duckdb
+```
+
+- `source_connection`: the name of the SharePoint connection defined in `.bruin.yml`.
+- `source_table`: the file path in the document library, optionally followed by ingestr hints such as `sheet`, `sheets`, `skip`, `drop_empty`, `date_cols`, `xlsx`, or `csv`.
+
+### Example assets
+
+These examples use DuckDB as the destination. Replace `connection` and `destination` with the destination connection you want to load into.
+
+Single Excel sheet:
+
+```yaml
+name: raw.sharepoint_products
+type: ingestr
+connection: duckdb
+
+parameters:
+  source_connection: my-sharepoint
+  source_table: "Reports/products.xlsx#xlsx,sheet=Sheet1"
+  destination: duckdb
+```
+
+Excel sheet with skipped rows and date conversion:
+
+```yaml
+name: raw.sharepoint_forecast
+type: ingestr
+connection: duckdb
+
+parameters:
+  source_connection: my-sharepoint
+  source_table: "Reports/parameters.xlsx#sheet=Forecast,skip=4,date_cols=Date|Month"
+  destination: duckdb
+```
+
+Multiple sheets from one workbook:
+
+```yaml
+name: raw.sharepoint_regional_data
+type: ingestr
+connection: duckdb
+
+parameters:
+  source_connection: my-sharepoint
+  source_table: "Reports/regional data.xlsx#sheets=North|South|East|West"
+  destination: duckdb
+```
+
+Multiple sheets from every workbook matched by a glob:
+
+```yaml
+name: raw.sharepoint_monthly
+type: ingestr
+connection: duckdb
+
+parameters:
+  source_connection: my-sharepoint
+  source_table: "Reports/monthly/*.xlsx#sheets=Jan|Feb|Mar"
+  destination: duckdb
+```
+
+CSV with explicit encoding and tab separator:
+
+```yaml
+name: raw.sharepoint_export
+type: ingestr
+connection: duckdb
+
+parameters:
+  source_connection: my-sharepoint
+  source_table: "Reports/export.csv#csv,encoding=utf-16le,sep=tab"
+  destination: duckdb
+```
+
+### Available `source_table` formats
+
+SharePoint does not expose fixed table names. The `source_table` value is a file path, or a glob of file paths, relative to the configured document library root.
+
+| Format | Example | Description |
+| --- | --- | --- |
+| `<path/to/file.xlsx>` | `Reports/products.xlsx` | Reads the first sheet from an Excel workbook. |
+| `<path/to/file.xlsx>#sheet=<sheet_name>` | `Reports/products.xlsx#sheet=Sheet1` | Reads a single named Excel sheet. |
+| `<path/to/file.xlsx>#sheets=<a>\|<b>` | `Reports/budget.xlsx#sheets=North\|South` | Reads and stacks multiple Excel sheets, unioning columns by name. |
+| `<path/to/files/*.xlsx>#sheets=<a>\|<b>` | `Reports/monthly/*.xlsx#sheets=Jan\|Feb\|Mar` | Reads every matching workbook and stacks the requested sheets. |
+| `<path/to/file.csv>` | `Exports/customers.csv` | Reads a CSV file using default CSV parsing. |
+| `<path/to/file.csv>#csv,encoding=<enc>,sep=<sep>` | `Exports/customers.csv#csv,encoding=utf-16le,sep=tab` | Reads a CSV file with explicit format, encoding, or separator hints. |
+| `<path/to/files/**>` | `Reports/**` | Reads all matching files recursively, detecting `.xlsx` or `.csv` per file. |
+
+Paths can include spaces, `&`, and glob wildcards: `*`, `**`, `?`, `[...]`, and `{a,b}`. If a file path contains a literal `#`, encode it as `%23`.
+
+### Source table hints
+
+Hints are appended after `#` and separated with commas. A bare token is a format or behavior flag; `key=value` sets a named option.
+
+| Hint | Applies to | Description |
+| --- | --- | --- |
+| `xlsx` or `csv` | all | Overrides the file format when it cannot be inferred from the extension. |
+| `sheet=<name>` | Excel | Reads a single named sheet. |
+| `sheets=<a>\|<b>` | Excel | Reads and stacks multiple sheets separated by `\|`. |
+| `skip=<n>` | all | Skips `n` rows before reading the header row. |
+| `drop_empty` | all | Skips rows where every data column is empty. |
+| `date_cols=<a>\|<b>` | Excel | Converts the named Excel serial date columns to ISO date strings. |
+| `raw` | Excel | Reads raw values. This is the default. |
+| `formatted` | Excel | Reads displayed/formatted cell text instead of raw values. |
+| `encoding=<enc>` | CSV | Sets input encoding, such as `utf-16le`. |
+| `sep=<sep>` | CSV | Sets field separator. Use `tab` or `\t` for tab-delimited files. |
+
+Every row includes metadata columns:
+
+| Column | Description |
+| --- | --- |
+| `_source_file` | The document-library path of the file the row came from. |
+| `_sheet_name` | The Excel sheet name. This is null for CSV files. |
+| `_row_idx` | Zero-based row position in the source sheet/file after `skip` and the header row. |
+
+SharePoint extraction is not incremental. The source defaults to `replace`; `append`, `merge`, and `delete+insert` can be selected, but each run still reads the full file or glob.
+
+### Step 3: Run the asset
+
+```bash
+bruin run assets/sharepoint_ingestion.yml
+```

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -957,6 +957,12 @@
           },
           "type": "array"
         },
+        "sharepoint": {
+          "items": {
+            "$ref": "#/$defs/SharePointConnection"
+          },
+          "type": "array"
+        },
         "applovinmax": {
           "items": {
             "$ref": "#/$defs/ApplovinMaxConnection"
@@ -1728,6 +1734,33 @@
         "verify_certs"
       ]
     },
+    "EspnConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "sport": {
+          "type": "string"
+        },
+        "league": {
+          "type": "string"
+        },
+        "season": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer"
+        },
+        "base_url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
     "FabricConnection": {
       "properties": {
         "name": {
@@ -1772,33 +1805,6 @@
         "host",
         "port",
         "database"
-      ]
-    },
-    "EspnConnection": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "sport": {
-          "type": "string"
-        },
-        "league": {
-          "type": "string"
-        },
-        "season": {
-          "type": "string"
-        },
-        "limit": {
-          "type": "integer"
-        },
-        "base_url": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
       ]
     },
     "FacebookAdsConnection": {
@@ -3551,6 +3557,47 @@
       "required": [
         "name",
         "api_key"
+      ]
+    },
+    "SharePointConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tenant_id": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "site": {
+          "type": "string"
+        },
+        "library": {
+          "type": "string"
+        },
+        "max_file_size": {
+          "type": "integer"
+        },
+        "max_files": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "tenant_id",
+        "client_id",
+        "client_secret",
+        "hostname",
+        "site"
       ]
     },
     "ShopifyConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1151,6 +1151,22 @@ func (c GCSConnection) GetName() string {
 	return c.Name
 }
 
+type SharePointConnection struct {
+	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	TenantID     string `yaml:"tenant_id" json:"tenant_id" mapstructure:"tenant_id"`
+	ClientID     string `yaml:"client_id" json:"client_id" mapstructure:"client_id"`
+	ClientSecret string `yaml:"client_secret" json:"client_secret" mapstructure:"client_secret"`
+	Hostname     string `yaml:"hostname" json:"hostname" mapstructure:"hostname"`
+	Site         string `yaml:"site" json:"site" mapstructure:"site"`
+	Library      string `yaml:"library,omitempty" json:"library,omitempty" mapstructure:"library"`
+	MaxFileSize  *int64 `yaml:"max_file_size,omitempty" json:"max_file_size,omitempty" mapstructure:"max_file_size"`
+	MaxFiles     *int64 `yaml:"max_files,omitempty" json:"max_files,omitempty" mapstructure:"max_files"`
+}
+
+func (c SharePointConnection) GetName() string {
+	return c.Name
+}
+
 type KinesisConnection struct {
 	Name            string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	AccessKeyID     string `yaml:"access_key_id,omitempty" json:"access_key_id" mapstructure:"access_key_id"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -91,6 +91,7 @@ type Connections struct {
 	RevenueCat          []RevenueCatConnection          `yaml:"revenuecat,omitempty" json:"revenuecat,omitempty" mapstructure:"revenuecat"`
 	Linear              []LinearConnection              `yaml:"linear,omitempty" json:"linear,omitempty" mapstructure:"linear"`
 	GCS                 []GCSConnection                 `yaml:"gcs,omitempty" json:"gcs,omitempty" mapstructure:"gcs"`
+	SharePoint          []SharePointConnection          `yaml:"sharepoint,omitempty" json:"sharepoint,omitempty" mapstructure:"sharepoint"`
 	ApplovinMax         []ApplovinMaxConnection         `yaml:"applovinmax,omitempty" json:"applovinmax,omitempty" mapstructure:"applovinmax"`
 	Personio            []PersonioConnection            `yaml:"personio,omitempty" json:"personio,omitempty" mapstructure:"personio"`
 	Kinesis             []KinesisConnection             `yaml:"kinesis,omitempty" json:"kinesis,omitempty" mapstructure:"kinesis"`
@@ -955,6 +956,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.GCS = append(env.Connections.GCS, conn)
+	case "sharepoint":
+		var conn SharePointConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.SharePoint = append(env.Connections.SharePoint, conn)
 	case "clickhouse":
 		var conn ClickHouseConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1497,6 +1505,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Linear = removeConnection(env.Connections.Linear, connectionName)
 	case "gcs":
 		env.Connections.GCS = removeConnection(env.Connections.GCS, connectionName)
+	case "sharepoint":
+		env.Connections.SharePoint = removeConnection(env.Connections.SharePoint, connectionName)
 	case "clickhouse":
 		env.Connections.ClickHouse = removeConnection(env.Connections.ClickHouse, connectionName)
 	case "applovinmax":
@@ -1730,6 +1740,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.RevenueCat, source.RevenueCat)
 	mergeConnectionList(&c.Linear, source.Linear)
 	mergeConnectionList(&c.GCS, source.GCS)
+	mergeConnectionList(&c.SharePoint, source.SharePoint)
 	mergeConnectionList(&c.ApplovinMax, source.ApplovinMax)
 	mergeConnectionList(&c.Personio, source.Personio)
 	mergeConnectionList(&c.Kinesis, source.Kinesis)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -28,6 +28,8 @@ func TestLoadFromFile(t *testing.T) {
 	}
 
 	clickhouseSecureValue := 0
+	sharePointMaxFileSize := int64(104857600)
+	sharePointMaxFiles := int64(10000)
 
 	devEnv := Environment{
 		Connections: &Connections{
@@ -812,6 +814,19 @@ func TestLoadFromFile(t *testing.T) {
 					League: "nfl",
 					Season: "2026",
 					Limit:  50,
+				},
+			},
+			SharePoint: []SharePointConnection{
+				{
+					Name:         "sharepoint-1",
+					TenantID:     "test-tenant-id",
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+					Hostname:     "example.sharepoint.com",
+					Site:         "sites/Example",
+					Library:      "Documents",
+					MaxFileSize:  &sharePointMaxFileSize,
+					MaxFiles:     &sharePointMaxFiles,
 				},
 			},
 		},

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -1287,6 +1287,21 @@ func TestConfig_AddConnection(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:     "Add SharePoint connection",
+			envName:  "default",
+			connType: "sharepoint",
+			connName: "sharepoint-conn",
+			creds: map[string]interface{}{
+				"tenant_id":     "tenant-id",
+				"client_id":     "client-id",
+				"client_secret": "client-secret",
+				"hostname":      "example.sharepoint.com",
+				"site":          "sites/Example",
+				"library":       "Documents",
+			},
+			expectedErr: false,
+		},
+		{
 			name:        "Add Invalid connection",
 			envName:     "default",
 			connType:    "invalid",
@@ -1374,6 +1389,15 @@ func TestConfig_AddConnection(t *testing.T) {
 					assert.Equal(t, tt.creds["client_id"], env.Connections.Fabric[0].ClientID)
 					assert.Equal(t, tt.creds["client_secret"], env.Connections.Fabric[0].ClientSecret)
 					assert.Equal(t, tt.creds["tenant_id"], env.Connections.Fabric[0].TenantID)
+				case "sharepoint":
+					assert.Len(t, env.Connections.SharePoint, 1)
+					assert.Equal(t, tt.connName, env.Connections.SharePoint[0].Name)
+					assert.Equal(t, tt.creds["tenant_id"], env.Connections.SharePoint[0].TenantID)
+					assert.Equal(t, tt.creds["client_id"], env.Connections.SharePoint[0].ClientID)
+					assert.Equal(t, tt.creds["client_secret"], env.Connections.SharePoint[0].ClientSecret)
+					assert.Equal(t, tt.creds["hostname"], env.Connections.SharePoint[0].Hostname)
+					assert.Equal(t, tt.creds["site"], env.Connections.SharePoint[0].Site)
+					assert.Equal(t, tt.creds["library"], env.Connections.SharePoint[0].Library)
 				}
 			}
 		})
@@ -1448,6 +1472,25 @@ func TestDeleteConnection(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:     "Delete existing SharePoint connection",
+			envName:  "default",
+			connName: "sharepoint-conn",
+			setupConfig: func() *Config {
+				return &Config{
+					Environments: map[string]Environment{
+						"default": {
+							Connections: &Connections{
+								SharePoint: []SharePointConnection{
+									{Name: "sharepoint-conn", TenantID: "tenant-id", ClientID: "client-id", ClientSecret: "secret", Hostname: "example.sharepoint.com", Site: "sites/Example"},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedErr: false,
+		},
+		{
 			name:     "Delete non-existent connection",
 			envName:  "staging",
 			connName: "non-existent-conn",
@@ -1495,6 +1538,8 @@ func TestDeleteConnection(t *testing.T) {
 					assert.Empty(t, env.Connections.AwsConnection)
 				case "fabric-conn":
 					assert.Empty(t, env.Connections.Fabric)
+				case "sharepoint-conn":
+					assert.Empty(t, env.Connections.SharePoint)
 				}
 
 				assert.False(t, env.Connections.Exists(tt.connName))
@@ -2103,6 +2148,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				RevenueCat:          []RevenueCatConnection{{Name: "revenuecat1"}},
 				Linear:              []LinearConnection{{Name: "linear1"}},
 				GCS:                 []GCSConnection{{Name: "gcs1"}},
+				SharePoint:          []SharePointConnection{{Name: "sharepoint1"}},
 				ApplovinMax:         []ApplovinMaxConnection{{Name: "applovinmax1"}},
 				Personio:            []PersonioConnection{{Name: "personio1"}},
 				Kinesis:             []KinesisConnection{{Name: "kinesis1"}},
@@ -2224,6 +2270,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				RevenueCat:          []RevenueCatConnection{{Name: "revenuecat1"}},
 				Linear:              []LinearConnection{{Name: "linear1"}},
 				GCS:                 []GCSConnection{{Name: "gcs1"}},
+				SharePoint:          []SharePointConnection{{Name: "sharepoint1"}},
 				ApplovinMax:         []ApplovinMaxConnection{{Name: "applovinmax1"}},
 				Personio:            []PersonioConnection{{Name: "personio1"}},
 				Kinesis:             []KinesisConnection{{Name: "kinesis1"}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -511,6 +511,16 @@ environments:
           league: "nfl"
           season: "2026"
           limit: 50
+      sharepoint:
+        - name: "sharepoint-1"
+          tenant_id: "test-tenant-id"
+          client_id: "test-client-id"
+          client_secret: "test-client-secret"
+          hostname: "example.sharepoint.com"
+          site: "sites/Example"
+          library: "Documents"
+          max_file_size: 104857600
+          max_files: 10000
 
   prod:
     connections:

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -512,6 +512,16 @@ environments:
           league: "nfl"
           season: "2026"
           limit: 50
+      sharepoint:
+        - name: "sharepoint-1"
+          tenant_id: "test-tenant-id"
+          client_id: "test-client-id"
+          client_secret: "test-client-secret"
+          hostname: "example.sharepoint.com"
+          site: "sites/Example"
+          library: "Documents"
+          max_file_size: 104857600
+          max_files: 10000
 
   prod:
     connections:

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -108,6 +108,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/salesforce"
 	"github.com/bruin-data/bruin/pkg/sendgrid"
 	"github.com/bruin-data/bruin/pkg/sftp"
+	"github.com/bruin-data/bruin/pkg/sharepoint"
 	"github.com/bruin-data/bruin/pkg/shopify"
 	"github.com/bruin-data/bruin/pkg/slack"
 	"github.com/bruin-data/bruin/pkg/smartsheet"
@@ -179,6 +180,7 @@ type Manager struct {
 	GoogleSheets         map[string]*gsheets.Client
 	Chess                map[string]*chess.Client
 	S3                   map[string]*s3.Client
+	SharePoint           map[string]*sharepoint.Client
 	Slack                map[string]*slack.Client
 	Socrata              map[string]*socrata.Client
 	Asana                map[string]*asana.Client
@@ -797,6 +799,36 @@ func (m *Manager) AddWistiaConnectionFromConfig(connection *config.WistiaConnect
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.Wistia[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
+func (m *Manager) AddSharePointConnectionFromConfig(connection *config.SharePointConnection) error {
+	m.mutex.Lock()
+	if m.SharePoint == nil {
+		m.SharePoint = make(map[string]*sharepoint.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := sharepoint.NewClient(sharepoint.Config{
+		TenantID:     connection.TenantID,
+		ClientID:     connection.ClientID,
+		ClientSecret: connection.ClientSecret,
+		Hostname:     connection.Hostname,
+		Site:         connection.Site,
+		Library:      connection.Library,
+		MaxFileSize:  connection.MaxFileSize,
+		MaxFiles:     connection.MaxFiles,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.SharePoint[connection.Name] = client
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection
 
@@ -3540,6 +3572,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.QuickBooks, connectionManager.AddQuickBooksConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Wise, connectionManager.AddWiseConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Wistia, connectionManager.AddWistiaConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.SharePoint, connectionManager.AddSharePointConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Zoom, connectionManager.AddZoomConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.EMRServerless, connectionManager.AddEMRServerlessConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.DataprocServerless, connectionManager.AddDataprocServerlessConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/notion"
 	"github.com/bruin-data/bruin/pkg/personio"
 	"github.com/bruin-data/bruin/pkg/postgres"
+	"github.com/bruin-data/bruin/pkg/sharepoint"
 	"github.com/bruin-data/bruin/pkg/shopify"
 	"github.com/bruin-data/bruin/pkg/snowflake"
 	"github.com/stretchr/testify/assert"
@@ -383,6 +384,40 @@ func Test_AddEMRServerlessConnectionFromConfig(t *testing.T) {
 	res, ok := m.GetConnection("test").(*emr_serverless.Client)
 	assert.True(t, ok)
 	assert.NotNil(t, res)
+}
+
+func Test_AddSharePointConnectionFromConfig(t *testing.T) {
+	t.Parallel()
+
+	m := Manager{
+		AllConnectionDetails: map[string]any{},
+		availableConnections: make(map[string]any),
+	}
+
+	maxFiles := int64(0)
+	configuration := &config.SharePointConnection{
+		Name:         "test",
+		TenantID:     "tenant-id",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Hostname:     "example.sharepoint.com",
+		Site:         "sites/Example",
+		Library:      "Documents",
+		MaxFiles:     &maxFiles,
+	}
+
+	err := m.AddSharePointConnectionFromConfig(configuration)
+	require.NoError(t, err)
+
+	res, ok := m.GetConnection("test").(*sharepoint.Client)
+	require.True(t, ok)
+	require.NotNil(t, res)
+
+	uri, err := res.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Contains(t, uri, "sharepoint://?")
+	assert.Contains(t, uri, "max_files=0")
+	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
 }
 
 func TestNewManagerFromConfig(t *testing.T) {

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -779,6 +779,15 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 	// SFTP (user-defined paths)
 	"sftp": {},
 
+	// SharePoint (user-defined document library paths)
+	"sharepoint": {
+		{Name: "<path/to/file.xlsx>", PrimaryKey: "_source_file,_sheet_name,_row_idx", IncKey: "", IncStrategy: "replace"},
+		{Name: "<path/to/file.xlsx>#sheet=<sheet_name>", PrimaryKey: "_source_file,_sheet_name,_row_idx", IncKey: "", IncStrategy: "replace"},
+		{Name: "<path/to/file.xlsx>#sheets=<sheet_a>|<sheet_b>", PrimaryKey: "_source_file,_sheet_name,_row_idx", IncKey: "", IncStrategy: "replace"},
+		{Name: "<path/to/files/*.xlsx>#sheets=<sheet_a>|<sheet_b>", PrimaryKey: "_source_file,_sheet_name,_row_idx", IncKey: "", IncStrategy: "replace"},
+		{Name: "<path/to/file.csv>#csv,encoding=utf-16le,sep=tab", PrimaryKey: "_source_file,_row_idx", IncKey: "", IncStrategy: "replace"},
+	},
+
 	// Shopify - E-commerce
 	"shopify": {
 		{Name: "orders", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},

--- a/pkg/ingestr/sources_test.go
+++ b/pkg/ingestr/sources_test.go
@@ -1,0 +1,31 @@
+package ingestr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharePointSourceTables(t *testing.T) {
+	t.Parallel()
+
+	source, err := GetSourceTables("sharepoint")
+	require.NoError(t, err)
+	require.Equal(t, "sharepoint", source.Name)
+	require.NotEmpty(t, source.Tables)
+
+	var hasExcelSheetExample, hasCSVExample bool
+	for _, table := range source.Tables {
+		switch table.Name {
+		case "<path/to/file.xlsx>#sheet=<sheet_name>":
+			hasExcelSheetExample = true
+			require.Equal(t, "replace", table.IncStrategy)
+		case "<path/to/file.csv>#csv,encoding=utf-16le,sep=tab":
+			hasCSVExample = true
+			require.Equal(t, "replace", table.IncStrategy)
+		}
+	}
+
+	require.True(t, hasExcelSheetExample)
+	require.True(t, hasCSVExample)
+}

--- a/pkg/sharepoint/client.go
+++ b/pkg/sharepoint/client.go
@@ -1,0 +1,13 @@
+package sharepoint
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{config: c}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}

--- a/pkg/sharepoint/config.go
+++ b/pkg/sharepoint/config.go
@@ -1,0 +1,60 @@
+package sharepoint
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type Config struct {
+	TenantID     string
+	ClientID     string
+	ClientSecret string
+	Hostname     string
+	Site         string
+	Library      string
+	MaxFileSize  *int64
+	MaxFiles     *int64
+}
+
+func (c Config) GetIngestrURI() (string, error) {
+	params := url.Values{}
+
+	required := map[string]string{
+		"tenant_id":     c.TenantID,
+		"client_id":     c.ClientID,
+		"client_secret": c.ClientSecret,
+		"hostname":      c.Hostname,
+		"site":          c.Site,
+	}
+
+	for key, value := range required {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", fmt.Errorf("sharepoint: %s must be provided", key)
+		}
+		params.Set(key, value)
+	}
+
+	if library := strings.TrimSpace(c.Library); library != "" {
+		params.Set("library", library)
+	}
+
+	if c.MaxFileSize != nil {
+		if *c.MaxFileSize < 0 {
+			return "", errors.New("sharepoint: max_file_size cannot be negative")
+		}
+		params.Set("max_file_size", strconv.FormatInt(*c.MaxFileSize, 10))
+	}
+
+	if c.MaxFiles != nil {
+		if *c.MaxFiles < 0 {
+			return "", errors.New("sharepoint: max_files cannot be negative")
+		}
+		params.Set("max_files", strconv.FormatInt(*c.MaxFiles, 10))
+	}
+
+	return "sharepoint://?" + params.Encode(), nil
+}

--- a/pkg/sharepoint/config.go
+++ b/pkg/sharepoint/config.go
@@ -22,20 +22,25 @@ type Config struct {
 func (c Config) GetIngestrURI() (string, error) {
 	params := url.Values{}
 
-	required := map[string]string{
-		"tenant_id":     c.TenantID,
-		"client_id":     c.ClientID,
-		"client_secret": c.ClientSecret,
-		"hostname":      c.Hostname,
-		"site":          c.Site,
+	type requiredField struct {
+		key   string
+		value string
 	}
 
-	for key, value := range required {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			return "", fmt.Errorf("sharepoint: %s must be provided", key)
+	requiredFields := []requiredField{
+		{"tenant_id", c.TenantID},
+		{"client_id", c.ClientID},
+		{"client_secret", c.ClientSecret},
+		{"hostname", c.Hostname},
+		{"site", c.Site},
+	}
+
+	for _, field := range requiredFields {
+		field.value = strings.TrimSpace(field.value)
+		if field.value == "" {
+			return "", fmt.Errorf("sharepoint: %s must be provided", field.key)
 		}
-		params.Set(key, value)
+		params.Set(field.key, field.value)
 	}
 
 	if library := strings.TrimSpace(c.Library); library != "" {

--- a/pkg/sharepoint/config_test.go
+++ b/pkg/sharepoint/config_test.go
@@ -1,0 +1,84 @@
+package sharepoint
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	maxFileSize := int64(1048576)
+	maxFiles := int64(0)
+	cfg := Config{
+		TenantID:     "tenant-id",
+		ClientID:     "client-id",
+		ClientSecret: "secret with spaces",
+		Hostname:     "example.sharepoint.com",
+		Site:         "sites/Example",
+		Library:      "Shared Documents",
+		MaxFileSize:  &maxFileSize,
+		MaxFiles:     &maxFiles,
+	}
+
+	uri, err := cfg.GetIngestrURI()
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(uri)
+	require.NoError(t, err)
+	require.Equal(t, "sharepoint", parsed.Scheme)
+	require.Empty(t, parsed.Host)
+
+	query := parsed.Query()
+	require.Equal(t, "tenant-id", query.Get("tenant_id"))
+	require.Equal(t, "client-id", query.Get("client_id"))
+	require.Equal(t, "secret with spaces", query.Get("client_secret"))
+	require.Equal(t, "example.sharepoint.com", query.Get("hostname"))
+	require.Equal(t, "sites/Example", query.Get("site"))
+	require.Equal(t, "Shared Documents", query.Get("library"))
+	require.Equal(t, "1048576", query.Get("max_file_size"))
+	require.Equal(t, "0", query.Get("max_files"))
+}
+
+func TestConfig_GetIngestrURI_RequiresCredentials(t *testing.T) {
+	t.Parallel()
+
+	_, err := (Config{}).GetIngestrURI()
+	require.ErrorContains(t, err, "sharepoint:")
+}
+
+func TestConfig_GetIngestrURI_RejectsNegativeLimits(t *testing.T) {
+	t.Parallel()
+
+	negative := int64(-1)
+	cfg := Config{
+		TenantID:     "tenant-id",
+		ClientID:     "client-id",
+		ClientSecret: "secret",
+		Hostname:     "example.sharepoint.com",
+		Site:         "sites/Example",
+		MaxFiles:     &negative,
+	}
+
+	_, err := cfg.GetIngestrURI()
+	require.ErrorContains(t, err, "max_files cannot be negative")
+}
+
+func TestClient_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{
+		TenantID:     "tenant-id",
+		ClientID:     "client-id",
+		ClientSecret: "secret",
+		Hostname:     "example.sharepoint.com",
+		Site:         "sites/Example",
+	})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	require.Contains(t, uri, "sharepoint://?")
+}

--- a/pkg/sharepoint/config_test.go
+++ b/pkg/sharepoint/config_test.go
@@ -46,7 +46,7 @@ func TestConfig_GetIngestrURI_RequiresCredentials(t *testing.T) {
 	t.Parallel()
 
 	_, err := (Config{}).GetIngestrURI()
-	require.ErrorContains(t, err, "sharepoint:")
+	require.ErrorContains(t, err, "sharepoint: tenant_id must be provided")
 }
 
 func TestConfig_GetIngestrURI_RejectsNegativeLimits(t *testing.T) {


### PR DESCRIPTION
Adds SharePoint as a Bruin connection type for ingestr assets, including URI construction, config manager wiring, and source-table examples. Updates the generated connection schema and SharePoint ingestion docs with available file patterns and example assets. Tests: make format; make test.