### PR TITLE
feat(ingestr): add Braze as a source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -285,6 +285,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Asana", link: "/ingestion/asana"},
                                     {text: "Attio", link: "/ingestion/attio"},
                                     {text: "BallDontLie FIFA", link: "/ingestion/balldontlie"},
+                                    {text: "Braze", link: "/ingestion/braze"},
                                     {text: "Bruin", link: "/ingestion/bruin"},
                                     {text: "Chess", link: "/ingestion/chess"},
                                     {text: "ClickUp", link: "/ingestion/clickup"},

--- a/docs/ingestion/braze.md
+++ b/docs/ingestion/braze.md
@@ -59,8 +59,11 @@ parameters:
 | `kpi_mau` | time | time | merge | Monthly active users (rolling 30-day) by date. |
 | `kpi_new_users` | time | time | merge | New users by date. |
 | `kpi_uninstalls` | time | time | merge | App uninstalls by date. |
+| `user_data` | braze_id, segment_id | - | replace | Users of a segment with their email/push subscription state and profile fields (a point-in-time snapshot). |
 
 The `kpi_*` tables aggregate across all apps by default. Append a comma-separated list of app identifiers to break a KPI down by app, e.g. `source_table: 'kpi_dau:app-one-id,app-two-id'`; each row then carries an `app_id` column.
+
+The `user_data` table requires one or more segment ids, passed as a comma-separated suffix, e.g. `source_table: 'user_data:<segment_id>'` or `'user_data:<segment_id_1>,<segment_id_2>'`. Each row is tagged with the `segment_id` it came from.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/braze.md
+++ b/docs/ingestion/braze.md
@@ -1,0 +1,71 @@
+# Braze
+
+[Braze](https://www.braze.com/) is a customer engagement platform for cross-channel messaging and customer analytics.
+
+Bruin supports Braze as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Braze into your data warehouse.
+
+To set up a Braze connection, you need a REST API key and your instance's REST endpoint. For more information, please refer [here](https://getbruin.com/docs/ingestr/supported-sources/braze.html)
+
+Follow the steps below to correctly set up Braze as a data source and run ingestion:
+
+## Configuration
+
+### Step 1: Add a connection to .bruin.yml file
+
+To connect to Braze, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+    connections:
+      braze:
+        - name: "my_braze"
+          api_key: "YOUR_BRAZE_REST_API_KEY"
+          endpoint: "rest.iad-01.braze.com"
+```
+
+- `api_key`: A Braze REST API key with access to the relevant export endpoints. Required.
+- `endpoint`: Your instance's REST endpoint host (e.g. `rest.iad-01.braze.com`). Braze is multi-instance, so the host depends on which cluster your account is on. Required.
+
+### Step 2: Create an asset file for data ingestion
+
+To ingest data from Braze, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., braze_ingestion.yml) inside the assets folder and add the following content:
+
+```yaml
+name: public.braze
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: my_braze
+  source_table: 'campaigns'
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Specifies the type of the asset. It will be always ingestr type for Braze.
+- `connection`: This is the destination connection.
+- `source_connection`: The name of the Braze connection defined in .bruin.yml.
+- `source_table`: The name of the data table in Braze you want to ingest. For example, `campaigns` would ingest campaign records.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| `campaigns` | id | last_edited | merge | Marketing campaigns (including archived) with their name, tags, and API flags. |
+| `canvases` | id | last_edited | merge | Canvas (journey) definitions (including archived) with their name and tags. |
+| `segments` | id | - | replace | Audience segments with their name and analytics-tracking flag. |
+| `events` | event_name | - | replace | Names of the custom events tracked in the workspace. |
+| `products` | product_id | - | replace | Product IDs seen in purchase events. |
+| `kpi_dau` | time | time | merge | Daily active users by date. |
+| `kpi_mau` | time | time | merge | Monthly active users (rolling 30-day) by date. |
+| `kpi_new_users` | time | time | merge | New users by date. |
+| `kpi_uninstalls` | time | time | merge | App uninstalls by date. |
+
+The `kpi_*` tables aggregate across all apps by default. Append a comma-separated list of app identifiers to break a KPI down by app, e.g. `source_table: 'kpi_dau:app-one-id,app-two-id'`; each row then carries an `app_id` column.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run ingestr.braze.asset.yml
+```
+
+As a result of this command, Bruin will ingest data from the given Braze table into your Postgres database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -365,6 +365,26 @@
         "api_key"
       ]
     },
+    "BrazeConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "api_key",
+        "endpoint"
+      ]
+    },
     "BruinCloudConnection": {
       "properties": {
         "name": {
@@ -1316,6 +1336,12 @@
         "twilio": {
           "items": {
             "$ref": "#/$defs/TwilioConnection"
+          },
+          "type": "array"
+        },
+        "braze": {
+          "items": {
+            "$ref": "#/$defs/BrazeConnection"
           },
           "type": "array"
         },

--- a/pkg/braze/config.go
+++ b/pkg/braze/config.go
@@ -1,0 +1,15 @@
+package braze
+
+import "net/url"
+
+type Config struct {
+	APIKey   string
+	Endpoint string
+}
+
+func (c *Config) GetIngestrURI() string {
+	params := url.Values{}
+	params.Set("api_key", c.APIKey)
+	params.Set("endpoint", c.Endpoint)
+	return "braze://?" + params.Encode()
+}

--- a/pkg/braze/db.go
+++ b/pkg/braze/db.go
@@ -1,0 +1,15 @@
+package braze
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1810,6 +1810,16 @@ func (c SendgridConnection) GetName() string {
 	return c.Name
 }
 
+type BrazeConnection struct {
+	Name     string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	APIKey   string `yaml:"api_key,omitempty" json:"api_key" mapstructure:"api_key"`
+	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint" mapstructure:"endpoint"`
+}
+
+func (c BrazeConnection) GetName() string {
+	return c.Name
+}
+
 type TwilioConnection struct {
 	Name       string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	AccountSID string `yaml:"account_sid,omitempty" json:"account_sid" mapstructure:"account_sid"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -143,6 +143,7 @@ type Connections struct {
 	CustomerIo          []CustomerIoConnection          `yaml:"customerio,omitempty" json:"customerio,omitempty" mapstructure:"customerio"`
 	Sendgrid            []SendgridConnection            `yaml:"sendgrid,omitempty" json:"sendgrid,omitempty" mapstructure:"sendgrid"`
 	Twilio              []TwilioConnection              `yaml:"twilio,omitempty" json:"twilio,omitempty" mapstructure:"twilio"`
+	Braze               []BrazeConnection               `yaml:"braze,omitempty" json:"braze,omitempty" mapstructure:"braze"`
 	Espn                []EspnConnection                `yaml:"espn,omitempty" json:"espn,omitempty" mapstructure:"espn"`
 	APIFootball         []APIFootballConnection         `yaml:"apifootball,omitempty" json:"apifootball,omitempty" mapstructure:"apifootball"`
 	FootballData        []FootballDataConnection        `yaml:"footballdata,omitempty" json:"footballdata,omitempty" mapstructure:"footballdata"`
@@ -1333,6 +1334,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Twilio = append(env.Connections.Twilio, conn)
+	case "braze":
+		var conn BrazeConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Braze = append(env.Connections.Braze, conn)
 	case "espn":
 		var conn EspnConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1643,6 +1651,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Sendgrid = removeConnection(env.Connections.Sendgrid, connectionName)
 	case "twilio":
 		env.Connections.Twilio = removeConnection(env.Connections.Twilio, connectionName)
+	case "braze":
+		env.Connections.Braze = removeConnection(env.Connections.Braze, connectionName)
 	case "espn":
 		env.Connections.Espn = removeConnection(env.Connections.Espn, connectionName)
 	case "apifootball":
@@ -1832,6 +1842,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.CustomerIo, source.CustomerIo)
 	mergeConnectionList(&c.Sendgrid, source.Sendgrid)
 	mergeConnectionList(&c.Twilio, source.Twilio)
+	mergeConnectionList(&c.Braze, source.Braze)
 	mergeConnectionList(&c.Espn, source.Espn)
 	mergeConnectionList(&c.APIFootball, source.APIFootball)
 	mergeConnectionList(&c.FootballData, source.FootballData)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -816,6 +816,13 @@ func TestLoadFromFile(t *testing.T) {
 					APISecret:  "test-api-secret",
 				},
 			},
+			Braze: []BrazeConnection{
+				{
+					Name:     "braze-1",
+					APIKey:   "test-api-key",
+					Endpoint: "rest.iad-01.braze.com",
+				},
+			},
 			Espn: []EspnConnection{
 				{
 					Name:   "espn-1",
@@ -2245,6 +2252,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				CustomerIo:          []CustomerIoConnection{{Name: "customerio1"}},
 				Sendgrid:            []SendgridConnection{{Name: "sendgrid1"}},
 				Twilio:              []TwilioConnection{{Name: "twilio1"}},
+				Braze:               []BrazeConnection{{Name: "braze1"}},
 				Espn:                []EspnConnection{{Name: "espn1"}},
 				APIFootball:         []APIFootballConnection{{Name: "apifootball1"}},
 				FootballData:        []FootballDataConnection{{Name: "footballdata1"}},
@@ -2371,6 +2379,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				CustomerIo:          []CustomerIoConnection{{Name: "customerio1"}},
 				Sendgrid:            []SendgridConnection{{Name: "sendgrid1"}},
 				Twilio:              []TwilioConnection{{Name: "twilio1"}},
+				Braze:               []BrazeConnection{{Name: "braze1"}},
 				Espn:                []EspnConnection{{Name: "espn1"}},
 				APIFootball:         []APIFootballConnection{{Name: "apifootball1"}},
 				FootballData:        []FootballDataConnection{{Name: "footballdata1"}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -511,6 +511,10 @@ environments:
           auth_token: "test-auth-token"
           api_key: "test-api-key"
           api_secret: "test-api-secret"
+      braze:
+        - name: "braze-1"
+          api_key: "test-api-key"
+          endpoint: "rest.iad-01.braze.com"
       espn:
         - name: "espn-1"
           sport: "football"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -512,6 +512,10 @@ environments:
           auth_token: "test-auth-token"
           api_key: "test-api-key"
           api_secret: "test-api-secret"
+      braze:
+        - name: "braze-1"
+          api_key: "test-api-key"
+          endpoint: "rest.iad-01.braze.com"
       espn:
         - name: "espn-1"
           sport: "football"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/attio"
 	"github.com/bruin-data/bruin/pkg/balldontlie"
 	"github.com/bruin-data/bruin/pkg/bigquery"
+	"github.com/bruin-data/bruin/pkg/braze"
 	"github.com/bruin-data/bruin/pkg/bruincloud"
 	"github.com/bruin-data/bruin/pkg/cassandra"
 	"github.com/bruin-data/bruin/pkg/chess"
@@ -259,6 +260,7 @@ type Manager struct {
 	CustomerIo           map[string]*customerio.Client
 	Sendgrid             map[string]*sendgrid.Client
 	Twilio               map[string]*twilio.Client
+	Braze                map[string]*braze.Client
 	Espn                 map[string]*espn.Client
 	APIFootball          map[string]*apifootball.Client
 	FootballData         map[string]*footballdata.Client
@@ -3166,6 +3168,26 @@ func (m *Manager) AddTwilioConnectionFromConfig(connection *config.TwilioConnect
 	return nil
 }
 
+func (m *Manager) AddBrazeConnectionFromConfig(connection *config.BrazeConnection) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.Braze == nil {
+		m.Braze = make(map[string]*braze.Client)
+	}
+
+	client, err := braze.NewClient(braze.Config{
+		APIKey:   connection.APIKey,
+		Endpoint: connection.Endpoint,
+	})
+	if err != nil {
+		return err
+	}
+	m.Braze[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddEspnConnectionFromConfig(connection *config.EspnConnection) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -3716,6 +3738,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.CustomerIo, connectionManager.AddCustomerIoConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Sendgrid, connectionManager.AddSendgridConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Twilio, connectionManager.AddTwilioConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Braze, connectionManager.AddBrazeConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Espn, connectionManager.AddEspnConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.APIFootball, connectionManager.AddAPIFootballConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.FootballData, connectionManager.AddFootballDataConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -822,6 +822,18 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "incoming_phone_numbers", PrimaryKey: "sid", IncKey: "", IncStrategy: "replace"},
 		{Name: "usage_records", PrimaryKey: "", IncKey: "", IncStrategy: "replace"},
 	},
+	// Braze - Customer engagement platform (campaigns, canvases, KPIs)
+	"braze": {
+		{Name: "campaigns", PrimaryKey: "id", IncKey: "last_edited", IncStrategy: "merge"},
+		{Name: "canvases", PrimaryKey: "id", IncKey: "last_edited", IncStrategy: "merge"},
+		{Name: "segments", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "events", PrimaryKey: "event_name", IncKey: "", IncStrategy: "replace"},
+		{Name: "products", PrimaryKey: "product_id", IncKey: "", IncStrategy: "replace"},
+		{Name: "kpi_dau", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
+		{Name: "kpi_mau", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
+		{Name: "kpi_new_users", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
+		{Name: "kpi_uninstalls", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
+	},
 
 	// SFTP (user-defined paths)
 	"sftp": {},

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -833,6 +833,7 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "kpi_mau", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
 		{Name: "kpi_new_users", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
 		{Name: "kpi_uninstalls", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
+		{Name: "user_data", PrimaryKey: "braze_id, segment_id", IncKey: "", IncStrategy: "replace"},
 	},
 
 	// SFTP (user-defined paths)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -833,7 +833,7 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "kpi_mau", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
 		{Name: "kpi_new_users", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
 		{Name: "kpi_uninstalls", PrimaryKey: "time", IncKey: "time", IncStrategy: "merge"},
-		{Name: "user_data", PrimaryKey: "braze_id, segment_id", IncKey: "", IncStrategy: "replace"},
+		{Name: "user_data:<segment_id>", PrimaryKey: "braze_id, segment_id", IncKey: "", IncStrategy: "replace"},
 	},
 
 	// SFTP (user-defined paths)


### PR DESCRIPTION
## Summary
Adds **Braze** as an ingestr source connection in Bruin, exposing the Braze export tables (including `user_data`) for use in [ingestr assets](/assets/ingestr).

## Connection
```yaml
connections:
  braze:
    - name: my_braze
      api_key: "YOUR_BRAZE_REST_API_KEY"
      endpoint: "rest.iad-01.braze.com"
```
- `api_key` — Braze REST API key (required)
- `endpoint` — instance REST host, e.g. `rest.iad-01.braze.com` (required; Braze is multi-instance)

Builds a `braze://?api_key=...&endpoint=...` ingestr URI.

## Source tables
`campaigns`, `canvases`, `segments`, `events`, `products`, `kpi_dau`, `kpi_mau`, `kpi_new_users`, `kpi_uninstalls`, and **`user_data`** (segment user export with subscription state; `user_data:<segment_id>[,<segment_id>]`, composite key `braze_id, segment_id`).