### PR TITLE
fix(query): preserve function-name case in --limit AST round-trip

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -170,14 +170,9 @@ func Query() *cli.Command {
 				return handleError(c.String("output"), err)
 			}
 
-			connName, conn, queryStr, assetType, pipelineInfo, err := prepareQueryExecution(ctx, c, fs, vars)
+			connName, conn, queryStr, dialect, pipelineInfo, err := prepareQueryExecution(ctx, c, fs, vars)
 			if err != nil {
 				return handleError(c.String("output"), err)
-			}
-
-			dialect, err := sqlparser.AssetTypeToDialect(assetType)
-			if err != nil {
-				dialect = ""
 			}
 
 			var parser *sqlparser.SQLParser
@@ -462,7 +457,7 @@ func validateFlags(connection, query, asset, pipelinePath string, hasSemanticFla
 	}
 }
 
-func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, vars map[string]any) (string, interface{}, string, pipeline.AssetType, *ppInfo, error) {
+func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, vars map[string]any) (string, interface{}, string, string, *ppInfo, error) {
 	assetPath := c.String("asset")
 	queryStr := c.String("query")
 	env := c.String("environment")
@@ -487,7 +482,7 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 
 	// Direct query mode (no asset path)
 	if assetPath == "" {
-		conn, err := getConnectionFromConfigWithContext(ctx, env, connectionName, fs, c.String("config-file"))
+		conn, connType, err := getConnectionAndTypeFromConfigWithContext(ctx, env, connectionName, fs, c.String("config-file"))
 		if err != nil {
 			return "", nil, "", "", nil, err
 		}
@@ -495,7 +490,7 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 		if err != nil {
 			return "", nil, "", "", nil, err
 		}
-		return connectionName, conn, queryStr, "", nil, nil
+		return connectionName, conn, queryStr, sqlparser.ConnectionTypeToDialect(connType), nil, nil
 	}
 
 	if queryStr != "" {
@@ -537,7 +532,7 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 			return "", nil, "", "", nil, err
 		}
 
-		return connName, conn, queryStr, pipelineInfo.Asset.Type, pipelineInfo, nil
+		return connName, conn, queryStr, dialectForAssetType(pipelineInfo.Asset.Type), pipelineInfo, nil
 	}
 	// Asset query mode (only asset path)
 	pipelineInfo, err := GetPipelineAndAsset(ctx, assetPath, fs, c.String("config-file"))
@@ -581,10 +576,20 @@ func prepareQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, var
 		return "", nil, "", "", nil, err
 	}
 
-	return connName, conn, queryStr, pipelineInfo.Asset.Type, pipelineInfo, nil
+	return connName, conn, queryStr, dialectForAssetType(pipelineInfo.Asset.Type), pipelineInfo, nil
 }
 
-func prepareSemanticQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, vars map[string]any, startDate time.Time, endDate time.Time) (string, interface{}, string, pipeline.AssetType, *ppInfo, error) {
+// dialectForAssetType returns the SQL parser dialect for the given asset type,
+// or the empty string when the asset type has no registered dialect.
+func dialectForAssetType(assetType pipeline.AssetType) string {
+	dialect, err := sqlparser.AssetTypeToDialect(assetType)
+	if err != nil {
+		return ""
+	}
+	return dialect
+}
+
+func prepareSemanticQueryExecution(ctx context.Context, c *cli.Command, fs afero.Fs, vars map[string]any, startDate time.Time, endDate time.Time) (string, interface{}, string, string, *ppInfo, error) {
 	semanticModelName := c.String("semantic-model")
 	assetPath := c.String("asset")
 	pipelinePath := c.String("pipeline")
@@ -662,7 +667,7 @@ func prepareSemanticQueryExecution(ctx context.Context, c *cli.Command, fs afero
 			return "", nil, "", "", nil, err
 		}
 
-		return connName, conn, queryStr, pipelineInfo.Asset.Type, pipelineInfo, nil
+		return connName, conn, queryStr, dialectForAssetType(pipelineInfo.Asset.Type), pipelineInfo, nil
 	} else {
 		renderer := newSemanticRenderer(pipelineInfo, vars, startDate, endDate)
 		extractor := &query.WholeFileExtractor{
@@ -673,7 +678,8 @@ func prepareSemanticQueryExecution(ctx context.Context, c *cli.Command, fs afero
 		if err != nil {
 			return "", nil, "", "", nil, err
 		}
-		return connName, conn, queryStr, "", pipelineInfo, nil
+		dialect := sqlparser.ConnectionTypeToDialect(pipelineInfo.Config.SelectedEnvironment.Connections.ConnectionsSummaryList()[connName])
+		return connName, conn, queryStr, dialect, pipelineInfo, nil
 	}
 }
 
@@ -886,9 +892,14 @@ func parseSemanticSortSpec(raw string) (semantic.SortSpec, error) {
 }
 
 func getConnectionFromConfigWithContext(ctx context.Context, env string, connectionName string, fs afero.Fs, configFilePath string) (interface{}, error) {
+	conn, _, err := getConnectionAndTypeFromConfigWithContext(ctx, env, connectionName, fs, configFilePath)
+	return conn, err
+}
+
+func getConnectionAndTypeFromConfigWithContext(ctx context.Context, env string, connectionName string, fs afero.Fs, configFilePath string) (interface{}, string, error) {
 	repoRoot, err := git.FindRepoFromPath(".")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to find the git repository root")
+		return nil, "", errors.Wrap(err, "failed to find the git repository root")
 	}
 
 	if configFilePath == "" {
@@ -896,31 +907,31 @@ func getConnectionFromConfigWithContext(ctx context.Context, env string, connect
 	}
 	cm, err := config.LoadOrCreate(fs, configFilePath)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load or create config")
+		return nil, "", errors.Wrap(err, "failed to load or create config")
 	}
 
 	if env != "" {
 		err := cm.SelectEnvironment(env)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to use the environment '%s'", env)
+			return nil, "", errors.Wrapf(err, "failed to use the environment '%s'", env)
 		}
 	}
 
 	manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
 	if len(errs) > 0 {
-		return nil, errors.Wrap(errs[0], "failed to create connection manager")
+		return nil, "", errors.Wrap(errs[0], "failed to create connection manager")
 	}
 
 	conn := manager.GetConnection(connectionName)
 	if conn == nil {
-		return nil, &config.MissingConnectionError{
+		return nil, "", &config.MissingConnectionError{
 			Name:            connectionName,
 			ConfigFilePath:  configFilePath,
 			EnvironmentName: cm.SelectedEnvironmentName,
 		}
 	}
 
-	return conn, nil
+	return conn, manager.GetConnectionType(connectionName), nil
 }
 
 func extractQuery(content string, extractor query.QueryExtractor) (string, error) {

--- a/pkg/sqlparser/parser.go
+++ b/pkg/sqlparser/parser.go
@@ -371,6 +371,40 @@ func AssetTypeToDialect(assetType pipeline.AssetType) (string, error) {
 	return dialect, nil
 }
 
+// connectionTypeDialectMap maps the connection type identifier used in the
+// connection manager (the yaml tag of each connection field in
+// config.Connections) to the dialect string the rust SQL parser understands.
+// This is used to pick a dialect for queries that are run directly against a
+// connection without going through a Bruin asset (where we'd otherwise know
+// the asset type).
+var connectionTypeDialectMap = map[string]string{
+	"google_cloud_platform": "bigquery",
+	"snowflake":             "snowflake",
+	"postgres":              "postgres",
+	"mysql":                 "mysql",
+	"redshift":              "redshift",
+	"athena":                "athena",
+	"trino":                 "trino",
+	"dremio":                "trino",
+	"sail":                  "trino",
+	"clickhouse":            "clickhouse",
+	"databricks":            "databricks",
+	"mssql":                 "tsql",
+	"synapse":               "tsql",
+	"duckdb":                "duckdb",
+	"motherduck":            "duckdb",
+	"oracle":                "oracle",
+	"fabric":                "fabric",
+	"vertica":               "postgres",
+}
+
+// ConnectionTypeToDialect maps a connection type identifier (e.g. "clickhouse")
+// to the dialect string used by the rust SQL parser. Returns the empty string
+// when no dialect is registered for the type.
+func ConnectionTypeToDialect(connectionType string) string {
+	return connectionTypeDialectMap[connectionType]
+}
+
 func (s *SQLParser) AddLimit(sql string, limit int, dialect string) (string, error) {
 	err := s.Start()
 	if err != nil {

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -1165,6 +1165,18 @@ func TestSqlParser_AddLimit(t *testing.T) { //nolint
 			dialect:  "",
 			expected: "SELECT id, name FROM users LIMIT 5",
 		},
+		{
+			// Regression for https://github.com/bruin-data/bruin/issues/2239:
+			// the rust parser's generic dialect uppercases function names,
+			// which breaks ClickHouse (case-sensitive function lookup).
+			// Round-tripping with the clickhouse dialect must preserve the
+			// original camelCase function names.
+			name:     "clickhouse dialect preserves camelCase function names",
+			query:    "SELECT toFloat64(amount_col) AS amount FROM my_db.my_table",
+			limit:    2,
+			dialect:  "clickhouse",
+			expected: "SELECT toFloat64(amount_col) AS amount FROM my_db.my_table LIMIT 2",
+		},
 	}
 
 	parser := sharedSQLParser
@@ -1178,6 +1190,28 @@ func TestSqlParser_AddLimit(t *testing.T) { //nolint
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, got)
 			}
+		})
+	}
+}
+
+func TestConnectionTypeToDialect(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"clickhouse":            "clickhouse",
+		"postgres":              "postgres",
+		"google_cloud_platform": "bigquery",
+		"snowflake":             "snowflake",
+		"mssql":                 "tsql",
+		"vertica":               "postgres",
+		"":                      "",
+		"unknown":               "",
+	}
+
+	for connType, want := range tests {
+		t.Run(connType, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, want, ConnectionTypeToDialect(connType))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Closes #2239.
- When `bruin query --connection <ch> --query "select toFloat64(...)" --limit N` runs in direct query mode, the asset type is empty and `AssetTypeToDialect` returns `""`. The rust SQL parser's `AddLimit` then falls back to its `Generic` dialect, which normalizes function names to uppercase. The query that reaches ClickHouse contains `TOFLOAT64`, and CH's case-sensitive function lookup fails with `code: 46, Function with name 'TOFLOAT64' does not exist`.
- Resolve the dialect from the connection's type (e.g. `clickhouse`, `postgres`, `google_cloud_platform → bigquery`) when no asset type is available, so the AST round-trip uses the right dialect and preserves the original case.

## Changes

- `pkg/sqlparser/parser.go`: new `ConnectionTypeToDialect()` mapping the connection-type yaml tags (from `config.Connections`) to the rust parser's dialect strings.
- `cmd/fetch.go`:
  - `prepareQueryExecution` / `prepareSemanticQueryExecution` now return a resolved `dialect string` instead of `pipeline.AssetType`; callers no longer need to know about asset-type → dialect mapping.
  - Direct query mode resolves dialect from the connection type via `getConnectionAndTypeFromConfigWithContext` (the existing `getConnectionFromConfigWithContext` is kept as a thin wrapper, so unrelated callers are not touched).
  - The pipeline-mode semantic path (no asset) also uses the connection type for the dialect.
- `pkg/sqlparser/parser_test.go`: regression test that `AddLimit` with the `clickhouse` dialect preserves `toFloat64`, plus a unit test for the new helper.

## Test plan

- [x] `make format`
- [x] `make test` (full unit suite with race)
- [x] New regression test: `go test ./pkg/sqlparser/ -run TestSqlParser_AddLimit` (covers `toFloat64` case preservation on the clickhouse dialect)
- [x] New helper test: `go test ./pkg/sqlparser/ -run TestConnectionTypeToDialect`
- [ ] Manual sanity: `./bin/bruin query -c <ch-conn> --query "select toFloat64(amount_col) as amount from db.t" --limit 2` → `toFloat64` preserved on the wire (verified against ClickHouse 26.6 local that the generic dialect uppercases vs clickhouse dialect preserves; awaiting reporter's confirmation against the real connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)