### PR TITLE
Add bruin query support for MongoDB (mongo + mongo_atlas)

### DIFF
--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -116,6 +116,57 @@ bruin query --connection my_connection \
 Scalar values are kept as literal strings (matching how pipeline variables work in YAML);
 only values that look like a JSON object or array are parsed as JSON.
 
+## Querying MongoDB
+
+MongoDB connections (`mongo` and `mongo_atlas`) are not SQL, so the `--query` value is a JSON
+object describing a single **find** or **aggregation** against one collection instead of a SQL
+statement. The returned documents are flattened into a table: columns are the union of the
+top-level fields (in first-seen order), and nested documents and arrays are shown as JSON.
+
+The envelope fields are:
+
+| Field        | Description                                                                 |
+|--------------|-----------------------------------------------------------------------------|
+| `collection` | **Required.** The collection to query.                                      |
+| `filter`     | Find filter document. Defaults to `{}` (all documents).                     |
+| `projection` | Find projection, e.g. `{"name":1,"_id":0}`.                                 |
+| `sort`       | Find sort, e.g. `{"age":-1}`.                                               |
+| `limit`      | Maximum number of documents to return.                                      |
+| `skip`       | Number of documents to skip.                                                |
+| `aggregate`  | Aggregation pipeline (an array of stages). Mutually exclusive with `filter`/`projection`/`sort`. |
+| `database`   | Override the connection's configured database for this query.               |
+
+Values are parsed as [MongoDB Extended JSON](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/),
+so query operators such as `$gt`, `$and`, and `$match` pass through unchanged while type wrappers
+such as `{"$oid":"..."}` and `{"$date":"..."}` are interpreted as the corresponding BSON types.
+
+> [!NOTE]
+> The SQL-oriented `--limit` flag does not apply to MongoDB queries. Set `"limit"` inside the
+> envelope instead.
+
+**Find example:**
+
+```bash
+bruin query --connection my_mongo \
+  --query '{"collection":"users","filter":{"age":{"$gt":21}},"sort":{"age":-1},"limit":10}'
+```
+
+```plaintext
++--------------------------+-------+-----+-----------+----------------+
+|           _id            | name  | age |   tags    |    address     |
++--------------------------+-------+-----+-----------+----------------+
+| 6a3bb9d9ca6a1b41199df8a5 | carol | 41  | ["x"]     |                |
+| 6a3bb9d9ca6a1b41199df8a3 | alice | 30  | ["a","b"] | {"city":"NYC"} |
++--------------------------+-------+-----+-----------+----------------+
+```
+
+**Aggregation example:**
+
+```bash
+bruin query --connection my_mongo \
+  --query '{"collection":"orders","aggregate":[{"$group":{"_id":"$status","n":{"$sum":1}}}]}'
+```
+
 ## Semantic Queries
 
 Semantic query mode compiles metrics, dimensions, segments, filters, joins, and windows from YAML models in the repository-level `semantic` directory. See the [semantic layer documentation](/core-concepts/semantic-layer) for model syntax.

--- a/docs/ingestion/mongo.md
+++ b/docs/ingestion/mongo.md
@@ -74,3 +74,14 @@ bruin run assets/mongo_ingestion.yml
 As a result of this command, Bruin will ingest data from the given MongoDB table into your Postgres database.
 
 <img width="1017" alt="image" src="https://github.com/user-attachments/assets/2bad9131-baa1-4f20-8e3d-eed4329e7f90">
+
+## Querying
+
+Beyond ingestion, you can run ad-hoc queries against a MongoDB connection with the [`query` command](/commands/query) and verify it with [`bruin connections test`](/commands/connections). Because MongoDB is not SQL, the query is a JSON object describing a find or aggregation against one collection:
+
+```bash
+bruin query --connection localMongo \
+  --query '{"collection":"users","filter":{"age":{"$gt":21}},"sort":{"age":-1},"limit":10}'
+```
+
+See [Querying MongoDB](/commands/query#querying-mongodb) for the full envelope syntax.

--- a/docs/platforms/mongoatlas.md
+++ b/docs/platforms/mongoatlas.md
@@ -5,7 +5,7 @@ MongoDB Atlas is a fully-managed cloud database service built on MongoDB. It pro
 Bruin supports MongoDB Atlas as a data platform for both ingestion sources and destinations.
 
 > [!NOTE]
-> MongoDB Atlas is supported as both a source and destination for ingestion using [Ingestr Assets](../assets/ingestr.md). It cannot be used for SQL-based transformations or other asset types.
+> MongoDB Atlas is supported as both a source and destination for ingestion using [Ingestr Assets](../assets/ingestr.md). It cannot be used for SQL-based transformations or other asset types, but you can run ad-hoc queries against it with [`bruin query`](../commands/query.md) and verify it with [`bruin connections test`](../commands/connections.md).
 
 ## Connection
 
@@ -38,6 +38,17 @@ mongodb+srv://your-username:your-password@cluster0.example.mongodb.net
 ```
 
 If your username or password contains special characters, Bruin URL-encodes them when it builds the URI.
+
+## Querying
+
+You can run ad-hoc queries against a MongoDB Atlas connection with the [`query` command](../commands/query.md). Because MongoDB is not SQL, the query is a JSON object describing a find or aggregation against one collection:
+
+```bash
+bruin query --connection connection_name \
+  --query '{"collection":"users","filter":{"age":{"$gt":21}},"sort":{"age":-1},"limit":10}'
+```
+
+See [Querying MongoDB](../commands/query.md#querying-mongodb) for the full envelope syntax.
 
 ## Using MongoDB Atlas as a Destination
 

--- a/pkg/mongo/db.go
+++ b/pkg/mongo/db.go
@@ -1,8 +1,20 @@
 package mongo
 
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
 type DB struct {
 	config *Config
 	Name   string
+
+	mu     sync.Mutex
+	client *mongo.Client
 }
 
 type MongoConnection interface {
@@ -15,4 +27,36 @@ func NewDB(c *Config) (*DB, error) {
 
 func (db *DB) GetIngestrURI() (string, error) {
 	return db.config.GetIngestrURI(), nil
+}
+
+// initClient lazily establishes a connection to MongoDB. The connection is not
+// opened in NewDB so that the ingestr-only code paths (which only need the URI)
+// never pay for a live connection.
+func (db *DB) initClient(ctx context.Context) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.client != nil {
+		return nil
+	}
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(db.config.GetIngestrURI()))
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to MongoDB")
+	}
+
+	db.client = client
+	return nil
+}
+
+func (db *DB) Ping(ctx context.Context) error {
+	if err := db.initClient(ctx); err != nil {
+		return err
+	}
+
+	if err := db.client.Ping(ctx, nil); err != nil {
+		return errors.Wrap(err, "failed to ping MongoDB connection")
+	}
+
+	return nil
 }

--- a/pkg/mongo/query.go
+++ b/pkg/mongo/query.go
@@ -259,15 +259,18 @@ func formatMongoValue(v interface{}) interface{} {
 
 // marshalExtJSONValue serializes a single BSON value to relaxed Extended JSON.
 // bson.MarshalExtJSON requires a top-level document, so the value is wrapped in
-// a one-key document and the wrapper is stripped back off.
+// a one-key document and the inner value is extracted back out. The wrapper is
+// valid JSON, so it is unmarshalled rather than string-stripped.
 func marshalExtJSONValue(v interface{}) interface{} {
 	b, err := bson.MarshalExtJSON(bson.D{{Key: "v", Value: v}}, false, false)
 	if err != nil {
 		return fmt.Sprintf("%v", v)
 	}
-	s := strings.TrimPrefix(string(b), `{"v":`)
-	s = strings.TrimSuffix(s, "}")
-	return s
+	var wrapper map[string]json.RawMessage
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(wrapper["v"])
 }
 
 func mongoTypeName(v interface{}) string {

--- a/pkg/mongo/query.go
+++ b/pkg/mongo/query.go
@@ -137,6 +137,9 @@ func openCursor(ctx context.Context, coll *mongo.Collection, mq *mongoQuery) (*m
 		if err := bson.UnmarshalExtJSON(mq.Aggregate, false, &pipeline); err != nil {
 			return nil, errors.Wrap(err, `invalid "aggregate" pipeline`)
 		}
+		if mq.Skip != nil {
+			pipeline = append(pipeline, bson.D{{Key: "$skip", Value: *mq.Skip}})
+		}
 		if mq.Limit != nil {
 			pipeline = append(pipeline, bson.D{{Key: "$limit", Value: *mq.Limit}})
 		}

--- a/pkg/mongo/query.go
+++ b/pkg/mongo/query.go
@@ -1,0 +1,302 @@
+package mongo
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// mongoQuery is the JSON envelope accepted by `bruin query` for MongoDB
+// connections. It describes a single find or aggregation against one collection:
+//
+//	{"collection":"users","filter":{"age":{"$gt":21}},"sort":{"age":-1},"limit":10}
+//	{"collection":"orders","aggregate":[{"$group":{"_id":"$status","n":{"$sum":1}}}]}
+//
+// The filter/projection/sort/aggregate values are parsed as MongoDB Extended
+// JSON, so type wrappers such as {"$oid":"..."} and {"$date":"..."} are honored
+// while ordinary query operators ($gt, $and, $match, ...) pass through unchanged.
+type mongoQuery struct {
+	Collection string          `json:"collection"`
+	Database   string          `json:"database,omitempty"`
+	Filter     json.RawMessage `json:"filter,omitempty"`
+	Projection json.RawMessage `json:"projection,omitempty"`
+	Sort       json.RawMessage `json:"sort,omitempty"`
+	Limit      *int64          `json:"limit,omitempty"`
+	Skip       *int64          `json:"skip,omitempty"`
+	Aggregate  json.RawMessage `json:"aggregate,omitempty"`
+}
+
+func parseMongoQuery(q string) (*mongoQuery, error) {
+	trimmed := strings.TrimSpace(stripLeadingSQLComments(q))
+	if trimmed == "" {
+		return nil, errors.New("empty query")
+	}
+
+	var mq mongoQuery
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&mq); err != nil {
+		return nil, errors.Wrap(err, `invalid MongoDB query; expected a JSON object such as {"collection":"users","filter":{...}}`)
+	}
+
+	if mq.Collection == "" {
+		return nil, errors.New(`query must specify a "collection"`)
+	}
+	if len(mq.Aggregate) > 0 && (len(mq.Filter) > 0 || len(mq.Projection) > 0 || len(mq.Sort) > 0) {
+		return nil, errors.New(`"aggregate" cannot be combined with "filter", "projection", or "sort"`)
+	}
+
+	return &mq, nil
+}
+
+// stripLeadingSQLComments removes leading blank and `--` comment lines. The
+// query command prepends a `-- @bruin.config: ...` annotation comment to ad-hoc
+// queries for tracking; that comment is meaningless for MongoDB and would break
+// JSON parsing, so it is dropped before decoding the envelope.
+func stripLeadingSQLComments(q string) string {
+	lines := strings.Split(q, "\n")
+	i := 0
+	for i < len(lines) {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			i++
+			continue
+		}
+		break
+	}
+	return strings.Join(lines[i:], "\n")
+}
+
+func (db *DB) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {
+	res, err := db.SelectWithSchema(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return res.Rows, nil
+}
+
+func (db *DB) SelectWithSchema(ctx context.Context, q *query.Query) (*query.QueryResult, error) {
+	if err := db.initClient(ctx); err != nil {
+		return nil, err
+	}
+	return RunQuery(ctx, db.client, db.config.Database, q.Query)
+}
+
+// RunQuery executes a MongoDB query envelope against the given client and
+// returns a tabular result. defaultDatabase is used when the envelope omits a
+// "database". It is shared by the mongo and mongo_atlas connection types.
+func RunQuery(ctx context.Context, client *mongo.Client, defaultDatabase, queryStr string) (*query.QueryResult, error) {
+	mq, err := parseMongoQuery(queryStr)
+	if err != nil {
+		return nil, err
+	}
+
+	dbName := defaultDatabase
+	if mq.Database != "" {
+		dbName = mq.Database
+	}
+	if dbName == "" {
+		return nil, errors.New(`no database configured for this connection; set it on the connection or via "database" in the query`)
+	}
+
+	coll := client.Database(dbName).Collection(mq.Collection)
+
+	cursor, err := openCursor(ctx, coll, mq)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	docs := make([]bson.D, 0)
+	for cursor.Next(ctx) {
+		var doc bson.D
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, errors.Wrap(err, "failed to decode document")
+		}
+		docs = append(docs, doc)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, errors.Wrap(err, "error during cursor iteration")
+	}
+
+	return buildResult(docs), nil
+}
+
+func openCursor(ctx context.Context, coll *mongo.Collection, mq *mongoQuery) (*mongo.Cursor, error) {
+	if len(mq.Aggregate) > 0 {
+		var pipeline bson.A
+		if err := bson.UnmarshalExtJSON(mq.Aggregate, false, &pipeline); err != nil {
+			return nil, errors.Wrap(err, `invalid "aggregate" pipeline`)
+		}
+		if mq.Limit != nil {
+			pipeline = append(pipeline, bson.D{{Key: "$limit", Value: *mq.Limit}})
+		}
+		return coll.Aggregate(ctx, pipeline)
+	}
+
+	filter := bson.M{}
+	if len(mq.Filter) > 0 {
+		if err := bson.UnmarshalExtJSON(mq.Filter, false, &filter); err != nil {
+			return nil, errors.Wrap(err, `invalid "filter"`)
+		}
+	}
+
+	opts := options.Find()
+	if len(mq.Projection) > 0 {
+		var projection bson.M
+		if err := bson.UnmarshalExtJSON(mq.Projection, false, &projection); err != nil {
+			return nil, errors.Wrap(err, `invalid "projection"`)
+		}
+		opts.SetProjection(projection)
+	}
+	if len(mq.Sort) > 0 {
+		var sort bson.D
+		if err := bson.UnmarshalExtJSON(mq.Sort, false, &sort); err != nil {
+			return nil, errors.Wrap(err, `invalid "sort"`)
+		}
+		opts.SetSort(sort)
+	}
+	if mq.Limit != nil {
+		opts.SetLimit(*mq.Limit)
+	}
+	if mq.Skip != nil {
+		opts.SetSkip(*mq.Skip)
+	}
+
+	return coll.Find(ctx, filter, opts)
+}
+
+func (db *DB) Limit(q string, limit int64) string {
+	return LimitQuery(q, limit)
+}
+
+// LimitQuery lets `bruin query --limit N` work for MongoDB by injecting the
+// limit into the query envelope. If the query can't be parsed it is returned
+// as-is. Shared by the mongo and mongo_atlas connection types.
+func LimitQuery(q string, limit int64) string {
+	mq, err := parseMongoQuery(q)
+	if err != nil {
+		return q
+	}
+	mq.Limit = &limit
+	b, err := json.Marshal(mq)
+	if err != nil {
+		return q
+	}
+	return string(b)
+}
+
+// buildResult flattens the returned documents into a tabular result. Columns are
+// the union of top-level field names in first-seen order; nested documents and
+// arrays are rendered as Extended JSON strings.
+func buildResult(docs []bson.D) *query.QueryResult {
+	columns := make([]string, 0)
+	colIndex := make(map[string]int)
+	for _, doc := range docs {
+		for _, field := range doc {
+			if _, ok := colIndex[field.Key]; !ok {
+				colIndex[field.Key] = len(columns)
+				columns = append(columns, field.Key)
+			}
+		}
+	}
+
+	types := make([]string, len(columns))
+	rows := make([][]interface{}, 0, len(docs))
+	for _, doc := range docs {
+		row := make([]interface{}, len(columns))
+		for _, field := range doc {
+			idx := colIndex[field.Key]
+			row[idx] = formatMongoValue(field.Value)
+			if types[idx] == "" && field.Value != nil {
+				types[idx] = mongoTypeName(field.Value)
+			}
+		}
+		rows = append(rows, row)
+	}
+	for i := range types {
+		if types[i] == "" {
+			types[i] = "null"
+		}
+	}
+
+	return &query.QueryResult{
+		Columns:     columns,
+		Rows:        rows,
+		ColumnTypes: types,
+	}
+}
+
+func formatMongoValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case nil:
+		return nil
+	case primitive.ObjectID:
+		return val.Hex()
+	case primitive.DateTime:
+		return val.Time().UTC()
+	case primitive.Decimal128:
+		return val.String()
+	case primitive.Binary:
+		return base64.StdEncoding.EncodeToString(val.Data)
+	case string, bool, int32, int64, float64:
+		return val
+	default:
+		// Nested documents/arrays and the less common BSON types are rendered as
+		// Extended JSON so they survive in a flat cell.
+		return marshalExtJSONValue(val)
+	}
+}
+
+// marshalExtJSONValue serializes a single BSON value to relaxed Extended JSON.
+// bson.MarshalExtJSON requires a top-level document, so the value is wrapped in
+// a one-key document and the wrapper is stripped back off.
+func marshalExtJSONValue(v interface{}) interface{} {
+	b, err := bson.MarshalExtJSON(bson.D{{Key: "v", Value: v}}, false, false)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	s := strings.TrimPrefix(string(b), `{"v":`)
+	s = strings.TrimSuffix(s, "}")
+	return s
+}
+
+func mongoTypeName(v interface{}) string {
+	switch v.(type) {
+	case primitive.ObjectID:
+		return "objectId"
+	case primitive.DateTime:
+		return "date"
+	case primitive.Decimal128:
+		return "decimal"
+	case primitive.Binary:
+		return "binary"
+	case primitive.A:
+		return "array"
+	case primitive.M, primitive.D:
+		return "object"
+	case bool:
+		return "bool"
+	case int32:
+		return "int"
+	case int64:
+		return "long"
+	case float64:
+		return "double"
+	case string:
+		return "string"
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}

--- a/pkg/mongo/query_test.go
+++ b/pkg/mongo/query_test.go
@@ -1,0 +1,158 @@
+package mongo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestParseMongoQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		query   string
+		wantErr string
+		assert  func(t *testing.T, mq *mongoQuery)
+	}{
+		{
+			name:  "simple find",
+			query: `{"collection":"users","filter":{"age":{"$gt":21}}}`,
+			assert: func(t *testing.T, mq *mongoQuery) {
+				t.Helper()
+				assert.Equal(t, "users", mq.Collection)
+				assert.JSONEq(t, `{"age":{"$gt":21}}`, string(mq.Filter))
+				assert.Nil(t, mq.Aggregate)
+			},
+		},
+		{
+			name:  "aggregate pipeline",
+			query: `{"collection":"orders","aggregate":[{"$group":{"_id":"$status","n":{"$sum":1}}}]}`,
+			assert: func(t *testing.T, mq *mongoQuery) {
+				t.Helper()
+				assert.Equal(t, "orders", mq.Collection)
+				assert.JSONEq(t, `[{"$group":{"_id":"$status","n":{"$sum":1}}}]`, string(mq.Aggregate))
+			},
+		},
+		{
+			name:    "missing collection",
+			query:   `{"filter":{"a":1}}`,
+			wantErr: `must specify a "collection"`,
+		},
+		{
+			name:    "aggregate combined with filter",
+			query:   `{"collection":"c","aggregate":[{"$match":{}}],"filter":{"a":1}}`,
+			wantErr: `"aggregate" cannot be combined`,
+		},
+		{
+			name:    "unknown field",
+			query:   `{"collection":"c","limitt":5}`,
+			wantErr: "invalid MongoDB query",
+		},
+		{
+			name:    "not json",
+			query:   `SELECT * FROM users`,
+			wantErr: "invalid MongoDB query",
+		},
+		{
+			name:    "empty",
+			query:   "   ",
+			wantErr: "empty query",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mq, err := parseMongoQuery(tt.query)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.assert != nil {
+				tt.assert(t, mq)
+			}
+		})
+	}
+}
+
+func TestParseMongoQueryStripsAnnotationComment(t *testing.T) {
+	t.Parallel()
+
+	// The query command prepends a `-- @bruin.config: ...` annotation comment.
+	q := "-- @bruin.config: {\"type\":\"adhoc_query\"}\n{\"collection\":\"users\",\"filter\":{\"age\":{\"$gt\":21}}}"
+	mq, err := parseMongoQuery(q)
+	require.NoError(t, err)
+	assert.Equal(t, "users", mq.Collection)
+	assert.JSONEq(t, `{"age":{"$gt":21}}`, string(mq.Filter))
+}
+
+func TestLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("injects limit and preserves filter", func(t *testing.T) {
+		t.Parallel()
+		out := (&DB{}).Limit(`{"collection":"users","filter":{"age":{"$gt":21}}}`, 5)
+		mq, err := parseMongoQuery(out)
+		require.NoError(t, err)
+		require.NotNil(t, mq.Limit)
+		assert.Equal(t, int64(5), *mq.Limit)
+		assert.JSONEq(t, `{"age":{"$gt":21}}`, string(mq.Filter))
+	})
+
+	t.Run("unparseable query is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := `SELECT 1`
+		assert.Equal(t, in, (&DB{}).Limit(in, 5))
+	})
+}
+
+func TestBuildResult(t *testing.T) {
+	t.Parallel()
+
+	oid := primitive.NewObjectID()
+	docs := []bson.D{
+		{{Key: "_id", Value: oid}, {Key: "name", Value: "alice"}, {Key: "age", Value: int32(30)}},
+		{{Key: "_id", Value: primitive.NewObjectID()}, {Key: "age", Value: int32(25)}, {Key: "tags", Value: bson.A{"x", "y"}}},
+	}
+
+	res := buildResult(docs)
+
+	// Columns are the union of keys in first-seen order.
+	assert.Equal(t, []string{"_id", "name", "age", "tags"}, res.Columns)
+	require.Len(t, res.ColumnTypes, len(res.Columns))
+	assert.Equal(t, []string{"objectId", "string", "int", "array"}, res.ColumnTypes)
+
+	require.Len(t, res.Rows, 2)
+	// First row: all but tags populated.
+	assert.Equal(t, oid.Hex(), res.Rows[0][0])
+	assert.Equal(t, "alice", res.Rows[0][1])
+	assert.Equal(t, int32(30), res.Rows[0][2])
+	assert.Nil(t, res.Rows[0][3])
+	// Second row: name missing -> nil, tags rendered as JSON.
+	assert.Nil(t, res.Rows[1][1])
+	assert.Equal(t, `["x","y"]`, res.Rows[1][3])
+}
+
+func TestFormatMongoValue(t *testing.T) {
+	t.Parallel()
+
+	oid := primitive.NewObjectID()
+	ts := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	assert.Nil(t, formatMongoValue(nil))
+	assert.Equal(t, oid.Hex(), formatMongoValue(oid))
+	assert.Equal(t, ts, formatMongoValue(primitive.NewDateTimeFromTime(ts)))
+	assert.Equal(t, "alice", formatMongoValue("alice"))
+	assert.Equal(t, int64(7), formatMongoValue(int64(7)))
+	assert.Equal(t, true, formatMongoValue(true))
+	// Nested document and array become Extended JSON strings.
+	assert.Equal(t, `{"c":2}`, formatMongoValue(bson.M{"c": int32(2)}))
+	assert.Equal(t, `[1,2]`, formatMongoValue(bson.A{int32(1), int32(2)}))
+}

--- a/pkg/mongo_atlas/db.go
+++ b/pkg/mongo_atlas/db.go
@@ -2,6 +2,7 @@ package mongoatlas
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -12,6 +13,8 @@ type DB struct {
 	client *mongo.Client
 	config *Config
 	Name   string
+
+	mu sync.Mutex
 }
 
 type MongoAtlasConnection interface {
@@ -42,13 +45,32 @@ func (db *DB) GetIngestrURI() (string, error) {
 	return db.config.GetIngestrURI(), nil
 }
 
-func (db *DB) Ping(ctx context.Context) error {
-	if db.client == nil {
-		return errors.New("MongoDB client is not initialized")
+// ensureClient lazily establishes a connection. The connection manager builds
+// Atlas connections via NewClient (eager), but instances created through NewDB
+// connect on first use instead.
+func (db *DB) ensureClient(ctx context.Context) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.client != nil {
+		return nil
 	}
 
-	err := db.client.Ping(ctx, nil)
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(db.config.GetIngestrURI()))
 	if err != nil {
+		return errors.Wrap(err, "failed to create MongoDB client")
+	}
+
+	db.client = client
+	return nil
+}
+
+func (db *DB) Ping(ctx context.Context) error {
+	if err := db.ensureClient(ctx); err != nil {
+		return err
+	}
+
+	if err := db.client.Ping(ctx, nil); err != nil {
 		return errors.Wrap(err, "failed to ping MongoDB Atlas connection")
 	}
 

--- a/pkg/mongo_atlas/query.go
+++ b/pkg/mongo_atlas/query.go
@@ -1,0 +1,27 @@
+package mongoatlas
+
+import (
+	"context"
+
+	bruinmongo "github.com/bruin-data/bruin/pkg/mongo"
+	"github.com/bruin-data/bruin/pkg/query"
+)
+
+func (db *DB) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {
+	res, err := db.SelectWithSchema(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return res.Rows, nil
+}
+
+func (db *DB) SelectWithSchema(ctx context.Context, q *query.Query) (*query.QueryResult, error) {
+	if err := db.ensureClient(ctx); err != nil {
+		return nil, err
+	}
+	return bruinmongo.RunQuery(ctx, db.client, db.config.Database, q.Query)
+}
+
+func (db *DB) Limit(q string, limit int64) string {
+	return bruinmongo.LimitQuery(q, limit)
+}


### PR DESCRIPTION
MongoDB connections previously only exposed an ingestr URI, so `bruin query` reported "does not support querying" and `connections test` did nothing.

Implement SelectWithSchema/Select/Limit and a lazily-initialized native driver client (plus Ping) for both the mongo and mongo_atlas connection types. Queries are expressed as a JSON envelope describing a find or aggregation against one collection, e.g.:

  {"collection":"users","filter":{"age":{"$gt":21}},"sort":{"age":-1},"limit":10}
  {"collection":"orders","aggregate":[{"$group":{"_id":"$status","n":{"$sum":1}}}]}

Filter/projection/sort/aggregate values are parsed as MongoDB Extended JSON, so operators ($gt, $match, ...) pass through while type wrappers ($oid, $date) are honored. Returned documents are flattened into columns/rows, with nested documents and arrays rendered as Extended JSON. The shared query engine lives in pkg/mongo and mongo_atlas delegates to it.

Leading `-- @bruin.config:` annotation comments are stripped before parsing, since the query command prepends them for SQL connections.