### PR TITLE
[codex] Update Salesforce ingestion auth docs

### DIFF
--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -4,52 +4,142 @@
 
 Bruin supports Salesforce as a source for [ingestr assets](/assets/ingestr), and you can use it to ingest data from Salesforce into your data platform.
 
-To set up a Salesforce connection, you must add a configuration item in the `.bruin.yml` and `asset` file. Salesforce supports two authentication methods:
+Bruin's Salesforce ingestr connection supports two credential forms:
 
-- **Username, password, and security token**: classic SOAP-style login. You can obtain your security token by logging into your Salesforce account and navigating to the user settings under "Reset My Security Token."
-- **OAuth access token**: an access token minted by the Salesforce CLI (`sf org auth show-access-token`). Use this when you want to authenticate interactively in a browser.
+- **Username, password, and security token**: recommended for scheduled runs when Salesforce SOAP API login is enabled.
+- **Static access token**: useful when SOAP API login is unavailable or username/password auth is blocked. Bruin does not run a Salesforce OAuth flow or refresh expired Salesforce access tokens for this source.
 
 Follow the steps below to set up Salesforce correctly as a data source and run ingestion.
 
 ## Configuration
 
-### Step 1: Add a connection to the .bruin.yml file
+### Step 1: Confirm Salesforce user access
 
-Use either the username/password/token combination:
+Use a Salesforce user that has:
+
+- API access
+- Access to the Salesforce objects you want to ingest
+- Permission to log in through API/SOAP if using username/password/security-token auth
+
+Common Salesforce objects include:
+
+- Account
+- Contact
+- Opportunity
+- Task
+
+### Step 2: Enable SOAP API login
+
+This is required for username/password/security-token auth.
+
+In Salesforce:
+
+1. Open **Setup**.
+2. Search for **User Interface**.
+3. Open **User Interface**.
+4. Scroll to **API Settings**.
+5. Enable **Enable SOAP API Login**.
+6. Save.
+
+If this option is unavailable, use static access-token auth instead.
+
+### Step 3: Get the Salesforce security token
+
+Log in as the Salesforce user Bruin should use.
+
+1. Click the user avatar.
+2. Open **Settings**.
+3. Search for **Reset My Security Token**.
+4. Click **Reset My Security Token**.
+5. Check the Salesforce user's email for the new token.
+
+The security token is case-sensitive.
+
+### Step 4: Add a connection to the .bruin.yml file
+
+Use the username/password/security-token combination when SOAP API login is enabled:
 
 ```yaml
 connections:
-      salesforce:
-            - name: "salesforce"
-              username: "user_123"
-              password: "pass_123"
-              token: "token_123"
-              domain: "your-domain.my.salesforce.com"
+  salesforce:
+    - name: "salesforce"
+      username: "user_123"
+      password: "pass_123"
+      token: "token_123"
+      domain: "https://your-domain.my.salesforce.com"
 ```
 
 - `username` is your Salesforce account username.
 - `password` is your Salesforce account password.
-- `token` is your Salesforce security token.
-- `domain` is your Salesforce domain (e.g., "your-company.my.salesforce.com").
+- `token` is your Salesforce security token. Do not append the security token to the password.
+- `domain` is your Salesforce domain, for example `https://your-domain.my.salesforce.com`. For sandboxes, use the sandbox My Domain URL.
 
-Or an OAuth access token:
+If SOAP API login is not enabled or username/password auth is blocked, use a static access token:
 
 ```yaml
 connections:
-      salesforce:
-            - name: "salesforce"
-              access_token: "00D...!AQ...your_oauth_access_token"
-              domain: "your-domain.my.salesforce.com"
+  salesforce:
+    - name: "salesforce"
+      access_token: "00D...!AQ...your_salesforce_access_token"
+      domain: "https://your-domain.my.salesforce.com"
 ```
 
-- `access_token` is an OAuth access token for your Salesforce org. You can obtain one with `sf org auth show-access-token --target-org <salesforce-username>` after logging in via `sf org login web`.
-- `domain` is your Salesforce instance domain — same field as above. You can pass it either as a host (e.g. `your-domain.my.salesforce.com`) or as a full URL (e.g. `https://your-domain.my.salesforce.com`); both are accepted. For sandboxes, use the sandbox My Domain URL.
+- `access_token` must be valid for the Salesforce org and user.
+- Bruin does not refresh this token when it expires.
+- `domain` is the Salesforce instance domain for the same org as the token.
 
 When `access_token` is set it takes precedence over `username`/`password`/`token`.
 
-### Step 2: Create an asset file for data ingestion
+Do not commit `.bruin.yml` if it contains Salesforce credentials.
 
-To ingest data from Salesforce, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., salesforce_ingestion.yml) inside the assets folder and add the following content:
+### Bruin Cloud connection setup
+
+In Bruin Cloud:
+
+1. Open the team or project.
+2. Go to **Connections**.
+3. Click **New connection**.
+4. Choose **Salesforce**.
+5. Set the connection name to match the pipeline asset config.
+
+For username/password/security-token auth:
+
+```text
+Access Token (OAuth): leave blank
+Username: <salesforce-username>
+Password: <salesforce-password>
+Security Token: <salesforce-security-token>
+Domain: https://your-domain.my.salesforce.com
+```
+
+Do not append the security token to the password if Bruin Cloud has a separate **Security Token** field.
+
+For static access-token auth:
+
+```text
+Access Token (OAuth): <salesforce-access-token>
+Username: leave blank
+Password: leave blank
+Security Token: leave blank
+Domain: https://your-domain.my.salesforce.com
+```
+
+The Bruin Cloud connection name must exactly match the asset's `source_connection` value. For example, if an asset uses:
+
+```yaml
+parameters:
+  source_connection: salesforce
+```
+
+then the Bruin Cloud connection name must be:
+
+```text
+salesforce
+```
+
+### Step 5: Create an asset file for data ingestion
+
+To ingest data from Salesforce, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file, such as `salesforce_ingestion.yml`, inside the assets folder and add the following content:
 
 ```yaml
 name: public.salesforce
@@ -58,16 +148,26 @@ connection: postgres
 
 parameters:
   source_connection: salesforce
-  source_table: 'publisher-report'
+  source_table: "account"
 
   destination: postgres
 ```
 
 - `name`: The name of the asset.
-- `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For Salesforce, it will be always `ingestr`.
-- `source_connection`: The name of the Salesforce connection defined in `.bruin.yml`.
+- `type`: Specifies the asset's type. Set this to `ingestr` to use the ingestr data pipeline. For Salesforce, it will be always `ingestr`.
+- `source_connection`: The name of the Salesforce connection defined in `.bruin.yml` or Bruin Cloud.
 - `source_table`: The name of the table in Salesforce to ingest.
 - `destination`: The name of the destination connection.
+
+Before running a full pipeline, test with one Salesforce ingestion asset.
+
+Expected logs include:
+
+```text
+Source: salesforce / account
+Fetched Account using Bulk API
+Ingestion completed successfully
+```
 
 ## Available Source Tables
 
@@ -90,10 +190,60 @@ parameters:
 | `event` | id | last_timestamp | merge | Used to track and manage calendar-based events, such as meetings, appointments, or calls. |
 | `custom:<custom_object_name>` | - | - | replace | Track and store data that's unique to your organization. |
 
-### Step 3: [Run](/commands/run) asset to ingest data
+### Step 6: [Run](/commands/run) asset to ingest data
 
 ```bash
 bruin run assets/salesforce_asset.yml
 ```
 
-As a result of this command, Bruin will ingest data from the given salesforce table into your Postgres database.
+As a result of this command, Bruin will ingest data from the given Salesforce table into your destination database.
+
+## Troubleshooting
+
+### `SOAP API login() is disabled by default in this org`
+
+The Salesforce org blocks username/password/security-token auth.
+
+Fix one of the following:
+
+- Enable **Enable SOAP API Login** in Salesforce **User Interface** settings.
+- Or use static access-token auth instead.
+
+### `INVALID_LOGIN`
+
+Salesforce rejected the login.
+
+Check:
+
+- Username is correct.
+- Password is correct.
+- Security token is correct and current.
+- User is not locked out.
+- User has API access.
+- SOAP API login is enabled.
+- Domain points to the correct Salesforce org.
+
+### `INVALID_SESSION_ID`
+
+The static access token expired or is invalid.
+
+Fix one of the following:
+
+- Generate a fresh Salesforce access token.
+- Update the Bruin Salesforce connection.
+- For scheduled runs, prefer username/password/security-token auth if SOAP API login is enabled.
+
+### Connection name mismatch
+
+If the asset uses:
+
+```yaml
+source_connection: salesforce
+```
+
+but the Bruin Cloud connection is named something else, the run will fail.
+
+Fix one of the following:
+
+- Rename the Bruin Cloud connection to match the asset.
+- Or update the asset to reference the Bruin Cloud connection name.

--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -66,13 +66,13 @@ connections:
       username: "user_123"
       password: "pass_123"
       token: "token_123"
-      domain: "https://your-domain.my.salesforce.com"
+      domain: "your-domain.my.salesforce.com"
 ```
 
 - `username` is your Salesforce account username.
 - `password` is your Salesforce account password.
 - `token` is your Salesforce security token. Do not append the security token to the password.
-- `domain` is your Salesforce domain, for example `https://your-domain.my.salesforce.com`. For sandboxes, use the sandbox My Domain URL.
+- `domain` is your Salesforce domain. You can pass either the host, such as `your-domain.my.salesforce.com`, or the full URL, such as `https://your-domain.my.salesforce.com`. For sandboxes, use the sandbox My Domain URL.
 
 If SOAP API login is not enabled or username/password auth is blocked, use a static access token:
 
@@ -81,18 +81,18 @@ connections:
   salesforce:
     - name: "salesforce"
       access_token: "00D...!AQ...your_salesforce_access_token"
-      domain: "https://your-domain.my.salesforce.com"
+      domain: "your-domain.my.salesforce.com"
 ```
 
 - `access_token` must be valid for the Salesforce org and user.
 - Bruin does not refresh this token when it expires.
-- `domain` is the Salesforce instance domain for the same org as the token.
+- `domain` is the Salesforce instance domain for the same org as the token. You can pass either the host or the full URL.
 
 When `access_token` is set it takes precedence over `username`/`password`/`token`.
 
 Do not commit `.bruin.yml` if it contains Salesforce credentials.
 
-### Bruin Cloud connection setup
+### Step 5: Create a Bruin Cloud connection
 
 In Bruin Cloud:
 
@@ -137,7 +137,7 @@ then the Bruin Cloud connection name must be:
 salesforce
 ```
 
-### Step 5: Create an asset file for data ingestion
+### Step 6: Create an asset file for data ingestion
 
 To ingest data from Salesforce, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file, such as `salesforce_ingestion.yml`, inside the assets folder and add the following content:
 
@@ -190,7 +190,7 @@ Ingestion completed successfully
 | `event` | id | last_timestamp | merge | Used to track and manage calendar-based events, such as meetings, appointments, or calls. |
 | `custom:<custom_object_name>` | - | - | replace | Track and store data that's unique to your organization. |
 
-### Step 6: [Run](/commands/run) asset to ingest data
+### Step 7: [Run](/commands/run) asset to ingest data
 
 ```bash
 bruin run assets/salesforce_asset.yml


### PR DESCRIPTION
## Summary
- Clarify that the Salesforce ingestr connection supports username/password/security-token auth and static access tokens only.
- Document SOAP API login setup, Bruin Cloud Salesforce connection fields, and connection-name matching.
- Add troubleshooting for SOAP login disabled, INVALID_LOGIN, INVALID_SESSION_ID, and mismatched connection names.

## Context
The previous docs implied OAuth setup guidance that did not match the current Bruin Salesforce ingestr implementation. Bruin forwards either username/password/security-token credentials or a provided static access token; it does not run a Salesforce OAuth flow or refresh expired Salesforce access tokens for this source.

## Validation
- npx markdownlint-cli2 --no-globs docs/ingestion/salesforce.md
- npm run docs:build
- Local VitePress preview route returned 200 OK for /bruin/ingestion/salesforce.html

Docs-only change, so make format and make test were not run.