### PR TITLE
feat: support data-diff for MongoDB

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -157,6 +157,7 @@ func DataDiffCmd() *cli.Command {
 	var reverse bool
 	var outputFormat string
 	var dryRun bool
+	var sampleSize int64
 
 	return &cli.Command{
 		Name:    "data-diff",
@@ -215,9 +216,18 @@ func DataDiffCmd() *cli.Command {
 				Usage:       "Estimate the cost of the comparison without executing it (outputs JSON). Only supported for BigQuery connections.",
 				Destination: &dryRun,
 			},
+			&cli.Int64Flag{
+				Name:        "sample",
+				Usage:       "For MongoDB sources, sample at most N documents instead of scanning the whole collection (statistics become approximate). 0 (default) scans everything. Ignored by other connection types.",
+				Destination: &sampleSize,
+				Value:       0,
+			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			ctx = query.WithQueryType(ctx, query.QueryTypeDiff)
+			if sampleSize > 0 {
+				ctx = diff.WithSampleSize(ctx, sampleSize)
+			}
 			if c.NArg() != 2 {
 				return errors.New("incorrect number of arguments, please provide two table names")
 			}

--- a/docs/commands/data-diff.md
+++ b/docs/commands/data-diff.md
@@ -45,6 +45,7 @@ table td:first-child {
 | `--fail-if-diff` | bool | `false` | Return a non-zero exit code if differences are found |
 | `--target-dialect` | str | auto-detect | Target SQL dialect for ALTER TABLE statements (postgresql, snowflake, bigquery, duckdb, generic). Auto-detected from connection types if not specified |
 | `--reverse` | bool | `false` | Reverse the direction of ALTER statements (transform Table1 to match Table2 instead of Table2 to match Table1) |
+| `--sample` | int | `0` | For MongoDB sources, sample at most N documents per collection instead of scanning the whole collection (statistics become approximate). `0` scans everything. Ignored by other connection types |
 
 ## Table Identifier Format
 
@@ -262,6 +263,24 @@ The `data-diff` command includes specialized type mapping support for the follow
 - **BigQuery** - Native support for BigQuery types including `INT64`, `FLOAT64`, `BIGNUMERIC`, and BigQuery-specific formatting
 - **PostgreSQL & AWS Redshift** - Complete support for PostgreSQL types including `SERIAL` types, `MONEY`, network types (`CIDR`, `INET`), and `JSONB`
 - **Snowflake** - Full support for Snowflake types including `NUMBER`, `VARIANT`, and timezone-aware timestamp types
+- **MongoDB & MongoDB Atlas** - Schema is inferred from the documents themselves (see [MongoDB Collections](#mongodb-collections) below), mapping BSON types such as `objectId`, `double`, `decimal`, `date`, and nested `object`/`array` fields to common categories
+
+### MongoDB Collections
+
+MongoDB has no fixed schema, so for MongoDB connections the `data-diff` command infers the schema by scanning the collection's documents. A "table" is a collection, and a "column" is a top-level field.
+
+- **Schema inference:** Field names, types, and nullability are derived from the documents. A field's type is the most common BSON type observed for it; a field is reported as nullable when it is absent or `null` in any scanned document.
+- **Identifier format:** Use the collection name (resolved against the connection's `database`), or qualify it as `database.collection` to compare across databases — e.g. `mongo:users` or `mongo:analytics.events`.
+- **Top-level fields only:** Nested documents and arrays are compared as `object`/`array` (JSON) fields — count and fill rate — rather than being flattened into dotted paths. `ObjectId` fields (such as `_id`) are compared as strings.
+- **Sampling large collections:** A full scan is exact but can be expensive on very large collections. Pass `--sample N` to base type inference and statistics on at most `N` randomly sampled documents instead. Row counts always reflect the true collection size; per-column statistics become approximate when sampling.
+
+```bash
+# Compare two collections in the connection's default database
+bruin data-diff -c mongo orders_v1 orders_v2 --full
+
+# Compare collections across databases, sampling 10k docs each
+bruin data-diff -c mongo prod.orders staging.orders --full --sample 10000
+```
 
 ### Type Mapping Features
 

--- a/pkg/diff/sample.go
+++ b/pkg/diff/sample.go
@@ -1,0 +1,23 @@
+package diff
+
+import "context"
+
+type sampleSizeContextKey struct{}
+
+// WithSampleSize stores the maximum number of records a summarizer should read
+// when producing a table summary. A value <= 0 means "scan everything".
+//
+// Only summarizers that support sampling (currently MongoDB) honor this; the
+// SQL-backed summarizers ignore it and always scan the full table.
+func WithSampleSize(ctx context.Context, size int64) context.Context {
+	return context.WithValue(ctx, sampleSizeContextKey{}, size)
+}
+
+// SampleSizeFromContext returns the sample size set via WithSampleSize, or 0 if
+// none was set, in which case the whole table should be scanned.
+func SampleSizeFromContext(ctx context.Context) int64 {
+	if size, ok := ctx.Value(sampleSizeContextKey{}).(int64); ok {
+		return size
+	}
+	return 0
+}

--- a/pkg/diff/types.go
+++ b/pkg/diff/types.go
@@ -352,6 +352,47 @@ func NewSnowflakeTypeMapper() *DatabaseTypeMapper {
 	return mapper
 }
 
+// NewMongoTypeMapper provides MongoDB type mapping. The keys are the BSON type
+// aliases reported by the aggregation `$type` operator (e.g. "double", "string",
+// "objectId"), since MongoDB has no static catalog and types are inferred from
+// the documents themselves.
+func NewMongoTypeMapper() *DatabaseTypeMapper {
+	mapper := NewDatabaseTypeMapper()
+
+	// Numeric BSON types
+	mapper.AddNumericTypes(
+		"double", "int", "long", "decimal",
+	)
+
+	// String-like BSON types. ObjectIds are stringified for comparison so they
+	// surface useful distinct/length statistics.
+	mapper.AddStringTypes(
+		"string", "objectId",
+	)
+
+	// Boolean BSON type
+	mapper.AddBooleanTypes(
+		"bool",
+	)
+
+	// DateTime BSON types
+	mapper.AddDateTimeTypes(
+		"date", "timestamp",
+	)
+
+	// Binary BSON type
+	mapper.AddBinaryTypes(
+		"binData",
+	)
+
+	// Nested document/array BSON types are treated as JSON.
+	mapper.AddJSONTypes(
+		"object", "array",
+	)
+
+	return mapper
+}
+
 type Table struct {
 	Name    string
 	Columns []*Column

--- a/pkg/mongo/diff.go
+++ b/pkg/mongo/diff.go
@@ -1,0 +1,532 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/bruin/pkg/diff"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// mongoTypeMapper maps BSON type aliases (as reported by the `$type` aggregation
+// operator) to Bruin's normalized data types.
+var mongoTypeMapper = diff.NewMongoTypeMapper()
+
+// BSON type groupings used both for type inference and for coercing values when
+// computing statistics. They mirror the categories in NewMongoTypeMapper.
+var (
+	numericBSONTypes = []string{"double", "int", "long", "decimal"}
+	stringBSONTypes  = []string{"string", "objectId"}
+)
+
+// GetTableSummary implements diff.TableSummarizer for MongoDB collections. The
+// table identifier is a collection name, optionally qualified as
+// "database.collection".
+func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly bool) (*diff.TableSummaryResult, error) {
+	if err := db.initClient(ctx); err != nil {
+		return nil, err
+	}
+	return BuildTableSummary(ctx, db.client, db.config.Database, tableName, schemaOnly, diff.SampleSizeFromContext(ctx))
+}
+
+// BuildTableSummary produces a diff.TableSummaryResult for a MongoDB collection.
+// MongoDB has no static schema, so the field set, types and nullability are
+// inferred by scanning the documents. When sampleSize > 0 at most that many
+// documents are sampled (via $sample) instead of scanning the whole collection,
+// which makes the resulting statistics approximate.
+//
+// It is shared by the mongo and mongo_atlas connection types.
+func BuildTableSummary(ctx context.Context, client *mongo.Client, defaultDatabase, tableName string, schemaOnly bool, sampleSize int64) (*diff.TableSummaryResult, error) {
+	dbName, collName, err := splitCollectionName(tableName, defaultDatabase)
+	if err != nil {
+		return nil, err
+	}
+	coll := client.Database(dbName).Collection(collName)
+
+	// Pass 1: infer the schema (field names, types, nullability) from documents.
+	facet, err := runSchemaFacet(ctx, coll, sampleSize)
+	if err != nil {
+		return nil, err
+	}
+	scanned, columns := summarizeSchema(facet)
+
+	result := &diff.TableSummaryResult{
+		Table: &diff.Table{
+			Name:    tableName,
+			Columns: columns,
+		},
+	}
+
+	// In schema-only mode, mirror the SQL summarizers: no row count, no stats.
+	if schemaOnly {
+		return result, nil
+	}
+
+	// Row count reflects the true collection size, independent of any sampling.
+	rowCount, err := coll.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to count documents in collection '%s'", collName)
+	}
+	result.RowCount = rowCount
+
+	if len(columns) == 0 {
+		return result, nil
+	}
+
+	// Pass 2: compute per-field statistics in a single aggregation.
+	statsDoc, err := runStats(ctx, coll, columns, sampleSize)
+	if err != nil {
+		return nil, err
+	}
+	parseStatsResult(statsDoc, columns, scanned)
+
+	return result, nil
+}
+
+// splitCollectionName resolves a data-diff table identifier into a database and
+// collection. The identifier may be "collection" (uses the connection's default
+// database) or "database.collection". MongoDB collection names may themselves
+// contain dots, so only the first dot is treated as the database separator.
+func splitCollectionName(identifier, defaultDatabase string) (string, string, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return "", "", errors.New("empty collection name")
+	}
+	if idx := strings.Index(identifier, "."); idx != -1 {
+		dbName := identifier[:idx]
+		collName := identifier[idx+1:]
+		if dbName == "" || collName == "" {
+			return "", "", fmt.Errorf("invalid collection identifier %q; expected 'collection' or 'database.collection'", identifier)
+		}
+		return dbName, collName, nil
+	}
+	if defaultDatabase == "" {
+		return "", "", fmt.Errorf("no database configured for this connection; qualify the collection as 'database.collection' (got %q)", identifier)
+	}
+	return defaultDatabase, identifier, nil
+}
+
+// ---- schema inference ------------------------------------------------------
+
+type schemaFieldKey struct {
+	Field string `bson:"f"`
+	Type  string `bson:"t"`
+}
+
+type schemaFacetField struct {
+	ID    schemaFieldKey `bson:"_id"`
+	Count int64          `bson:"n"`
+}
+
+type countResult struct {
+	N int64 `bson:"n"`
+}
+
+// schemaFacetResult is the shape returned by the schema-inference aggregation: a
+// total document count plus per (field, BSON type) counts.
+type schemaFacetResult struct {
+	Total  []countResult      `bson:"total"`
+	Fields []schemaFacetField `bson:"fields"`
+}
+
+// buildSchemaPipeline builds the aggregation that, for every top-level field,
+// reports how many documents carry it with each BSON type. A $facet is used so
+// the total document count (needed for nullability) comes from the same scan.
+func buildSchemaPipeline(sampleSize int64) bson.A {
+	pipeline := bson.A{}
+	if sampleSize > 0 {
+		pipeline = append(pipeline, bson.D{{Key: "$sample", Value: bson.D{{Key: "size", Value: sampleSize}}}})
+	}
+	pipeline = append(pipeline, bson.D{{Key: "$facet", Value: bson.D{
+		{Key: "total", Value: bson.A{bson.D{{Key: "$count", Value: "n"}}}},
+		{Key: "fields", Value: bson.A{
+			bson.D{{Key: "$project", Value: bson.D{{Key: "kv", Value: bson.D{{Key: "$objectToArray", Value: "$$ROOT"}}}}}},
+			bson.D{{Key: "$unwind", Value: "$kv"}},
+			bson.D{{Key: "$group", Value: bson.D{
+				{Key: "_id", Value: bson.D{
+					{Key: "f", Value: "$kv.k"},
+					{Key: "t", Value: bson.D{{Key: "$type", Value: "$kv.v"}}},
+				}},
+				{Key: "n", Value: bson.D{{Key: "$sum", Value: 1}}},
+			}}},
+		}},
+	}}})
+	return pipeline
+}
+
+func runSchemaFacet(ctx context.Context, coll *mongo.Collection, sampleSize int64) (schemaFacetResult, error) {
+	pipeline := buildSchemaPipeline(sampleSize)
+	cursor, err := coll.Aggregate(ctx, pipeline, options.Aggregate().SetAllowDiskUse(true))
+	if err != nil {
+		return schemaFacetResult{}, errors.Wrap(err, "failed to run schema inference aggregation")
+	}
+	defer cursor.Close(ctx)
+
+	var results []schemaFacetResult
+	if err := cursor.All(ctx, &results); err != nil {
+		return schemaFacetResult{}, errors.Wrap(err, "failed to decode schema inference result")
+	}
+	if len(results) == 0 {
+		return schemaFacetResult{}, nil
+	}
+	return results[0], nil
+}
+
+// summarizeSchema turns the raw facet counts into ordered columns. Columns are
+// emitted with `_id` first, then alphabetically, for deterministic output. The
+// returned count is the number of documents scanned (used for nullability and as
+// the basis for statistics counts).
+func summarizeSchema(facet schemaFacetResult) (int64, []*diff.Column) {
+	var scanned int64
+	if len(facet.Total) > 0 {
+		scanned = facet.Total[0].N
+	}
+
+	typeCounts := make(map[string]map[string]int64)
+	order := make([]string, 0)
+	for _, f := range facet.Fields {
+		field := f.ID.Field
+		if _, ok := typeCounts[field]; !ok {
+			typeCounts[field] = make(map[string]int64)
+			order = append(order, field)
+		}
+		typeCounts[field][f.ID.Type] += f.Count
+	}
+
+	sort.Slice(order, func(i, j int) bool {
+		switch {
+		case order[i] == "_id":
+			return true
+		case order[j] == "_id":
+			return false
+		default:
+			return order[i] < order[j]
+		}
+	})
+
+	columns := make([]*diff.Column, 0, len(order))
+	for _, field := range order {
+		counts := typeCounts[field]
+
+		var presentNonNull int64
+		for t, c := range counts {
+			if t != "null" {
+				presentNonNull += c
+			}
+		}
+
+		bsonType := dominantType(counts)
+		columns = append(columns, &diff.Column{
+			Name:           field,
+			Type:           bsonType,
+			NormalizedType: mongoTypeMapper.MapType(bsonType),
+			// A field is nullable if it is absent or explicitly null in any
+			// scanned document.
+			Nullable: presentNonNull < scanned,
+		})
+	}
+	return scanned, columns
+}
+
+// dominantType returns the most frequently observed BSON type for a field,
+// ignoring "null" unless the field is exclusively null. Ties break on type name
+// for determinism.
+func dominantType(counts map[string]int64) string {
+	best := ""
+	var bestCount int64 = -1
+	for t, c := range counts {
+		if t == "null" {
+			continue
+		}
+		if c > bestCount || (c == bestCount && t < best) {
+			best = t
+			bestCount = c
+		}
+	}
+	if best == "" {
+		return "null"
+	}
+	return best
+}
+
+// ---- statistics ------------------------------------------------------------
+
+// buildStatsPipeline builds a single $group that computes, for every column, the
+// statistics appropriate to its inferred type. Each column's accumulators are
+// keyed by its positional index to avoid any clash with user field names.
+func buildStatsPipeline(columns []*diff.Column, sampleSize int64) bson.A {
+	group := bson.D{{Key: "_id", Value: nil}}
+	for i, col := range columns {
+		group = append(group, statAccumulators(i, col)...)
+	}
+
+	pipeline := bson.A{}
+	if sampleSize > 0 {
+		pipeline = append(pipeline, bson.D{{Key: "$sample", Value: bson.D{{Key: "size", Value: sampleSize}}}})
+	}
+	pipeline = append(pipeline, bson.D{{Key: "$group", Value: group}})
+	return pipeline
+}
+
+func statAccumulators(i int, col *diff.Column) []bson.E {
+	p := strconv.Itoa(i)
+	fieldRef := "$" + col.Name
+	present := bson.E{Key: p + "_present", Value: sum(presentExpr(fieldRef))}
+
+	switch col.NormalizedType {
+	case diff.CommonTypeNumeric:
+		num := coerce(fieldRef, numericBSONTypes)
+		return []bson.E{
+			present,
+			{Key: p + "_min", Value: accumulator("$min", num)},
+			{Key: p + "_max", Value: accumulator("$max", num)},
+			{Key: p + "_avg", Value: accumulator("$avg", num)},
+			{Key: p + "_sum", Value: accumulator("$sum", num)},
+			{Key: p + "_std", Value: accumulator("$stdDevPop", num)},
+		}
+	case diff.CommonTypeString:
+		str := stringCoerce(fieldRef)
+		strLen := bson.D{{Key: "$cond", Value: bson.A{
+			bson.D{{Key: "$eq", Value: bson.A{str, nil}}},
+			nil,
+			bson.D{{Key: "$strLenCP", Value: str}},
+		}}}
+		return []bson.E{
+			present,
+			{Key: p + "_distinct", Value: accumulator("$addToSet", str)},
+			{Key: p + "_empty", Value: sum(ifThen(eq(str, ""), 1, 0))},
+			{Key: p + "_minlen", Value: accumulator("$min", strLen)},
+			{Key: p + "_maxlen", Value: accumulator("$max", strLen)},
+			{Key: p + "_avglen", Value: accumulator("$avg", strLen)},
+		}
+	case diff.CommonTypeBoolean:
+		return []bson.E{
+			present,
+			{Key: p + "_true", Value: sum(ifThen(eq(fieldRef, true), 1, 0))},
+			{Key: p + "_false", Value: sum(ifThen(eq(fieldRef, false), 1, 0))},
+		}
+	case diff.CommonTypeDateTime:
+		dt := coerce(fieldRef, []string{"date"})
+		return []bson.E{
+			present,
+			{Key: p + "_min", Value: accumulator("$min", dt)},
+			{Key: p + "_max", Value: accumulator("$max", dt)},
+			{Key: p + "_distinct", Value: accumulator("$addToSet", dt)},
+		}
+	default:
+		// json, binary and unknown types only track presence.
+		return []bson.E{present}
+	}
+}
+
+func runStats(ctx context.Context, coll *mongo.Collection, columns []*diff.Column, sampleSize int64) (bson.M, error) {
+	pipeline := buildStatsPipeline(columns, sampleSize)
+	cursor, err := coll.Aggregate(ctx, pipeline, options.Aggregate().SetAllowDiskUse(true))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to run statistics aggregation")
+	}
+	defer cursor.Close(ctx)
+
+	var results []bson.M
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, errors.Wrap(err, "failed to decode statistics result")
+	}
+	if len(results) == 0 {
+		return bson.M{}, nil
+	}
+	return results[0], nil
+}
+
+// parseStatsResult fills in col.Stats for each column from the aggregation's
+// single result document. scanned is the number of documents the statistics were
+// computed over; Count is reported as scanned and NullCount as the documents that
+// were missing or null for that field, mirroring the SQL summarizers.
+func parseStatsResult(doc bson.M, columns []*diff.Column, scanned int64) {
+	for i, col := range columns {
+		p := strconv.Itoa(i)
+		present := getInt64(doc[p+"_present"])
+		nullCount := scanned - present
+
+		switch col.NormalizedType {
+		case diff.CommonTypeNumeric:
+			col.Stats = &diff.NumericalStatistics{
+				Count:     scanned,
+				NullCount: nullCount,
+				Min:       getFloatPtr(doc[p+"_min"]),
+				Max:       getFloatPtr(doc[p+"_max"]),
+				Avg:       getFloatPtr(doc[p+"_avg"]),
+				Sum:       getFloatPtr(doc[p+"_sum"]),
+				StdDev:    getFloatPtr(doc[p+"_std"]),
+			}
+		case diff.CommonTypeString:
+			col.Stats = &diff.StringStatistics{
+				Count:         scanned,
+				NullCount:     nullCount,
+				DistinctCount: distinctCount(doc[p+"_distinct"]),
+				EmptyCount:    getInt64(doc[p+"_empty"]),
+				MinLength:     int(getInt64(doc[p+"_minlen"])),
+				MaxLength:     int(getInt64(doc[p+"_maxlen"])),
+				AvgLength:     getFloat(doc[p+"_avglen"]),
+			}
+		case diff.CommonTypeBoolean:
+			col.Stats = &diff.BooleanStatistics{
+				Count:      scanned,
+				NullCount:  nullCount,
+				TrueCount:  getInt64(doc[p+"_true"]),
+				FalseCount: getInt64(doc[p+"_false"]),
+			}
+		case diff.CommonTypeDateTime:
+			col.Stats = &diff.DateTimeStatistics{
+				Count:        scanned,
+				NullCount:    nullCount,
+				UniqueCount:  distinctCount(doc[p+"_distinct"]),
+				EarliestDate: getTimePtr(doc[p+"_min"]),
+				LatestDate:   getTimePtr(doc[p+"_max"]),
+			}
+		case diff.CommonTypeJSON:
+			col.Stats = &diff.JSONStatistics{
+				Count:     scanned,
+				NullCount: nullCount,
+			}
+		default:
+			col.Stats = &diff.UnknownStatistics{}
+		}
+	}
+}
+
+// ---- aggregation expression helpers ----------------------------------------
+
+func toBSONA(values []string) bson.A {
+	out := make(bson.A, len(values))
+	for i, v := range values {
+		out[i] = v
+	}
+	return out
+}
+
+func typeOf(fieldRef string) bson.D {
+	return bson.D{{Key: "$type", Value: fieldRef}}
+}
+
+func eq(a, b interface{}) bson.D {
+	return bson.D{{Key: "$eq", Value: bson.A{a, b}}}
+}
+
+func ifThen(cond, then, otherwise interface{}) bson.D {
+	return bson.D{{Key: "$cond", Value: bson.A{cond, then, otherwise}}}
+}
+
+func sum(expr interface{}) bson.D {
+	return bson.D{{Key: "$sum", Value: expr}}
+}
+
+func accumulator(op string, expr interface{}) bson.D {
+	return bson.D{{Key: op, Value: expr}}
+}
+
+// presentExpr yields 1 when the field exists and is not null, else 0.
+func presentExpr(fieldRef string) bson.D {
+	return ifThen(
+		bson.D{{Key: "$in", Value: bson.A{typeOf(fieldRef), bson.A{"missing", "null"}}}},
+		0, 1,
+	)
+}
+
+// coerce returns the field's value when its BSON type is one of `types`, else null.
+func coerce(fieldRef string, types []string) bson.D {
+	return ifThen(
+		bson.D{{Key: "$in", Value: bson.A{typeOf(fieldRef), toBSONA(types)}}},
+		fieldRef, nil,
+	)
+}
+
+// stringCoerce returns string values unchanged and stringifies ObjectIds; any
+// other type becomes null.
+func stringCoerce(fieldRef string) bson.D {
+	return ifThen(
+		bson.D{{Key: "$in", Value: bson.A{typeOf(fieldRef), toBSONA(stringBSONTypes)}}},
+		bson.D{{Key: "$toString", Value: fieldRef}},
+		nil,
+	)
+}
+
+// ---- BSON value conversion -------------------------------------------------
+
+func getInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int32:
+		return int64(n)
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	case primitive.Decimal128:
+		f, _ := strconv.ParseFloat(n.String(), 64)
+		return int64(f)
+	default:
+		return 0
+	}
+}
+
+func getFloat(v interface{}) float64 {
+	switch n := v.(type) {
+	case int32:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case float64:
+		return n
+	case primitive.Decimal128:
+		f, _ := strconv.ParseFloat(n.String(), 64)
+		return f
+	default:
+		return 0
+	}
+}
+
+func getFloatPtr(v interface{}) *float64 {
+	switch v.(type) {
+	case int32, int64, float64, primitive.Decimal128:
+		f := getFloat(v)
+		return &f
+	default:
+		return nil
+	}
+}
+
+func getTimePtr(v interface{}) *time.Time {
+	switch t := v.(type) {
+	case primitive.DateTime:
+		tm := t.Time().UTC()
+		return &tm
+	case time.Time:
+		tm := t.UTC()
+		return &tm
+	default:
+		return nil
+	}
+}
+
+// distinctCount counts the non-null entries of an $addToSet result.
+func distinctCount(v interface{}) int64 {
+	arr, ok := v.(primitive.A)
+	if !ok {
+		return 0
+	}
+	var count int64
+	for _, item := range arr {
+		if item == nil {
+			continue
+		}
+		count++
+	}
+	return count
+}

--- a/pkg/mongo/diff.go
+++ b/pkg/mongo/diff.go
@@ -263,7 +263,8 @@ func dominantType(counts map[string]int64) string {
 // statistics appropriate to its inferred type. Each column's accumulators are
 // keyed by its positional index to avoid any clash with user field names.
 func buildStatsPipeline(columns []*diff.Column, sampleSize int64) bson.A {
-	group := bson.D{{Key: "_id", Value: nil}}
+	group := make(bson.D, 0, 1+len(columns)*6)
+	group = append(group, bson.E{Key: "_id", Value: nil})
 	for i, col := range columns {
 		group = append(group, statAccumulators(i, col)...)
 	}

--- a/pkg/mongo/diff.go
+++ b/pkg/mongo/diff.go
@@ -23,8 +23,9 @@ var mongoTypeMapper = diff.NewMongoTypeMapper()
 // BSON type groupings used both for type inference and for coercing values when
 // computing statistics. They mirror the categories in NewMongoTypeMapper.
 var (
-	numericBSONTypes = []string{"double", "int", "long", "decimal"}
-	stringBSONTypes  = []string{"string", "objectId"}
+	numericBSONTypes  = []string{"double", "int", "long", "decimal"}
+	stringBSONTypes   = []string{"string", "objectId"}
+	datetimeBSONTypes = []string{"date", "timestamp"}
 )
 
 // GetTableSummary implements diff.TableSummarizer for MongoDB collections. The
@@ -259,9 +260,13 @@ func dominantType(counts map[string]int64) string {
 
 // ---- statistics ------------------------------------------------------------
 
-// buildStatsPipeline builds a single $group that computes, for every column, the
-// statistics appropriate to its inferred type. Each column's accumulators are
-// keyed by its positional index to avoid any clash with user field names.
+// buildStatsPipeline builds a $facet that computes, for every column, the
+// statistics appropriate to its inferred type. A single "stats" branch holds the
+// scalar accumulators (keyed by positional index to avoid clashing with user
+// field names). Distinct counts get their own branch per column: rather than
+// accumulating every distinct value into one array (which can exceed MongoDB's
+// 16 MB document limit on large collections), each branch groups by value and
+// returns only the count.
 func buildStatsPipeline(columns []*diff.Column, sampleSize int64) bson.A {
 	group := make(bson.D, 0, 1+len(columns)*6)
 	group = append(group, bson.E{Key: "_id", Value: nil})
@@ -269,12 +274,42 @@ func buildStatsPipeline(columns []*diff.Column, sampleSize int64) bson.A {
 		group = append(group, statAccumulators(i, col)...)
 	}
 
+	facet := make(bson.D, 0, 1+len(columns))
+	facet = append(facet, bson.E{Key: "stats", Value: bson.A{bson.D{{Key: "$group", Value: group}}}})
+	for i, col := range columns {
+		expr, ok := distinctExpr(col)
+		if !ok {
+			continue
+		}
+		facet = append(facet, bson.E{Key: strconv.Itoa(i) + "_distinct", Value: bson.A{
+			bson.D{{Key: "$group", Value: bson.D{{Key: "_id", Value: expr}}}},
+			bson.D{{Key: "$match", Value: bson.D{{Key: "_id", Value: bson.D{{Key: "$ne", Value: nil}}}}}},
+			bson.D{{Key: "$count", Value: "n"}},
+		}})
+	}
+
 	pipeline := bson.A{}
 	if sampleSize > 0 {
 		pipeline = append(pipeline, bson.D{{Key: "$sample", Value: bson.D{{Key: "size", Value: sampleSize}}}})
 	}
-	pipeline = append(pipeline, bson.D{{Key: "$group", Value: group}})
+	pipeline = append(pipeline, bson.D{{Key: "$facet", Value: facet}})
 	return pipeline
+}
+
+// distinctExpr returns the value expression whose distinct, non-null count is
+// tracked for a column, and whether the column has one. Only string and datetime
+// columns carry a distinct count; the expression matches the coercion used for
+// the column's other statistics so the count covers the same values.
+func distinctExpr(col *diff.Column) (bson.D, bool) {
+	fieldRef := "$" + col.Name
+	switch col.NormalizedType {
+	case diff.CommonTypeString:
+		return stringCoerce(fieldRef), true
+	case diff.CommonTypeDateTime:
+		return coerce(fieldRef, datetimeBSONTypes), true
+	default:
+		return nil, false
+	}
 }
 
 func statAccumulators(i int, col *diff.Column) []bson.E {
@@ -302,7 +337,6 @@ func statAccumulators(i int, col *diff.Column) []bson.E {
 		}}}
 		return []bson.E{
 			present,
-			{Key: p + "_distinct", Value: accumulator("$addToSet", str)},
 			{Key: p + "_empty", Value: sum(ifThen(eq(str, ""), 1, 0))},
 			{Key: p + "_minlen", Value: accumulator("$min", strLen)},
 			{Key: p + "_maxlen", Value: accumulator("$max", strLen)},
@@ -315,12 +349,11 @@ func statAccumulators(i int, col *diff.Column) []bson.E {
 			{Key: p + "_false", Value: sum(ifThen(eq(fieldRef, false), 1, 0))},
 		}
 	case diff.CommonTypeDateTime:
-		dt := coerce(fieldRef, []string{"date"})
+		dt := coerce(fieldRef, datetimeBSONTypes)
 		return []bson.E{
 			present,
 			{Key: p + "_min", Value: accumulator("$min", dt)},
 			{Key: p + "_max", Value: accumulator("$max", dt)},
-			{Key: p + "_distinct", Value: accumulator("$addToSet", dt)},
 		}
 	default:
 		// json, binary and unknown types only track presence.
@@ -351,9 +384,10 @@ func runStats(ctx context.Context, coll *mongo.Collection, columns []*diff.Colum
 // computed over; Count is reported as scanned and NullCount as the documents that
 // were missing or null for that field, mirroring the SQL summarizers.
 func parseStatsResult(doc bson.M, columns []*diff.Column, scanned int64) {
+	stats := firstFacetDoc(doc["stats"])
 	for i, col := range columns {
 		p := strconv.Itoa(i)
-		present := getInt64(doc[p+"_present"])
+		present := getInt64(stats[p+"_present"])
 		nullCount := scanned - present
 
 		switch col.NormalizedType {
@@ -361,36 +395,36 @@ func parseStatsResult(doc bson.M, columns []*diff.Column, scanned int64) {
 			col.Stats = &diff.NumericalStatistics{
 				Count:     scanned,
 				NullCount: nullCount,
-				Min:       getFloatPtr(doc[p+"_min"]),
-				Max:       getFloatPtr(doc[p+"_max"]),
-				Avg:       getFloatPtr(doc[p+"_avg"]),
-				Sum:       getFloatPtr(doc[p+"_sum"]),
-				StdDev:    getFloatPtr(doc[p+"_std"]),
+				Min:       getFloatPtr(stats[p+"_min"]),
+				Max:       getFloatPtr(stats[p+"_max"]),
+				Avg:       getFloatPtr(stats[p+"_avg"]),
+				Sum:       getFloatPtr(stats[p+"_sum"]),
+				StdDev:    getFloatPtr(stats[p+"_std"]),
 			}
 		case diff.CommonTypeString:
 			col.Stats = &diff.StringStatistics{
 				Count:         scanned,
 				NullCount:     nullCount,
-				DistinctCount: distinctCount(doc[p+"_distinct"]),
-				EmptyCount:    getInt64(doc[p+"_empty"]),
-				MinLength:     int(getInt64(doc[p+"_minlen"])),
-				MaxLength:     int(getInt64(doc[p+"_maxlen"])),
-				AvgLength:     getFloat(doc[p+"_avglen"]),
+				DistinctCount: facetCount(doc[p+"_distinct"]),
+				EmptyCount:    getInt64(stats[p+"_empty"]),
+				MinLength:     int(getInt64(stats[p+"_minlen"])),
+				MaxLength:     int(getInt64(stats[p+"_maxlen"])),
+				AvgLength:     getFloat(stats[p+"_avglen"]),
 			}
 		case diff.CommonTypeBoolean:
 			col.Stats = &diff.BooleanStatistics{
 				Count:      scanned,
 				NullCount:  nullCount,
-				TrueCount:  getInt64(doc[p+"_true"]),
-				FalseCount: getInt64(doc[p+"_false"]),
+				TrueCount:  getInt64(stats[p+"_true"]),
+				FalseCount: getInt64(stats[p+"_false"]),
 			}
 		case diff.CommonTypeDateTime:
 			col.Stats = &diff.DateTimeStatistics{
 				Count:        scanned,
 				NullCount:    nullCount,
-				UniqueCount:  distinctCount(doc[p+"_distinct"]),
-				EarliestDate: getTimePtr(doc[p+"_min"]),
-				LatestDate:   getTimePtr(doc[p+"_max"]),
+				UniqueCount:  facetCount(doc[p+"_distinct"]),
+				EarliestDate: getTimePtr(stats[p+"_min"]),
+				LatestDate:   getTimePtr(stats[p+"_max"]),
 			}
 		case diff.CommonTypeJSON:
 			col.Stats = &diff.JSONStatistics{
@@ -508,6 +542,10 @@ func getTimePtr(v interface{}) *time.Time {
 	case primitive.DateTime:
 		tm := t.Time().UTC()
 		return &tm
+	case primitive.Timestamp:
+		// BSON timestamps carry seconds since the Unix epoch in T.
+		tm := time.Unix(int64(t.T), 0).UTC()
+		return &tm
 	case time.Time:
 		tm := t.UTC()
 		return &tm
@@ -516,18 +554,21 @@ func getTimePtr(v interface{}) *time.Time {
 	}
 }
 
-// distinctCount counts the non-null entries of an $addToSet result.
-func distinctCount(v interface{}) int64 {
-	arr, ok := v.(primitive.A)
-	if !ok {
-		return 0
+// firstFacetDoc returns the first document of a $facet sub-pipeline result, or an
+// empty document when the branch produced no rows.
+func firstFacetDoc(v interface{}) bson.M {
+	arr, ok := v.(bson.A)
+	if !ok || len(arr) == 0 {
+		return bson.M{}
 	}
-	var count int64
-	for _, item := range arr {
-		if item == nil {
-			continue
-		}
-		count++
+	if m, ok := arr[0].(bson.M); ok {
+		return m
 	}
-	return count
+	return bson.M{}
+}
+
+// facetCount reads the {n: <count>} document produced by a [..., {$count: "n"}]
+// $facet sub-pipeline. A branch that matched no documents yields 0.
+func facetCount(v interface{}) int64 {
+	return getInt64(firstFacetDoc(v)["n"])
 }

--- a/pkg/mongo/diff_test.go
+++ b/pkg/mongo/diff_test.go
@@ -1,0 +1,292 @@
+package mongo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bruin-data/bruin/pkg/diff"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestSplitCollectionName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		identifier string
+		defaultDB  string
+		wantDB     string
+		wantColl   string
+		wantErr    bool
+	}{
+		{name: "collection only with default db", identifier: "users", defaultDB: "shop", wantDB: "shop", wantColl: "users"},
+		{name: "qualified database.collection", identifier: "analytics.events", defaultDB: "shop", wantDB: "analytics", wantColl: "events"},
+		{name: "dotted collection name keeps trailing dots", identifier: "shop.orders.2024", defaultDB: "ignored", wantDB: "shop", wantColl: "orders.2024"},
+		{name: "trims surrounding whitespace", identifier: "  users  ", defaultDB: "shop", wantDB: "shop", wantColl: "users"},
+		{name: "no default db and unqualified", identifier: "users", defaultDB: "", wantErr: true},
+		{name: "empty identifier", identifier: "", defaultDB: "shop", wantErr: true},
+		{name: "leading dot", identifier: ".users", defaultDB: "shop", wantErr: true},
+		{name: "trailing dot", identifier: "shop.", defaultDB: "shop", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotDB, gotColl, err := splitCollectionName(tt.identifier, tt.defaultDB)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDB, gotDB)
+			assert.Equal(t, tt.wantColl, gotColl)
+		})
+	}
+}
+
+func TestDominantType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		counts map[string]int64
+		want   string
+	}{
+		{name: "single type", counts: map[string]int64{"string": 10}, want: "string"},
+		{name: "ignores null when other types exist", counts: map[string]int64{"int": 5, "null": 100}, want: "int"},
+		{name: "exclusively null", counts: map[string]int64{"null": 7}, want: "null"},
+		{name: "picks the most common", counts: map[string]int64{"int": 3, "long": 9, "double": 1}, want: "long"},
+		{name: "tie breaks on name", counts: map[string]int64{"long": 4, "int": 4}, want: "int"},
+		{name: "empty", counts: map[string]int64{}, want: "null"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dominantType(tt.counts))
+		})
+	}
+}
+
+func TestSummarizeSchema(t *testing.T) {
+	t.Parallel()
+
+	facet := schemaFacetResult{
+		Total: []countResult{{N: 100}},
+		Fields: []schemaFacetField{
+			{ID: schemaFieldKey{Field: "_id", Type: "objectId"}, Count: 100},
+			{ID: schemaFieldKey{Field: "name", Type: "string"}, Count: 100},
+			{ID: schemaFieldKey{Field: "age", Type: "int"}, Count: 80},
+			{ID: schemaFieldKey{Field: "age", Type: "null"}, Count: 5},
+			{ID: schemaFieldKey{Field: "active", Type: "bool"}, Count: 100},
+			{ID: schemaFieldKey{Field: "created", Type: "date"}, Count: 100},
+			{ID: schemaFieldKey{Field: "address", Type: "object"}, Count: 100},
+			{ID: schemaFieldKey{Field: "score", Type: "double"}, Count: 50},
+			{ID: schemaFieldKey{Field: "score", Type: "int"}, Count: 30},
+		},
+	}
+
+	scanned, columns := summarizeSchema(facet)
+	assert.Equal(t, int64(100), scanned)
+
+	// `_id` must be first; the remainder alphabetical.
+	gotOrder := make([]string, len(columns))
+	for i, c := range columns {
+		gotOrder[i] = c.Name
+	}
+	assert.Equal(t, []string{"_id", "active", "address", "age", "created", "name", "score"}, gotOrder)
+
+	byName := map[string]*diff.Column{}
+	for _, c := range columns {
+		byName[c.Name] = c
+	}
+
+	// _id present in every doc -> not nullable, stringified type.
+	assert.Equal(t, "objectId", byName["_id"].Type)
+	assert.Equal(t, diff.CommonTypeString, byName["_id"].NormalizedType)
+	assert.False(t, byName["_id"].Nullable)
+
+	// age present in 80 docs (non-null) of 100 -> nullable, dominant type int.
+	assert.Equal(t, "int", byName["age"].Type)
+	assert.Equal(t, diff.CommonTypeNumeric, byName["age"].NormalizedType)
+	assert.True(t, byName["age"].Nullable)
+
+	// score is polymorphic (double:50, int:30) and missing in 20 docs.
+	assert.Equal(t, "double", byName["score"].Type)
+	assert.Equal(t, diff.CommonTypeNumeric, byName["score"].NormalizedType)
+	assert.True(t, byName["score"].Nullable)
+
+	assert.Equal(t, diff.CommonTypeBoolean, byName["active"].NormalizedType)
+	assert.Equal(t, diff.CommonTypeDateTime, byName["created"].NormalizedType)
+	assert.Equal(t, diff.CommonTypeJSON, byName["address"].NormalizedType)
+}
+
+func TestSummarizeSchemaEmpty(t *testing.T) {
+	t.Parallel()
+
+	scanned, columns := summarizeSchema(schemaFacetResult{})
+	assert.Equal(t, int64(0), scanned)
+	assert.Empty(t, columns)
+}
+
+func TestMongoTypeMapper(t *testing.T) {
+	t.Parallel()
+
+	mapper := diff.NewMongoTypeMapper()
+	cases := map[string]diff.CommonDataType{
+		"double":    diff.CommonTypeNumeric,
+		"int":       diff.CommonTypeNumeric,
+		"long":      diff.CommonTypeNumeric,
+		"decimal":   diff.CommonTypeNumeric,
+		"string":    diff.CommonTypeString,
+		"objectId":  diff.CommonTypeString,
+		"bool":      diff.CommonTypeBoolean,
+		"date":      diff.CommonTypeDateTime,
+		"timestamp": diff.CommonTypeDateTime,
+		"object":    diff.CommonTypeJSON,
+		"array":     diff.CommonTypeJSON,
+		"binData":   diff.CommonTypeBinary,
+		"regex":     diff.CommonTypeUnknown,
+		"null":      diff.CommonTypeUnknown,
+	}
+	for bsonType, want := range cases {
+		assert.Equalf(t, want, mapper.MapType(bsonType), "mapping for %q", bsonType)
+	}
+}
+
+func TestParseStatsResult(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	columns := []*diff.Column{
+		{Name: "_id", NormalizedType: diff.CommonTypeString},
+		{Name: "age", NormalizedType: diff.CommonTypeNumeric},
+		{Name: "active", NormalizedType: diff.CommonTypeBoolean},
+		{Name: "created", NormalizedType: diff.CommonTypeDateTime},
+		{Name: "address", NormalizedType: diff.CommonTypeJSON},
+		{Name: "blob", NormalizedType: diff.CommonTypeBinary},
+	}
+
+	doc := map[string]interface{}{
+		// _id (string) at index 0
+		"0_present":  int32(100),
+		"0_distinct": primitive.A{"a", "b", "c", nil},
+		"0_empty":    int32(0),
+		"0_minlen":   int32(24),
+		"0_maxlen":   int32(24),
+		"0_avglen":   float64(24),
+		// age (numeric) at index 1
+		"1_present": int64(95),
+		"1_min":     int32(18),
+		"1_max":     int32(80),
+		"1_avg":     float64(42.5),
+		"1_sum":     int64(4037),
+		"1_std":     float64(10.1),
+		// active (boolean) at index 2
+		"2_present": int32(100),
+		"2_true":    int32(60),
+		"2_false":   int32(40),
+		// created (datetime) at index 3
+		"3_present":  int32(100),
+		"3_min":      primitive.NewDateTimeFromTime(created),
+		"3_max":      primitive.NewDateTimeFromTime(created.Add(48 * time.Hour)),
+		"3_distinct": primitive.A{primitive.NewDateTimeFromTime(created), primitive.NewDateTimeFromTime(created.Add(48 * time.Hour))},
+		// address (json) at index 4
+		"4_present": int32(90),
+		// blob (binary) at index 5
+		"5_present": int32(10),
+	}
+
+	parseStatsResult(doc, columns, 100)
+
+	idStats, ok := columns[0].Stats.(*diff.StringStatistics)
+	require.True(t, ok)
+	assert.Equal(t, int64(100), idStats.Count)
+	assert.Equal(t, int64(0), idStats.NullCount)
+	assert.Equal(t, int64(3), idStats.DistinctCount) // nil excluded
+	assert.Equal(t, 24, idStats.MinLength)
+	assert.Equal(t, 24, idStats.MaxLength)
+
+	ageStats, ok := columns[1].Stats.(*diff.NumericalStatistics)
+	require.True(t, ok)
+	assert.Equal(t, int64(100), ageStats.Count)
+	assert.Equal(t, int64(5), ageStats.NullCount)
+	require.NotNil(t, ageStats.Min)
+	assert.InDelta(t, 18, *ageStats.Min, 0.001)
+	require.NotNil(t, ageStats.Avg)
+	assert.InDelta(t, 42.5, *ageStats.Avg, 0.001)
+
+	activeStats, ok := columns[2].Stats.(*diff.BooleanStatistics)
+	require.True(t, ok)
+	assert.Equal(t, int64(60), activeStats.TrueCount)
+	assert.Equal(t, int64(40), activeStats.FalseCount)
+
+	dtStats, ok := columns[3].Stats.(*diff.DateTimeStatistics)
+	require.True(t, ok)
+	require.NotNil(t, dtStats.EarliestDate)
+	assert.Equal(t, created.UTC(), dtStats.EarliestDate.UTC())
+	assert.Equal(t, int64(2), dtStats.UniqueCount)
+
+	jsonStats, ok := columns[4].Stats.(*diff.JSONStatistics)
+	require.True(t, ok)
+	assert.Equal(t, int64(100), jsonStats.Count)
+	assert.Equal(t, int64(10), jsonStats.NullCount)
+
+	_, ok = columns[5].Stats.(*diff.UnknownStatistics)
+	require.True(t, ok)
+}
+
+func TestParseStatsResultNullNumeric(t *testing.T) {
+	t.Parallel()
+
+	// A numeric field that is null/missing in every document yields nil pointers.
+	columns := []*diff.Column{{Name: "x", NormalizedType: diff.CommonTypeNumeric}}
+	doc := map[string]interface{}{"0_present": int32(0)}
+
+	parseStatsResult(doc, columns, 50)
+
+	stats, ok := columns[0].Stats.(*diff.NumericalStatistics)
+	require.True(t, ok)
+	assert.Equal(t, int64(50), stats.Count)
+	assert.Equal(t, int64(50), stats.NullCount)
+	assert.Nil(t, stats.Min)
+	assert.Nil(t, stats.Avg)
+}
+
+func TestBuildSchemaPipeline(t *testing.T) {
+	t.Parallel()
+
+	// Without sampling: just the $facet stage.
+	pipeline := buildSchemaPipeline(0)
+	require.Len(t, pipeline, 1)
+
+	// With sampling: a leading $sample stage.
+	sampled := buildSchemaPipeline(500)
+	require.Len(t, sampled, 2)
+	stage := sampled[0].(bson.D)
+	assert.Equal(t, "$sample", stage[0].Key)
+}
+
+func TestBuildStatsPipeline(t *testing.T) {
+	t.Parallel()
+
+	columns := []*diff.Column{
+		{Name: "age", NormalizedType: diff.CommonTypeNumeric},
+		{Name: "name", NormalizedType: diff.CommonTypeString},
+	}
+
+	pipeline := buildStatsPipeline(columns, 0)
+	require.Len(t, pipeline, 1)
+	group := pipeline[0].(bson.D)
+	assert.Equal(t, "$group", group[0].Key)
+
+	// With sampling: leading $sample stage.
+	sampled := buildStatsPipeline(columns, 100)
+	require.Len(t, sampled, 2)
+	assert.Equal(t, "$sample", sampled[0].(bson.D)[0].Key)
+}

--- a/pkg/mongo/diff_test.go
+++ b/pkg/mongo/diff_test.go
@@ -33,7 +33,6 @@ func TestSplitCollectionName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			gotDB, gotColl, err := splitCollectionName(tt.identifier, tt.defaultDB)
@@ -65,7 +64,6 @@ func TestDominantType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, dominantType(tt.counts))

--- a/pkg/mongo/diff_test.go
+++ b/pkg/mongo/diff_test.go
@@ -171,33 +171,37 @@ func TestParseStatsResult(t *testing.T) {
 	}
 
 	doc := map[string]interface{}{
-		// _id (string) at index 0
-		"0_present":  int32(100),
-		"0_distinct": primitive.A{"a", "b", "c", nil},
-		"0_empty":    int32(0),
-		"0_minlen":   int32(24),
-		"0_maxlen":   int32(24),
-		"0_avglen":   float64(24),
-		// age (numeric) at index 1
-		"1_present": int64(95),
-		"1_min":     int32(18),
-		"1_max":     int32(80),
-		"1_avg":     float64(42.5),
-		"1_sum":     int64(4037),
-		"1_std":     float64(10.1),
-		// active (boolean) at index 2
-		"2_present": int32(100),
-		"2_true":    int32(60),
-		"2_false":   int32(40),
-		// created (datetime) at index 3
-		"3_present":  int32(100),
-		"3_min":      primitive.NewDateTimeFromTime(created),
-		"3_max":      primitive.NewDateTimeFromTime(created.Add(48 * time.Hour)),
-		"3_distinct": primitive.A{primitive.NewDateTimeFromTime(created), primitive.NewDateTimeFromTime(created.Add(48 * time.Hour))},
-		// address (json) at index 4
-		"4_present": int32(90),
-		// blob (binary) at index 5
-		"5_present": int32(10),
+		// Scalar accumulators live in the "stats" $facet branch, keyed by index.
+		"stats": bson.A{bson.M{
+			// _id (string) at index 0
+			"0_present": int32(100),
+			"0_empty":   int32(0),
+			"0_minlen":  int32(24),
+			"0_maxlen":  int32(24),
+			"0_avglen":  float64(24),
+			// age (numeric) at index 1
+			"1_present": int64(95),
+			"1_min":     int32(18),
+			"1_max":     int32(80),
+			"1_avg":     float64(42.5),
+			"1_sum":     int64(4037),
+			"1_std":     float64(10.1),
+			// active (boolean) at index 2
+			"2_present": int32(100),
+			"2_true":    int32(60),
+			"2_false":   int32(40),
+			// created (datetime) at index 3
+			"3_present": int32(100),
+			"3_min":     primitive.NewDateTimeFromTime(created),
+			"3_max":     primitive.NewDateTimeFromTime(created.Add(48 * time.Hour)),
+			// address (json) at index 4
+			"4_present": int32(90),
+			// blob (binary) at index 5
+			"5_present": int32(10),
+		}},
+		// Distinct counts each have their own [..., {$count: "n"}] branch.
+		"0_distinct": bson.A{bson.M{"n": int32(3)}},
+		"3_distinct": bson.A{bson.M{"n": int32(2)}},
 	}
 
 	parseStatsResult(doc, columns, 100)
@@ -244,7 +248,7 @@ func TestParseStatsResultNullNumeric(t *testing.T) {
 
 	// A numeric field that is null/missing in every document yields nil pointers.
 	columns := []*diff.Column{{Name: "x", NormalizedType: diff.CommonTypeNumeric}}
-	doc := map[string]interface{}{"0_present": int32(0)}
+	doc := map[string]interface{}{"stats": bson.A{bson.M{"0_present": int32(0)}}}
 
 	parseStatsResult(doc, columns, 50)
 
@@ -254,6 +258,47 @@ func TestParseStatsResultNullNumeric(t *testing.T) {
 	assert.Equal(t, int64(50), stats.NullCount)
 	assert.Nil(t, stats.Min)
 	assert.Nil(t, stats.Avg)
+}
+
+func TestGetTimePtr(t *testing.T) {
+	t.Parallel()
+
+	when := time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	// BSON date.
+	got := getTimePtr(primitive.NewDateTimeFromTime(when))
+	require.NotNil(t, got)
+	assert.Equal(t, when, got.UTC())
+
+	// BSON timestamp: seconds since the epoch are carried in T.
+	ts := getTimePtr(primitive.Timestamp{T: uint32(when.Unix()), I: 1})
+	require.NotNil(t, ts)
+	assert.Equal(t, when, ts.UTC())
+
+	// Unrelated types yield nil.
+	assert.Nil(t, getTimePtr("not a time"))
+	assert.Nil(t, getTimePtr(nil))
+}
+
+func TestFacetCount(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, int64(7), facetCount(bson.A{bson.M{"n": int32(7)}}))
+	// An empty branch (no matching documents) means zero distinct values.
+	assert.Equal(t, int64(0), facetCount(bson.A{}))
+	assert.Equal(t, int64(0), facetCount(nil))
+}
+
+func TestDistinctExpr(t *testing.T) {
+	t.Parallel()
+
+	_, ok := distinctExpr(&diff.Column{Name: "name", NormalizedType: diff.CommonTypeString})
+	assert.True(t, ok)
+	_, ok = distinctExpr(&diff.Column{Name: "created", NormalizedType: diff.CommonTypeDateTime})
+	assert.True(t, ok)
+	// Numeric, boolean and json columns do not carry a distinct count.
+	_, ok = distinctExpr(&diff.Column{Name: "age", NormalizedType: diff.CommonTypeNumeric})
+	assert.False(t, ok)
 }
 
 func TestBuildSchemaPipeline(t *testing.T) {
@@ -280,11 +325,26 @@ func TestBuildStatsPipeline(t *testing.T) {
 
 	pipeline := buildStatsPipeline(columns, 0)
 	require.Len(t, pipeline, 1)
-	group := pipeline[0].(bson.D)
-	assert.Equal(t, "$group", group[0].Key)
+	facet := pipeline[0].(bson.D)
+	assert.Equal(t, "$facet", facet[0].Key)
+
+	// The facet carries the scalar "stats" branch plus one distinct-count branch
+	// for the string column (index 1); the numeric column has no distinct branch.
+	branches := facet[0].Value.(bson.D)
+	keys := make([]string, len(branches))
+	for i, b := range branches {
+		keys[i] = b.Key
+	}
+	assert.Equal(t, []string{"stats", "1_distinct"}, keys)
+
+	// The distinct branch ends in a $count stage so it returns only a number.
+	distinct := branches[1].Value.(bson.A)
+	last := distinct[len(distinct)-1].(bson.D)
+	assert.Equal(t, "$count", last[0].Key)
 
 	// With sampling: leading $sample stage.
 	sampled := buildStatsPipeline(columns, 100)
 	require.Len(t, sampled, 2)
 	assert.Equal(t, "$sample", sampled[0].(bson.D)[0].Key)
+	assert.Equal(t, "$facet", sampled[1].(bson.D)[0].Key)
 }

--- a/pkg/mongo_atlas/diff.go
+++ b/pkg/mongo_atlas/diff.go
@@ -1,0 +1,18 @@
+package mongoatlas
+
+import (
+	"context"
+
+	"github.com/bruin-data/bruin/pkg/diff"
+	bruinmongo "github.com/bruin-data/bruin/pkg/mongo"
+)
+
+// GetTableSummary implements diff.TableSummarizer for MongoDB Atlas collections.
+// It reuses the shared MongoDB summarizer; the table identifier is a collection
+// name, optionally qualified as "database.collection".
+func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly bool) (*diff.TableSummaryResult, error) {
+	if err := db.ensureClient(ctx); err != nil {
+		return nil, err
+	}
+	return bruinmongo.BuildTableSummary(ctx, db.client, db.config.Database, tableName, schemaOnly, diff.SampleSizeFromContext(ctx))
+}


### PR DESCRIPTION
MongoDB connections previously failed `bruin data-diff` because they did not implement the diff.TableSummarizer interface, so the command exited with status 1 ("does not support table summarization").

This adds a MongoDB summarizer, shared by the mongo and mongo_atlas connection types. Since MongoDB has no static catalog, the schema (field names, types, nullability) is inferred from the documents:

- Schema inference: a single $facet aggregation reports, per top-level field, the BSON types seen and the document count. The dominant type wins; a field is nullable when absent or null in any scanned document. Columns are emitted deterministically (_id first, then alphabetical).
- Statistics (--full): one $group computes type-appropriate stats for all fields in a single scan (numeric/string/boolean/datetime, plus JSON count for nested object/array). ObjectIds are stringified.
- Top-level fields only; nested documents/arrays compared as JSON.
- Identifiers accept "collection" or "database.collection".

A new --sample N flag bases inference and statistics on a sampled subset (via $sample) for large collections; row counts still reflect the true collection size, so per-column stats become approximate when sampling. The sample size is threaded through the context so the shared TableSummarizer interface is unchanged and other platforms ignore it.

Docs updated; unit tests cover name parsing, type inference, polymorphic fields, and statistic parsing.