### PR TITLE
fix(import): surface swallowed errors and normalize Tableau host

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -185,7 +185,12 @@ Example:
 			projectID := c.String("project-id")
 			location := c.String("location")
 
-			return runScheduledQueriesImport(ctx, pipelinePath, connectionName, environment, configFile, projectID, location)
+			if err := runScheduledQueriesImport(ctx, pipelinePath, connectionName, environment, configFile, projectID, location); err != nil {
+				errorPrinter.Printf("Failed to import scheduled queries: %s\n", err)
+				return cli.Exit("", 1)
+			}
+
+			return nil
 		},
 	}
 }
@@ -2686,7 +2691,12 @@ Example:
 			projectFilter := c.String("project")
 			importAll := c.Bool("all")
 
-			return runTableauImport(ctx, pipelinePath, connectionName, environment, configFile, workbookFilter, projectFilter, importAll)
+			if err := runTableauImport(ctx, pipelinePath, connectionName, environment, configFile, workbookFilter, projectFilter, importAll); err != nil {
+				errorPrinter.Printf("Failed to import Tableau dashboards: %s\n", err)
+				return cli.Exit("", 1)
+			}
+
+			return nil
 		},
 	}
 }

--- a/cmd/import_quicksight.go
+++ b/cmd/import_quicksight.go
@@ -722,7 +722,12 @@ Example:
 			configFile := c.String("config-file")
 			importAll := c.Bool("all")
 
-			return runQuickSightImport(ctx, pipelinePath, connectionName, environment, configFile, importAll)
+			if err := runQuickSightImport(ctx, pipelinePath, connectionName, environment, configFile, importAll); err != nil {
+				errorPrinter.Printf("Failed to import QuickSight assets: %s\n", err)
+				return cli.Exit("", 1)
+			}
+
+			return nil
 		},
 	}
 }

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -655,12 +655,12 @@ In your `.bruin.yml`:
 
 ```yaml
 connections:
-  tableau-prod:
-    type: tableau
-    base_url: https://prod-useast-b.online.tableau.com
-    site_id: internetsociety
-    personal_access_token: ${TABLEAU_PAT_TOKEN}
-    personal_access_token_name: ${TABLEAU_PAT_NAME}
+  tableau:
+    - name: tableau-prod
+      host: prod-useast-b.online.tableau.com # hostname only, without https://
+      site_id: internetsociety
+      personal_access_token_name: ${TABLEAU_PAT_NAME}
+      personal_access_token_secret: ${TABLEAU_PAT_TOKEN}
 ```
 
 ### Output

--- a/pkg/tableau/client.go
+++ b/pkg/tableau/client.go
@@ -93,6 +93,10 @@ const (
 )
 
 func NewClient(c Config) (*Client, error) {
+	// Normalize the host so URLs built via fmt.Sprintf("https://%s/...", host)
+	// never end up with a duplicated scheme (e.g. "https://https://...") when the
+	// user includes a scheme or trailing slash in the configured host.
+	c.Host = normalizeHost(c.Host)
 	if c.Host == "" {
 		return nil, errors.New("host is required for Tableau connection")
 	}
@@ -361,6 +365,21 @@ func shouldRetryWithoutIncremental(statusCode int, body []byte) bool {
 	}
 
 	return strings.Contains(response, "incremental")
+}
+
+// normalizeHost strips any URL scheme and trailing slashes from the configured
+// host. The client builds every request URL via fmt.Sprintf("https://%s/...", host),
+// so a host that already contains a scheme would otherwise produce an invalid URL
+// such as "https://https://...".
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(host)
+	for _, scheme := range []string{"https://", "http://"} {
+		if len(host) >= len(scheme) && strings.EqualFold(host[:len(scheme)], scheme) {
+			host = host[len(scheme):]
+			break
+		}
+	}
+	return strings.TrimRight(host, "/")
 }
 
 // GetHost returns the Tableau host URL.

--- a/pkg/tableau/client_test.go
+++ b/pkg/tableau/client_test.go
@@ -104,6 +104,46 @@ func TestNewClient_MissingRequiredFields(t *testing.T) {
 	}
 }
 
+func TestNormalizeHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "bare hostname unchanged", host: "tableau.example.com", want: "tableau.example.com"},
+		{name: "strips https scheme", host: "https://tableau.example.com", want: "tableau.example.com"},
+		{name: "strips http scheme", host: "http://tableau.example.com", want: "tableau.example.com"},
+		{name: "strips scheme case-insensitively", host: "HTTPS://tableau.example.com", want: "tableau.example.com"},
+		{name: "strips trailing slash", host: "https://tableau.example.com/", want: "tableau.example.com"},
+		{name: "trims surrounding whitespace", host: "  https://tableau.example.com  ", want: "tableau.example.com"},
+		{name: "empty stays empty", host: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, normalizeHost(tt.host))
+		})
+	}
+}
+
+func TestNewClient_NormalizesHost(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		Host:                      "https://tableau.example.com/",
+		PersonalAccessTokenName:   "my-token",
+		PersonalAccessTokenSecret: "my-secret",
+		SiteID:                    "site123",
+		APIVersion:                "3.4",
+	}
+
+	client, err := NewClient(config)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Equal(t, "tableau.example.com", client.GetHost())
+}
+
 func TestNewClient_DefaultAPIVersion(t *testing.T) {
 	t.Parallel()
 	config := Config{


### PR DESCRIPTION
The tableau, bq-scheduled-queries, and quicksight import commands returned their errors directly from the cli Action. cli.HandleExitCoder only prints errors implementing ExitCoder/MultiError, so plain wrapped errors were silently dropped and the process just exited with code 1. Print via errorPrinter and return cli.Exit("", 1) to match the other import commands.

Also normalize the Tableau host in NewClient by stripping any URL scheme and trailing slash. Every request URL (including auth) is built via fmt.Sprintf("https://%s/...", host), so a host containing https:// produced "https://https://..." and broke auth. Fix the docs example accordingly.