### PR TITLE
feat: support `bruin import database` for MongoDB

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -18,6 +18,8 @@ import (
 	"github.com/bruin-data/bruin/pkg/bigquery"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/logger"
+	"github.com/bruin-data/bruin/pkg/mongo"
+	mongoatlas "github.com/bruin-data/bruin/pkg/mongo_atlas"
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/path"
@@ -430,6 +432,14 @@ func resolvePipelinePath(pipelinePath string) string {
 }
 
 func fillAssetColumnsFromDB(ctx context.Context, asset *pipeline.Asset, conn interface{}, schemaName, tableName string) error {
+	// MongoDB collections are schemaless, so there is no column metadata to import.
+	// Skip silently rather than falling through to SelectWithSchema, which would
+	// receive a SQL string it cannot parse and surface a confusing warning.
+	switch conn.(type) {
+	case *mongo.DB, *mongoatlas.DB:
+		return nil
+	}
+
 	// Prefer database-native column metadata when available. PostgreSQL supports
 	// this through information_schema, which avoids relying on SELECT field
 	// descriptions that are not always returned by the driver.
@@ -895,6 +905,9 @@ func determineAssetTypeFromConnection(connectionName string, conn interface{}) p
 		if strings.Contains(connType, "synapse") {
 			return pipeline.AssetTypeSynapseSource
 		}
+		if strings.Contains(connType, "mongo") {
+			return pipeline.AssetTypeMongoSource
+		}
 	}
 
 	// Fallback: try to detect the connection type from the connection name
@@ -932,6 +945,9 @@ func determineAssetTypeFromConnection(connectionName string, conn interface{}) p
 	}
 	if strings.Contains(connectionLower, "oracle") {
 		return pipeline.AssetTypeOracleSource
+	}
+	if strings.Contains(connectionLower, "mongo") {
+		return pipeline.AssetTypeMongoSource
 	}
 
 	// Default to empty if we can't determine the type

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -36,6 +36,8 @@ var supportedImportConnectionTypes = map[string]bool{
 	"synapse":               true,
 	"redshift":              true,
 	"sqlite":                true,
+	"mongo":                 true,
+	"mongo_atlas":           true,
 }
 
 const (

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/mongo"
+	mongoatlas "github.com/bruin-data/bruin/pkg/mongo_atlas"
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/postgres"
@@ -393,6 +395,24 @@ func TestDetermineAssetTypeFromConnection(t *testing.T) {
 			want:           pipeline.AssetTypeMsSQLSource,
 		},
 		{
+			name:           "mongo connection type overrides name",
+			connectionName: "prod",
+			conn:           &mongo.DB{},
+			want:           pipeline.AssetTypeMongoSource,
+		},
+		{
+			name:           "mongo atlas connection type overrides name",
+			connectionName: "prod",
+			conn:           &mongoatlas.DB{},
+			want:           pipeline.AssetTypeMongoSource,
+		},
+		{
+			name:           "mongo by name",
+			connectionName: "mongo-prod",
+			conn:           &mockConnection{},
+			want:           pipeline.AssetTypeMongoSource,
+		},
+		{
 			name:           "unknown connection defaults to empty",
 			connectionName: "unknown-db",
 			conn:           &mockConnection{},
@@ -546,6 +566,32 @@ func TestFillAssetColumnsFromDB(t *testing.T) {
 				{Name: "name", Type: "VARCHAR", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
 				{Name: "status", Type: "VARCHAR", Checks: []pipeline.ColumnCheck{}, Upstreams: []*pipeline.UpstreamColumn{}},
 			},
+		},
+		{
+			name: "mongo connection is skipped without columns or error",
+			setupConn: func() interface{} {
+				// MongoDB is schemaless; column filling must be skipped silently
+				// instead of falling through to SelectWithSchema.
+				return &mongo.DB{}
+			},
+			setupAsset: func() *pipeline.Asset {
+				return &pipeline.Asset{Name: "test_asset"}
+			},
+			schemaName: "test_schema",
+			tableName:  "test_table",
+			wantCols:   nil,
+		},
+		{
+			name: "mongo atlas connection is skipped without columns or error",
+			setupConn: func() interface{} {
+				return &mongoatlas.DB{}
+			},
+			setupAsset: func() *pipeline.Asset {
+				return &pipeline.Asset{Name: "test_asset"}
+			},
+			schemaName: "test_schema",
+			tableName:  "test_table",
+			wantCols:   nil,
 		},
 	}
 

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -68,6 +68,13 @@ table td:first-child {
 - **ClickHouse** → `clickhouse`
 - **Azure Synapse** → `synapse`
 - **MS SQL Server** → `mssql`
+- **MongoDB** → `mongo`, `mongo_atlas`
+
+#### MongoDB
+
+MongoDB is schemaless and has no `database → schema → table` hierarchy, so it maps as **database → schema** and **collection → table**. The import scans every database on the server (excluding the internal `admin`, `local`, and `config` databases) and creates one `mongo.source` asset per collection under `assets/<database>/`. Use `--schema <database>` to import a single database.
+
+Because collections have no fixed schema, imported MongoDB assets are created **without columns** — they are name + metadata stubs (the `--no-columns` flag has no additional effect). You can add column definitions yourself afterwards, for example when turning a collection into an `ingestr` asset, where columns drive schema enforcement, masking, and primary keys.
 
 ### How It Works
 

--- a/pkg/executor/defaults.go
+++ b/pkg/executor/defaults.go
@@ -86,6 +86,12 @@ var DefaultExecutorsV2 = map[pipeline.AssetType]Config{
 		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},
 		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
 	},
+	pipeline.AssetTypeMongoSource: {
+		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
+		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},
+		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},
+		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
+	},
 	pipeline.AssetTypeBigquerySeed: {
 		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
 		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},

--- a/pkg/mongo/db.go
+++ b/pkg/mongo/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -59,4 +60,13 @@ func (db *DB) Ping(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// GetDatabaseSummary enumerates the databases and collections on the server so
+// `bruin import database` can turn them into assets.
+func (db *DB) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error) {
+	if err := db.initClient(ctx); err != nil {
+		return nil, err
+	}
+	return DatabaseSummary(ctx, db.client, db.config.Database)
 }

--- a/pkg/mongo/summary.go
+++ b/pkg/mongo/summary.go
@@ -1,0 +1,108 @@
+package mongo
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// systemDatabases are MongoDB's internal databases. They are skipped when
+// importing, since they hold server state rather than user data.
+var systemDatabases = map[string]bool{
+	"admin":  true,
+	"local":  true,
+	"config": true,
+}
+
+// DatabaseSummary enumerates the databases and collections reachable through the
+// given client and returns them as an ansisql.DBDatabase tree: each MongoDB
+// database maps to a schema and each collection to a table. MongoDB is
+// schemaless, so tables are returned without columns. Row counts are populated
+// best-effort. It is shared by the mongo and mongo_atlas connection types.
+func DatabaseSummary(ctx context.Context, client *mongo.Client, summaryName string) (*ansisql.DBDatabase, error) {
+	dbNames, err := client.ListDatabaseNames(ctx, bson.D{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list MongoDB databases")
+	}
+
+	collectionsByDB := make(map[string][]string, len(dbNames))
+	for _, dbName := range dbNames {
+		if systemDatabases[dbName] {
+			continue
+		}
+
+		collections, err := client.Database(dbName).ListCollectionNames(ctx, bson.D{})
+		if err != nil {
+			// Skip databases we cannot introspect (e.g. missing privileges) rather
+			// than failing the whole import.
+			continue
+		}
+		collectionsByDB[dbName] = collections
+	}
+
+	if summaryName == "" {
+		summaryName = "mongo"
+	}
+	summary := buildDatabaseSummary(summaryName, collectionsByDB)
+
+	// Best-effort row counts; ignore failures so a slow or locked collection does
+	// not break the import. EstimatedDocumentCount reads collection metadata and
+	// avoids a full scan.
+	for _, schema := range summary.Schemas {
+		for _, table := range schema.Tables {
+			count, err := client.Database(schema.Name).Collection(table.Name).EstimatedDocumentCount(ctx)
+			if err != nil {
+				continue
+			}
+			rowCount := count
+			table.RowCount = &rowCount
+		}
+	}
+
+	return summary, nil
+}
+
+// buildDatabaseSummary turns a database->collections map into an ansisql.DBDatabase
+// tree. It drops system databases and system collections, and sorts databases and
+// collections so the output is deterministic. It performs no I/O, which keeps it
+// unit-testable without a live MongoDB.
+func buildDatabaseSummary(name string, collectionsByDB map[string][]string) *ansisql.DBDatabase {
+	dbNames := make([]string, 0, len(collectionsByDB))
+	for dbName := range collectionsByDB {
+		if systemDatabases[dbName] {
+			continue
+		}
+		dbNames = append(dbNames, dbName)
+	}
+	sort.Strings(dbNames)
+
+	schemas := make([]*ansisql.DBSchema, 0, len(dbNames))
+	for _, dbName := range dbNames {
+		collections := make([]string, 0, len(collectionsByDB[dbName]))
+		for _, coll := range collectionsByDB[dbName] {
+			if strings.HasPrefix(coll, "system.") {
+				continue
+			}
+			collections = append(collections, coll)
+		}
+		sort.Strings(collections)
+
+		tables := make([]*ansisql.DBTable, 0, len(collections))
+		for _, coll := range collections {
+			tables = append(tables, &ansisql.DBTable{
+				Name:    coll,
+				Type:    ansisql.DBTableTypeTable,
+				Columns: []*ansisql.DBColumn{},
+			})
+		}
+
+		schemas = append(schemas, &ansisql.DBSchema{Name: dbName, Tables: tables})
+	}
+
+	return &ansisql.DBDatabase{Name: name, Schemas: schemas}
+}

--- a/pkg/mongo/summary.go
+++ b/pkg/mongo/summary.go
@@ -2,6 +2,8 @@ package mongo
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -31,6 +33,7 @@ func DatabaseSummary(ctx context.Context, client *mongo.Client, summaryName stri
 	}
 
 	collectionsByDB := make(map[string][]string, len(dbNames))
+	var skipped []string
 	for _, dbName := range dbNames {
 		if systemDatabases[dbName] {
 			continue
@@ -39,10 +42,19 @@ func DatabaseSummary(ctx context.Context, client *mongo.Client, summaryName stri
 		collections, err := client.Database(dbName).ListCollectionNames(ctx, bson.D{})
 		if err != nil {
 			// Skip databases we cannot introspect (e.g. missing privileges) rather
-			// than failing the whole import.
+			// than failing the whole import, but record them so the partial result
+			// is not mistaken for a complete one.
+			skipped = append(skipped, fmt.Sprintf("%s (%v)", dbName, err))
 			continue
 		}
 		collectionsByDB[dbName] = collections
+	}
+
+	// Surface skipped databases instead of failing silently, so an import that
+	// omits collections (commonly because of missing privileges) is visible.
+	if len(skipped) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: skipped %d MongoDB database(s) that could not be introspected: %s\n",
+			len(skipped), strings.Join(skipped, ", "))
 	}
 
 	if summaryName == "" {

--- a/pkg/mongo/summary_test.go
+++ b/pkg/mongo/summary_test.go
@@ -1,0 +1,107 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDatabaseSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		summaryName     string
+		collectionsByDB map[string][]string
+		want            *ansisql.DBDatabase
+	}{
+		{
+			name:            "empty server",
+			summaryName:     "mongo",
+			collectionsByDB: map[string][]string{},
+			want: &ansisql.DBDatabase{
+				Name:    "mongo",
+				Schemas: []*ansisql.DBSchema{},
+			},
+		},
+		{
+			name:        "maps databases to schemas and collections to tables, sorted",
+			summaryName: "mongo",
+			collectionsByDB: map[string][]string{
+				"shop":      {"orders", "users"},
+				"analytics": {"events"},
+			},
+			want: &ansisql.DBDatabase{
+				Name: "mongo",
+				Schemas: []*ansisql.DBSchema{
+					{
+						Name: "analytics",
+						Tables: []*ansisql.DBTable{
+							{Name: "events", Type: ansisql.DBTableTypeTable, Columns: []*ansisql.DBColumn{}},
+						},
+					},
+					{
+						Name: "shop",
+						Tables: []*ansisql.DBTable{
+							{Name: "orders", Type: ansisql.DBTableTypeTable, Columns: []*ansisql.DBColumn{}},
+							{Name: "users", Type: ansisql.DBTableTypeTable, Columns: []*ansisql.DBColumn{}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "skips system databases and system collections",
+			summaryName: "mongo",
+			collectionsByDB: map[string][]string{
+				"admin":  {"system.users"},
+				"local":  {"oplog.rs"},
+				"config": {"shards"},
+				"shop":   {"users", "system.views", "system.profile"},
+			},
+			want: &ansisql.DBDatabase{
+				Name: "mongo",
+				Schemas: []*ansisql.DBSchema{
+					{
+						Name: "shop",
+						Tables: []*ansisql.DBTable{
+							{Name: "users", Type: ansisql.DBTableTypeTable, Columns: []*ansisql.DBColumn{}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "database with only system collections yields an empty schema",
+			summaryName: "mongo",
+			collectionsByDB: map[string][]string{
+				"shop": {"system.views"},
+			},
+			want: &ansisql.DBDatabase{
+				Name: "mongo",
+				Schemas: []*ansisql.DBSchema{
+					{Name: "shop", Tables: []*ansisql.DBTable{}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildDatabaseSummary(tt.summaryName, tt.collectionsByDB)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got)
+
+			// Imported MongoDB collections must never carry columns.
+			for _, schema := range got.Schemas {
+				for _, table := range schema.Tables {
+					assert.Empty(t, table.Columns)
+				}
+			}
+		})
+	}
+}

--- a/pkg/mongo_atlas/query.go
+++ b/pkg/mongo_atlas/query.go
@@ -3,6 +3,7 @@ package mongoatlas
 import (
 	"context"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	bruinmongo "github.com/bruin-data/bruin/pkg/mongo"
 	"github.com/bruin-data/bruin/pkg/query"
 )
@@ -24,4 +25,13 @@ func (db *DB) SelectWithSchema(ctx context.Context, q *query.Query) (*query.Quer
 
 func (db *DB) Limit(q string, limit int64) string {
 	return bruinmongo.LimitQuery(q, limit)
+}
+
+// GetDatabaseSummary enumerates the databases and collections on the Atlas
+// cluster so `bruin import database` can turn them into assets.
+func (db *DB) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error) {
+	if err := db.ensureClient(ctx); err != nil {
+		return nil, err
+	}
+	return bruinmongo.DatabaseSummary(ctx, db.client, db.config.Database)
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -70,6 +70,7 @@ const (
 	AssetTypeLookerStudio              = AssetType("looker_studio")
 	AssetTypeMetabase                  = AssetType("metabase")
 	AssetTypeModeBI                    = AssetType("modebi")
+	AssetTypeMongoSource               = AssetType("mongo.source")
 	AssetTypeMotherduckQuery           = AssetType("motherduck.sql")
 	AssetTypeMsSQLQuery                = AssetType("ms.sql")
 	AssetTypeMsSQLQuerySensor          = AssetType("ms.sensor.query")
@@ -786,6 +787,7 @@ var AssetTypeConnectionMapping = map[AssetType]string{
 	AssetTypeMySQLSeed:                 "mysql",
 	AssetTypeMySQLQuerySensor:          "mysql",
 	AssetTypeMySQLTableSensor:          "mysql",
+	AssetTypeMongoSource:               "mongo",
 	AssetTypeRedshiftQuery:             "redshift",
 	AssetTypeRedshiftSeed:              "redshift",
 	AssetTypeRedshiftQuerySensor:       "redshift",

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -854,6 +854,27 @@ var AssetTypeConnectionMapping = map[AssetType]string{
 	AssetTypeQuicksightDashboard:       "quicksight",
 }
 
+// assetTypeConnectionAlternates lists every connection platform key that can back
+// an asset type, in priority order, for the asset types that more than one
+// connection type can serve. A mongo.source asset, for example, can be backed by
+// either a "mongo" or a "mongo_atlas" connection, so resolving its default
+// connection must consider both keys. Asset types absent here resolve through
+// their single AssetTypeConnectionMapping entry.
+var assetTypeConnectionAlternates = map[AssetType][]string{
+	AssetTypeMongoSource: {"mongo", "mongo_atlas"},
+}
+
+// connectionPlatformsForAssetType returns the connection platform keys to try when
+// resolving an asset's default connection, in priority order. It falls back to the
+// asset type's single AssetTypeConnectionMapping entry (passed as primary) when the
+// type has no alternates.
+func connectionPlatformsForAssetType(assetType AssetType, primary string) []string {
+	if alternates, ok := assetTypeConnectionAlternates[assetType]; ok {
+		return alternates
+	}
+	return []string{primary}
+}
+
 var IngestrTypeConnectionMapping = map[string]AssetType{
 	"athena":        AssetTypeAthenaQuery,
 	"bigquery":      AssetTypeBigqueryQuery,
@@ -2155,9 +2176,14 @@ func (p *Pipeline) GetConnectionNameForAsset(asset *Asset) (string, error) {
 		return "", errors.Errorf("no connection mapping found for asset type '%s'", assetType)
 	}
 
-	conn, ok := p.DefaultConnections[mapping]
-	if ok {
-		return conn, nil
+	// Some asset types can be served by more than one connection platform (e.g. a
+	// mongo.source asset accepts either a "mongo" or a "mongo_atlas" connection), so
+	// check every candidate platform's explicit default connection before falling
+	// back to the magic default name.
+	for _, platform := range connectionPlatformsForAssetType(assetType, mapping) {
+		if conn, ok := p.DefaultConnections[platform]; ok {
+			return conn, nil
+		}
 	}
 
 	defaultConn, ok := defaultMapping[mapping]

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -748,6 +748,32 @@ func TestPipeline_GetConnectionNameForAsset(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "postgres-default", found)
 	})
+
+	t.Run("mongo.source resolves a mongo default connection", func(t *testing.T) {
+		t.Parallel()
+		mongoPipeline := &pipeline.Pipeline{
+			Name:               "mongo-pipeline",
+			DefaultConnections: map[string]string{"mongo": "my-mongo"},
+		}
+		found, err := mongoPipeline.GetConnectionNameForAsset(&pipeline.Asset{
+			Type: pipeline.AssetTypeMongoSource,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-mongo", found)
+	})
+
+	t.Run("mongo.source falls back to a mongo_atlas default connection", func(t *testing.T) {
+		t.Parallel()
+		atlasPipeline := &pipeline.Pipeline{
+			Name:               "atlas-pipeline",
+			DefaultConnections: map[string]string{"mongo_atlas": "my-atlas"},
+		}
+		found, err := atlasPipeline.GetConnectionNameForAsset(&pipeline.Asset{
+			Type: pipeline.AssetTypeMongoSource,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-atlas", found)
+	})
 }
 
 func intPointer(i int) *int {


### PR DESCRIPTION
Implement GetDatabaseSummary for the mongo and mongo_atlas connections so they can be imported. Each MongoDB database maps to a schema and each collection to a mongo.source asset. All databases on the server are enumerated (excluding the internal admin/local/config databases).

MongoDB is schemaless, so collections are imported without columns; the column-fill path is skipped to avoid sending a SQL string to the query engine. The new mongo.source asset type is registered in the executor defaults and connection mapping so imported assets validate.