### PR TITLE
fix(mongo): skip ALTER TABLE generation in data-diff

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -66,6 +66,14 @@ func compareTables(ctx context.Context, summarizer1, summarizer2 diff.TableSumma
 	return &result, nil
 }
 
+// isSchemalessConnection reports whether a connection's schema is inferred from
+// its data rather than declared in a catalog (e.g. MongoDB). ALTER TABLE
+// statements are not generated for such connections.
+func isSchemalessConnection(conn any) bool {
+	s, ok := conn.(diff.SchemalessSummarizer)
+	return ok && s.IsSchemaless()
+}
+
 // generateAlterStatements generates ALTER TABLE SQL statements based on schema comparison.
 func generateAlterStatements(schemaComparison diff.SchemaComparisonResult, conn1Name, conn2Name, targetDialect string, reverse bool) []string {
 	var dialect diff.DatabaseDialect
@@ -355,9 +363,11 @@ func DataDiffCmd() *cli.Command {
 			}
 
 			if schemaComparison != nil {
-				// Generate ALTER TABLE statements
+				// Generate ALTER TABLE statements, unless either side is a
+				// schemaless source (e.g. MongoDB) where DDL is meaningless.
+				ddlSupported := !isSchemalessConnection(conn1) && !isSchemalessConnection(conn2)
 				var alterStatements []string
-				if schemaComparison.HasSchemaDifferences {
+				if schemaComparison.HasSchemaDifferences && ddlSupported {
 					alterStatements = generateAlterStatements(*schemaComparison, conn1Name, conn2Name, targetDialect, reverse)
 				}
 

--- a/cmd/datadiff_test.go
+++ b/cmd/datadiff_test.go
@@ -440,6 +440,29 @@ func TestBuildColumnStatisticsDoesNotRenderNaNFillRateForEmptyCounts(t *testing.
 	assert.NotContains(t, fillRate.DiffPercent, "NaN")
 }
 
+type fakeSchemalessConn struct{ schemaless bool }
+
+func (f fakeSchemalessConn) IsSchemaless() bool { return f.schemaless }
+
+func TestIsSchemalessConnection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("connection that reports schemaless", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, isSchemalessConnection(fakeSchemalessConn{schemaless: true}))
+	})
+
+	t.Run("connection that implements the interface but is not schemaless", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isSchemalessConnection(fakeSchemalessConn{schemaless: false}))
+	})
+
+	t.Run("connection that does not implement the interface", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isSchemalessConnection(struct{}{}))
+	})
+}
+
 func TestGenerateAlterStatements(t *testing.T) {
 	t.Parallel()
 

--- a/docs/commands/data-diff.md
+++ b/docs/commands/data-diff.md
@@ -129,6 +129,8 @@ The command generates several detailed tables:
 
 When schema differences are detected, the command automatically generates ALTER TABLE SQL statements to synchronize the schemas. These statements are output to stdout (separate from the comparison tables which go to stderr), making it easy to capture and review them.
 
+ALTER TABLE statements are only generated for sources with a fixed, DDL-managed schema. They are skipped when either side is a schemaless source such as MongoDB, where there is no schema to alter (see [MongoDB Collections](#mongodb-collections)).
+
 The generated statements can:
 
 - Add missing columns
@@ -273,6 +275,7 @@ MongoDB has no fixed schema, so for MongoDB connections the `data-diff` command 
 - **Identifier format:** Use the collection name (resolved against the connection's `database`), or qualify it as `database.collection` to compare across databases — e.g. `mongo:users` or `mongo:analytics.events`.
 - **Top-level fields only:** Nested documents and arrays are compared as `object`/`array` (JSON) fields — count and fill rate — rather than being flattened into dotted paths. `ObjectId` fields (such as `_id`) are compared as strings.
 - **Sampling large collections:** A full scan is exact but can be expensive on very large collections. Pass `--sample N` to base type inference and statistics on at most `N` randomly sampled documents instead. Row counts always reflect the true collection size; per-column statistics become approximate when sampling.
+- **No ALTER TABLE statements:** Because collections have no fixed schema to alter, the [ALTER TABLE generation](#alter-table-statement-generation) (and the `--target-dialect` / `--reverse` flags) is skipped whenever either side is a MongoDB collection. The schema and statistics comparison tables are still produced.
 
 ```bash
 # Compare two collections in the connection's default database

--- a/pkg/diff/interfaces.go
+++ b/pkg/diff/interfaces.go
@@ -9,6 +9,15 @@ type TableSummarizer interface {
 	GetTableSummary(ctx context.Context, tableName string, schemaOnly bool) (*TableSummaryResult, error)
 }
 
+// SchemalessSummarizer is implemented by TableSummarizers whose schema is
+// inferred from the underlying data (e.g. MongoDB) rather than declared in a
+// catalog. For such sources, data-diff omits ALTER TABLE statement generation,
+// which has no meaning without a fixed, DDL-managed schema.
+type SchemalessSummarizer interface {
+	// IsSchemaless reports whether the source lacks a fixed, catalog-defined schema.
+	IsSchemaless() bool
+}
+
 type CostEstimator interface {
 	EstimateTableDiffCost(ctx context.Context, tableName string, schemaOnly bool) (*TableDiffCostEstimate, error)
 }

--- a/pkg/mongo/diff.go
+++ b/pkg/mongo/diff.go
@@ -38,6 +38,11 @@ func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly 
 	return BuildTableSummary(ctx, db.client, db.config.Database, tableName, schemaOnly, diff.SampleSizeFromContext(ctx))
 }
 
+// IsSchemaless reports that MongoDB has no fixed, catalog-defined schema; the
+// schema is inferred from documents. It implements diff.SchemalessSummarizer so
+// data-diff skips ALTER TABLE statement generation for MongoDB sources.
+func (db *DB) IsSchemaless() bool { return true }
+
 // BuildTableSummary produces a diff.TableSummaryResult for a MongoDB collection.
 // MongoDB has no static schema, so the field set, types and nullability are
 // inferred by scanning the documents. When sampleSize > 0 at most that many

--- a/pkg/mongo_atlas/diff.go
+++ b/pkg/mongo_atlas/diff.go
@@ -16,3 +16,8 @@ func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly 
 	}
 	return bruinmongo.BuildTableSummary(ctx, db.client, db.config.Database, tableName, schemaOnly, diff.SampleSizeFromContext(ctx))
 }
+
+// IsSchemaless reports that MongoDB Atlas has no fixed, catalog-defined schema;
+// the schema is inferred from documents. It implements diff.SchemalessSummarizer
+// so data-diff skips ALTER TABLE statement generation for MongoDB Atlas sources.
+func (db *DB) IsSchemaless() bool { return true }


### PR DESCRIPTION
MongoDB has no fixed, catalog-defined schema, so the ALTER TABLE statements data-diff emits to synchronize schemas are meaningless for it.

Add a diff.SchemalessSummarizer capability interface, implement it on the mongo and mongo_atlas connections, and skip ALTER statement generation (along with the --target-dialect/--reverse flags) whenever either side of a diff is a schemaless source. The schema and statistics comparison tables are unchanged.