### PR TITLE
feat(ingestr): add football-data.org as a source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -299,6 +299,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Facebook", link: "/ingestion/facebook-ads"},
                                     {text: "Fireflies", link: "/ingestion/fireflies"},
                                     {text: "Fluxx", link: "/ingestion/fluxx"},
+                                    {text: "football-data.org", link: "/ingestion/footballdata"},
                                     {text: "Frankfurter", link: "/ingestion/frankfurter"},
                                     {text: "FundraiseUp", link: "/ingestion/fundraiseup"},
                                     {text: "Freshdesk", link: "/ingestion/freshdesk"},

--- a/docs/ingestion/footballdata.md
+++ b/docs/ingestion/footballdata.md
@@ -1,0 +1,75 @@
+# football-data.org
+
+[football-data.org](https://www.football-data.org/) provides soccer competition data, including World Cup teams, fixtures, standings, players, and plan-dependent deep match and squad data.
+
+Bruin supports football-data.org as a source for [Ingestr assets](/assets/ingestr), so you can ingest soccer data into your data warehouse.
+
+For the underlying connector reference, see the [ingestr documentation](https://getbruin.com/docs/ingestr/supported-sources/football-data-org.html).
+
+Follow the steps below to set up football-data.org as a data source and run ingestion:
+
+## Configuration
+
+### Step 1: Add a connection to .bruin.yml file
+
+The connection routes to a specific competition and season. The default configuration targets World Cup 2026 with `competition=WC` and `season=2026`.
+
+```yaml
+    connections:
+      footballdata:
+        - name: "footballdata_worldcup"
+          api_key: "<your-api-key>"
+          competition: "WC"
+          season: "2026"
+```
+
+- `name`: Name of the connection.
+- `api_key`: football-data.org API token (sent in the `X-Auth-Token` header). Required.
+- `competition` (optional): Competition code or ID. Defaults to `WC` (FIFA World Cup).
+- `season` (optional): Season year. Defaults to `2026`.
+- `base_url` (optional): Overrides the API base URL. Defaults to `https://api.football-data.org/v4`.
+- `matchday` (optional): Restrict `matches`/`match_events` to a single matchday.
+- `status` (optional): Filter matches by status (e.g. `SCHEDULED`, `FINISHED`).
+- `stage` (optional): Filter matches by stage (e.g. `GROUP_STAGE`, `FINAL`).
+- `group` (optional): Filter matches by group (e.g. `GROUP_A`).
+- `unfold_goals`, `unfold_bookings`, `unfold_subs`, `unfold_lineups` (optional): `true`/`false` flags that request deep match arrays via the `X-Unfold-*` headers. Required for `match_events`; need Deep Data plan access.
+
+### Step 2: Create an asset file for data ingestion
+
+```yaml
+name: public.football_data_matches
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: footballdata_worldcup
+  source_table: 'matches'
+  destination: postgres
+```
+
+- `name`: Name of the asset.
+- `type`: Always `ingestr` for football-data.org.
+- `connection`: Destination connection name.
+- `source_connection`: Name of the football-data.org connection defined in `.bruin.yml`.
+- `source_table`: One of the tables listed below.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| `teams` | `id` | - | merge | Teams for the configured competition/season from `/competitions/<competition>/teams`. |
+| `stadiums` | `venue_key` | - | replace | Venues derived from teams and matches; the originating object is kept under `raw`. |
+| `group_standings` | `competition_id, season_id, stage, standing_type, group_name, team_id` | - | replace | Standings table from `/competitions/<competition>/standings`. |
+| `matches` | `id` | - | merge | Matches from `/competitions/<competition>/matches`. Honors `--interval-start`/`--interval-end` via the `dateFrom`/`dateTo` filter. |
+| `players` | `team_id, id` | - | replace | Squad members hydrated through `/teams/<id>`. Requires plan access. |
+| `match_events` | `event_key` | - | merge | Goal, booking, and substitution events normalized from match unfold arrays. Requires the Deep Data plan. |
+
+Nested football-data.org objects are preserved as JSON columns in the destination; schema inference derives types from the actual payload.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run ingestr.football_data.asset.yml
+```
+
+As a result of this command, Bruin will ingest data from the configured football-data.org endpoint into your destination database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1303,6 +1303,12 @@
           },
           "type": "array"
         },
+        "footballdata": {
+          "items": {
+            "$ref": "#/$defs/FootballDataConnection"
+          },
+          "type": "array"
+        },
         "vertica": {
           "items": {
             "$ref": "#/$defs/VerticaConnection"
@@ -1899,6 +1905,55 @@
         "instance",
         "client_id",
         "client_secret"
+      ]
+    },
+    "FootballDataConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        },
+        "competition": {
+          "type": "string"
+        },
+        "season": {
+          "type": "string"
+        },
+        "base_url": {
+          "type": "string"
+        },
+        "matchday": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "stage": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "unfold_goals": {
+          "type": "boolean"
+        },
+        "unfold_bookings": {
+          "type": "boolean"
+        },
+        "unfold_subs": {
+          "type": "boolean"
+        },
+        "unfold_lineups": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "api_key"
       ]
     },
     "FrankfurterConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1836,6 +1836,26 @@ func (c APIFootballConnection) GetName() string {
 	return c.Name
 }
 
+type FootballDataConnection struct {
+	Name           string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	APIKey         string `yaml:"api_key,omitempty" json:"api_key" mapstructure:"api_key"`
+	Competition    string `yaml:"competition,omitempty" json:"competition,omitempty" mapstructure:"competition"`
+	Season         string `yaml:"season,omitempty" json:"season,omitempty" mapstructure:"season"`
+	BaseURL        string `yaml:"base_url,omitempty" json:"base_url,omitempty" mapstructure:"base_url"`
+	Matchday       string `yaml:"matchday,omitempty" json:"matchday,omitempty" mapstructure:"matchday"`
+	Status         string `yaml:"status,omitempty" json:"status,omitempty" mapstructure:"status"`
+	Stage          string `yaml:"stage,omitempty" json:"stage,omitempty" mapstructure:"stage"`
+	Group          string `yaml:"group,omitempty" json:"group,omitempty" mapstructure:"group"`
+	UnfoldGoals    bool   `yaml:"unfold_goals,omitempty" json:"unfold_goals,omitempty" mapstructure:"unfold_goals"`
+	UnfoldBookings bool   `yaml:"unfold_bookings,omitempty" json:"unfold_bookings,omitempty" mapstructure:"unfold_bookings"`
+	UnfoldSubs     bool   `yaml:"unfold_subs,omitempty" json:"unfold_subs,omitempty" mapstructure:"unfold_subs"`
+	UnfoldLineups  bool   `yaml:"unfold_lineups,omitempty" json:"unfold_lineups,omitempty" mapstructure:"unfold_lineups"`
+}
+
+func (c FootballDataConnection) GetName() string {
+	return c.Name
+}
+
 type VerticaConnection struct {
 	Name     string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	Username string `yaml:"username,omitempty" json:"username" mapstructure:"username"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -144,6 +144,7 @@ type Connections struct {
 	Sendgrid            []SendgridConnection            `yaml:"sendgrid,omitempty" json:"sendgrid,omitempty" mapstructure:"sendgrid"`
 	Espn                []EspnConnection                `yaml:"espn,omitempty" json:"espn,omitempty" mapstructure:"espn"`
 	APIFootball         []APIFootballConnection         `yaml:"apifootball,omitempty" json:"apifootball,omitempty" mapstructure:"apifootball"`
+	FootballData        []FootballDataConnection        `yaml:"footballdata,omitempty" json:"footballdata,omitempty" mapstructure:"footballdata"`
 	Vertica             []VerticaConnection             `yaml:"vertica,omitempty" json:"vertica,omitempty" mapstructure:"vertica"`
 	SurveyMonkey        []SurveyMonkeyConnection        `yaml:"surveymonkey,omitempty" json:"surveymonkey,omitempty" mapstructure:"surveymonkey"`
 	Dune                []DuneConnection                `yaml:"dune,omitempty" json:"dune,omitempty" mapstructure:"dune"`
@@ -1337,6 +1338,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.APIFootball = append(env.Connections.APIFootball, conn)
+	case "footballdata":
+		var conn FootballDataConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.FootballData = append(env.Connections.FootballData, conn)
 	case "vertica":
 		var conn VerticaConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1621,6 +1629,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Espn = removeConnection(env.Connections.Espn, connectionName)
 	case "apifootball":
 		env.Connections.APIFootball = removeConnection(env.Connections.APIFootball, connectionName)
+	case "footballdata":
+		env.Connections.FootballData = removeConnection(env.Connections.FootballData, connectionName)
 	case "vertica":
 		env.Connections.Vertica = removeConnection(env.Connections.Vertica, connectionName)
 	case "surveymonkey":
@@ -1803,6 +1813,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Sendgrid, source.Sendgrid)
 	mergeConnectionList(&c.Espn, source.Espn)
 	mergeConnectionList(&c.APIFootball, source.APIFootball)
+	mergeConnectionList(&c.FootballData, source.FootballData)
 	mergeConnectionList(&c.Vertica, source.Vertica)
 	mergeConnectionList(&c.SurveyMonkey, source.SurveyMonkey)
 	mergeConnectionList(&c.Dune, source.Dune)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -837,6 +837,14 @@ func TestLoadFromFile(t *testing.T) {
 					Season: "2026",
 				},
 			},
+			FootballData: []FootballDataConnection{
+				{
+					Name:        "footballdata-1",
+					APIKey:      "test-api-key",
+					Competition: "WC",
+					Season:      "2026",
+				},
+			},
 		},
 	}
 
@@ -2222,6 +2230,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Sendgrid:            []SendgridConnection{{Name: "sendgrid1"}},
 				Espn:                []EspnConnection{{Name: "espn1"}},
 				APIFootball:         []APIFootballConnection{{Name: "apifootball1"}},
+				FootballData:        []FootballDataConnection{{Name: "footballdata1"}},
 				Vertica:             []VerticaConnection{{Name: "vertica1"}},
 				Dune:                []DuneConnection{{Name: "dune1"}},
 			},
@@ -2345,6 +2354,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Sendgrid:            []SendgridConnection{{Name: "sendgrid1"}},
 				Espn:                []EspnConnection{{Name: "espn1"}},
 				APIFootball:         []APIFootballConnection{{Name: "apifootball1"}},
+				FootballData:        []FootballDataConnection{{Name: "footballdata1"}},
 				Vertica:             []VerticaConnection{{Name: "vertica1"}},
 				Dune:                []DuneConnection{{Name: "dune1"}},
 			},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -526,6 +526,11 @@ environments:
           api_key: "test-api-key"
           league: "1"
           season: "2026"
+      footballdata:
+        - name: "footballdata-1"
+          api_key: "test-api-key"
+          competition: "WC"
+          season: "2026"
 
   prod:
     connections:

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -527,6 +527,11 @@ environments:
           api_key: "test-api-key"
           league: "1"
           season: "2026"
+      footballdata:
+        - name: "footballdata-1"
+          api_key: "test-api-key"
+          competition: "WC"
+          season: "2026"
 
   prod:
     connections:

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -51,6 +51,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/facebookads"
 	"github.com/bruin-data/bruin/pkg/fireflies"
 	"github.com/bruin-data/bruin/pkg/fluxx"
+	"github.com/bruin-data/bruin/pkg/footballdata"
 	"github.com/bruin-data/bruin/pkg/frankfurter"
 	"github.com/bruin-data/bruin/pkg/freshdesk"
 	"github.com/bruin-data/bruin/pkg/fundraiseup"
@@ -257,6 +258,7 @@ type Manager struct {
 	Sendgrid             map[string]*sendgrid.Client
 	Espn                 map[string]*espn.Client
 	APIFootball          map[string]*apifootball.Client
+	FootballData         map[string]*footballdata.Client
 	Generic              map[string]*config.GenericConnection
 	mutex                sync.Mutex
 	availableConnections map[string]any
@@ -3184,6 +3186,36 @@ func (m *Manager) AddAPIFootballConnectionFromConfig(connection *config.APIFootb
 	return nil
 }
 
+func (m *Manager) AddFootballDataConnectionFromConfig(connection *config.FootballDataConnection) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.FootballData == nil {
+		m.FootballData = make(map[string]*footballdata.Client)
+	}
+
+	client, err := footballdata.NewClient(footballdata.Config{
+		APIKey:         connection.APIKey,
+		Competition:    connection.Competition,
+		Season:         connection.Season,
+		BaseURL:        connection.BaseURL,
+		Matchday:       connection.Matchday,
+		Status:         connection.Status,
+		Stage:          connection.Stage,
+		Group:          connection.Group,
+		UnfoldGoals:    connection.UnfoldGoals,
+		UnfoldBookings: connection.UnfoldBookings,
+		UnfoldSubs:     connection.UnfoldSubs,
+		UnfoldLineups:  connection.UnfoldLineups,
+	})
+	if err != nil {
+		return err
+	}
+	m.FootballData[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddDuneConnectionFromConfig(connection *config.DuneConnection) error {
 	m.mutex.Lock()
 	if m.Dune == nil {
@@ -3638,6 +3670,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Sendgrid, connectionManager.AddSendgridConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Espn, connectionManager.AddEspnConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.APIFootball, connectionManager.AddAPIFootballConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.FootballData, connectionManager.AddFootballDataConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Dune, connectionManager.AddDuneConnectionFromConfig, &wg, &errList, &mu)
 	wg.Wait()
 	return connectionManager, errList

--- a/pkg/footballdata/config.go
+++ b/pkg/footballdata/config.go
@@ -1,0 +1,57 @@
+package footballdata
+
+import "net/url"
+
+type Config struct {
+	APIKey         string
+	Competition    string
+	Season         string
+	BaseURL        string
+	Matchday       string
+	Status         string
+	Stage          string
+	Group          string
+	UnfoldGoals    bool
+	UnfoldBookings bool
+	UnfoldSubs     bool
+	UnfoldLineups  bool
+}
+
+func (c *Config) GetIngestrURI() string {
+	params := url.Values{}
+	params.Set("api_key", c.APIKey)
+	if c.Competition != "" {
+		params.Set("competition", c.Competition)
+	}
+	if c.Season != "" {
+		params.Set("season", c.Season)
+	}
+	if c.BaseURL != "" {
+		params.Set("base_url", c.BaseURL)
+	}
+	if c.Matchday != "" {
+		params.Set("matchday", c.Matchday)
+	}
+	if c.Status != "" {
+		params.Set("status", c.Status)
+	}
+	if c.Stage != "" {
+		params.Set("stage", c.Stage)
+	}
+	if c.Group != "" {
+		params.Set("group", c.Group)
+	}
+	if c.UnfoldGoals {
+		params.Set("unfold_goals", "true")
+	}
+	if c.UnfoldBookings {
+		params.Set("unfold_bookings", "true")
+	}
+	if c.UnfoldSubs {
+		params.Set("unfold_subs", "true")
+	}
+	if c.UnfoldLineups {
+		params.Set("unfold_lineups", "true")
+	}
+	return "footballdata://?" + params.Encode()
+}

--- a/pkg/footballdata/db.go
+++ b/pkg/footballdata/db.go
@@ -1,0 +1,15 @@
+package footballdata
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -96,6 +96,16 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "match_events", PrimaryKey: "event_key", IncKey: "", IncStrategy: "merge"},
 	},
 
+	// football-data.org - FIFA World Cup soccer data
+	"footballdata": {
+		{Name: "teams", PrimaryKey: "id", IncKey: "", IncStrategy: "merge"},
+		{Name: "stadiums", PrimaryKey: "venue_key", IncKey: "", IncStrategy: "replace"},
+		{Name: "group_standings", PrimaryKey: "competition_id, season_id, stage, standing_type, group_name, team_id", IncKey: "", IncStrategy: "replace"},
+		{Name: "matches", PrimaryKey: "id", IncKey: "", IncStrategy: "merge"},
+		{Name: "players", PrimaryKey: "team_id, id", IncKey: "", IncStrategy: "replace"},
+		{Name: "match_events", PrimaryKey: "event_key", IncKey: "", IncStrategy: "merge"},
+	},
+
 	// Apple Ads - Apple Search Ads campaign management
 	"appleads": {
 		{Name: "campaigns", PrimaryKey: "orgId,id", IncKey: "modificationTime", IncStrategy: "merge"},


### PR DESCRIPTION
## What

Adds **football-data.org** as an Ingestr source connection, so users can ingest FIFA World Cup soccer data (teams, stadiums, standings, matches, players, match events) into their warehouse via a `footballdata` connection.
