### PR TITLE
Support column masks for ingestr assets

### DIFF
--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -41,6 +41,7 @@ Each column will have the following keys:
 | `name`            | String  | yes  | The name of the column                                                          |
 | `source_column`   | String  | no   | For ingestr assets, the source column name to map onto `name`. See [Column name mapping](#column-name-mapping-ingestr-assets). |
 | `type`            | String  | no   | The column type in the DB                                                       |
+| `mask`            | String  | no   | For ingestr assets, a masking rule or method. See [Column masking](#column-masking-ingestr-assets). |
 | `description`     | String  | no   | The description for the column                                                  |
 | `tags`            | String[]| no   | Tags applied to the column for categorization and filtering                     |
 | `primary_key`     | Bool    | no   | Whether the column is a primary key                                             |
@@ -161,4 +162,26 @@ columns:
     type: string
   - name: email
     source_column: eml          # type omitted: ingestr just renames, no type enforcement
+```
+
+### Column masking (ingestr assets)
+
+For ingestr assets, you can define a column mask next to the column metadata. If `mask`
+contains only the masking method, Bruin qualifies it with the column name before passing
+it to ingestr:
+
+```yaml
+columns:
+  - name: email
+    type: string
+    mask: hash
+```
+
+The example above is passed to ingestr as `--mask email:hash`. You can also provide the
+full ingestr mask rule directly:
+
+```yaml
+columns:
+  - name: email
+    mask: email:hash
 ```

--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -105,7 +105,7 @@ parameters:
 
 ### Column metadata
 
-Define columns on the asset to enrich the metadata passed to Ingestr. Columns flagged as `primary_key: true` are translated into repeated `--primary-key` flags, and date-typed incremental keys automatically surface through `--columns`. See [Column metadata](./columns.md) for the syntax.
+Define columns on the asset to enrich the metadata passed to Ingestr. Columns flagged as `primary_key: true` are translated into repeated `--primary-key` flags, columns with `mask` are translated into repeated `--mask` flags, and date-typed incremental keys automatically surface through `--columns`. See [Column metadata](./columns.md) for the syntax.
 
 ### Custom SQL queries
 
@@ -205,6 +205,7 @@ columns:
     type: string
   - name: email
     type: string
+    mask: hash
   - name: age
     type: integer
   - name: created_at

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -411,6 +411,8 @@ func handleColumnEntry(columnFields []string, task *Asset, value string) error {
 		}
 	case "type":
 		task.Columns[columnIndex].Type = strings.ToLower(strings.TrimSpace(value))
+	case "mask":
+		task.Columns[columnIndex].Mask = strings.TrimSpace(value)
 	case "primary_key":
 		boolValue, err := strconv.ParseBool(value)
 		if err != nil {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -708,6 +708,7 @@ type Column struct {
 	Name            string            `json:"name" yaml:"name,omitempty" mapstructure:"name"`
 	SourceColumn    string            `json:"source_column" yaml:"source_column,omitempty" mapstructure:"source_column"`
 	Type            string            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
+	Mask            string            `json:"mask,omitempty" yaml:"mask,omitempty" mapstructure:"mask"`
 	Description     string            `json:"description" yaml:"description,omitempty" mapstructure:"description"`
 	Tags            EmptyStringArray  `json:"tags" yaml:"tags,omitempty" mapstructure:"tags"`
 	PrimaryKey      bool              `json:"primary_key" yaml:"primary_key,omitempty" mapstructure:"primary_key"`
@@ -3015,6 +3016,7 @@ func mergeColumnDefault(target *Column, defaults Column, assetName string) {
 	applyStringDefault(&target.Name, defaults.Name)
 	applyStringDefault(&target.SourceColumn, defaults.SourceColumn)
 	applyStringDefault(&target.Type, defaults.Type)
+	applyStringDefault(&target.Mask, defaults.Mask)
 	applyStringDefault(&target.Description, defaults.Description)
 	appendMissingStringValues(&target.Tags, defaults.Tags)
 	if !target.PrimaryKey && defaults.PrimaryKey {

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -470,6 +470,9 @@ func renderAssetStrings(render RenderFunc, a *Asset) error {
 		if c.Type, err = maybeRender(render, fmt.Sprintf("asset[%s].columns[%d].type", originalName, i), c.Type); err != nil {
 			return err
 		}
+		if c.Mask, err = maybeRender(render, fmt.Sprintf("asset[%s].columns[%d].mask", originalName, i), c.Mask); err != nil {
+			return err
+		}
 		if c.Description, err = maybeRender(render, fmt.Sprintf("asset[%s].columns[%d].description", originalName, i), c.Description); err != nil {
 			return err
 		}

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -289,6 +289,7 @@ type column struct {
 	Name          string            `yaml:"name"`
 	SourceColumn  string            `yaml:"source_column"`
 	Type          string            `yaml:"type"`
+	Mask          string            `yaml:"mask"`
 	Description   string            `yaml:"description"`
 	Tests         []columnCheck     `yaml:"checks"`
 	PrimaryKey    bool              `yaml:"primary_key"`
@@ -513,6 +514,7 @@ func taskDefinitionToAsset(definition taskDefinition) (*Asset, error) {
 			Name:            column.Name,
 			SourceColumn:    column.SourceColumn,
 			Type:            strings.TrimSpace(column.Type),
+			Mask:            strings.TrimSpace(column.Mask),
 			Description:     column.Description,
 			Checks:          tests,
 			PrimaryKey:      column.PrimaryKey,

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -449,14 +449,17 @@ columns:
   - name: first_name
     source_column: fname
     type: string
+    mask: hash
   - name: email
     type: string
-`)))
+	`)))
 	require.NoError(t, err)
 	require.Len(t, task.Columns, 2)
 	require.Equal(t, "first_name", task.Columns[0].Name)
 	require.Equal(t, "fname", task.Columns[0].SourceColumn)
+	require.Equal(t, "hash", task.Columns[0].Mask)
 	require.Empty(t, task.Columns[1].SourceColumn)
+	require.Empty(t, task.Columns[1].Mask)
 }
 
 func TestConvertYamlToTask_ColumnMetadata(t *testing.T) {

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -21,7 +21,6 @@ var ingestrValueParameterFlags = []string{
 	"sql_reflection_level",
 	"sql_limit",
 	"sql_exclude_columns",
-	"mask",
 	"pipelines_dir",
 	"staging_bucket",
 	"staging_dataset",
@@ -39,6 +38,7 @@ var ingestrBoolParameterFlags = []string{
 
 func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs []string, columnOpts *ColumnHintOptions) ([]string, error) {
 	cmdArgs = appendIngestrParameterFlags(asset.Parameters, cmdArgs)
+	cmdArgs = appendIngestrMaskFlags(asset.Parameters, asset.Columns, cmdArgs, columnOpts != nil && columnOpts.NormalizeColumnNames)
 
 	if value, exists := asset.Parameters.GetString("incremental_key"); exists && value != "" {
 		// Check if the incremental key column exists and is of date type
@@ -112,6 +112,46 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 	}
 
 	return cmdArgs, nil
+}
+
+func appendIngestrMaskFlags(params pipeline.ParameterMap, cols []pipeline.Column, cmdArgs []string, normalizeColumnNames bool) []string {
+	seen := make(map[string]struct{})
+	if mask, exists := params.GetString("mask"); exists {
+		cmdArgs = appendIngestrMaskRule(cmdArgs, seen, strings.TrimSpace(mask))
+	}
+
+	for _, col := range cols {
+		mask := strings.TrimSpace(col.Mask)
+		if mask == "" {
+			continue
+		}
+
+		rule := mask
+		if !strings.Contains(mask, ":") {
+			columnName := strings.TrimSpace(col.Name)
+			if columnName == "" {
+				continue
+			}
+			if normalizeColumnNames {
+				columnName = NormalizeColumnName(columnName)
+			}
+			rule = columnName + ":" + mask
+		}
+		cmdArgs = appendIngestrMaskRule(cmdArgs, seen, rule)
+	}
+
+	return cmdArgs
+}
+
+func appendIngestrMaskRule(cmdArgs []string, seen map[string]struct{}, rule string) []string {
+	if rule == "" {
+		return cmdArgs
+	}
+	if _, ok := seen[rule]; ok {
+		return cmdArgs
+	}
+	seen[rule] = struct{}{}
+	return append(cmdArgs, "--mask", rule)
 }
 
 func appendIngestrParameterFlags(params pipeline.ParameterMap, cmdArgs []string) []string {

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -104,7 +104,6 @@ func TestConsolidatedParameters_IngestrFlagPassthrough(t *testing.T) {
 		"--sql-reflection-level", "full",
 		"--sql-limit", "500",
 		"--sql-exclude-columns", "internal_notes",
-		"--mask", "email:hash",
 		"--pipelines-dir", ".ingestr",
 		"--staging-bucket", "gs://bucket/path",
 		"--staging-dataset", "scratch",
@@ -115,6 +114,7 @@ func TestConsolidatedParameters_IngestrFlagPassthrough(t *testing.T) {
 		"--no-inference",
 		"--trim-whitespace",
 		"--stream",
+		"--mask", "email:hash",
 	}, result)
 }
 
@@ -151,6 +151,78 @@ func TestConsolidatedParameters_TrimWhitespace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := ConsolidatedParameters(t.Context(), &pipeline.Asset{Parameters: tt.params}, []string{"--existing"}, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConsolidatedParameters_ColumnMasks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		params     pipeline.ParameterMap
+		columns    []pipeline.Column
+		columnOpts *ColumnHintOptions
+		expected   []string
+	}{
+		{
+			name: "column mask method emits column-qualified mask flag",
+			columns: []pipeline.Column{
+				{Name: "email", Mask: "hash"},
+				{Name: "phone", Mask: "sha256"},
+			},
+			expected: []string{"--existing", "--mask", "email:hash", "--mask", "phone:sha256"},
+		},
+		{
+			name: "full mask rule is preserved",
+			columns: []pipeline.Column{
+				{Name: "email", Mask: "contact_email:hash"},
+			},
+			expected: []string{"--existing", "--mask", "contact_email:hash"},
+		},
+		{
+			name: "column names are normalized when requested",
+			columns: []pipeline.Column{
+				{Name: "Contact Email", Mask: "hash"},
+			},
+			columnOpts: &ColumnHintOptions{
+				NormalizeColumnNames: true,
+			},
+			expected: []string{"--existing", "--mask", "contact_email:hash"},
+		},
+		{
+			name: "asset mask is preserved and duplicate column mask is skipped",
+			params: pipeline.ParameterMap{
+				"mask": "email:hash",
+			},
+			columns: []pipeline.Column{
+				{Name: "email", Mask: "hash"},
+				{Name: "phone", Mask: "sha256"},
+			},
+			expected: []string{"--existing", "--mask", "email:hash", "--mask", "phone:sha256"},
+		},
+		{
+			name: "empty masks are ignored",
+			columns: []pipeline.Column{
+				{Name: "email", Mask: " "},
+			},
+			expected: []string{"--existing"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params := tt.params
+			if params == nil {
+				params = pipeline.ParameterMap{}
+			}
+			result, err := ConsolidatedParameters(t.Context(), &pipeline.Asset{
+				Parameters: params,
+				Columns:    tt.columns,
+			}, []string{"--existing"}, tt.columnOpts)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})


### PR DESCRIPTION
Adds `columns[].mask` for ingestr assets and turns shorthand values like `hash` into `--mask column:hash`, while preserving full mask rules.

This carries the field through YAML, comments, defaults, and variant rendering, with docs and tests updated.

Closes #2158.

Checks: `make format`, `make test`.