### PR TITLE
feat(ingestr): add Twilio as a source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -360,6 +360,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "SQLite", link: "/ingestion/sqlite"},
                                     {text: "SurveyMonkey", link: "/ingestion/surveymonkey"},
                                     {text: "TikTok Ads", link: "/ingestion/tiktokads"},
+                                    {text: "Twilio", link: "/ingestion/twilio"},
                                     {text: "Wise", link: "/ingestion/wise"},
                                     {text: "Zendesk", link: "/ingestion/zendesk"},
                                     {text: "Zoom", link: "/ingestion/zoom"},

--- a/docs/ingestion/twilio.md
+++ b/docs/ingestion/twilio.md
@@ -1,0 +1,69 @@
+# Twilio
+
+[Twilio](https://www.twilio.com/) is a cloud communications platform for messaging, voice, and phone numbers.
+
+Bruin supports Twilio as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Twilio into your data warehouse.
+
+To set up a Twilio connection, you need your Account SID and either an Auth Token or an API Key SID + Secret. For more information, please refer [here](https://getbruin.com/docs/ingestr/supported-sources/twilio.html)
+
+Follow the steps below to correctly set up Twilio as a data source and run ingestion:
+
+## Configuration
+
+### Step 1: Add a connection to .bruin.yml file
+
+To connect to Twilio, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+    connections:
+      twilio:
+        - name: "my_twilio"
+          account_sid: "YOUR_TWILIO_ACCOUNT_SID"
+          auth_token: "YOUR_TWILIO_AUTH_TOKEN"
+```
+
+- `account_sid`: Your Twilio Account SID (starts with `AC`). Required.
+- `auth_token`: Your Twilio Auth Token. Required unless `api_key`/`api_secret` are provided.
+- `api_key` (optional): An API Key SID, used instead of the Auth Token. Requires `api_secret`.
+- `api_secret` (optional): The secret for the API Key. Required when `api_key` is set.
+
+Authentication uses HTTP Basic Auth; the API Key + Secret pair takes precedence over the Auth Token when both are provided.
+
+### Step 2: Create an asset file for data ingestion
+
+To ingest data from Twilio, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., twilio_ingestion.yml) inside the assets folder and add the following content:
+
+```yaml
+name: public.twilio
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: my_twilio
+  source_table: 'messages'
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Specifies the type of the asset. It will be always ingestr type for Twilio.
+- `connection`: This is the destination connection.
+- `source_connection`: The name of the Twilio connection defined in .bruin.yml.
+- `source_table`: The name of the data table in Twilio you want to ingest. For example, `messages` would ingest message records.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| `messages` | sid | - | replace | SMS and MMS messages. Fully replaced each run because redactions and deletions can't be detected incrementally. |
+| `calls` | sid | date_updated | merge | Voice calls. Lifecycle changes (status/duration/end_time) bump `date_updated`. |
+| `recordings` | sid | date_updated | merge | Call recordings, including deleted ones (soft-deletes surface as `status=deleted`). |
+| `incoming_phone_numbers` | sid | - | replace | Phone numbers owned by the account. |
+| `usage_records` | - | - | replace | Usage totals per category over the account lifetime. Accepts an optional `:daily`, `:monthly`, or `:yearly` granularity suffix (e.g. `usage_records:daily`) that loads incrementally by period. |
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run ingestr.twilio.asset.yml
+```
+
+As a result of this command, Bruin will ingest data from the given Twilio table into your Postgres database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1313,6 +1313,12 @@
           },
           "type": "array"
         },
+        "twilio": {
+          "items": {
+            "$ref": "#/$defs/TwilioConnection"
+          },
+          "type": "array"
+        },
         "espn": {
           "items": {
             "$ref": "#/$defs/EspnConnection"
@@ -4177,6 +4183,31 @@
         "name",
         "business_unit_id",
         "api_key"
+      ]
+    },
+    "TwilioConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "account_sid": {
+          "type": "string"
+        },
+        "auth_token": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        },
+        "api_secret": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "account_sid"
       ]
     },
     "VerticaConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1810,6 +1810,18 @@ func (c SendgridConnection) GetName() string {
 	return c.Name
 }
 
+type TwilioConnection struct {
+	Name       string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	AccountSID string `yaml:"account_sid,omitempty" json:"account_sid" mapstructure:"account_sid"`
+	AuthToken  string `yaml:"auth_token,omitempty" json:"auth_token,omitempty" mapstructure:"auth_token"`
+	APIKey     string `yaml:"api_key,omitempty" json:"api_key,omitempty" mapstructure:"api_key"`
+	APISecret  string `yaml:"api_secret,omitempty" json:"api_secret,omitempty" mapstructure:"api_secret"`
+}
+
+func (c TwilioConnection) GetName() string {
+	return c.Name
+}
+
 type EspnConnection struct {
 	Name    string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	Sport   string `yaml:"sport,omitempty" json:"sport,omitempty" mapstructure:"sport"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -142,6 +142,7 @@ type Connections struct {
 	Indeed              []IndeedConnection              `yaml:"indeed,omitempty" json:"indeed,omitempty" mapstructure:"indeed"`
 	CustomerIo          []CustomerIoConnection          `yaml:"customerio,omitempty" json:"customerio,omitempty" mapstructure:"customerio"`
 	Sendgrid            []SendgridConnection            `yaml:"sendgrid,omitempty" json:"sendgrid,omitempty" mapstructure:"sendgrid"`
+	Twilio              []TwilioConnection              `yaml:"twilio,omitempty" json:"twilio,omitempty" mapstructure:"twilio"`
 	Espn                []EspnConnection                `yaml:"espn,omitempty" json:"espn,omitempty" mapstructure:"espn"`
 	APIFootball         []APIFootballConnection         `yaml:"apifootball,omitempty" json:"apifootball,omitempty" mapstructure:"apifootball"`
 	FootballData        []FootballDataConnection        `yaml:"footballdata,omitempty" json:"footballdata,omitempty" mapstructure:"footballdata"`
@@ -1325,6 +1326,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Sendgrid = append(env.Connections.Sendgrid, conn)
+	case "twilio":
+		var conn TwilioConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Twilio = append(env.Connections.Twilio, conn)
 	case "espn":
 		var conn EspnConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1633,6 +1641,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.CustomerIo = removeConnection(env.Connections.CustomerIo, connectionName)
 	case "sendgrid":
 		env.Connections.Sendgrid = removeConnection(env.Connections.Sendgrid, connectionName)
+	case "twilio":
+		env.Connections.Twilio = removeConnection(env.Connections.Twilio, connectionName)
 	case "espn":
 		env.Connections.Espn = removeConnection(env.Connections.Espn, connectionName)
 	case "apifootball":
@@ -1821,6 +1831,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Indeed, source.Indeed)
 	mergeConnectionList(&c.CustomerIo, source.CustomerIo)
 	mergeConnectionList(&c.Sendgrid, source.Sendgrid)
+	mergeConnectionList(&c.Twilio, source.Twilio)
 	mergeConnectionList(&c.Espn, source.Espn)
 	mergeConnectionList(&c.APIFootball, source.APIFootball)
 	mergeConnectionList(&c.FootballData, source.FootballData)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -807,6 +807,15 @@ func TestLoadFromFile(t *testing.T) {
 					OnBehalfOf: "test-subuser",
 				},
 			},
+			Twilio: []TwilioConnection{
+				{
+					Name:       "twilio-1",
+					AccountSID: "test-account-sid",
+					AuthToken:  "test-auth-token",
+					APIKey:     "test-api-key",
+					APISecret:  "test-api-secret",
+				},
+			},
 			Espn: []EspnConnection{
 				{
 					Name:   "espn-1",
@@ -2235,6 +2244,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Indeed:              []IndeedConnection{{Name: "indeed1"}},
 				CustomerIo:          []CustomerIoConnection{{Name: "customerio1"}},
 				Sendgrid:            []SendgridConnection{{Name: "sendgrid1"}},
+				Twilio:              []TwilioConnection{{Name: "twilio1"}},
 				Espn:                []EspnConnection{{Name: "espn1"}},
 				APIFootball:         []APIFootballConnection{{Name: "apifootball1"}},
 				FootballData:        []FootballDataConnection{{Name: "footballdata1"}},
@@ -2360,6 +2370,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Indeed:              []IndeedConnection{{Name: "indeed1"}},
 				CustomerIo:          []CustomerIoConnection{{Name: "customerio1"}},
 				Sendgrid:            []SendgridConnection{{Name: "sendgrid1"}},
+				Twilio:              []TwilioConnection{{Name: "twilio1"}},
 				Espn:                []EspnConnection{{Name: "espn1"}},
 				APIFootball:         []APIFootballConnection{{Name: "apifootball1"}},
 				FootballData:        []FootballDataConnection{{Name: "footballdata1"}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -505,6 +505,12 @@ environments:
         - name: "sendgrid-1"
           api_key: "test-api-key"
           on_behalf_of: "test-subuser"
+      twilio:
+        - name: "twilio-1"
+          account_sid: "test-account-sid"
+          auth_token: "test-auth-token"
+          api_key: "test-api-key"
+          api_secret: "test-api-secret"
       espn:
         - name: "espn-1"
           sport: "football"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -506,6 +506,12 @@ environments:
         - name: "sendgrid-1"
           api_key: "test-api-key"
           on_behalf_of: "test-subuser"
+      twilio:
+        - name: "twilio-1"
+          account_sid: "test-account-sid"
+          auth_token: "test-auth-token"
+          api_key: "test-api-key"
+          api_secret: "test-api-secret"
       espn:
         - name: "espn-1"
           sport: "football"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -127,6 +127,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/tiktokads"
 	"github.com/bruin-data/bruin/pkg/trino"
 	"github.com/bruin-data/bruin/pkg/trustpilot"
+	"github.com/bruin-data/bruin/pkg/twilio"
 	"github.com/bruin-data/bruin/pkg/vertica"
 	"github.com/bruin-data/bruin/pkg/wise"
 	"github.com/bruin-data/bruin/pkg/wistia"
@@ -257,6 +258,7 @@ type Manager struct {
 	Vertica              map[string]*vertica.DB
 	CustomerIo           map[string]*customerio.Client
 	Sendgrid             map[string]*sendgrid.Client
+	Twilio               map[string]*twilio.Client
 	Espn                 map[string]*espn.Client
 	APIFootball          map[string]*apifootball.Client
 	FootballData         map[string]*footballdata.Client
@@ -3142,6 +3144,28 @@ func (m *Manager) AddSendgridConnectionFromConfig(connection *config.SendgridCon
 	return nil
 }
 
+func (m *Manager) AddTwilioConnectionFromConfig(connection *config.TwilioConnection) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.Twilio == nil {
+		m.Twilio = make(map[string]*twilio.Client)
+	}
+
+	client, err := twilio.NewClient(twilio.Config{
+		AccountSID: connection.AccountSID,
+		AuthToken:  connection.AuthToken,
+		APIKey:     connection.APIKey,
+		APISecret:  connection.APISecret,
+	})
+	if err != nil {
+		return err
+	}
+	m.Twilio[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddEspnConnectionFromConfig(connection *config.EspnConnection) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -3691,6 +3715,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Vertica, connectionManager.AddVerticaConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.CustomerIo, connectionManager.AddCustomerIoConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Sendgrid, connectionManager.AddSendgridConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Twilio, connectionManager.AddTwilioConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Espn, connectionManager.AddEspnConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.APIFootball, connectionManager.AddAPIFootballConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.FootballData, connectionManager.AddFootballDataConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -814,6 +814,14 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "lists", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
 		{Name: "single_sends", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
 	},
+	// Twilio - Cloud communications (messaging, voice, phone numbers)
+	"twilio": {
+		{Name: "messages", PrimaryKey: "sid", IncKey: "", IncStrategy: "replace"},
+		{Name: "calls", PrimaryKey: "sid", IncKey: "date_updated", IncStrategy: "merge"},
+		{Name: "recordings", PrimaryKey: "sid", IncKey: "date_updated", IncStrategy: "merge"},
+		{Name: "incoming_phone_numbers", PrimaryKey: "sid", IncKey: "", IncStrategy: "replace"},
+		{Name: "usage_records", PrimaryKey: "", IncKey: "", IncStrategy: "replace"},
+	},
 
 	// SFTP (user-defined paths)
 	"sftp": {},

--- a/pkg/twilio/config.go
+++ b/pkg/twilio/config.go
@@ -1,0 +1,25 @@
+package twilio
+
+import "net/url"
+
+type Config struct {
+	AccountSID string
+	AuthToken  string
+	APIKey     string
+	APISecret  string
+}
+
+func (c *Config) GetIngestrURI() string {
+	params := url.Values{}
+	params.Set("account_sid", c.AccountSID)
+	if c.AuthToken != "" {
+		params.Set("auth_token", c.AuthToken)
+	}
+	if c.APIKey != "" {
+		params.Set("api_key", c.APIKey)
+	}
+	if c.APISecret != "" {
+		params.Set("api_secret", c.APISecret)
+	}
+	return "twilio://?" + params.Encode()
+}

--- a/pkg/twilio/db.go
+++ b/pkg/twilio/db.go
@@ -1,0 +1,15 @@
+package twilio
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}


### PR DESCRIPTION
## What

Adds **Twilio** as an ingestr source connection in Bruin.

### Connection params (all from the `twilio://` URI)
| Param | Required | Notes |
|---|---|---|
| `account_sid` | ✅ | Twilio Account SID (`AC…`) |
| `auth_token` | — | Required unless `api_key`/`api_secret` are used |
| `api_key` | — | API Key SID, used instead of the Auth Token |
| `api_secret` | — | Required when `api_key` is set |

`GetIngestrURI()` builds `twilio://?account_sid=…&auth_token=…&api_key=…&api_secret=…` (only non-empty fields are added; `account_sid` always present).