### PR TITLE
fix(snowflake): honor database component of three-part asset names

### DIFF
--- a/pkg/ansisql/schema.go
+++ b/pkg/ansisql/schema.go
@@ -31,7 +31,13 @@ func (sc *SchemaCreator) CreateSchemaIfNotExist(ctx context.Context, qr queryRun
 	case 2:
 		schemaName = strings.ToUpper(tableComponents[0])
 	case 3:
-		schemaName = strings.ToUpper(tableComponents[1])
+		// Three-part names are `database.schema.table` (Snowflake) or
+		// `catalog.schema.table` (Databricks). Qualify the schema with the
+		// first component so it is created in the database/catalog named in the
+		// asset rather than the connection's default database. Keeping the
+		// qualifier in the cache key also stops the same schema name in two
+		// different databases from being deduped into a single creation.
+		schemaName = strings.ToUpper(tableComponents[0]) + "." + strings.ToUpper(tableComponents[1])
 	default:
 		return nil
 	}

--- a/pkg/ansisql/schema_test.go
+++ b/pkg/ansisql/schema_test.go
@@ -63,6 +63,29 @@ func TestSchemaCreator_CreateSchemaIfNotExist(t *testing.T) {
 			expectedError: "failed to create or ensure database: TEST_SCHEMA: creation failed",
 		},
 		{
+			name: "three-part name qualifies schema with the database/catalog",
+			asset: &pipeline.Asset{
+				Name: "other_db.test_schema.test_table",
+			},
+			mockSetup: func(db *mockDB, cache *sync.Map) {
+				// The schema must be created in the database/catalog named in the
+				// asset, not the connection's default, so it has to be qualified.
+				db.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "CREATE SCHEMA IF NOT EXISTS OTHER_DB.TEST_SCHEMA"}).Return(nil)
+			},
+		},
+		{
+			name: "same schema name in different databases is not deduped by the cache",
+			asset: &pipeline.Asset{
+				Name: "other_db.test_schema.test_table",
+			},
+			mockSetup: func(db *mockDB, cache *sync.Map) {
+				// A bare "TEST_SCHEMA" was already created in the default database;
+				// the cache must not skip creating it in OTHER_DB.
+				cache.Store("TEST_SCHEMA", true)
+				db.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "CREATE SCHEMA IF NOT EXISTS OTHER_DB.TEST_SCHEMA"}).Return(nil)
+			},
+		},
+		{
 			name: "asset name with 1 component",
 			asset: &pipeline.Asset{
 				Name: "test_table",

--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -522,13 +522,16 @@ func (db *DB) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset)
 
 func (db *DB) RecreateTableOnMaterializationTypeMismatch(ctx context.Context, asset *pipeline.Asset) error {
 	tableComponents := strings.Split(asset.Name, ".")
+	var databaseName string
 	var schemaName string
 	var tableName string
 	switch len(tableComponents) {
 	case 2:
+		databaseName = db.config.Database
 		schemaName = strings.ToUpper(tableComponents[0])
 		tableName = strings.ToUpper(tableComponents[1])
 	case 3:
+		databaseName = strings.ToUpper(tableComponents[0])
 		schemaName = strings.ToUpper(tableComponents[1])
 		tableName = strings.ToUpper(tableComponents[2])
 	default:
@@ -537,7 +540,7 @@ func (db *DB) RecreateTableOnMaterializationTypeMismatch(ctx context.Context, as
 
 	queryStr := fmt.Sprintf(
 		`SELECT TABLE_TYPE FROM %s.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'`,
-		db.config.Database, schemaName, tableName,
+		databaseName, schemaName, tableName,
 	)
 
 	result, err := db.Select(ctx, &query.Query{Query: queryStr})
@@ -569,11 +572,11 @@ func (db *DB) RecreateTableOnMaterializationTypeMismatch(ctx context.Context, as
 	}
 	if dbMaterializationType != asset.Materialization.Type {
 		dropQuery := query.Query{
-			Query: fmt.Sprintf("DROP %s IF EXISTS %s.%s", materializationType, schemaName, tableName),
+			Query: fmt.Sprintf("DROP %s IF EXISTS %s.%s.%s", materializationType, databaseName, schemaName, tableName),
 		}
 
 		if dropErr := db.RunQueryWithoutResult(ctx, &dropQuery); dropErr != nil {
-			return errors.Wrapf(dropErr, "failed to drop existing %s: %s.%s", materializationType, schemaName, tableName)
+			return errors.Wrapf(dropErr, "failed to drop existing %s: %s.%s.%s", materializationType, databaseName, schemaName, tableName)
 		}
 	}
 
@@ -582,13 +585,16 @@ func (db *DB) RecreateTableOnMaterializationTypeMismatch(ctx context.Context, as
 
 func (db *DB) PushColumnDescriptions(ctx context.Context, asset *pipeline.Asset) error {
 	tableComponents := strings.Split(asset.Name, ".")
+	var databaseName string
 	var schemaName string
 	var tableName string
 	switch len(tableComponents) {
 	case 2:
+		databaseName = db.config.Database
 		schemaName = strings.ToUpper(tableComponents[0])
 		tableName = strings.ToUpper(tableComponents[1])
 	case 3:
+		databaseName = strings.ToUpper(tableComponents[0])
 		schemaName = strings.ToUpper(tableComponents[1])
 		tableName = strings.ToUpper(tableComponents[2])
 	default:
@@ -600,10 +606,10 @@ func (db *DB) PushColumnDescriptions(ctx context.Context, asset *pipeline.Asset)
 	}
 
 	queryStr := fmt.Sprintf(
-		`SELECT COLUMN_NAME, COMMENT 
-          FROM %s.INFORMATION_SCHEMA.COLUMNS 
+		`SELECT COLUMN_NAME, COMMENT
+          FROM %s.INFORMATION_SCHEMA.COLUMNS
           WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'`,
-		db.config.Database, schemaName, tableName,
+		databaseName, schemaName, tableName,
 	)
 
 	rows, err := db.Select(ctx, &query.Query{Query: queryStr})
@@ -627,7 +633,7 @@ func (db *DB) PushColumnDescriptions(ctx context.Context, asset *pipeline.Asset)
 		if col.Description != "" && existingComments[col.Name] != col.Description {
 			query := fmt.Sprintf(
 				`ALTER TABLE %s.%s.%s MODIFY COLUMN %s COMMENT '%s'`,
-				db.config.Database, schemaName, tableName, col.Name, escapeSQLString(col.Description),
+				databaseName, schemaName, tableName, col.Name, escapeSQLString(col.Description),
 			)
 			updateQueries = append(updateQueries, query)
 		}
@@ -642,7 +648,7 @@ func (db *DB) PushColumnDescriptions(ctx context.Context, asset *pipeline.Asset)
 	if asset.Description != "" {
 		updateTableQuery := fmt.Sprintf(
 			`COMMENT ON TABLE %s.%s.%s IS '%s'`,
-			db.config.Database, schemaName, tableName, escapeSQLString(asset.Description),
+			databaseName, schemaName, tableName, escapeSQLString(asset.Description),
 		)
 		if err := db.RunQueryWithoutResult(ctx, &query.Query{Query: updateTableQuery}); err != nil {
 			return errors.Wrap(err, "failed to update table description")

--- a/pkg/snowflake/db_test.go
+++ b/pkg/snowflake/db_test.go
@@ -726,11 +726,28 @@ func TestDB_RecreateTableOnMaterializationTypeMismatch(t *testing.T) {
 				mock.ExpectQuery(`SELECT TABLE_TYPE FROM MYDB.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'TEST_SCHEMA' AND TABLE_NAME = 'TEST_TABLE'`).
 					WillReturnRows(sqlmock.NewRows([]string{"TABLE_TYPE"}).AddRow("VIEW"))
 
-				mock.ExpectQuery(`DROP VIEW IF EXISTS TEST_SCHEMA.TEST_TABLE`).
+				mock.ExpectQuery(`DROP VIEW IF EXISTS MYDB.TEST_SCHEMA.TEST_TABLE`).
 					WillReturnRows(sqlmock.NewRows(nil))
 			},
 			asset: &pipeline.Asset{
 				Name: "test_schema.test_table",
+				Materialization: pipeline.Materialization{
+					Type: pipeline.MaterializationTypeTable,
+				},
+			},
+		},
+		{
+			name: "three-part name looks up and drops in the named database",
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				// Must use OTHER_DB (from the asset name), not MYDB (the config default).
+				mock.ExpectQuery(`SELECT TABLE_TYPE FROM OTHER_DB.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'TEST_SCHEMA' AND TABLE_NAME = 'TEST_TABLE'`).
+					WillReturnRows(sqlmock.NewRows([]string{"TABLE_TYPE"}).AddRow("VIEW"))
+
+				mock.ExpectQuery(`DROP VIEW IF EXISTS OTHER_DB.TEST_SCHEMA.TEST_TABLE`).
+					WillReturnRows(sqlmock.NewRows(nil))
+			},
+			asset: &pipeline.Asset{
+				Name: "other_db.test_schema.test_table",
 				Materialization: pipeline.Materialization{
 					Type: pipeline.MaterializationTypeTable,
 				},
@@ -869,6 +886,16 @@ func TestDB_CreateSchemaIfNotExist(t *testing.T) {
 			expectedError: "failed to create or ensure database: TEST_SCHEMA: creation failed",
 		},
 		{
+			name: "three-part name creates the schema in the named database",
+			asset: &pipeline.Asset{
+				Name: "other_db.test_schema.test_table",
+			},
+			mockSetup: func(mock sqlmock.Sqlmock, cache *sync.Map) {
+				mock.ExpectQuery("CREATE SCHEMA IF NOT EXISTS OTHER_DB.TEST_SCHEMA").
+					WillReturnRows(sqlmock.NewRows(nil))
+			},
+		},
+		{
 			name: "asset name with 1 component",
 			asset: &pipeline.Asset{
 				Name: "test_table",
@@ -976,6 +1003,27 @@ func TestDB_PushColumnDescriptions(t *testing.T) {
 			},
 		},
 
+		{
+			name: "three-part name pushes metadata to the named database",
+			asset: &pipeline.Asset{
+				Name:        "other_db.test_schema.test_table",
+				Description: "",
+				Columns: []pipeline.Column{
+					{Name: "col1", Description: "Description 1"},
+				},
+			},
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				// Lookup and ALTER must target OTHER_DB, not the MYDB config default.
+				mock.ExpectQuery(
+					`SELECT COLUMN_NAME, COMMENT FROM OTHER_DB.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'TEST_SCHEMA' AND TABLE_NAME = 'TEST_TABLE'`,
+				).WillReturnRows(sqlmock.NewRows([]string{"COLUMN_NAME", "COMMENT"}).
+					AddRow("COL1", ""))
+
+				mock.ExpectQuery(
+					`ALTER TABLE OTHER_DB.TEST_SCHEMA.TEST_TABLE MODIFY COLUMN col1 COMMENT 'Description 1'`,
+				).WillReturnRows(sqlmock.NewRows(nil))
+			},
+		},
 		{
 			name: "successfully update table description",
 			asset: &pipeline.Asset{


### PR DESCRIPTION
Three-part Snowflake names (`database.schema.table`) were parsed correctly but the database component was dropped in several places and replaced with the connection's configured default database:

- ansisql.SchemaCreator issued an unqualified `CREATE SCHEMA IF NOT EXISTS <schema>`, so the schema was ensured in the default database rather than the one named in the asset. When the asset's database differed from the configured one, the subsequent `CREATE OR REPLACE TABLE db.schema.table` failed because that schema never existed there. The schema-name cache was also keyed on the bare schema name, so the same schema name in two databases was deduped into one creation.
- RecreateTableOnMaterializationTypeMismatch looked up table metadata in and dropped from `config.Database` instead of the named database.
- PushColumnDescriptions queried/altered metadata against `config.Database` instead of the named database.

The shared SchemaCreator change also fixes Databricks Unity Catalog three-part names (`catalog.schema.table`).

Adds regression tests covering three-part names with a non-default database for all three paths.