### PR TITLE
[codex] clarify Mongo connection configuration docs

### DIFF
--- a/docs/ingestion/mongo.md
+++ b/docs/ingestion/mongo.md
@@ -21,16 +21,27 @@ To connect to MongoDB, you need to add a configuration item to the connections s
           username: "testUser"
           password: "testPass123"
           host: "localhost"
-          port: 27018
-          database: "testDB"
+          port: 27017
 ```
 
 - `name`: The name to identify this MongoDB connection
 - `username`: The MongoDB username with access to the database
 - `password`: The password for the specified username
-- `host`: The host address of the MongoDB server (e.g., localhost or an IP address)
-- `port`: The port number the database server is listening on (default: 27017)
-- `database`:  The name of the database to connect to
+- `host`: The host address of the MongoDB server, without the `mongodb://` protocol or port (for example, `localhost` or `mongo.example.com`)
+- `port`: The port number the database server is listening on. Use `27017` for the MongoDB default port.
+- `database`: Optional. If set, Bruin appends it to the connection URI path. For ingestr assets, the target database is usually provided in `source_table` as `database.collection`.
+
+Bruin turns this configuration into a MongoDB URI in the following form:
+
+```text
+mongodb://testUser:testPass123@localhost:27017
+```
+
+If `username` is empty, Bruin omits the username and password from the URI.
+If your username or password contains special characters, Bruin URL-encodes them when it builds the URI.
+
+> [!CAUTION]
+> Always set `port` for `mongo` connections. The current configuration loader does not apply the schema default when reading `.bruin.yml`, so omitting `port` will build a URI with port `0`.
 
 ### Step 2: Create an asset file for data ingestion
 
@@ -52,7 +63,7 @@ parameters:
 - `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
 - `source_connection`: The name of the MongoDB connection defined in .bruin.yml.
-- `source_table`: The name of the data table in MongoDB that you want to ingest.
+- `source_table`: The MongoDB collection to ingest, in `database.collection` format.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/platforms/mongoatlas.md
+++ b/docs/platforms/mongoatlas.md
@@ -18,18 +18,26 @@ To set up a MongoDB Atlas connection, you need to add a configuration item to `c
           username: "your-username"
           password: "your-password"
           host: "cluster0.example.mongodb.net"
-          database: "your-database"
 ```
 
 **Parameters**:
 
+- `name`: The name to identify this MongoDB Atlas connection in Bruin assets and pipeline defaults
 - `username`: MongoDB Atlas database username
 - `password`: MongoDB Atlas database password
-- `host`: MongoDB Atlas cluster hostname (e.g., `cluster0.example.mongodb.net`)
-- `database`: The database name to connect to
+- `host`: MongoDB Atlas cluster hostname, without the `mongodb+srv://` protocol (e.g., `cluster0.example.mongodb.net`)
+- `database`: Optional. If set, Bruin appends it to the connection URI path. For ingestr assets, the target database is usually provided in `source_table` or `destination_table` as `database.collection`.
 
 > [!NOTE]
-> The connection uses the `mongodb+srv://` protocol which is the standard for MongoDB Atlas connections. You don't need to specify the protocol in the configuration.
+> The connection uses the `mongodb+srv://` protocol, which is the standard for MongoDB Atlas connections. You don't need to specify the protocol or a port in the configuration.
+
+Bruin turns this configuration into a MongoDB Atlas URI in the following form:
+
+```text
+mongodb+srv://your-username:your-password@cluster0.example.mongodb.net
+```
+
+If your username or password contains special characters, Bruin URL-encodes them when it builds the URI.
 
 ## Using MongoDB Atlas as a Destination
 
@@ -47,14 +55,16 @@ parameters:
   source_table: 'public.users'
 
   destination: mongo_atlas
-  destination_connection: mongo_atlas
-  destination_table: 'users'
+  destination_connection: connection_name
+  destination_table: 'mydb.users'
 ```
 
 This configuration will:
 
 1. Extract data from the `public.users` table in PostgreSQL
-2. Load the data into the `users` collection in your MongoDB Atlas database
+2. Load the data into the `users` collection in the `mydb` MongoDB Atlas database
+
+`destination_connection` must match the `name` of a `mongo_atlas` connection in `.bruin.yml`. `destination_table` uses `database.collection` format.
 
 ## Using MongoDB Atlas as a Source
 
@@ -68,7 +78,7 @@ type: ingestr
 connection: postgres
 
 parameters:
-  source_connection: mongo_atlas
+  source_connection: connection_name
   source_table: 'users.details'
 
   destination: postgres
@@ -76,5 +86,7 @@ parameters:
 
 This configuration will:
 
-1. Extract data from the `users.details` collection in your MongoDB Atlas database
+1. Extract data from the `details` collection in the `users` MongoDB Atlas database
 2. Load the data into the `public.atlas_users` table in PostgreSQL
+
+`source_connection` must match the `name` of a `mongo_atlas` connection in `.bruin.yml`. `source_table` uses `database.collection` format.


### PR DESCRIPTION
## Summary
- clarify standard MongoDB `.bruin.yml` connection configuration and generated URI behavior
- clarify MongoDB Atlas `mongo_atlas` configuration, SRV URI behavior, and no-port requirement
- fix MongoDB Atlas example connection references and document `database.collection` source/destination table format

## Validation
- `npm run docs:build`
- `npx markdownlint-cli2 --no-globs docs/ingestion/mongo.md docs/platforms/mongoatlas.md`
- `git diff --check -- docs/ingestion/mongo.md docs/platforms/mongoatlas.md`

Full `make format` / `make test` not run because this is a docs-only change.
