### PR TITLE
Support structured asset parameters

### DIFF
--- a/cmd/const.go
+++ b/cmd/const.go
@@ -60,14 +60,77 @@ func renderAssetParamsMutator(renderer jinja.RendererInterface) pipeline.AssetMu
 			return nil, fmt.Errorf("error creating renderer for asset %s: %w", a.Name, err)
 		}
 		for key, value := range a.Parameters {
-			renderedValue, err := renderer.Render(value)
+			renderedValue, err := renderParameterValue(renderer, value)
 			if err != nil {
 				return nil, fmt.Errorf("error rendering parameter %q: %w", key, err)
 			}
-			a.Parameters[key] = strings.TrimSpace(renderedValue)
+			a.Parameters[key] = renderedValue
 		}
 
 		return a, nil
+	}
+}
+
+func renderParameterValue(renderer jinja.RendererInterface, value interface{}) (interface{}, error) {
+	switch typed := value.(type) {
+	case string:
+		renderedValue, err := renderer.Render(typed)
+		if err != nil {
+			return nil, err
+		}
+		return strings.TrimSpace(renderedValue), nil
+	case []interface{}:
+		renderedValues := make([]interface{}, len(typed))
+		for i, item := range typed {
+			renderedItem, err := renderParameterValue(renderer, item)
+			if err != nil {
+				return nil, err
+			}
+			renderedValues[i] = renderedItem
+		}
+		return renderedValues, nil
+	case []string:
+		renderedValues := make([]string, len(typed))
+		for i, item := range typed {
+			renderedItem, err := renderParameterValue(renderer, item)
+			if err != nil {
+				return nil, err
+			}
+			renderedValues[i] = renderedItem.(string)
+		}
+		return renderedValues, nil
+	case map[string]interface{}:
+		renderedValues := make(map[string]interface{}, len(typed))
+		for key, item := range typed {
+			renderedItem, err := renderParameterValue(renderer, item)
+			if err != nil {
+				return nil, err
+			}
+			renderedValues[key] = renderedItem
+		}
+		return renderedValues, nil
+	case map[string]string:
+		renderedValues := make(map[string]string, len(typed))
+		for key, item := range typed {
+			renderedItem, err := renderParameterValue(renderer, item)
+			if err != nil {
+				return nil, err
+			}
+			renderedValues[key] = renderedItem.(string)
+		}
+		return renderedValues, nil
+	case pipeline.ParameterMap:
+		renderedValues := make(pipeline.ParameterMap, len(typed))
+		for key, item := range typed {
+			renderedItem, err := renderParameterValue(renderer, item)
+			if err != nil {
+				return nil, err
+			}
+			renderedValues[key] = renderedItem
+		}
+		return renderedValues, nil
+	default:
+		return value, nil
 	}
 }
 

--- a/cmd/const_test.go
+++ b/cmd/const_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -72,6 +74,65 @@ func TestRenderAssetHooks_Error(t *testing.T) {
 	err := renderAssetHooks(t.Context(), &pipeline.Pipeline{Name: "pipe"}, asset, jinja.NewRenderer(jinja.Context{}))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "error rendering hooks for asset schema.asset")
+}
+
+func TestRenderAssetParamsMutatorPreservesStructuredParameters(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "schema.asset",
+		Parameters: pipeline.ParameterMap{
+			"string":  "{{ this }} ",
+			"number":  3,
+			"enabled": true,
+			"nested": map[string]interface{}{
+				"value": "{{ start_date }}",
+				"count": 2,
+			},
+			"list": []interface{}{
+				"{{ end_date }}",
+				4,
+				map[string]interface{}{"inner": "{{ run_id }}"},
+			},
+			"string_list": []string{
+				"{{ start_datetime }}",
+				"{{ this }}",
+			},
+			"string_map": map[string]string{
+				"value": "{{ end_datetime }}",
+				"asset": "{{ this }}",
+			},
+		},
+	}
+
+	mutator := renderAssetParamsMutator(jinja.NewRenderer(jinja.Context{}))
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	executionDate := time.Date(2024, 1, 1, 6, 0, 0, 0, time.UTC)
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, executionDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
+	_, err := mutator(ctx, asset, &pipeline.Pipeline{Name: "pipe"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "schema.asset", asset.Parameters["string"])
+	assert.Equal(t, 3, asset.Parameters["number"])
+	assert.Equal(t, true, asset.Parameters["enabled"])
+	assert.Equal(t, map[string]interface{}{
+		"value": "2024-01-01",
+		"count": 2,
+	}, asset.Parameters["nested"])
+	assert.Equal(t, []interface{}{
+		"2024-01-02",
+		4,
+		map[string]interface{}{"inner": "test-run-id"},
+	}, asset.Parameters["list"])
+	assert.Equal(t, []string{"2024-01-01T00:00:00", "schema.asset"}, asset.Parameters["string_list"])
+	assert.Equal(t, map[string]string{
+		"value": "2024-01-02T00:00:00",
+		"asset": "schema.asset",
+	}, asset.Parameters["string_map"])
 }
 
 func TestVariableOverridesMutator_VariantWinsOnOverlap(t *testing.T) {

--- a/cmd/enhance.go
+++ b/cmd/enhance.go
@@ -730,7 +730,7 @@ func getAssetConnectionName(asset *pipeline.Asset) string {
 	}
 
 	// Check if there's a connection in parameters
-	if conn, ok := asset.Parameters["connection"]; ok && conn != "" {
+	if conn, ok := asset.Parameters.GetString("connection"); ok && conn != "" {
 		return conn
 	}
 

--- a/cmd/enhance_test.go
+++ b/cmd/enhance_test.go
@@ -24,7 +24,7 @@ func TestGetAssetConnectionName(t *testing.T) {
 		{
 			name: "returns connection from parameters when connection field is empty",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"connection": "param_database",
 				},
 			},
@@ -34,7 +34,7 @@ func TestGetAssetConnectionName(t *testing.T) {
 			name: "prefers connection field over parameters",
 			asset: &pipeline.Asset{
 				Connection: "my_database",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"connection": "param_database",
 				},
 			},
@@ -58,7 +58,7 @@ func TestGetAssetConnectionName(t *testing.T) {
 		{
 			name: "returns empty string when connection parameter is empty",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"connection": "",
 				},
 			},
@@ -67,7 +67,7 @@ func TestGetAssetConnectionName(t *testing.T) {
 		{
 			name: "returns empty string when parameters has other keys but not connection",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"other_param": "value",
 				},
 			},

--- a/cmd/import_quicksight.go
+++ b/cmd/import_quicksight.go
@@ -440,7 +440,7 @@ func createQuickSightDatasetAsset(
 	fileName := assetName + ".asset.yml"
 	filePath := filepath.Join(assetsPath, fileName)
 
-	parameters := map[string]string{
+	parameters := pipeline.ParameterMap{
 		"dataset_id":   detail.ID,
 		"dataset_name": detail.Name,
 		"import_mode":  detail.ImportMode,
@@ -509,7 +509,7 @@ func createQuickSightDashboardAsset(
 	fileName := assetName + ".asset.yml"
 	filePath := filepath.Join(assetsPath, fileName)
 
-	parameters := map[string]string{
+	parameters := pipeline.ParameterMap{
 		"dashboard_id":   detail.ID,
 		"dashboard_name": detail.Name,
 	}

--- a/cmd/import_tableau.go
+++ b/cmd/import_tableau.go
@@ -699,7 +699,7 @@ func createDataSourceAsset(dataSource *tableau.DataSourceInfo, assetsPath string
 	filePath := filepath.Join(assetsPath, fileName)
 
 	// Build parameters map
-	parameters := map[string]string{
+	parameters := pipeline.ParameterMap{
 		"datasource_id":   dataSource.ID,
 		"datasource_name": dataSource.Name,
 		"refresh":         "false", // Default to not auto-refreshing
@@ -737,7 +737,7 @@ func createWorkbookAsset(dashboardInfo *TableauDashboard, assetsPath string, cli
 	filePath := filepath.Join(assetsPath, fileName)
 
 	// Build parameters map
-	parameters := map[string]string{
+	parameters := pipeline.ParameterMap{
 		"workbook_id":   dashboardInfo.WorkbookID,
 		"workbook_name": dashboardInfo.WorkbookName,
 		"refresh":       "false", // Default to not auto-refreshing
@@ -842,7 +842,7 @@ func createEnhancedAssetFromTableauDashboard(dashboard TableauDashboard, assetsP
 	filePath := filepath.Join(assetsPath, fileName)
 
 	// Build parameters map
-	parameters := map[string]string{
+	parameters := pipeline.ParameterMap{
 		"dashboard_id":   dashboard.ViewID,
 		"dashboard_name": dashboard.ViewName,
 		"refresh":        "false",

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -397,7 +397,7 @@ func (r *RenderCommand) Run(pl *pipeline.Pipeline, task *pipeline.Asset, modifie
 	// For query sensor assets, extract query from Parameters instead of ExecutableFile.Content
 	var queryString string
 	if isQuerySensorAsset(task.Type) {
-		queryParam, ok := task.Parameters["query"]
+		queryParam, ok := task.Parameters.GetString("query")
 		if !ok {
 			r.printErrorOrJSON("query sensor asset requires a parameter named 'query'")
 			return cli.Exit("", 1)

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -355,7 +355,7 @@ func TestRenderCommand_Run_QuerySensors(t *testing.T) { //nolint:paralleltest
 			task: &pipeline.Asset{
 				Name: "bq-sensor",
 				Type: pipeline.AssetTypeBigqueryQuerySensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"query": "SELECT COUNT(*) FROM `project.dataset.table` WHERE created_at > '{{ start_date }}'",
 				},
 				ExecutableFile: pipeline.ExecutableFile{
@@ -378,7 +378,7 @@ func TestRenderCommand_Run_QuerySensors(t *testing.T) { //nolint:paralleltest
 			task: &pipeline.Asset{
 				Name: "bq-sensor",
 				Type: pipeline.AssetTypeBigqueryQuerySensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"query": "SELECT COUNT(*) FROM `project.dataset.table` WHERE created_at > '{{ start_date }}'",
 				},
 				Hooks: pipeline.Hooks{
@@ -412,7 +412,7 @@ func TestRenderCommand_Run_QuerySensors(t *testing.T) { //nolint:paralleltest
 			task: &pipeline.Asset{
 				Name: "sf-sensor",
 				Type: pipeline.AssetTypeSnowflakeQuerySensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"query": "SELECT * FROM sensor_table WHERE timestamp > '{{ start_date }}'",
 				},
 				ExecutableFile: pipeline.ExecutableFile{
@@ -435,7 +435,7 @@ func TestRenderCommand_Run_QuerySensors(t *testing.T) { //nolint:paralleltest
 			task: &pipeline.Asset{
 				Name: "bq-sensor",
 				Type: pipeline.AssetTypeBigqueryQuerySensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"project_id": "my-project",
 				},
 				ExecutableFile: pipeline.ExecutableFile{

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -229,6 +229,43 @@ func TestIndividualTasks(t *testing.T) {
 			},
 		},
 		{
+			name: "validate-nested-params-rendering",
+			task: e2e.Task{
+				Name:    "validate-nested-params-rendering",
+				Command: binary,
+				Args:    []string{"validate", filepath.Join(currentFolder, "test-pipelines/nested-params-rendering")},
+				Env:     []string{},
+				Expected: e2e.Output{
+					ExitCode: 0,
+					Contains: []string{"Successfully validated 1 assets across 1 pipeline"},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
+			name: "validate-nested-params-do-not-expose-parameters-to-jinja",
+			task: e2e.Task{
+				Name:    "validate-nested-params-do-not-expose-parameters-to-jinja",
+				Command: binary,
+				Args:    []string{"validate", filepath.Join(currentFolder, "test-pipelines/nested-params-no-jinja-access")},
+				Env:     []string{},
+				Expected: e2e.Output{
+					ExitCode: 1,
+					Contains: []string{
+						`error rendering parameter "nested"`,
+						`missing variable 'parameters'`,
+					},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
 			name: "policy-variables",
 			task: e2e.Task{
 				Name:    "policy-variables",

--- a/integration-tests/test-pipelines/nested-params-no-jinja-access/assets/invalid.sql
+++ b/integration-tests/test-pipelines/nested-params-no-jinja-access/assets/invalid.sql
@@ -1,0 +1,10 @@
+/* @bruin
+name: nested_params_no_jinja_access.invalid
+type: duckdb.sql
+parameters:
+  scalar: hidden
+  nested:
+    should_fail: "{{ parameters.scalar }}"
+@bruin */
+
+SELECT 1 AS id;

--- a/integration-tests/test-pipelines/nested-params-no-jinja-access/pipeline.yml
+++ b/integration-tests/test-pipelines/nested-params-no-jinja-access/pipeline.yml
@@ -1,0 +1,6 @@
+name: nested_params_no_jinja_access
+schedule: daily
+start_date: "2024-01-01"
+
+default_connections:
+  duckdb: duckdb-default

--- a/integration-tests/test-pipelines/nested-params-rendering/assets/valid.sql
+++ b/integration-tests/test-pipelines/nested-params-rendering/assets/valid.sql
@@ -1,0 +1,18 @@
+/* @bruin
+name: nested_params_rendering.valid
+type: duckdb.sql
+parameters:
+  plain: "{{ this }}"
+  nested:
+    asset_name: "{{ this }}"
+    window:
+      start: "{{ start_date }}"
+      end: "{{ end_date }}"
+    list:
+      - "{{ this }}"
+      - 3
+      - full_refresh: "{{ full_refresh }}"
+        pipeline: "{{ pipeline }}"
+@bruin */
+
+SELECT 1 AS id;

--- a/integration-tests/test-pipelines/nested-params-rendering/pipeline.yml
+++ b/integration-tests/test-pipelines/nested-params-rendering/pipeline.yml
@@ -1,0 +1,6 @@
+name: nested_params_rendering
+schedule: daily
+start_date: "2024-01-01"
+
+default_connections:
+  duckdb: duckdb-default

--- a/pkg/ansisql/operator.go
+++ b/pkg/ansisql/operator.go
@@ -42,7 +42,7 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 	if o.sensorMode == "skip" {
 		return nil
 	}
-	qq, ok := t.Parameters["query"]
+	qq, ok := t.Parameters.GetString("query")
 	if !ok {
 		return errors.New("query sensor requires a parameter named 'query'")
 	}
@@ -147,7 +147,7 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return nil
 	}
 
-	tableName, ok := t.Parameters["table"]
+	tableName, ok := t.Parameters.GetString("table")
 	if !ok {
 		return errors.New("table sensor requires a parameter named 'table'")
 	}

--- a/pkg/ansisql/operator_test.go
+++ b/pkg/ansisql/operator_test.go
@@ -121,7 +121,7 @@ func TestNewTableSensorNoConnectionForAsset(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table": "test_table",
 		},
 	})
@@ -146,7 +146,7 @@ func TestNewTableSensorConnectionNotFound(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table": "test_table",
 		},
 	})
@@ -170,7 +170,7 @@ func TestNewTableSensorNoTableExistsChecker(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table": "test.table",
 		},
 	})
@@ -196,7 +196,7 @@ func TestNewTableSensorBuildTableExistsQueryError(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table": "test.table",
 		},
 	})
@@ -223,7 +223,7 @@ func TestNewTableSensorExtractQueriesFromStringError(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table": "database.test.table",
 		},
 	})
@@ -253,7 +253,7 @@ func TestTableSensorTimesOutWhenConfigured(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table":         "database.test.table",
 			"timeout":       "100ms",
 			"poke_interval": "0",
@@ -284,7 +284,7 @@ func TestNewTableSensorgNoQueries(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "some content",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"table": "database.test.table",
 		},
 	})

--- a/pkg/athena/operator.go
+++ b/pkg/athena/operator.go
@@ -180,7 +180,7 @@ func (o *QuerySensor) Run(ctx context.Context, ti scheduler.TaskInstance) error 
 }
 
 func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Asset) error {
-	qq, ok := t.Parameters["query"]
+	qq, ok := t.Parameters.GetString("query")
 	if !ok {
 		return errors.New("query sensor requires a parameter named 'query'")
 	}

--- a/pkg/bigquery/adc_helper.go
+++ b/pkg/bigquery/adc_helper.go
@@ -163,7 +163,7 @@ func CheckADCCredentialsForPipeline(ctx context.Context, p *pipeline.Pipeline, a
 		// Check ingestr assets for BigQuery source or destination
 		if asset.Type == pipeline.AssetTypeIngestr {
 			// Check if source connection is BigQuery
-			if sourceConn, ok := asset.Parameters["source_connection"]; ok {
+			if sourceConn, ok := asset.Parameters.GetString("source_connection"); ok {
 				if conn := connGetter.GetConnection(sourceConn); conn != nil {
 					if _, isBQ := conn.(DB); isBQ {
 						bigQueryConnections[sourceConn] = true
@@ -172,9 +172,9 @@ func CheckADCCredentialsForPipeline(ctx context.Context, p *pipeline.Pipeline, a
 			}
 
 			// Check if destination is BigQuery
-			if dest, ok := asset.Parameters["destination"]; ok && dest == "bigquery" {
+			if dest, ok := asset.Parameters.GetString("destination"); ok && dest == "bigquery" {
 				// Get destination connection name
-				if destConn, ok := asset.Parameters["destination_connection"]; ok {
+				if destConn, ok := asset.Parameters.GetString("destination_connection"); ok {
 					bigQueryConnections[destConn] = true
 				} else {
 					// Infer from pipeline defaults

--- a/pkg/bigquery/dryrun.go
+++ b/pkg/bigquery/dryrun.go
@@ -39,7 +39,7 @@ func (r *DryRunner) DryRun(ctx context.Context, p pipeline.Pipeline, a pipeline.
 	case pipeline.AssetTypeBigqueryQuery:
 		queryString = a.ExecutableFile.Content
 	case pipeline.AssetTypeBigqueryQuerySensor:
-		queryParam, ok := a.Parameters["query"]
+		queryParam, ok := a.Parameters.GetString("query")
 		if !ok {
 			return nil, errors.New("query sensor requires a parameter named 'query'")
 		}

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -282,7 +282,7 @@ func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipe
 	if o.sensorMode == "skip" {
 		return nil
 	}
-	qq, ok := t.Parameters["query"]
+	qq, ok := t.Parameters.GetString("query")
 	if !ok {
 		return errors.New("query sensor requires a parameter named 'query'")
 	}
@@ -382,7 +382,7 @@ func (ts *TableSensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	if ts.sensorMode == "skip" {
 		return nil
 	}
-	tableName, ok := t.Parameters["table"]
+	tableName, ok := t.Parameters.GetString("table")
 	if !ok {
 		return errors.New("table sensor requires a parameter named 'table'")
 	}

--- a/pkg/claudecode/operator.go
+++ b/pkg/claudecode/operator.go
@@ -260,34 +260,34 @@ func (o *ClaudeCodeOperator) extractParameters(asset *pipeline.Asset) (*ClaudePa
 	}
 
 	// Required: prompt
-	prompt, exists := asset.Parameters[ParamPrompt]
+	prompt, exists := asset.Parameters.GetString(ParamPrompt)
 	if !exists || strings.TrimSpace(prompt) == "" {
 		return nil, errors.New("'prompt' parameter is required and cannot be empty")
 	}
 	params.Prompt = prompt
 
 	// Optional: model
-	if model, exists := asset.Parameters[ParamModel]; exists && model != "" {
+	if model, exists := asset.Parameters.GetString(ParamModel); exists && model != "" {
 		params.Model = model
 	}
 
 	// Optional: fallback_model
-	if fallbackModel, exists := asset.Parameters[ParamFallbackModel]; exists && fallbackModel != "" {
+	if fallbackModel, exists := asset.Parameters.GetString(ParamFallbackModel); exists && fallbackModel != "" {
 		params.FallbackModel = fallbackModel
 	}
 
 	// Optional: output_format
-	if format, exists := asset.Parameters[ParamOutputFormat]; exists && format != "" {
+	if format, exists := asset.Parameters.GetString(ParamOutputFormat); exists && format != "" {
 		params.OutputFormat = format
 	}
 
 	// Optional: system_prompt
-	if systemPrompt, exists := asset.Parameters[ParamSystemPrompt]; exists && systemPrompt != "" {
+	if systemPrompt, exists := asset.Parameters.GetString(ParamSystemPrompt); exists && systemPrompt != "" {
 		params.SystemPrompt = systemPrompt
 	}
 
 	// Optional: allowed_directories (comma-separated)
-	if dirs, exists := asset.Parameters[ParamAllowedDirs]; exists && dirs != "" {
+	if dirs, exists := asset.Parameters.GetString(ParamAllowedDirs); exists && dirs != "" {
 		params.AllowedDirs = strings.Split(dirs, ",")
 		for i := range params.AllowedDirs {
 			params.AllowedDirs[i] = strings.TrimSpace(params.AllowedDirs[i])
@@ -295,47 +295,47 @@ func (o *ClaudeCodeOperator) extractParameters(asset *pipeline.Asset) (*ClaudePa
 	}
 
 	// Optional: allowed_tools
-	if tools, exists := asset.Parameters[ParamAllowedTools]; exists && tools != "" {
+	if tools, exists := asset.Parameters.GetString(ParamAllowedTools); exists && tools != "" {
 		params.AllowedTools = tools
 	}
 
 	// Optional: disallowed_tools
-	if tools, exists := asset.Parameters[ParamDisallowedTools]; exists && tools != "" {
+	if tools, exists := asset.Parameters.GetString(ParamDisallowedTools); exists && tools != "" {
 		params.DisallowedTools = tools
 	}
 
 	// Optional: skip_permissions
-	if skip, exists := asset.Parameters[ParamSkipPermissions]; exists {
+	if skip, exists := asset.Parameters.GetString(ParamSkipPermissions); exists {
 		params.SkipPermissions = skip == "true" || skip == "yes" || skip == "1"
 	}
 
 	// Optional: permission_mode
-	if mode, exists := asset.Parameters[ParamPermissionMode]; exists && mode != "" {
+	if mode, exists := asset.Parameters.GetString(ParamPermissionMode); exists && mode != "" {
 		params.PermissionMode = mode
 	}
 
 	// Optional: session_id
-	if sessionID, exists := asset.Parameters[ParamSessionID]; exists && sessionID != "" {
+	if sessionID, exists := asset.Parameters.GetString(ParamSessionID); exists && sessionID != "" {
 		params.SessionID = sessionID
 	}
 
 	// Optional: continue_session
-	if continueSession, exists := asset.Parameters[ParamContinueSession]; exists {
+	if continueSession, exists := asset.Parameters.GetString(ParamContinueSession); exists {
 		params.ContinueSession = continueSession == "true" || continueSession == "yes" || continueSession == "1"
 	}
 
 	// Optional: debug
-	if debug, exists := asset.Parameters[ParamDebug]; exists {
+	if debug, exists := asset.Parameters.GetString(ParamDebug); exists {
 		params.Debug = debug == "true" || debug == "yes" || debug == "1"
 	}
 
 	// Optional: verbose
-	if verbose, exists := asset.Parameters[ParamVerbose]; exists {
+	if verbose, exists := asset.Parameters.GetString(ParamVerbose); exists {
 		params.Verbose = verbose == "true" || verbose == "yes" || verbose == "1"
 	}
 
 	// Optional: working_dir
-	if workingDir, exists := asset.Parameters[ParamWorkingDir]; exists && workingDir != "" {
+	if workingDir, exists := asset.Parameters.GetString(ParamWorkingDir); exists && workingDir != "" {
 		// If working_dir is relative, make it absolute relative to the asset definition file
 		if !filepath.IsAbs(workingDir) {
 			assetDir := filepath.Dir(asset.DefinitionFile.Path)

--- a/pkg/claudecode/operator_test.go
+++ b/pkg/claudecode/operator_test.go
@@ -36,7 +36,7 @@ func TestExtractParameters(t *testing.T) {
 			name: "minimal valid parameters",
 			asset: &pipeline.Asset{
 				Name: "test_asset",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"prompt": "Test prompt",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -57,7 +57,7 @@ func TestExtractParameters(t *testing.T) {
 				DefinitionFile: pipeline.TaskDefinitionFile{
 					Path: absAssetPath,
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"prompt":              "Test prompt",
 					"model":               "sonnet",
 					"fallback_model":      "haiku",
@@ -100,7 +100,7 @@ func TestExtractParameters(t *testing.T) {
 				DefinitionFile: pipeline.TaskDefinitionFile{
 					Path: absAssetPath,
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"model": "sonnet",
 				},
 			},
@@ -114,7 +114,7 @@ func TestExtractParameters(t *testing.T) {
 				DefinitionFile: pipeline.TaskDefinitionFile{
 					Path: absAssetPath,
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"prompt": "  ",
 				},
 			},
@@ -137,7 +137,7 @@ func TestExtractParameters(t *testing.T) {
 			name: "with absolute working_dir",
 			asset: &pipeline.Asset{
 				Name: "test_asset",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"prompt":      "Test prompt",
 					"working_dir": absWorkingDir,
 				},
@@ -157,7 +157,7 @@ func TestExtractParameters(t *testing.T) {
 			name: "with relative working_dir",
 			asset: &pipeline.Asset{
 				Name: "test_asset",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"prompt":      "Test prompt",
 					"working_dir": "../data",
 				},
@@ -177,7 +177,7 @@ func TestExtractParameters(t *testing.T) {
 			name: "with relative dot working_dir",
 			asset: &pipeline.Asset{
 				Name: "test_asset",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"prompt":      "Test prompt",
 					"working_dir": "./subdir",
 				},
@@ -388,7 +388,7 @@ func TestClaudeCodeOperator_Run_MissingPrompt(t *testing.T) {
 	asset := &pipeline.Asset{
 		Name:       "test_claude_asset",
 		Type:       pipeline.AssetTypeAgentClaudeCode,
-		Parameters: map[string]string{},
+		Parameters: pipeline.ParameterMap{},
 	}
 
 	instance := &scheduler.AssetInstance{

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -1716,7 +1716,7 @@ func TestCanRunTaskInstances(t *testing.T) {
 					{
 						Type:       pipeline.AssetTypeIngestr,
 						Connection: "conn2",
-						Parameters: map[string]string{"source_connection": "conn3"},
+						Parameters: pipeline.ParameterMap{"source_connection": "conn3"},
 					},
 				},
 			},
@@ -1754,7 +1754,7 @@ func TestCanRunTaskInstances(t *testing.T) {
 					},
 					{
 						Type: pipeline.AssetTypeIngestr,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"source_connection": "conn3",
 							"destination":       "snowflake",
 						},
@@ -1795,7 +1795,7 @@ func TestCanRunTaskInstances(t *testing.T) {
 					},
 					{
 						Type: pipeline.AssetTypeIngestr,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"source_connection": "conn3",
 							"destination":       "snowflake",
 						},
@@ -1849,7 +1849,7 @@ func TestCanRunTaskInstances(t *testing.T) {
 					},
 					{
 						Type: pipeline.AssetTypeIngestr,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"source_connection": "conn3",
 							"destination":       "snowflake",
 						},
@@ -1899,7 +1899,7 @@ func TestCanRunTaskInstances(t *testing.T) {
 					},
 					{
 						Type: pipeline.AssetTypeIngestr,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"source_connection": "conn3",
 							"destination":       "snowflake",
 						},

--- a/pkg/dataproc_serverless/job.go
+++ b/pkg/dataproc_serverless/job.go
@@ -58,13 +58,17 @@ type JobRunParams struct {
 	MetastoreService string
 }
 
-func parseParams(cfg *Client, params map[string]string) *JobRunParams {
+func parseParams(cfg *Client, params pipeline.ParameterMap) *JobRunParams {
+	runtimeVersion, _ := params.GetString("runtime_version")
+	containerImage, _ := params.GetString("container_image")
+	config, _ := params.GetString("config")
+
 	jobParams := JobRunParams{
 		Project:          cfg.ProjectID,
 		Region:           cfg.Region,
-		RuntimeVersion:   params["runtime_version"],
-		ContainerImage:   params["container_image"],
-		Config:           params["config"],
+		RuntimeVersion:   runtimeVersion,
+		ContainerImage:   containerImage,
+		Config:           config,
 		Workspace:        cfg.Workspace,
 		ExecutionRole:    cfg.ExecutionRole,
 		SubnetworkURI:    cfg.SubnetworkURI,
@@ -79,14 +83,14 @@ func parseParams(cfg *Client, params map[string]string) *JobRunParams {
 		jobParams.RuntimeVersion = "2.2"
 	}
 
-	if params["timeout"] != "" {
-		t, err := time.ParseDuration(params["timeout"])
+	if timeout, _ := params.GetString("timeout"); timeout != "" {
+		t, err := time.ParseDuration(timeout)
 		if err == nil {
 			jobParams.Timeout = t
 		}
 	}
-	if params["args"] != "" {
-		arglist := strings.Split(strings.TrimSpace(params["args"]), " ")
+	if args, _ := params.GetString("args"); args != "" {
+		arglist := strings.Split(strings.TrimSpace(args), " ")
 		for _, arg := range arglist {
 			arg = strings.TrimSpace(arg)
 			if arg != "" {

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -86,8 +86,9 @@ type connectionRemapper struct {
 }
 
 func (cr *connectionRemapper) GetConnection(string) any {
+	athenaConn, _ := cr.ti.GetAsset().Parameters.GetString("athena_connection")
 	name := cmp.Or(
-		cr.ti.GetAsset().Parameters["athena_connection"],
+		athenaConn,
 		cr.ti.GetPipeline().DefaultConnections["athena"],
 	)
 	return cr.connGetter.GetConnection(name)

--- a/pkg/emr_serverless/job.go
+++ b/pkg/emr_serverless/job.go
@@ -52,25 +52,28 @@ type JobRunParams struct {
 	Workspace     string
 }
 
-func parseParams(cfg *Client, params map[string]string) *JobRunParams {
+func parseParams(cfg *Client, params pipeline.ParameterMap) *JobRunParams {
+	entrypoint, _ := params.GetString("entrypoint")
+	config, _ := params.GetString("config")
+	logs, _ := params.GetString("logs")
 	jobParams := JobRunParams{
 		ApplicationID: cfg.ApplicationID,
 		ExecutionRole: cfg.ExecutionRole,
 		Region:        cfg.Region,
-		Entrypoint:    params["entrypoint"],
-		Config:        params["config"],
-		Logs:          params["logs"],
+		Entrypoint:    entrypoint,
+		Config:        config,
+		Logs:          logs,
 		Workspace:     cfg.Workspace,
 	}
 
-	if params["timeout"] != "" {
-		t, err := time.ParseDuration(params["timeout"])
+	if timeoutVal, _ := params.GetString("timeout"); timeoutVal != "" {
+		t, err := time.ParseDuration(timeoutVal)
 		if err == nil {
 			jobParams.Timeout = t
 		}
 	}
-	if params["args"] != "" {
-		arglist := strings.Split(strings.TrimSpace(params["args"]), " ")
+	if argsVal, _ := params.GetString("args"); argsVal != "" {
+		arglist := strings.Split(strings.TrimSpace(argsVal), " ")
 		for _, arg := range arglist {
 			arg = strings.TrimSpace(arg)
 			if arg != "" {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -20,7 +20,7 @@ import (
 )
 
 func GetIngestrDestinationType(asset *pipeline.Asset) (pipeline.AssetType, error) {
-	ingestrDestination, ok := asset.Parameters["destination"]
+	ingestrDestination, ok := asset.Parameters.GetString("destination")
 	if !ok {
 		return "", errors.New("`destination` parameter not found")
 	}
@@ -240,7 +240,7 @@ func TrimToLength(s string, maxLength int) string {
 }
 
 func GetPokeInterval(ctx context.Context, t *pipeline.Asset) int64 {
-	pokeIntervalStr, ok := t.Parameters["poke_interval"]
+	pokeIntervalStr, ok := t.Parameters.GetString("poke_interval")
 	var pokeInterval int64
 	if ok {
 		var err error
@@ -315,7 +315,7 @@ func ParseSensorDuration(raw string) (time.Duration, error) {
 // GetSensorTimeout returns the configured sensor timeout for an asset, falling
 // back to DefaultSensorTimeout when unset, invalid, or non-positive.
 func GetSensorTimeout(t *pipeline.Asset) time.Duration {
-	raw, ok := t.Parameters["timeout"]
+	raw, ok := t.Parameters.GetString("timeout")
 	if !ok || strings.TrimSpace(raw) == "" {
 		return DefaultSensorTimeout
 	}

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -27,7 +27,7 @@ func TestGetIngestrDestinationType(t *testing.T) {
 		{
 			name: "postgres",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"destination": "postgres",
 				},
 			},
@@ -36,7 +36,7 @@ func TestGetIngestrDestinationType(t *testing.T) {
 		{
 			name: "gcp",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"destination": "bigquery",
 				},
 			},
@@ -45,7 +45,7 @@ func TestGetIngestrDestinationType(t *testing.T) {
 		{
 			name: "not found",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"destination": "sqlite",
 				},
 			},
@@ -307,25 +307,25 @@ func TestGetSensorTimeout(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		params map[string]string
+		params pipeline.ParameterMap
 		want   time.Duration
 	}{
 		{name: "unset returns default", params: nil, want: DefaultSensorTimeout},
-		{name: "empty returns default", params: map[string]string{"timeout": ""}, want: DefaultSensorTimeout},
-		{name: "blank returns default", params: map[string]string{"timeout": "   "}, want: DefaultSensorTimeout},
-		{name: "valid 1h", params: map[string]string{"timeout": "1h"}, want: time.Hour},
-		{name: "valid 90m", params: map[string]string{"timeout": "90m"}, want: 90 * time.Minute},
-		{name: "valid 1d", params: map[string]string{"timeout": "1d"}, want: 24 * time.Hour},
-		{name: "invalid falls back to default", params: map[string]string{"timeout": "foo"}, want: DefaultSensorTimeout},
-		{name: "month suffix falls back to default", params: map[string]string{"timeout": "1M"}, want: DefaultSensorTimeout},
-		{name: "zero falls back to default", params: map[string]string{"timeout": "0s"}, want: DefaultSensorTimeout},
-		{name: "negative falls back to default", params: map[string]string{"timeout": "-1h"}, want: DefaultSensorTimeout},
+		{name: "empty returns default", params: pipeline.ParameterMap{"timeout": ""}, want: DefaultSensorTimeout},
+		{name: "blank returns default", params: pipeline.ParameterMap{"timeout": "   "}, want: DefaultSensorTimeout},
+		{name: "valid 1h", params: pipeline.ParameterMap{"timeout": "1h"}, want: time.Hour},
+		{name: "valid 90m", params: pipeline.ParameterMap{"timeout": "90m"}, want: 90 * time.Minute},
+		{name: "valid 1d", params: pipeline.ParameterMap{"timeout": "1d"}, want: 24 * time.Hour},
+		{name: "invalid falls back to default", params: pipeline.ParameterMap{"timeout": "foo"}, want: DefaultSensorTimeout},
+		{name: "month suffix falls back to default", params: pipeline.ParameterMap{"timeout": "1M"}, want: DefaultSensorTimeout},
+		{name: "zero falls back to default", params: pipeline.ParameterMap{"timeout": "0s"}, want: DefaultSensorTimeout},
+		{name: "negative falls back to default", params: pipeline.ParameterMap{"timeout": "-1h"}, want: DefaultSensorTimeout},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			asset := &pipeline.Asset{Parameters: pipeline.EmptyStringMap{}}
+			asset := &pipeline.Asset{Parameters: pipeline.ParameterMap{}}
 			for k, v := range tt.params {
 				asset.Parameters[k] = v
 			}

--- a/pkg/ingestr/checks_test.go
+++ b/pkg/ingestr/checks_test.go
@@ -69,7 +69,7 @@ func TestColumnCheckOperatorOperator(t *testing.T) {
 					ExecutableFile:  pipeline.ExecutableFile{},
 					DefinitionFile:  pipeline.TaskDefinitionFile{},
 					Materialization: pipeline.Materialization{},
-					Parameters: map[string]string{
+					Parameters: pipeline.ParameterMap{
 						"destination": "postgres",
 					},
 				},
@@ -135,7 +135,7 @@ func TestCustomColumnCheckOperatorOperator(t *testing.T) {
 					ExecutableFile:  pipeline.ExecutableFile{},
 					DefinitionFile:  pipeline.TaskDefinitionFile{},
 					Materialization: pipeline.Materialization{},
-					Parameters: map[string]string{
+					Parameters: pipeline.ParameterMap{
 						"destination": "postgres",
 					},
 				},

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -42,7 +42,8 @@ type resolvedEngine struct {
 // Bare family markers (v0, v1, ...) resolve to the corresponding pinned PyPI
 // version; fully-qualified vMAJOR.MINOR.PATCH overrides to an exact PyPI version.
 func resolveIngestrEngine(asset *pipeline.Asset) (resolvedEngine, error) {
-	versionParam := strings.TrimSpace(asset.Parameters["version"])
+	versionRaw, _ := asset.Parameters.GetString("version")
+	versionParam := strings.TrimSpace(versionRaw)
 
 	if versionParam == "" {
 		return resolvedEngine{family: versionFamilyV1, ingestrVersion: python.IngestrVersionV1}, nil
@@ -202,7 +203,7 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 	}
 
 	// Source connection
-	sourceConnectionName, ok := asset.Parameters["source_connection"]
+	sourceConnectionName, ok := asset.Parameters.GetString("source_connection")
 	if !ok {
 		return errors.New("source connection not configured")
 	}
@@ -230,12 +231,12 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 
 	// some connection types can be shared among sources, therefore inferring source URI from the connection type is not
 	// always feasible. In the case of GSheets, we have to reuse the same GCP credentials, but change the prefix with gsheets://
-	if asset.Parameters["source"] == "gsheets" {
+	if sourceVal, _ := asset.Parameters.GetString("source"); sourceVal == "gsheets" {
 		sourceURI = strings.ReplaceAll(sourceURI, "bigquery://", "gsheets://")
 	}
 
 	// Handle CDC mode - transform PostgreSQL URI to CDC format and auto-set merge strategy
-	if asset.Parameters["cdc"] == "true" {
+	if cdcVal, _ := asset.Parameters.GetString("cdc"); cdcVal == "true" {
 		parsedURI, err := url.Parse(sourceURI)
 		if err != nil {
 			return fmt.Errorf("failed to parse source URI for CDC: %w", err)
@@ -244,16 +245,16 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		parsedURI.Scheme = strings.ReplaceAll(parsedURI.Scheme, "postgresql", "postgres+cdc")
 
 		q := parsedURI.Query()
-		if pub := asset.Parameters["cdc_publication"]; pub != "" {
+		if pub, _ := asset.Parameters.GetString("cdc_publication"); pub != "" {
 			q.Set("publication", pub)
 		}
-		if slot := asset.Parameters["cdc_slot"]; slot != "" {
+		if slot, _ := asset.Parameters.GetString("cdc_slot"); slot != "" {
 			q.Set("slot", slot)
 		}
-		if mode := asset.Parameters["cdc_mode"]; mode != "" {
+		if mode, _ := asset.Parameters.GetString("cdc_mode"); mode != "" {
 			q.Set("mode", mode)
 		}
-		if destSchema := asset.Parameters["cdc_dest_schema"]; destSchema != "" {
+		if destSchema, _ := asset.Parameters.GetString("cdc_dest_schema"); destSchema != "" {
 			q.Set("dest_schema", destSchema)
 		}
 		parsedURI.RawQuery = q.Encode()
@@ -266,12 +267,12 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		}
 	}
 
-	sourceTable, ok := asset.Parameters["source_table"]
+	sourceTable, ok := asset.Parameters.GetString("source_table")
 	if !ok {
 		return errors.New("source table not configured")
 	}
 
-	fileType, ok := asset.Parameters["file_type"]
+	fileType, ok := asset.Parameters.GetString("file_type")
 	if ok {
 		sourceTable = sourceTable + "#" + fileType
 	}
@@ -310,7 +311,7 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 	}
 
 	// Omit --source-table for CDC wildcard mode so ingestr replicates all tables
-	if asset.Parameters["cdc"] != "true" || sourceTable != "*" {
+	if cdcWild, _ := asset.Parameters.GetString("cdc"); cdcWild != "true" || sourceTable != "*" {
 		baseArgs = append(baseArgs, "--source-table", sourceTable)
 	}
 
@@ -411,7 +412,7 @@ func resolveSeedSourceURI(seedPath, fileType, assetDir string) (string, error) {
 	return scheme + "://" + filepath.Join(assetDir, seedPath), nil
 }
 
-func applyClickHouseEngineParams(destURI string, params map[string]string) string {
+func applyClickHouseEngineParams(destURI string, params pipeline.ParameterMap) string {
 	parsedURI, err := url.Parse(destURI)
 	if err != nil {
 		return destURI
@@ -419,12 +420,13 @@ func applyClickHouseEngineParams(destURI string, params map[string]string) strin
 
 	q := parsedURI.Query()
 
-	if engine, exists := params["engine"]; exists && engine != "" {
+	if engine, exists := params.GetString("engine"); exists && engine != "" {
 		q.Set("engine", engine)
 	}
 
-	for key, value := range params {
+	for key := range params {
 		key = strings.TrimSpace(key)
+		value, _ := params.GetString(key)
 		if strings.HasPrefix(key, "engine.") && value != "" {
 			q.Set(
 				key,
@@ -474,12 +476,13 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		asset.IntervalModifiers.End = renderedEnd
 	}
 
-	sourceConnectionPath, ok := asset.Parameters["path"]
+	sourceConnectionPath, ok := asset.Parameters.GetString("path")
 	if !ok {
 		return errors.New("source connection not configured")
 	}
 
-	sourceURI, err := resolveSeedSourceURI(sourceConnectionPath, asset.Parameters["file_type"], filepath.Dir(asset.ExecutableFile.Path))
+	seedFileType, _ := asset.Parameters.GetString("file_type")
+	sourceURI, err := resolveSeedSourceURI(sourceConnectionPath, seedFileType, filepath.Dir(asset.ExecutableFile.Path))
 	if err != nil {
 		return err
 	}

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -86,19 +86,19 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 	tests := []struct {
 		name   string
 		uri    string
-		params map[string]string
+		params pipeline.ParameterMap
 		want   string
 	}{
 		{
 			name:   "no engine params",
 			uri:    "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{},
+			params: pipeline.ParameterMap{},
 			want:   "clickhouse://user:pass@localhost:9000",
 		},
 		{
 			name: "engine only",
 			uri:  "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"engine": "merge_tree",
 			},
 			want: "clickhouse://user:pass@localhost:9000?engine=merge_tree",
@@ -106,7 +106,7 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 		{
 			name: "engine with settings",
 			uri:  "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"engine":                   "merge_tree",
 				"engine.index_granularity": "8125",
 			},
@@ -115,7 +115,7 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 		{
 			name: "engine settings without engine",
 			uri:  "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"engine.index_granularity": "8125",
 			},
 			want: "clickhouse://user:pass@localhost:9000?engine.index_granularity=8125",
@@ -123,7 +123,7 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 		{
 			name: "preserves existing query params",
 			uri:  "clickhouse://user:pass@localhost:9000?http_port=8123",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"engine": "merge_tree",
 			},
 			want: "clickhouse://user:pass@localhost:9000?engine=merge_tree&http_port=8123",
@@ -131,7 +131,7 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 		{
 			name: "empty engine value is ignored",
 			uri:  "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"engine": "",
 			},
 			want: "clickhouse://user:pass@localhost:9000",
@@ -139,7 +139,7 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 		{
 			name: "empty engine setting value is ignored",
 			uri:  "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"engine.index_granularity": "",
 			},
 			want: "clickhouse://user:pass@localhost:9000",
@@ -147,7 +147,7 @@ func TestApplyClickHouseEngineParams(t *testing.T) {
 		{
 			name: "non-engine params are not added",
 			uri:  "clickhouse://user:pass@localhost:9000",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"source_connection": "sf",
 				"source_table":      "some_table",
 				"engine":            "merge_tree",
@@ -200,7 +200,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "public.table",
 				Connection: "ch",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":        "sf",
 					"source_table":             "source-table",
 					"engine":                   "merge_tree",
@@ -222,7 +222,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "source-table",
 					"destination":       "bigquery",
@@ -235,7 +235,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "source-table",
 					"destination":       "bigquery",
@@ -249,7 +249,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "duck",
 					"source_table":      "source-table",
 					"destination":       "bigquery",
@@ -268,7 +268,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "duck",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "source-table",
 					"destination":       "duckdb",
@@ -281,7 +281,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "sf",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "bq",
 					"source":            "gsheets",
 					"source_table":      "source-table",
@@ -295,7 +295,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "sf",
 					"source_table":         "source-table",
 					"destination":          "bigquery",
@@ -325,7 +325,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 					{Name: "name"},
 					{Name: "updated_at"},
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "sf",
 					"source_table":         "source-table",
 					"destination":          "bigquery",
@@ -357,7 +357,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 					{Name: "name"},
 					{Name: "updated_at"},
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "sf",
 					"source_table":         "source-table",
 					"destination":          "bigquery",
@@ -391,7 +391,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 					{Name: "name"},
 					{Name: "updated_at"},
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "sf",
 					"source_table":         "source-table",
 					"destination":          "bigquery",
@@ -488,7 +488,7 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand_IntervalStartAndEnd(t
 			Name:       "asset-name",
 			Type:       pipeline.AssetTypeMsSQLQuery,
 			Connection: "ms",
-			Parameters: map[string]string{
+			Parameters: pipeline.ParameterMap{
 				"source_connection": "sf",
 				"source_table":      "source-table",
 				"destination":       "mssql",
@@ -547,7 +547,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "bq",
 				Type:       pipeline.AssetTypeBigquerySeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.csv",
 				},
 			},
@@ -559,7 +559,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Type:       pipeline.AssetTypeDuckDBSeed,
 				Connection: "duck",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.csv",
 				},
 			},
@@ -570,7 +570,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "asset-name",
 				Connection: "duck",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.csv",
 				},
 				Columns: []pipeline.Column{
@@ -611,7 +611,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "events",
 				Connection: "athena",
 				Type:       pipeline.AssetTypeAthenaSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.csv",
 				},
 			},
@@ -636,7 +636,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "duck",
 				Type:       pipeline.AssetTypeDuckDBSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.parquet",
 				},
 			},
@@ -648,7 +648,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "duck",
 				Type:       pipeline.AssetTypeDuckDBSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.jsonl",
 				},
 			},
@@ -660,7 +660,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "duck",
 				Type:       pipeline.AssetTypeDuckDBSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.ndjson",
 				},
 			},
@@ -672,7 +672,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "duck",
 				Type:       pipeline.AssetTypeDuckDBSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.json",
 				},
 			},
@@ -684,7 +684,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "duck",
 				Type:       pipeline.AssetTypeDuckDBSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "seed.avro",
 				},
 			},
@@ -696,7 +696,7 @@ func TestBasicOperator_ConvertSeedTaskInstanceToIngestrCommand(t *testing.T) {
 				Name:       "asset-name",
 				Connection: "duck",
 				Type:       pipeline.AssetTypeDuckDBSeed,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path":      "seed.dat",
 					"file_type": "parquet",
 				},
@@ -919,7 +919,7 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "cdc-asset",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "pg",
 					"source_table":      "public.users",
 					"destination":       "bigquery",
@@ -942,7 +942,7 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "cdc-asset-with-params",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "pg",
 					"source_table":      "public.users",
 					"destination":       "bigquery",
@@ -967,7 +967,7 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "cdc-wildcard-asset",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "pg",
 					"source_table":      "*",
 					"destination":       "bigquery",
@@ -989,7 +989,7 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "cdc-asset-stream-mode",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "pg",
 					"source_table":      "public.users",
 					"destination":       "bigquery",
@@ -1013,7 +1013,7 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "cdc-asset-explicit-strategy",
 				Connection: "bq",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "pg",
 					"source_table":         "public.users",
 					"destination":          "bigquery",
@@ -1141,7 +1141,7 @@ func TestBasicOperator_Run_MissingConnectionError(t *testing.T) {
 				Asset: &pipeline.Asset{
 					Name:       "asset-name",
 					Connection: tt.assetConnection,
-					Parameters: map[string]string{
+					Parameters: pipeline.ParameterMap{
 						"source_connection": tt.sourceConnection,
 						"source_table":      "source-table",
 						"destination":       "bigquery",
@@ -1173,63 +1173,63 @@ func TestResolveIngestrEngine(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		params    map[string]string
+		params    pipeline.ParameterMap
 		want      resolvedEngine
 		expectErr string
 	}{
 		{
 			name:   "unset defaults to v1 (latest)",
-			params: map[string]string{},
+			params: pipeline.ParameterMap{},
 			want:   resolvedEngine{family: versionFamilyV1, ingestrVersion: python.IngestrVersionV1},
 		},
 		{
 			name:   "bare v0 pins to legacy version",
-			params: map[string]string{"version": "v0"},
+			params: pipeline.ParameterMap{"version": "v0"},
 			want:   resolvedEngine{family: versionFamilyV0, ingestrVersion: python.IngestrVersionV0},
 		},
 		{
 			name:   "bare v1 pins to latest version",
-			params: map[string]string{"version": "v1"},
+			params: pipeline.ParameterMap{"version": "v1"},
 			want:   resolvedEngine{family: versionFamilyV1, ingestrVersion: python.IngestrVersionV1},
 		},
 		{
 			name:   "v0.14.2 selects exact version in v0 family",
-			params: map[string]string{"version": "v0.14.2"},
+			params: pipeline.ParameterMap{"version": "v0.14.2"},
 			want:   resolvedEngine{family: versionFamilyV0, ingestrVersion: "0.14.2"},
 		},
 		{
 			name:   "v1.0.5 selects exact version in v1 family",
-			params: map[string]string{"version": "v1.0.5"},
+			params: pipeline.ParameterMap{"version": "v1.0.5"},
 			want:   resolvedEngine{family: versionFamilyV1, ingestrVersion: "1.0.5"},
 		},
 		{
 			name:   "future major v2 maps to v1 family with v1 pin",
-			params: map[string]string{"version": "v2"},
+			params: pipeline.ParameterMap{"version": "v2"},
 			want:   resolvedEngine{family: versionFamilyV1, ingestrVersion: python.IngestrVersionV1},
 		},
 		{
 			name:   "future major v2.0.0 keeps exact pin in v1 family",
-			params: map[string]string{"version": "v2.0.0"},
+			params: pipeline.ParameterMap{"version": "v2.0.0"},
 			want:   resolvedEngine{family: versionFamilyV1, ingestrVersion: "2.0.0"},
 		},
 		{
 			name:      "v0.14 partial is rejected",
-			params:    map[string]string{"version": "v0.14"},
+			params:    pipeline.ParameterMap{"version": "v0.14"},
 			expectErr: "invalid parameters.version",
 		},
 		{
 			name:      "leading-zero major is rejected",
-			params:    map[string]string{"version": "v01"},
+			params:    pipeline.ParameterMap{"version": "v01"},
 			expectErr: "invalid parameters.version",
 		},
 		{
 			name:      "non-prefixed version is rejected",
-			params:    map[string]string{"version": "0.14.2"},
+			params:    pipeline.ParameterMap{"version": "0.14.2"},
 			expectErr: "invalid parameters.version",
 		},
 		{
 			name:      "latest is rejected",
-			params:    map[string]string{"version": "latest"},
+			params:    pipeline.ParameterMap{"version": "latest"},
 			expectErr: "invalid parameters.version",
 		},
 	}
@@ -1277,8 +1277,8 @@ func TestBasicOperator_Version(t *testing.T) {
 		}
 	}
 
-	makeAsset := func(extra map[string]string) *pipeline.Asset {
-		params := map[string]string{
+	makeAsset := func(extra pipeline.ParameterMap) *pipeline.Asset {
+		params := pipeline.ParameterMap{
 			"source_connection": "sf",
 			"source_table":      "source-table",
 		}
@@ -1294,14 +1294,14 @@ func TestBasicOperator_Version(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		params      map[string]string
+		params      pipeline.ParameterMap
 		wantVersion string
 	}{
 		{name: "unset defaults to v1", params: nil, wantVersion: python.IngestrVersionV1},
-		{name: "bare v0 pins legacy", params: map[string]string{"version": "v0"}, wantVersion: python.IngestrVersionV0},
-		{name: "bare v1 pins latest", params: map[string]string{"version": "v1"}, wantVersion: python.IngestrVersionV1},
-		{name: "exact v0.14.2 honors pin", params: map[string]string{"version": "v0.14.2"}, wantVersion: "0.14.2"},
-		{name: "exact v1.0.5 honors pin", params: map[string]string{"version": "v1.0.5"}, wantVersion: "1.0.5"},
+		{name: "bare v0 pins legacy", params: pipeline.ParameterMap{"version": "v0"}, wantVersion: python.IngestrVersionV0},
+		{name: "bare v1 pins latest", params: pipeline.ParameterMap{"version": "v1"}, wantVersion: python.IngestrVersionV1},
+		{name: "exact v0.14.2 honors pin", params: pipeline.ParameterMap{"version": "v0.14.2"}, wantVersion: "0.14.2"},
+		{name: "exact v1.0.5 honors pin", params: pipeline.ParameterMap{"version": "v1.0.5"}, wantVersion: "1.0.5"},
 	}
 
 	for _, tt := range tests {
@@ -1325,7 +1325,7 @@ func TestBasicOperator_Version(t *testing.T) {
 
 		runner := new(mockRunner)
 		o := makeOperator(runner)
-		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(map[string]string{"version": "latest"})}
+		ti := scheduler.AssetInstance{Pipeline: &pipeline.Pipeline{}, Asset: makeAsset(pipeline.ParameterMap{"version": "latest"})}
 		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
 
 		err := o.Run(ctx, &ti)

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -272,7 +272,7 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 			return issues, nil
 		}
 
-		value, exists := asset.Parameters[key]
+		value, exists := asset.Parameters.GetString(key)
 		if !exists || value == "" {
 			issues = append(issues, &Issue{
 				Task:        asset,
@@ -283,7 +283,7 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 		}
 	}
 
-	if value, exists := asset.Parameters["incremental_strategy"]; exists && value != "" {
+	if value, exists := asset.Parameters.GetString("incremental_strategy"); exists && value != "" {
 		if !python.IsIngestrStrategySupported(value) {
 			issues = append(issues, &Issue{
 				Task:        asset,
@@ -299,21 +299,21 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 			Description: "Ingestr assets do not support the 'update_on_merge' field, the strategy used decide the update behavior",
 		})
 	}
-	if mode, exists := asset.Parameters["cdc_mode"]; exists && mode != "stream" && mode != "batch" {
+	if mode, exists := asset.Parameters.GetString("cdc_mode"); exists && mode != "stream" && mode != "batch" {
 		issues = append(issues, &Issue{
 			Task:        asset,
 			Description: "Invalid 'cdc_mode' value: must be 'stream' or 'batch'",
 		})
 	}
-	if v, exists := asset.Parameters["version"]; exists && v != "" && !ingestrVersionPattern.MatchString(v) {
+	if v, exists := asset.Parameters.GetString("version"); exists && v != "" && !ingestrVersionPattern.MatchString(v) {
 		issues = append(issues, &Issue{
 			Task:        asset,
 			Description: fmt.Sprintf("Invalid 'version' value %q: must be 'vMAJOR' or fully-qualified 'vMAJOR.MINOR.PATCH'", v),
 		})
 	}
-	if value, exists := asset.Parameters["incremental_strategy"]; exists && value == "merge" {
+	if value, exists := asset.Parameters.GetString("incremental_strategy"); exists && value == "merge" {
 		// Skip PK validation for CDC mode - PKs are determined by the source
-		if asset.Parameters["cdc"] != "true" {
+		if cdcVal, _ := asset.Parameters.GetString("cdc"); cdcVal != "true" {
 			primaryKeys := asset.ColumnNamesWithPrimaryKey()
 			if len(primaryKeys) == 0 {
 				issues = append(issues, &Issue{
@@ -563,7 +563,7 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 				Description: "Materialization is not allowed on a seed asset",
 			})
 		}
-		seedPath := asset.Parameters["path"]
+		seedPath, _ := asset.Parameters.GetString("path")
 		if seedPath == "" {
 			issues = append(issues, &Issue{
 				Task:        asset,
@@ -578,11 +578,12 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 			return issues, nil
 		}
 
-		fileType := strings.ToLower(strings.TrimSpace(asset.Parameters["file_type"]))
+		seedFileTypeRaw, _ := asset.Parameters.GetString("file_type")
+		fileType := strings.ToLower(strings.TrimSpace(seedFileTypeRaw))
 		if fileType != "" && !supportedSeedFileTypes[fileType] {
 			issues = append(issues, &Issue{
 				Task:        asset,
-				Description: fmt.Sprintf("Unsupported seed file_type %q (supported: csv, parquet, pq, json, jsonl, ndjson, avro)", asset.Parameters["file_type"]),
+				Description: fmt.Sprintf("Unsupported seed file_type %q (supported: csv, parquet, pq, json, jsonl, ndjson, avro)", seedFileTypeRaw),
 			})
 			return issues, nil
 		}
@@ -597,7 +598,7 @@ func ValidateAssetSeedValidation(ctx context.Context, p *pipeline.Pipeline, asse
 			return issues, nil
 		}
 
-		if !isCSVSeed(seedPath, asset.Parameters["file_type"]) {
+		if !isCSVSeed(seedPath, seedFileTypeRaw) {
 			// For parquet/json/jsonl/ndjson/avro the schema is binary or
 			// semi-structured; column-vs-header validation is left to ingestr
 			// at runtime, just like the URL case above.
@@ -713,7 +714,8 @@ func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset
 	}
 
 	for _, key := range required {
-		value := strings.TrimSpace(asset.Parameters[key])
+		rawVal, _ := asset.Parameters.GetString(key)
+		value := strings.TrimSpace(rawVal)
 		if value == "" {
 			issues = append(issues, &Issue{
 				Task: asset,
@@ -734,7 +736,8 @@ func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset
 		}
 	}
 
-	timeoutSpec := strings.TrimSpace(asset.Parameters["timeout"])
+	timeoutRaw, _ := asset.Parameters.GetString("timeout")
+	timeoutSpec := strings.TrimSpace(timeoutRaw)
 	if timeoutSpec != "" {
 		timeout, err := time.ParseDuration(timeoutSpec)
 		if err != nil {
@@ -751,7 +754,8 @@ func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset
 		}
 	}
 
-	executionRole := strings.TrimSpace(asset.Parameters["execution_role"])
+	executionRoleRaw, _ := asset.Parameters.GetString("execution_role")
+	executionRole := strings.TrimSpace(executionRoleRaw)
 	if executionRole != "" && !arnPattern.MatchString(executionRole) {
 		issues = append(issues, &Issue{
 			Task:        asset,
@@ -759,7 +763,8 @@ func ValidateEMRServerlessAsset(ctx context.Context, p *pipeline.Pipeline, asset
 		})
 	}
 
-	logLocation := strings.TrimSpace(asset.Parameters["logs"])
+	logLocationRaw, _ := asset.Parameters.GetString("logs")
+	logLocation := strings.TrimSpace(logLocationRaw)
 	if logLocation != "" {
 		logURI, err := url.Parse(logLocation)
 		if err != nil {
@@ -1487,7 +1492,7 @@ func EnsureSnowflakeSensorHasQueryParameterForASingleAsset(ctx context.Context, 
 		return issues, nil
 	}
 
-	query, ok := asset.Parameters["query"]
+	query, ok := asset.Parameters.GetString("query")
 	if !ok {
 		issues = append(issues, &Issue{
 			Task:        asset,
@@ -1538,7 +1543,7 @@ func ValidateTableSensorTableParameter(ctx context.Context, p *pipeline.Pipeline
 		return issues, nil
 	}
 
-	table, ok := asset.Parameters["table"]
+	table, ok := asset.Parameters.GetString("table")
 	if !ok {
 		platformName := platformNames[asset.Type]
 		issues = append(issues, &Issue{
@@ -1651,7 +1656,7 @@ func ValidateSensorTimeout(ctx context.Context, p *pipeline.Pipeline, asset *pip
 		return issues, nil
 	}
 
-	raw, ok := asset.Parameters["timeout"]
+	raw, ok := asset.Parameters.GetString("timeout")
 	if !ok || strings.TrimSpace(raw) == "" {
 		return issues, nil
 	}
@@ -1672,7 +1677,7 @@ func EnsureBigQueryQuerySensorHasQueryParameterForASingleAsset(ctx context.Conte
 		return issues, nil
 	}
 
-	query, ok := asset.Parameters["query"]
+	query, ok := asset.Parameters.GetString("query")
 	if !ok {
 		issues = append(issues, &Issue{
 			Task:        asset,

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1553,7 +1553,7 @@ func TestEnsureSnowflakeSensorHasQueryParameter(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeSnowflakeQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"query": "",
 						},
 					},
@@ -1569,7 +1569,7 @@ func TestEnsureSnowflakeSensorHasQueryParameter(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeSnowflakeQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"query": "SELECT 1",
 						},
 					},
@@ -1632,7 +1632,7 @@ func TestEnsureBigqueryQuerySensorHasQueryParameter(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"query": "",
 						},
 					},
@@ -1648,7 +1648,7 @@ func TestEnsureBigqueryQuerySensorHasQueryParameter(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"query": "SELECT 1",
 						},
 					},
@@ -1698,7 +1698,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuery,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "bogus",
 						},
 					},
@@ -1725,7 +1725,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "",
 						},
 					},
@@ -1740,7 +1740,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "1h",
 						},
 					},
@@ -1755,7 +1755,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeDuckDBQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "2d",
 						},
 					},
@@ -1770,7 +1770,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "1M",
 						},
 					},
@@ -1786,7 +1786,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "-1h",
 						},
 					},
@@ -1802,7 +1802,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeS3KeySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "0s",
 						},
 					},
@@ -1818,7 +1818,7 @@ func TestValidateSensorTimeout(t *testing.T) {
 					{
 						Name: "task1",
 						Type: pipeline.AssetTypeBigqueryQuerySensor,
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"timeout": "foo",
 						},
 					},
@@ -1873,7 +1873,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "asset with some params missing",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source": "source",
 				},
 			},
@@ -1884,7 +1884,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "asset with all params there but has some update-on-merge columns",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":      "source_connection",
 					"source_table":           "source_table",
 					"destination":            "destination",
@@ -1903,7 +1903,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "asset with all params there",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":      "source_connection",
 					"source_table":           "source_table",
 					"destination":            "destination",
@@ -1918,7 +1918,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "ingestr asset with merge strategy but no primary key",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -1936,7 +1936,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "valid ingestr asset with merge strategy and primary key",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -1954,7 +1954,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "CDC ingestr asset with merge strategy but no primary key should pass",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -1969,7 +1969,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "CDC ingestr asset with cdc_mode stream should pass",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -1985,7 +1985,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "CDC ingestr asset with cdc_mode batch should pass",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -2001,7 +2001,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "CDC ingestr asset with invalid cdc_mode should fail",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -2017,7 +2017,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "CDC ingestr asset with publication and slot params should pass",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection":    "conn1",
 					"source_table":         "table1",
 					"destination":          "dest1",
@@ -2034,7 +2034,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "valid version v0",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -2048,7 +2048,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "valid version v0.14.2",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -2062,7 +2062,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "valid version v1",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -2076,7 +2076,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "valid future major v2.0.0",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -2090,7 +2090,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "rejected partial version v0.14",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -2104,7 +2104,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "rejected leading-zero major",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -2118,7 +2118,7 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			name: "rejected version latest",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"source_connection": "sf",
 					"source_table":      "t",
 					"destination":       "bigquery",
@@ -3924,7 +3924,7 @@ func TestValidateAssetSeedValidation_CaseInsensitive(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "./test.csv",
 				},
 				Columns: []pipeline.Column{
@@ -3943,7 +3943,7 @@ func TestValidateAssetSeedValidation_CaseInsensitive(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "./test.csv",
 				},
 				Columns: []pipeline.Column{
@@ -3991,7 +3991,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "https://example.com/data.csv",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4005,7 +4005,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "http://example.com/data.csv",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4019,7 +4019,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "https://d37ci6vzurychx.cloudfront.net/misc/taxi_zone_lookup.csv",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4033,7 +4033,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "HTTPS://example.com/data.csv",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4047,7 +4047,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "Http://example.com/data.csv",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4061,7 +4061,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "",
 				},
 				DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4073,7 +4073,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 					Task: &pipeline.Asset{
 						Name: "test_seed",
 						Type: "duckdb.seed",
-						Parameters: map[string]string{
+						Parameters: pipeline.ParameterMap{
 							"path": "",
 						},
 						DefinitionFile: pipeline.TaskDefinitionFile{
@@ -4089,7 +4089,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name:       "test_seed",
 				Type:       "duckdb.seed",
-				Parameters: map[string]string{},
+				Parameters: pipeline.ParameterMap{},
 				DefinitionFile: pipeline.TaskDefinitionFile{
 					Path: "/test/assets/test.asset.yml",
 				},
@@ -4099,7 +4099,7 @@ func TestValidateAssetSeedValidation_URLSupport(t *testing.T) {
 					Task: &pipeline.Asset{
 						Name:       "test_seed",
 						Type:       "duckdb.seed",
-						Parameters: map[string]string{},
+						Parameters: pipeline.ParameterMap{},
 						DefinitionFile: pipeline.TaskDefinitionFile{
 							Path: "/test/assets/test.asset.yml",
 						},
@@ -4130,7 +4130,7 @@ func TestValidateAssetSeedValidation_InvalidFileType(t *testing.T) {
 	asset := &pipeline.Asset{
 		Name: "test_seed",
 		Type: "duckdb.seed",
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"path":      "data.dat",
 			"file_type": "xml",
 		},
@@ -4177,7 +4177,7 @@ func TestValidateAssetSeedValidation_NonCSVFormats(t *testing.T) {
 			asset := &pipeline.Asset{
 				Name: "test_seed",
 				Type: "duckdb.seed",
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": tt.seedPath,
 				},
 				Columns: []pipeline.Column{
@@ -4223,7 +4223,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "",
 				},
 			},
@@ -4235,7 +4235,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "dataset",
 				},
 			},
@@ -4247,7 +4247,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "project.dataset.table.extra",
 				},
 			},
@@ -4259,7 +4259,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "dataset.table",
 				},
 			},
@@ -4271,7 +4271,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "project.dataset.table",
 				},
 			},
@@ -4294,7 +4294,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeSnowflakeTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema",
 				},
 			},
@@ -4306,7 +4306,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeSnowflakeTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4318,7 +4318,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeSnowflakeTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "database.schema.table",
 				},
 			},
@@ -4341,7 +4341,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeDatabricksTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4353,7 +4353,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeDatabricksTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4376,7 +4376,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeAthenaTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "database.table",
 				},
 			},
@@ -4388,7 +4388,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeAthenaTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4411,7 +4411,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypePostgresTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table.extra",
 				},
 			},
@@ -4423,7 +4423,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypePostgresTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4435,7 +4435,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypePostgresTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4458,7 +4458,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeRedshiftTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4470,7 +4470,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeRedshiftTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4493,7 +4493,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeMsSQLTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4505,7 +4505,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeMsSQLTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4528,7 +4528,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeClickHouseTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "database.table.extra",
 				},
 			},
@@ -4540,7 +4540,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeClickHouseTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4552,7 +4552,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeClickHouseTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4575,7 +4575,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeMySQLTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "analytics.",
 				},
 			},
@@ -4587,7 +4587,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeMySQLTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "analytics.sales.daily",
 				},
 			},
@@ -4599,7 +4599,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeMySQLTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "orders",
 				},
 			},
@@ -4611,7 +4611,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeMySQLTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "analytics.orders",
 				},
 			},
@@ -4634,7 +4634,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeSynapseTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "table",
 				},
 			},
@@ -4646,7 +4646,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeSynapseTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "schema.table",
 				},
 			},
@@ -4671,7 +4671,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": "dataset..table",
 				},
 			},
@@ -4683,7 +4683,7 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "task1",
 				Type: pipeline.AssetTypeBigqueryTableSensor,
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"table": ".dataset.table",
 				},
 			},

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -209,7 +209,7 @@ func singleLineCommentsToTask(scanner *bufio.Scanner, commentMarker, filePath st
 
 func commentRowsToTask(commentRows []string) (*Asset, error) {
 	task := Asset{
-		Parameters:   make(map[string]string),
+		Parameters:   make(ParameterMap),
 		Columns:      make([]Column, 0),
 		CustomChecks: make([]CustomCheck, 0),
 		Secrets:      make([]SecretMapping, 0),

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -68,7 +68,7 @@ func Test_createTaskFromFile(t *testing.T) {
 					Path:    path.AbsPathForTests(t, "testdata/comments/test.sql"),
 					Content: "select *\nfrom foo;",
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1":       "first-parameter",
 					"param2":       "second-parameter",
 					"s3_file_path": "s3://bucket/path",
@@ -120,7 +120,7 @@ func Test_createTaskFromFile(t *testing.T) {
 					Path:    path.AbsPathForTests(t, "testdata/comments/embeddedyaml.sql"),
 					Content: "select *\nfrom foo;",
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1":       "first-parameter",
 					"param2":       "second-parameter",
 					"s3_file_path": "s3://bucket/path",
@@ -172,7 +172,7 @@ func Test_createTaskFromFile(t *testing.T) {
 					Path:    path.AbsPathForTests(t, "testdata/comments/test.py"),
 					Content: "print('hello world')",
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "first-parameter",
 					"param2": "second-parameter",
 					"param3": "third-parameter",
@@ -245,7 +245,7 @@ func Test_createTaskFromFile(t *testing.T) {
 					Path:    path.AbsPathForTests(t, "testdata/comments/testblockcomments.py"),
 					Content: "print('hello world')",
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "first-parameter",
 					"param2": "second-parameter",
 					"param3": "third-parameter",
@@ -342,7 +342,7 @@ func Test_createTaskFromFile(t *testing.T) {
 					Path:    path.AbsPathForTests(t, "testdata/comments/test.r"),
 					Content: "cat(\"Hello from R!\\n\")\nprint(\"This is an R script\")",
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "first-parameter",
 					"param2": "second-parameter",
 					"param3": "third-parameter",

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -897,7 +897,7 @@ type Asset struct { //nolint:recvcheck
 	Tier              int                `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
 	ExecutableFile    ExecutableFile     `json:"executable_file" yaml:"-" mapstructure:"-"`
 	DefinitionFile    TaskDefinitionFile `json:"definition_file" yaml:"-" mapstructure:"-"`
-	Parameters        EmptyStringMap     `json:"parameters" yaml:"parameters,omitempty" mapstructure:"parameters"`
+	Parameters        ParameterMap       `json:"parameters" yaml:"parameters,omitempty" mapstructure:"parameters"`
 	Secrets           []SecretMapping    `json:"secrets" yaml:"secrets,omitempty" mapstructure:"secrets"`
 	Extends           []string           `json:"extends" yaml:"extends,omitempty" mapstructure:"extends"`
 	Columns           []Column           `json:"columns" yaml:"columns,omitempty" mapstructure:"columns"`
@@ -1383,10 +1383,10 @@ func (a Asset) Persist(fs afero.Fs, pipeline ...*Pipeline) error {
 	// Remove parameters that match pipeline defaults
 	// pipeline is optional - if provided and has defaults, filter them out
 	if len(pipeline) > 0 && pipeline[0] != nil && pipeline[0].DefaultValues != nil && len(pipeline[0].DefaultValues.Parameters) > 0 {
-		filteredParams := EmptyStringMap{}
+		filteredParams := ParameterMap{}
 		for key, value := range a.Parameters {
 			// Only keep parameters that are NOT in defaults or have different values
-			if defaultValue, existsInDefaults := pipeline[0].DefaultValues.Parameters[key]; !existsInDefaults || defaultValue != value {
+			if defaultValue, existsInDefaults := pipeline[0].DefaultValues.Parameters[key]; !existsInDefaults || !reflect.DeepEqual(defaultValue, value) {
 				filteredParams[key] = value
 			}
 		}
@@ -1542,6 +1542,78 @@ func (b *EmptyStringMap) UnmarshalJSON(data []byte) error {
 
 	*b = v
 	return nil
+}
+
+// ParameterMap stores asset parameters with arbitrary value types, allowing
+// parameters to hold strings, numbers, booleans, or nested structures.
+type ParameterMap map[string]interface{} //nolint:recvcheck
+
+func (m ParameterMap) MarshalJSON() ([]byte, error) { //nolint:recvcheck
+	if m == nil {
+		return []byte{'{', '}'}, nil
+	}
+	return json.Marshal(map[string]interface{}(m))
+}
+
+func (m *ParameterMap) UnmarshalJSON(data []byte) error {
+	if data == nil {
+		return nil
+	}
+	var v map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	if len(v) == 0 {
+		return nil
+	}
+	*m = v
+	return nil
+}
+
+// GetString returns the value for key as a string. Scalar primitives are
+// coerced to their string representations so that YAML configs with unquoted
+// values continue to work. Structured values intentionally do not stringify.
+// Returns ("", false) if the key is absent or the value is nil.
+func (m ParameterMap) GetString(key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	switch val := v.(type) {
+	case string:
+		return val, true
+	case int8:
+		return strconv.FormatInt(int64(val), 10), true
+	case int16:
+		return strconv.FormatInt(int64(val), 10), true
+	case int32:
+		return strconv.FormatInt(int64(val), 10), true
+	case int:
+		return strconv.Itoa(val), true
+	case int64:
+		return strconv.FormatInt(val, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(val), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(val), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(val), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(val), 10), true
+	case uint64:
+		return strconv.FormatUint(val, 10), true
+	case float32:
+		return strconv.FormatFloat(float64(val), 'f', -1, 32), true
+	case float64:
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10), true
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64), true
+	case bool:
+		return strconv.FormatBool(val), true
+	default:
+		return "", false
+	}
 }
 
 type EmptyStringArray []string
@@ -1779,7 +1851,7 @@ type DefaultValues struct {
 	Instance          string            `json:"instance,omitempty" yaml:"instance,omitempty" mapstructure:"instance"`
 	Owner             string            `json:"owner,omitempty" yaml:"owner,omitempty" mapstructure:"owner"`
 	Tier              int               `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
-	Parameters        map[string]string `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
+	Parameters        ParameterMap      `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
 	Secrets           []secretMapping   `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
 	Extends           []string          `json:"extends,omitempty" yaml:"extends,omitempty" mapstructure:"extends"`
 	Columns           []Column          `json:"columns,omitempty" yaml:"columns,omitempty" mapstructure:"columns"`
@@ -1868,20 +1940,21 @@ func (p *Pipeline) GetAllConnectionNamesForAsset(asset *Asset) ([]string, error)
 		}
 		return secretKeys, nil
 	} else if assetType == AssetTypeIngestr {
-		ingestrSource, ok := asset.Parameters["source_connection"]
+		ingestrSource, ok := asset.Parameters.GetString("source_connection")
 		if !ok {
 			return []string{}, errors.Errorf("No source connection in asset")
 		}
 
-		ingestrDestination, ok := asset.Parameters["destination_connection"]
+		ingestrDestination, ok := asset.Parameters.GetString("destination_connection")
 		if ok {
 			return []string{ingestrDestination, ingestrSource}, nil
 		}
 
 		// if destination connection not specified, we infer from destination type
-		assetType, ok = IngestrTypeConnectionMapping[asset.Parameters["destination"]]
+		ingestrDest, _ := asset.Parameters.GetString("destination")
+		assetType, ok = IngestrTypeConnectionMapping[ingestrDest]
 		if !ok {
-			return []string{}, errors.Errorf("connection type could not be inferred for destination '%s', please specify a `connection` key in the asset", asset.Parameters["destination"])
+			return []string{}, errors.Errorf("connection type could not be inferred for destination '%s', please specify a `connection` key in the asset", ingestrDest)
 		}
 
 		mapping, ok := AssetTypeConnectionMapping[assetType]
@@ -1919,9 +1992,10 @@ func (p *Pipeline) GetConnectionNameForAsset(asset *Asset) (string, error) {
 	var ok bool
 	switch assetType {
 	case AssetTypeIngestr:
-		assetType, ok = IngestrTypeConnectionMapping[asset.Parameters["destination"]]
+		ingestrDest, _ := asset.Parameters.GetString("destination")
+		assetType, ok = IngestrTypeConnectionMapping[ingestrDest]
 		if !ok {
-			return "", errors.Errorf("connection type could not be inferred for destination '%s', please specify a `connection` key in the asset", asset.Parameters["destination"])
+			return "", errors.Errorf("connection type could not be inferred for destination '%s', please specify a `connection` key in the asset", ingestrDest)
 		}
 	case AssetTypePython, AssetTypeEmpty:
 		assetType = p.GetMajorityAssetTypesFromSQLAssets(AssetTypeBigqueryQuery)
@@ -1983,7 +2057,7 @@ func (p *Pipeline) GetMajorityAssetTypesFromSQLAssets(defaultIfNone AssetType) A
 		assetType := asset.Type
 
 		if assetType == AssetTypeIngestr {
-			ingestrDestination, ok := asset.Parameters["destination"]
+			ingestrDestination, ok := asset.Parameters.GetString("destination")
 			if !ok {
 				continue
 			}
@@ -2615,7 +2689,7 @@ func (b *Builder) SetupDefaultsFromPipeline(ctx context.Context, asset *Asset, f
 
 	// merge parameters from the default values to asset parameters
 	if len(asset.Parameters) == 0 {
-		asset.Parameters = EmptyStringMap{}
+		asset.Parameters = ParameterMap{}
 	}
 
 	for key, value := range defaults.Parameters {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1838,34 +1838,34 @@ func (p *Pipeline) UnmarshalJSON(data []byte) error {
 }
 
 type DefaultValues struct {
-	Type              string            `json:"type" yaml:"type" mapstructure:"type"`
-	Description       string            `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description"`
-	StartDate         string            `json:"start_date,omitempty" yaml:"start_date,omitempty" mapstructure:"start_date"`
-	Connection        string            `json:"connection,omitempty" yaml:"connection,omitempty" mapstructure:"connection"`
-	Tags              EmptyStringArray  `json:"tags,omitempty" yaml:"tags,omitempty" mapstructure:"tags"`
-	Domains           EmptyStringArray  `json:"domains,omitempty" yaml:"domains,omitempty" mapstructure:"domains"`
-	Meta              EmptyStringMap    `json:"meta,omitempty" yaml:"meta,omitempty" mapstructure:"meta"`
-	Materialization   Materialization   `json:"materialization,omitempty" yaml:"materialization,omitempty" mapstructure:"materialization"`
-	Upstreams         []Upstream        `json:"upstreams,omitempty" yaml:"depends,omitempty" mapstructure:"depends"`
-	Image             string            `json:"image,omitempty" yaml:"image,omitempty" mapstructure:"image"`
-	Instance          string            `json:"instance,omitempty" yaml:"instance,omitempty" mapstructure:"instance"`
-	Owner             string            `json:"owner,omitempty" yaml:"owner,omitempty" mapstructure:"owner"`
-	Tier              int               `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
-	Parameters        ParameterMap      `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
-	Secrets           []secretMapping   `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
-	Extends           []string          `json:"extends,omitempty" yaml:"extends,omitempty" mapstructure:"extends"`
-	Columns           []Column          `json:"columns,omitempty" yaml:"columns,omitempty" mapstructure:"columns"`
-	CustomChecks      []CustomCheck     `json:"custom_checks,omitempty" yaml:"custom_checks,omitempty" mapstructure:"custom_checks"`
-	Hooks             Hooks             `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
-	Metadata          EmptyStringMap    `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata"`
-	Snowflake         SnowflakeConfig   `json:"snowflake,omitempty" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
-	Athena            AthenaConfig      `json:"athena,omitempty" yaml:"athena,omitempty" mapstructure:"athena"`
-	Routing           *RoutingConfig    `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
-	IntervalModifiers IntervalModifiers `json:"interval_modifiers" yaml:"interval_modifiers" mapstructure:"interval_modifiers"`
-	RerunCooldown     *int              `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
-	Retries           *int              `json:"retries,omitempty" yaml:"retries,omitempty" mapstructure:"retries"`
-	RefreshRestricted *bool             `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
-	Notifications     *Notifications    `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
+	Type              string                 `json:"type" yaml:"type" mapstructure:"type"`
+	Description       string                 `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description"`
+	StartDate         string                 `json:"start_date,omitempty" yaml:"start_date,omitempty" mapstructure:"start_date"`
+	Connection        string                 `json:"connection,omitempty" yaml:"connection,omitempty" mapstructure:"connection"`
+	Tags              EmptyStringArray       `json:"tags,omitempty" yaml:"tags,omitempty" mapstructure:"tags"`
+	Domains           EmptyStringArray       `json:"domains,omitempty" yaml:"domains,omitempty" mapstructure:"domains"`
+	Meta              EmptyStringMap         `json:"meta,omitempty" yaml:"meta,omitempty" mapstructure:"meta"`
+	Materialization   Materialization        `json:"materialization,omitempty" yaml:"materialization,omitempty" mapstructure:"materialization"`
+	Upstreams         []Upstream             `json:"upstreams,omitempty" yaml:"depends,omitempty" mapstructure:"depends"`
+	Image             string                 `json:"image,omitempty" yaml:"image,omitempty" mapstructure:"image"`
+	Instance          string                 `json:"instance,omitempty" yaml:"instance,omitempty" mapstructure:"instance"`
+	Owner             string                 `json:"owner,omitempty" yaml:"owner,omitempty" mapstructure:"owner"`
+	Tier              int                    `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier"`
+	Parameters        map[string]interface{} `json:"parameters" yaml:"parameters" mapstructure:"parameters"`
+	Secrets           []secretMapping        `json:"secrets" yaml:"secrets" mapstructure:"secrets"`
+	Extends           []string               `json:"extends,omitempty" yaml:"extends,omitempty" mapstructure:"extends"`
+	Columns           []Column               `json:"columns,omitempty" yaml:"columns,omitempty" mapstructure:"columns"`
+	CustomChecks      []CustomCheck          `json:"custom_checks,omitempty" yaml:"custom_checks,omitempty" mapstructure:"custom_checks"`
+	Hooks             Hooks                  `json:"hooks" yaml:"hooks" mapstructure:"hooks"`
+	Metadata          EmptyStringMap         `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata"`
+	Snowflake         SnowflakeConfig        `json:"snowflake,omitempty" yaml:"snowflake,omitempty" mapstructure:"snowflake"`
+	Athena            AthenaConfig           `json:"athena,omitempty" yaml:"athena,omitempty" mapstructure:"athena"`
+	Routing           *RoutingConfig         `json:"routing,omitempty" yaml:"routing,omitempty" mapstructure:"routing"`
+	IntervalModifiers IntervalModifiers      `json:"interval_modifiers" yaml:"interval_modifiers" mapstructure:"interval_modifiers"`
+	RerunCooldown     *int                   `json:"rerun_cooldown,omitempty" yaml:"rerun_cooldown,omitempty" mapstructure:"rerun_cooldown"`
+	Retries           *int                   `json:"retries,omitempty" yaml:"retries,omitempty" mapstructure:"retries"`
+	RefreshRestricted *bool                  `json:"refresh_restricted,omitempty" yaml:"refresh_restricted,omitempty" mapstructure:"refresh_restricted"`
+	Notifications     *Notifications         `json:"notifications,omitempty" yaml:"notifications,omitempty" mapstructure:"notifications"`
 }
 
 func (d *DefaultValues) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -1605,7 +1606,8 @@ func (m ParameterMap) GetString(key string) (string, bool) {
 	case float32:
 		return strconv.FormatFloat(float64(val), 'f', -1, 32), true
 	case float64:
-		if val == float64(int64(val)) {
+		const maxInt64Float = float64(1 << 63)
+		if val >= -maxInt64Float && val < maxInt64Float && val == math.Trunc(val) {
 			return strconv.FormatInt(int64(val), 10), true
 		}
 		return strconv.FormatFloat(val, 'f', -1, 64), true

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -108,7 +108,9 @@ parameters:
 	assert.Equal(t, "value", asset.Parameters["string"])
 	assert.Equal(t, 3, asset.Parameters["count"])
 	assert.Equal(t, true, asset.Parameters["enabled"])
-	assert.Equal(t, pipeline.ParameterMap{"key": "value"}, asset.Parameters["nested"])
+	nested, ok := asset.Parameters["nested"].(pipeline.ParameterMap)
+	require.True(t, ok)
+	assert.Equal(t, map[string]interface{}{"key": "value"}, map[string]interface{}(nested))
 	assert.Equal(t, []interface{}{"one", 2}, asset.Parameters["list"])
 }
 

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -44,6 +44,74 @@ func (m *mockGlossaryReader) GetEntities(pathToPipeline string) ([]*glossary.Ent
 	return m.entities, nil
 }
 
+func TestParameterMapGetString(t *testing.T) {
+	t.Parallel()
+
+	params := pipeline.ParameterMap{
+		"string": "value",
+		"int":    3,
+		"float":  1.5,
+		"bool":   true,
+		"nested": map[string]interface{}{"key": "value"},
+		"list":   []interface{}{"value"},
+		"nil":    nil,
+	}
+
+	got, ok := params.GetString("string")
+	require.True(t, ok)
+	assert.Equal(t, "value", got)
+
+	got, ok = params.GetString("int")
+	require.True(t, ok)
+	assert.Equal(t, "3", got)
+
+	got, ok = params.GetString("float")
+	require.True(t, ok)
+	assert.Equal(t, "1.5", got)
+
+	got, ok = params.GetString("bool")
+	require.True(t, ok)
+	assert.Equal(t, "true", got)
+
+	_, ok = params.GetString("nested")
+	assert.False(t, ok)
+
+	_, ok = params.GetString("list")
+	assert.False(t, ok)
+
+	_, ok = params.GetString("nil")
+	assert.False(t, ok)
+
+	_, ok = params.GetString("missing")
+	assert.False(t, ok)
+}
+
+func TestAssetParametersYAMLSupportStructuredValues(t *testing.T) {
+	t.Parallel()
+
+	var asset pipeline.Asset
+	err := yaml.Unmarshal([]byte(`
+name: structured-params
+type: duckdb.sql
+parameters:
+  string: value
+  count: 3
+  enabled: true
+  nested:
+    key: value
+  list:
+    - one
+    - 2
+`), &asset)
+	require.NoError(t, err)
+
+	assert.Equal(t, "value", asset.Parameters["string"])
+	assert.Equal(t, 3, asset.Parameters["count"])
+	assert.Equal(t, true, asset.Parameters["enabled"])
+	assert.Equal(t, pipeline.ParameterMap{"key": "value"}, asset.Parameters["nested"])
+	assert.Equal(t, []interface{}{"one", 2}, asset.Parameters["list"])
+}
+
 func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +140,7 @@ func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 			Path: path.AbsPathForTests(t, "testdata/pipeline/first-pipeline/tasks/task1/task.yml"),
 			Type: pipeline.YamlTask,
 		},
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"param1": "value1",
 			"param2": "value2",
 		},
@@ -96,7 +164,7 @@ func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 		ID:   "c69409a1840ddb3639a4acbaaec46c238c63b6431cc74ee5254b6dcef7b88c4b",
 		Name: "second-task",
 		Type: "bq.transfer",
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"transfer_config_id": "some-uuid",
 			"project_id":         "a-new-project-id",
 			"location":           "europe-west1",
@@ -132,7 +200,7 @@ func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 			Path: path.AbsPathForTests(t, "testdata/pipeline/first-pipeline/tasks/test.py"),
 			Type: pipeline.CommentTask,
 		},
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"param1": "first-parameter",
 			"param2": "second-parameter",
 			"param3": "third-parameter",
@@ -170,7 +238,7 @@ func Test_pipelineBuilder_CreatePipelineFromPath(t *testing.T) {
 			Path: path.AbsPathForTests(t, "testdata/pipeline/first-pipeline/tasks/test.sql"),
 			Type: pipeline.CommentTask,
 		},
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"param1": "first-parameter",
 			"param2": "second-parameter",
 		},
@@ -654,7 +722,7 @@ func TestPipeline_GetConnectionNameForAsset(t *testing.T) {
 		t.Parallel()
 		found, err := pipeline1.GetConnectionNameForAsset(&pipeline.Asset{
 			Type:       "ingestr",
-			Parameters: map[string]string{"destination": "bigquery"},
+			Parameters: pipeline.ParameterMap{"destination": "bigquery"},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "default-gcp-connection", found)
@@ -2054,7 +2122,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				IntervalModifiers: pipeline.IntervalModifiers{
 					Start: pipeline.TimeModifier{Days: 1},
 					End:   pipeline.TimeModifier{Days: -1},
@@ -2080,7 +2148,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				IntervalModifiers: pipeline.IntervalModifiers{
 					Start: pipeline.TimeModifier{Hours: 2},
 					End:   pipeline.TimeModifier{Hours: -2},
@@ -2107,7 +2175,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			want: &pipeline.Asset{
 				Name:       "test-asset",
 				Type:       pipeline.AssetTypeBigqueryQuery,
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.sql",
 				},
@@ -2137,7 +2205,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			want: &pipeline.Asset{
 				Name:       "test-asset",
 				Type:       pipeline.AssetTypePython,
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.py",
 				},
@@ -2163,7 +2231,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			want: &pipeline.Asset{
 				Name:       "test-asset",
 				Type:       pipeline.AssetTypeBigqueryQuery,
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.asset.yml",
 				},
@@ -2193,7 +2261,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			want: &pipeline.Asset{
 				Name:       "test-asset",
 				Type:       pipeline.AssetTypeIngestr,
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				ExecutableFile: pipeline.ExecutableFile{
 					Path: "/tmp/test-asset.sql",
 				},
@@ -2218,7 +2286,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				Hooks: pipeline.Hooks{
 					Pre:  []pipeline.Hook{{Query: "select 9"}},
 					Post: []pipeline.Hook{{Query: "select 10"}},
@@ -2237,7 +2305,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
 			},
 		},
@@ -2254,7 +2322,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-vendor-us"},
 			},
 		},
@@ -2271,7 +2339,7 @@ func TestBuilder_SetupDefaultsFromPipeline(t *testing.T) {
 			},
 			want: &pipeline.Asset{
 				Name:       "test-asset",
-				Parameters: pipeline.EmptyStringMap{},
+				Parameters: pipeline.ParameterMap{},
 				Routing:    &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"},
 			},
 		},
@@ -2360,7 +2428,7 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 			Strategy: pipeline.MaterializationStrategyAppend,
 		},
 		Upstreams: []pipeline.Upstream{{Type: "asset", Value: "asset-upstream"}},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"shared": "asset",
 		},
 		Extends: []string{"asset.extend"},
@@ -2404,7 +2472,7 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 		Instance:   "b1.small",
 		Owner:      "data",
 		Tier:       2,
-		Parameters: map[string]string{"shared": "default", "default": "yes"},
+		Parameters: pipeline.ParameterMap{"shared": "default", "default": "yes"},
 		Extends:    []string{"default.extend", "asset.extend"},
 		Columns: []pipeline.Column{
 			{
@@ -2472,7 +2540,7 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 	assert.Equal(t, "b1.small", got.Instance)
 	assert.Equal(t, "data", got.Owner)
 	assert.Equal(t, 2, got.Tier)
-	assert.Equal(t, pipeline.EmptyStringMap{"shared": "asset", "default": "yes"}, got.Parameters)
+	assert.Equal(t, pipeline.ParameterMap{"shared": "asset", "default": "yes"}, got.Parameters)
 	assert.Equal(t, []string{"asset.extend", "default.extend"}, got.Extends)
 	assert.Equal(t, pipeline.EmptyStringMap{"catalog": "default"}, got.Metadata)
 	assert.Equal(t, "default-wh", got.Snowflake.Warehouse)

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -294,7 +294,7 @@ func assetFromDefaultValues(dv *DefaultValues) *Asset {
 		Instance:          dv.Instance,
 		Owner:             dv.Owner,
 		Tier:              dv.Tier,
-		Parameters:        dv.Parameters,
+		Parameters:        ParameterMap(dv.Parameters),
 		Secrets:           secrets,
 		Extends:           dv.Extends,
 		Columns:           dv.Columns,
@@ -331,7 +331,7 @@ func copyAssetToDefaultValues(dv *DefaultValues, asset *Asset) {
 	dv.Instance = asset.Instance
 	dv.Owner = asset.Owner
 	dv.Tier = asset.Tier
-	dv.Parameters = asset.Parameters
+	dv.Parameters = map[string]interface{}(asset.Parameters)
 	dv.Secrets = secrets
 	dv.Extends = asset.Extends
 	dv.Columns = asset.Columns

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -294,7 +294,7 @@ func assetFromDefaultValues(dv *DefaultValues) *Asset {
 		Instance:          dv.Instance,
 		Owner:             dv.Owner,
 		Tier:              dv.Tier,
-		Parameters:        EmptyStringMap(dv.Parameters),
+		Parameters:        dv.Parameters,
 		Secrets:           secrets,
 		Extends:           dv.Extends,
 		Columns:           dv.Columns,
@@ -331,7 +331,7 @@ func copyAssetToDefaultValues(dv *DefaultValues, asset *Asset) {
 	dv.Instance = asset.Instance
 	dv.Owner = asset.Owner
 	dv.Tier = asset.Tier
-	dv.Parameters = map[string]string(asset.Parameters)
+	dv.Parameters = asset.Parameters
 	dv.Secrets = secrets
 	dv.Extends = asset.Extends
 	dv.Columns = asset.Columns

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -287,13 +287,13 @@ func TestPipeline_MaterializeVariant(t *testing.T) {
 		// correctly at run time.
 		pl := build()
 		pl.DefaultValues = &pipeline.DefaultValues{
-			Parameters: map[string]string{"region": "{{ var.region }}"},
+			Parameters: pipeline.ParameterMap{"region": "{{ var.region }}"},
 			Hooks: pipeline.Hooks{
 				Pre:  []pipeline.Hook{{Query: "select '{{ start_date }}'"}},
 				Post: []pipeline.Hook{{Query: "select '{{ end_date }}'"}},
 			},
 		}
-		pl.Assets[0].Parameters = map[string]string{
+		pl.Assets[0].Parameters = pipeline.ParameterMap{
 			"database": "{{ var.client }}_db",
 			"query":    "select '{{ start_date }}'",
 		}
@@ -526,7 +526,7 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 		Upstreams: []pipeline.Upstream{
 			{Type: "asset", Value: "x", Metadata: map[string]string{"k": "v"}, Columns: []pipeline.DependsColumn{{Name: "n", Usage: "u"}}},
 		},
-		Parameters: map[string]string{"k": "v"},
+		Parameters: pipeline.ParameterMap{"k": "v"},
 		Secrets:    []pipeline.SecretMapping{{SecretKey: "k", InjectedKey: "i"}},
 		Extends:    []string{"x"},
 		Columns: []pipeline.Column{
@@ -571,7 +571,7 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 			Image:      "image",
 			Instance:   "instance",
 			Owner:      "owner",
-			Parameters: map[string]string{"k": "v"},
+			Parameters: pipeline.ParameterMap{"k": "v"},
 			Extends:    []string{"x"},
 			Columns: []pipeline.Column{
 				{

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -346,7 +346,7 @@ type taskDefinition struct {
 	Type                  string            `yaml:"type"`
 	RunFile               string            `yaml:"run"`
 	Depends               depends           `yaml:"depends"`
-	Parameters            map[string]string `yaml:"parameters"`
+	Parameters            ParameterMap      `yaml:"parameters"`
 	Connections           map[string]string `yaml:"connections"`
 	Secrets               []secretMapping   `yaml:"secrets"`
 	Connection            string            `yaml:"connection"`

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -54,7 +54,7 @@ func TestCreateTaskFromYamlDefinition(t *testing.T) {
 					Path:    path.AbsPathForTests(t, filepath.Join("testdata", "yaml", "task1", "hello.sql")),
 					Content: mustRead(t, filepath.Join("testdata", "yaml", "task1", "hello.sql")),
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "value1",
 					"param2": "value2",
 				},
@@ -135,7 +135,7 @@ func TestCreateTaskFromYamlDefinition(t *testing.T) {
 					Path:    path.AbsPathForTests(t, filepath.Join("testdata", "yaml", "task-with-nested", "some", "dir", "hello.sh")),
 					Content: mustRead(t, filepath.Join("testdata", "yaml", "task-with-nested", "some", "dir", "hello.sh")),
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "value1",
 					"param2": "value2",
 				},
@@ -168,7 +168,7 @@ func TestCreateTaskFromYamlDefinition(t *testing.T) {
 					Path:    path.AbsPathForTests(t, filepath.Join("testdata", "yaml", "task-with-toplevel-runfile", "hello.sh")),
 					Content: mustRead(t, filepath.Join("testdata", "yaml", "task-with-toplevel-runfile", "hello.sh")),
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "value1",
 					"param2": "value2",
 				},
@@ -201,7 +201,7 @@ func TestCreateTaskFromYamlDefinition(t *testing.T) {
 					Path:    path.AbsPathForTests(t, filepath.Join("testdata", "yaml", "task-with-no-runfile", "task.yml")),
 					Content: mustReadWithoutReplacement(t, filepath.Join("testdata", "yaml", "task-with-no-runfile", "task.yml")),
 				},
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"param1": "value1",
 					"param2": "value2",
 				},

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -40,7 +40,7 @@ var ingestrBoolParameterFlags = []string{
 func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs []string, columnOpts *ColumnHintOptions) ([]string, error) {
 	cmdArgs = appendIngestrParameterFlags(asset.Parameters, cmdArgs)
 
-	if value, exists := asset.Parameters["incremental_key"]; exists && value != "" {
+	if value, exists := asset.Parameters.GetString("incremental_key"); exists && value != "" {
 		// Check if the incremental key column exists and is of date type
 		for _, column := range asset.Columns {
 			if column.Name == value && strings.ToLower(column.Type) == "date" {
@@ -99,7 +99,7 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 	// Handle column hints based on enforce_schema parameter
 	if columnOpts != nil && len(asset.Columns) > 0 {
 		shouldEnforce := columnOpts.EnforceSchemaByDefault
-		if value, exists := asset.Parameters["enforce_schema"]; exists {
+		if value, exists := asset.Parameters.GetString("enforce_schema"); exists {
 			shouldEnforce = value == "true"
 		}
 
@@ -114,15 +114,15 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 	return cmdArgs, nil
 }
 
-func appendIngestrParameterFlags(params map[string]string, cmdArgs []string) []string {
+func appendIngestrParameterFlags(params pipeline.ParameterMap, cmdArgs []string) []string {
 	for _, param := range ingestrValueParameterFlags {
-		if value, exists := params[param]; exists && value != "" {
+		if value, exists := params.GetString(param); exists && value != "" {
 			cmdArgs = append(cmdArgs, "--"+strings.ReplaceAll(param, "_", "-"), value)
 		}
 	}
 
 	for _, param := range ingestrBoolParameterFlags {
-		if value, exists := params[param]; exists && value == "true" {
+		if value, exists := params.GetString(param); exists && value == "true" {
 			cmdArgs = append(cmdArgs, "--"+strings.ReplaceAll(param, "_", "-"))
 		}
 	}

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -20,7 +20,7 @@ func Test_uvPythonRunner_ingestrLoaderFileFormat(t *testing.T) {
 		{
 			name: "should append loader file format when parameter exists",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"loader_file_format": "parquet",
 				},
 			},
@@ -30,7 +30,7 @@ func Test_uvPythonRunner_ingestrLoaderFileFormat(t *testing.T) {
 		{
 			name: "should not append loader file format when parameter is empty",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"loader_file_format": "",
 				},
 			},
@@ -40,7 +40,7 @@ func Test_uvPythonRunner_ingestrLoaderFileFormat(t *testing.T) {
 		{
 			name: "should not append loader file format when parameter doesn't exist",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{},
+				Parameters: pipeline.ParameterMap{},
 			},
 			cmdArgs:  []string{"--existing", "arg"},
 			expected: []string{"--existing", "arg"},
@@ -61,7 +61,7 @@ func TestConsolidatedParameters_IngestrFlagPassthrough(t *testing.T) {
 	t.Parallel()
 
 	asset := &pipeline.Asset{
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"incremental_key":      "updated_at",
 			"incremental_strategy": "merge",
 			"partition_by":         "event_date",
@@ -123,26 +123,26 @@ func TestConsolidatedParameters_TrimWhitespace(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		params   map[string]string
+		params   pipeline.ParameterMap
 		expected []string
 	}{
 		{
 			name: "true appends trim whitespace flag",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"trim_whitespace": "true",
 			},
 			expected: []string{"--existing", "--trim-whitespace"},
 		},
 		{
 			name: "false does not append trim whitespace flag",
-			params: map[string]string{
+			params: pipeline.ParameterMap{
 				"trim_whitespace": "false",
 			},
 			expected: []string{"--existing"},
 		},
 		{
 			name:     "missing does not append trim whitespace flag",
-			params:   map[string]string{},
+			params:   pipeline.ParameterMap{},
 			expected: []string{"--existing"},
 		},
 	}
@@ -298,7 +298,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "enforce_schema=true adds columns",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"enforce_schema": "true",
 				},
 				Columns: []pipeline.Column{
@@ -314,7 +314,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "enforce_schema=false does not add columns",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"enforce_schema": "false",
 				},
 				Columns: []pipeline.Column{
@@ -330,7 +330,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "default enforces when EnforceSchemaByDefault=true",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{},
+				Parameters: pipeline.ParameterMap{},
 				Columns: []pipeline.Column{
 					{Name: "id", Type: "integer"},
 				},
@@ -344,7 +344,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "default does not enforce when EnforceSchemaByDefault=false",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{},
+				Parameters: pipeline.ParameterMap{},
 				Columns: []pipeline.Column{
 					{Name: "id", Type: "integer"},
 				},
@@ -358,7 +358,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "nil columnOpts does not add columns",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"enforce_schema": "true",
 				},
 				Columns: []pipeline.Column{
@@ -371,7 +371,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "normalizes column names when NormalizeColumnNames=true",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"enforce_schema": "true",
 				},
 				Columns: []pipeline.Column{
@@ -387,7 +387,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "seed asset with path parameter can disable enforce_schema",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path":           "./seed.csv",
 					"enforce_schema": "false",
 				},
@@ -405,7 +405,7 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 		{
 			name: "seed asset without enforce_schema uses default (true)",
 			asset: &pipeline.Asset{
-				Parameters: map[string]string{
+				Parameters: pipeline.ParameterMap{
 					"path": "./seed.csv",
 				},
 				Columns: []pipeline.Column{
@@ -444,7 +444,7 @@ func TestConsolidatedParameters_SourceColumn(t *testing.T) {
 	t.Run("source_column with enforce_schema=true emits dest:type:source", func(t *testing.T) {
 		t.Parallel()
 		asset := &pipeline.Asset{
-			Parameters: map[string]string{
+			Parameters: pipeline.ParameterMap{
 				"enforce_schema": "true",
 			},
 			Columns: []pipeline.Column{
@@ -468,7 +468,7 @@ func TestConsolidatedParameters_SourceColumn(t *testing.T) {
 	t.Run("source_column without enforce_schema does not emit --columns", func(t *testing.T) {
 		t.Parallel()
 		asset := &pipeline.Asset{
-			Parameters: map[string]string{},
+			Parameters: pipeline.ParameterMap{},
 			Columns: []pipeline.Column{
 				{Name: "id", SourceColumn: "sourceid", Type: "integer"},
 			},

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -438,7 +438,7 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 	_, _ = output.Write([]byte("Successfully collected the data from the asset, uploading to the destination...\n"))
 
 	if len(asset.Parameters) == 0 {
-		asset.Parameters = make(map[string]string)
+		asset.Parameters = make(pipeline.ParameterMap)
 	}
 
 	if mat.Strategy != "" {
@@ -510,7 +510,8 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 	}
 
 	ingestrCtx := ctx
-	showLogs := asset.Parameters["show_ingestr_logs"] == "true"
+	showLogsVal, _ := asset.Parameters.GetString("show_ingestr_logs")
+	showLogs := showLogsVal == "true"
 	var logBuffer *tailBuffer
 	if !showLogs {
 		logBuffer = newTailBuffer(1 << 20) // 1MB cap

--- a/pkg/quicksight/operator.go
+++ b/pkg/quicksight/operator.go
@@ -52,7 +52,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return fmt.Errorf("connection '%s' is not a quicksight connection", connName)
 	}
 
-	if t.Parameters["refresh"] != "true" {
+	if refreshVal, _ := t.Parameters.GetString("refresh"); refreshVal != "true" {
 		return nil
 	}
 
@@ -67,7 +67,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 }
 
 func (o BasicOperator) handleDatasetRefresh(ctx context.Context, client *Client, t *pipeline.Asset) error {
-	datasetID, ok := t.Parameters["dataset_id"]
+	datasetID, ok := t.Parameters.GetString("dataset_id")
 	if !ok || datasetID == "" {
 		return errors.New("quicksight.dataset asset requires 'dataset_id' parameter when 'refresh' is true")
 	}
@@ -138,7 +138,7 @@ func pollIngestionStatus(ctx context.Context, client *Client, datasetID, ingesti
 	}
 }
 
-func resolveIncrementalRefresh(ctx context.Context, params map[string]string) bool {
+func resolveIncrementalRefresh(ctx context.Context, params pipeline.ParameterMap) bool {
 	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
 	if fullRefresh {
 		return false
@@ -151,7 +151,7 @@ func resolveIncrementalRefresh(ctx context.Context, params map[string]string) bo
 	return true
 }
 
-func resolveRefreshTimeout(params map[string]string) time.Duration {
+func resolveRefreshTimeout(params pipeline.ParameterMap) time.Duration {
 	timeoutMinutes, ok := getIntParam(params, "refresh_timeout_minutes")
 	if !ok || timeoutMinutes <= 0 {
 		return defaultRefreshTimeout
@@ -173,8 +173,8 @@ func isIncrementalNotSupported(err error) bool {
 	return strings.Contains(msg, "incremental")
 }
 
-func getBoolParam(params map[string]string, key string) (bool, bool) {
-	value, ok := params[key]
+func getBoolParam(params pipeline.ParameterMap, key string) (bool, bool) {
+	value, ok := params.GetString(key)
 	if !ok {
 		return false, false
 	}
@@ -189,8 +189,8 @@ func getBoolParam(params map[string]string, key string) (bool, bool) {
 	return parsed, true
 }
 
-func getIntParam(params map[string]string, key string) (int, bool) {
-	value, ok := params[key]
+func getIntParam(params pipeline.ParameterMap, key string) (int, bool) {
+	value, ok := params.GetString(key)
 	if !ok {
 		return 0, false
 	}

--- a/pkg/quicksight/operator_test.go
+++ b/pkg/quicksight/operator_test.go
@@ -30,29 +30,29 @@ func TestResolveIncrementalRefresh(t *testing.T) {
 
 	t.Run("default is incremental", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, resolveIncrementalRefresh(context.Background(), map[string]string{}))
+		assert.True(t, resolveIncrementalRefresh(context.Background(), pipeline.ParameterMap{}))
 	})
 
 	t.Run("explicit incremental true", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, resolveIncrementalRefresh(context.Background(), map[string]string{"incremental": "true"}))
+		assert.True(t, resolveIncrementalRefresh(context.Background(), pipeline.ParameterMap{"incremental": "true"}))
 	})
 
 	t.Run("explicit incremental false", func(t *testing.T) {
 		t.Parallel()
-		assert.False(t, resolveIncrementalRefresh(context.Background(), map[string]string{"incremental": "false"}))
+		assert.False(t, resolveIncrementalRefresh(context.Background(), pipeline.ParameterMap{"incremental": "false"}))
 	})
 
 	t.Run("full refresh flag overrides incremental", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.WithValue(context.Background(), pipeline.RunConfigFullRefresh, true)
-		assert.False(t, resolveIncrementalRefresh(ctx, map[string]string{"incremental": "true"}))
+		assert.False(t, resolveIncrementalRefresh(ctx, pipeline.ParameterMap{"incremental": "true"}))
 	})
 
 	t.Run("full refresh flag overrides default", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.WithValue(context.Background(), pipeline.RunConfigFullRefresh, true)
-		assert.False(t, resolveIncrementalRefresh(ctx, map[string]string{}))
+		assert.False(t, resolveIncrementalRefresh(ctx, pipeline.ParameterMap{}))
 	})
 }
 
@@ -61,32 +61,32 @@ func TestResolveRefreshTimeout(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		params   map[string]string
+		params   pipeline.ParameterMap
 		expected time.Duration
 	}{
 		{
 			name:     "default timeout",
-			params:   map[string]string{},
+			params:   pipeline.ParameterMap{},
 			expected: 60 * time.Minute,
 		},
 		{
 			name:     "custom timeout",
-			params:   map[string]string{"refresh_timeout_minutes": "30"},
+			params:   pipeline.ParameterMap{"refresh_timeout_minutes": "30"},
 			expected: 30 * time.Minute,
 		},
 		{
 			name:     "invalid timeout uses default",
-			params:   map[string]string{"refresh_timeout_minutes": "abc"},
+			params:   pipeline.ParameterMap{"refresh_timeout_minutes": "abc"},
 			expected: 60 * time.Minute,
 		},
 		{
 			name:     "zero timeout uses default",
-			params:   map[string]string{"refresh_timeout_minutes": "0"},
+			params:   pipeline.ParameterMap{"refresh_timeout_minutes": "0"},
 			expected: 60 * time.Minute,
 		},
 		{
 			name:     "negative timeout uses default",
-			params:   map[string]string{"refresh_timeout_minutes": "-5"},
+			params:   pipeline.ParameterMap{"refresh_timeout_minutes": "-5"},
 			expected: 60 * time.Minute,
 		},
 	}
@@ -105,16 +105,16 @@ func TestGetBoolParam(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		params    map[string]string
+		params    pipeline.ParameterMap
 		key       string
 		wantValue bool
 		wantOk    bool
 	}{
-		{"missing key", map[string]string{}, "key", false, false},
-		{"empty value", map[string]string{"key": ""}, "key", false, false},
-		{"true", map[string]string{"key": "true"}, "key", true, true},
-		{"false", map[string]string{"key": "false"}, "key", false, true},
-		{"invalid", map[string]string{"key": "maybe"}, "key", false, false},
+		{"missing key", pipeline.ParameterMap{}, "key", false, false},
+		{"empty value", pipeline.ParameterMap{"key": ""}, "key", false, false},
+		{"true", pipeline.ParameterMap{"key": "true"}, "key", true, true},
+		{"false", pipeline.ParameterMap{"key": "false"}, "key", false, true},
+		{"invalid", pipeline.ParameterMap{"key": "maybe"}, "key", false, false},
 	}
 
 	for _, tt := range tests {
@@ -132,15 +132,15 @@ func TestGetIntParam(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		params    map[string]string
+		params    pipeline.ParameterMap
 		key       string
 		wantValue int
 		wantOk    bool
 	}{
-		{"missing key", map[string]string{}, "key", 0, false},
-		{"empty value", map[string]string{"key": ""}, "key", 0, false},
-		{"valid int", map[string]string{"key": "42"}, "key", 42, true},
-		{"invalid", map[string]string{"key": "abc"}, "key", 0, false},
+		{"missing key", pipeline.ParameterMap{}, "key", 0, false},
+		{"empty value", pipeline.ParameterMap{"key": ""}, "key", 0, false},
+		{"valid int", pipeline.ParameterMap{"key": "42"}, "key", 42, true},
+		{"invalid", pipeline.ParameterMap{"key": "abc"}, "key", 0, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/s3/operator.go
+++ b/pkg/s3/operator.go
@@ -137,12 +137,12 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 		return nil
 	}
 
-	bucketName, ok := t.Parameters["bucket_name"]
+	bucketName, ok := t.Parameters.GetString("bucket_name")
 	if !ok {
 		return errors.New("S3 key sensor requires a parameter named 'bucket_name'")
 	}
 
-	bucketKey, ok := t.Parameters["bucket_key"]
+	bucketKey, ok := t.Parameters.GetString("bucket_key")
 	if !ok {
 		return errors.New("S3 key sensor requires a parameter named 'bucket_key'")
 	}

--- a/pkg/s3/operator_test.go
+++ b/pkg/s3/operator_test.go
@@ -175,7 +175,7 @@ func TestKeySensor_RunTask_MissingBucketName(t *testing.T) {
 
 	ks := NewKeySensor(&mockConnectionGetter{}, "once")
 	asset := &pipeline.Asset{
-		Parameters: map[string]string{},
+		Parameters: pipeline.ParameterMap{},
 	}
 	err := ks.RunTask(t.Context(), &pipeline.Pipeline{}, asset)
 	require.Error(t, err)
@@ -187,7 +187,7 @@ func TestKeySensor_RunTask_MissingBucketKey(t *testing.T) {
 
 	ks := NewKeySensor(&mockConnectionGetter{}, "once")
 	asset := &pipeline.Asset{
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"bucket_name": "my-bucket",
 		},
 	}
@@ -205,7 +205,7 @@ func TestKeySensor_RunTask_ConnectionNotFound(t *testing.T) {
 	ks := NewKeySensor(conn, "once")
 	asset := &pipeline.Asset{
 		Connection: "my-conn",
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"bucket_name": "my-bucket",
 			"bucket_key":  "path/to/file.csv",
 		},
@@ -224,7 +224,7 @@ func TestKeySensor_RunTask_WrongConnectionType(t *testing.T) {
 	ks := NewKeySensor(conn, "once")
 	asset := &pipeline.Asset{
 		Connection: "my-conn",
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"bucket_name": "my-bucket",
 			"bucket_key":  "path/to/file.csv",
 		},
@@ -248,7 +248,7 @@ func TestKeySensor_RunTask_AwsConnectionUsesCorrectCredentials(t *testing.T) {
 	ks := NewKeySensor(conn, "once")
 	asset := &pipeline.Asset{
 		Connection: "my-conn",
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"bucket_name": "my-bucket",
 			"bucket_key":  "path/to/file.csv",
 		},
@@ -278,7 +278,7 @@ func TestKeySensor_RunTask_S3ConnectionUsesCorrectCredentials(t *testing.T) {
 	ks := NewKeySensor(conn, "once")
 	asset := &pipeline.Asset{
 		Connection: "my-s3-conn",
-		Parameters: map[string]string{
+		Parameters: pipeline.ParameterMap{
 			"bucket_name": "my-bucket",
 			"bucket_key":  "path/to/file.csv",
 		},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -711,7 +711,7 @@ func TestScheduler_WillRunTaskOfType(t *testing.T) {
 	t1000 := &pipeline.Asset{
 		Name:       "task4000",
 		Type:       "ingestr",
-		Parameters: map[string]string{"destination": "postgres"},
+		Parameters: pipeline.ParameterMap{"destination": "postgres"},
 	}
 
 	p := &pipeline.Pipeline{

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -212,7 +212,7 @@ func (o *QuerySensor) Run(ctx context.Context, ti scheduler.TaskInstance) error 
 }
 
 func (o *QuerySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Asset) error {
-	qq, ok := t.Parameters["query"]
+	qq, ok := t.Parameters.GetString("query")
 	if !ok {
 		return errors.New("query sensor requires a parameter named 'query'")
 	}

--- a/pkg/snowflake/operator_test.go
+++ b/pkg/snowflake/operator_test.go
@@ -267,7 +267,7 @@ func TestQuerySensorTimesOutWhenConfigured(t *testing.T) {
 			Path:    "test-file.sql",
 			Content: "select 1",
 		},
-		Parameters: pipeline.EmptyStringMap{
+		Parameters: pipeline.ParameterMap{
 			"query":   "select 1",
 			"timeout": "100ms",
 		},

--- a/pkg/tableau/operator.go
+++ b/pkg/tableau/operator.go
@@ -44,7 +44,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return errors.Errorf("connection '%s' is not a tableau connection", connName)
 	}
 
-	if t.Parameters["refresh"] == "" {
+	if refreshVal, _ := t.Parameters.GetString("refresh"); refreshVal == "" {
 		return nil
 	}
 
@@ -64,16 +64,16 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 
 // nolint
 func (o BasicOperator) handleDatasourceRefresh(ctx context.Context, client *Client, t *pipeline.Asset) error {
-	refreshVal, ok := t.Parameters["refresh"]
+	refreshVal, ok := t.Parameters.GetString("refresh")
 	refresh := refreshVal == "true"
 	// if refresh is false, or if the parameter is not present, we treat
 	if !ok || !refresh {
 		return nil
 	}
 
-	datasourceID, ok := t.Parameters["datasource_id"]
+	datasourceID, ok := t.Parameters.GetString("datasource_id")
 	if !ok || datasourceID == "" {
-		name, hasName := t.Parameters["datasource_name"]
+		name, hasName := t.Parameters.GetString("datasource_name")
 		if !hasName || name == "" {
 			return errors.New("tableau.datasource asset requires either 'datasource_id' or 'datasource_name' parameter when 'refresh' is true")
 		}
@@ -101,16 +101,16 @@ func (o BasicOperator) handleDatasourceRefresh(ctx context.Context, client *Clie
 
 // nolint
 func (o BasicOperator) handleWorkbookRefresh(ctx context.Context, client *Client, t *pipeline.Asset) error {
-	refreshVal, ok := t.Parameters["refresh"]
+	refreshVal, ok := t.Parameters.GetString("refresh")
 	refresh := refreshVal == "true"
 	// if refresh is false, or if the parameter is not present, we treat
 	if !ok || !refresh {
 		return nil
 	}
 
-	workbookID, ok := t.Parameters["workbook_id"]
+	workbookID, ok := t.Parameters.GetString("workbook_id")
 	if !ok || workbookID == "" {
-		name, hasName := t.Parameters["workbook_name"]
+		name, hasName := t.Parameters.GetString("workbook_name")
 		if !hasName || name == "" {
 			return errors.New("tableau.workbook asset requires either 'workbook_id' or 'workbook_name' parameter when 'refresh' is true")
 		}
@@ -136,7 +136,7 @@ func (o BasicOperator) handleWorkbookRefresh(ctx context.Context, client *Client
 	return nil
 }
 
-func resolveIncrementalRefresh(ctx context.Context, params map[string]string) bool {
+func resolveIncrementalRefresh(ctx context.Context, params pipeline.ParameterMap) bool {
 	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
 	if fullRefresh {
 		return false
@@ -150,7 +150,7 @@ func resolveIncrementalRefresh(ctx context.Context, params map[string]string) bo
 	return true
 }
 
-func resolveRefreshTimeout(params map[string]string) time.Duration {
+func resolveRefreshTimeout(params pipeline.ParameterMap) time.Duration {
 	timeoutMinutes, ok := getIntParam(params, "refresh_timeout_minutes")
 	if !ok || timeoutMinutes <= 0 {
 		return defaultRefreshTimeout
@@ -159,8 +159,8 @@ func resolveRefreshTimeout(params map[string]string) time.Duration {
 	return time.Duration(timeoutMinutes) * time.Minute
 }
 
-func getBoolParam(params map[string]string, key string) (bool, bool) {
-	value, ok := params[key]
+func getBoolParam(params pipeline.ParameterMap, key string) (bool, bool) {
+	value, ok := params.GetString(key)
 	if !ok {
 		return false, false
 	}
@@ -178,8 +178,8 @@ func getBoolParam(params map[string]string, key string) (bool, bool) {
 	return parsed, true
 }
 
-func getIntParam(params map[string]string, key string) (int, bool) {
-	value, ok := params[key]
+func getIntParam(params pipeline.ParameterMap, key string) (int, bool) {
+	value, ok := params.GetString(key)
 	if !ok {
 		return 0, false
 	}

--- a/pkg/tableau/operator_test.go
+++ b/pkg/tableau/operator_test.go
@@ -12,7 +12,7 @@ import (
 type incrementalTestCase struct {
 	name       string
 	ctxFunc    func(t *testing.T) context.Context
-	parameters map[string]string
+	parameters pipeline.ParameterMap
 	want       bool
 }
 
@@ -22,13 +22,13 @@ func TestResolveIncrementalRefresh(t *testing.T) {
 	tests := []incrementalTestCase{
 		{
 			name:       "defaults to incremental",
-			parameters: map[string]string{},
+			parameters: pipeline.ParameterMap{},
 			want:       true,
 			ctxFunc:    func(t *testing.T) context.Context { return t.Context() },
 		},
 		{
 			name: "uses explicit incremental true",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"incremental": "true",
 			},
 			want:    true,
@@ -36,7 +36,7 @@ func TestResolveIncrementalRefresh(t *testing.T) {
 		},
 		{
 			name: "uses explicit incremental false",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"incremental": "false",
 			},
 			want:    false,
@@ -44,7 +44,7 @@ func TestResolveIncrementalRefresh(t *testing.T) {
 		},
 		{
 			name: "run full refresh overrides incremental true",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"incremental": "true",
 			},
 			want: false,
@@ -54,7 +54,7 @@ func TestResolveIncrementalRefresh(t *testing.T) {
 		},
 		{
 			name: "invalid incremental falls back to default",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"incremental": "maybe",
 			},
 			want:    true,
@@ -62,7 +62,7 @@ func TestResolveIncrementalRefresh(t *testing.T) {
 		},
 		{
 			name: "empty incremental falls back to default",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"incremental": " ",
 			},
 			want:    true,
@@ -83,31 +83,31 @@ func TestResolveRefreshTimeout(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		parameters map[string]string
+		parameters pipeline.ParameterMap
 		want       time.Duration
 	}{
 		{
 			name:       "defaults to sixty minutes",
-			parameters: map[string]string{},
+			parameters: pipeline.ParameterMap{},
 			want:       60 * time.Minute,
 		},
 		{
 			name: "uses explicit timeout value",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"refresh_timeout_minutes": "90",
 			},
 			want: 90 * time.Minute,
 		},
 		{
 			name: "invalid timeout falls back to default",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"refresh_timeout_minutes": "abc",
 			},
 			want: 60 * time.Minute,
 		},
 		{
 			name: "non-positive timeout falls back to default",
-			parameters: map[string]string{
+			parameters: pipeline.ParameterMap{
 				"refresh_timeout_minutes": "0",
 			},
 			want: 60 * time.Minute,


### PR DESCRIPTION
## Summary
- Change asset parameters from string-only maps to structured parameter maps.
- Update existing parameter consumers to read scalar values through GetString.
- Recursively render Jinja inside nested parameter values without exposing asset parameters to the Jinja context.
- Add unit and integration coverage for nested rendering and no parameter-context access.

## Validation
- make format
- make test
- make integration-test-light
- git diff --check