### PR TITLE
feat(import): add --as-ingestr flag for MongoDB database import

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -142,9 +142,14 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 
 // validateIngestrImportFlags validates the --as-ingestr / --destination flag
 // combination. The destination is required (and must be a known ingestr
-// destination platform) so the generated ingestr assets are runnable.
+// destination platform) so the generated ingestr assets are runnable, and it
+// is rejected without --as-ingestr so a forgotten --as-ingestr does not
+// silently fall back to plain source placeholders.
 func validateIngestrImportFlags(asIngestr bool, destination string) error {
 	if !asIngestr {
+		if destination != "" {
+			return errors.New("--destination has no effect without --as-ingestr")
+		}
 		return nil
 	}
 
@@ -389,6 +394,7 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 
 	totalTables := 0
 	mergedTableCount := 0
+	skippedTableCount := 0
 	var warnings []importWarning
 
 	for _, schemaObj := range summary.Schemas {
@@ -425,6 +431,11 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 				}
 				existingAssets[assetName] = createdAsset
 				totalTables++
+			} else if asIngestr {
+				// ingestr assets carry no columns, so there is nothing to merge
+				// into an existing asset; skip it without re-persisting to avoid
+				// a misleading "Merged" count on re-runs.
+				skippedTableCount++
 			} else {
 				existingAsset := existingAssets[assetName]
 				existingColumns := make(map[string]pipeline.Column, len(existingAsset.Columns))
@@ -454,6 +465,10 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 
 	fmt.Printf("Imported %d tables and Merged %d from data warehouse '%s'%s into pipeline '%s'\n",
 		totalTables, mergedTableCount, summary.Name, filterDesc, pipelinePath)
+
+	if skippedTableCount > 0 {
+		fmt.Printf("Skipped %d existing assets (already present in the pipeline)\n", skippedTableCount)
+	}
 
 	if len(warnings) > 0 {
 		fmt.Printf("\nWarnings encountered during import (%d tables affected):\n", len(warnings))

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -79,6 +80,14 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 				Aliases: []string{"n"},
 				Usage:   "skip filling column metadata from database schema",
 			},
+			&cli.BoolFlag{
+				Name:  "as-ingestr",
+				Usage: "generate runnable ingestr assets that replicate the source instead of source placeholders (MongoDB only)",
+			},
+			&cli.StringFlag{
+				Name:  "destination",
+				Usage: "destination platform for --as-ingestr assets (e.g. duckdb, postgres, bigquery)",
+			},
 			&cli.StringFlag{
 				Name:    "environment",
 				Aliases: []string{"env"},
@@ -99,12 +108,18 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 
 			connectionName := c.String("connection")
 			noColumns := c.Bool("no-columns")
+			asIngestr := c.Bool("as-ingestr")
+			destination := c.String("destination")
 			environment := c.String("environment")
 			configFile := c.String("config-file")
 			var err error
 
+			if validationErr := validateIngestrImportFlags(asIngestr, destination); validationErr != nil {
+				return cli.Exit(validationErr.Error(), 1)
+			}
+
 			if connectionName == "" {
-				err = runImportDatabaseTUI(ctx, pipelinePath, environment, configFile, !noColumns)
+				err = runImportDatabaseTUI(ctx, pipelinePath, environment, configFile, !noColumns, asIngestr, destination)
 			} else {
 				schema := c.String("schema")
 				schemas := c.StringSlice("schemas")
@@ -113,7 +128,7 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 				}
 
 				log := makeLogger(*isDebug)
-				err = runImport(ctx, log, pipelinePath, connectionName, schema, schemas, !noColumns, environment, configFile)
+				err = runImport(ctx, log, pipelinePath, connectionName, schema, schemas, !noColumns, environment, configFile, asIngestr, destination)
 			}
 
 			if err != nil {
@@ -123,6 +138,30 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 			return nil
 		},
 	}
+}
+
+// validateIngestrImportFlags validates the --as-ingestr / --destination flag
+// combination. The destination is required (and must be a known ingestr
+// destination platform) so the generated ingestr assets are runnable.
+func validateIngestrImportFlags(asIngestr bool, destination string) error {
+	if !asIngestr {
+		return nil
+	}
+
+	if destination == "" {
+		return errors.New("--destination is required when using --as-ingestr")
+	}
+
+	if _, ok := pipeline.IngestrTypeConnectionMapping[destination]; !ok {
+		valid := make([]string, 0, len(pipeline.IngestrTypeConnectionMapping))
+		for name := range pipeline.IngestrTypeConnectionMapping {
+			valid = append(valid, name)
+		}
+		sort.Strings(valid)
+		return fmt.Errorf("invalid --destination %q; valid destinations are: %s", destination, strings.Join(valid, ", "))
+	}
+
+	return nil
 }
 
 func ImportScheduledQueries() *cli.Command {
@@ -268,11 +307,11 @@ type importWarning struct {
 	message   string
 }
 
-func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionName, schema string, schemas []string, fillColumns bool, environment, configFile string) error {
+func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionName, schema string, schemas []string, fillColumns bool, environment, configFile string, asIngestr bool, destination string) error {
 	fs := afero.NewOsFs()
 
-	log.Debugf("starting database import: connection=%s, schema=%q, schemas=%v, fillColumns=%v, environment=%q",
-		connectionName, schema, schemas, fillColumns, environment)
+	log.Debugf("starting database import: connection=%s, schema=%q, schemas=%v, fillColumns=%v, environment=%q, asIngestr=%v, destination=%q",
+		connectionName, schema, schemas, fillColumns, environment, asIngestr, destination)
 
 	conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
 	if err != nil {
@@ -280,6 +319,10 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 	}
 
 	log.Debugf("resolved connection type: %T", conn)
+
+	if asIngestr && !isMongoConnection(conn) {
+		return fmt.Errorf("--as-ingestr is currently only supported for MongoDB connections, but '%s' is not a MongoDB connection", connectionName)
+	}
 
 	var summary *ansisql.DBDatabase
 
@@ -354,7 +397,13 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 		}
 		for _, table := range schemaObj.Tables {
 			fullName := fmt.Sprintf("%s.%s", schemaObj.Name, table.Name)
-			createdAsset, warning := createAsset(ctx, assetsPath, schemaObj.Name, table.Name, assetType, conn, fillColumns, table)
+			var createdAsset *pipeline.Asset
+			var warning string
+			if asIngestr {
+				createdAsset = createIngestrAsset(assetsPath, schemaObj.Name, table.Name, connectionName, destination, table)
+			} else {
+				createdAsset, warning = createAsset(ctx, assetsPath, schemaObj.Name, table.Name, assetType, conn, fillColumns, table)
+			}
 			if warning != "" {
 				warnings = append(warnings, importWarning{tableName: fullName, message: warning})
 			}
@@ -731,6 +780,42 @@ func createAsset(ctx context.Context, assetsPath, schemaName, tableName string, 
 	}
 
 	return asset, ""
+}
+
+// isMongoConnection reports whether the given connection is a MongoDB
+// connection (regular or Atlas), used to gate --as-ingestr support.
+func isMongoConnection(conn interface{}) bool {
+	switch conn.(type) {
+	case *mongo.DB, *mongoatlas.DB:
+		return true
+	default:
+		return false
+	}
+}
+
+// createIngestrAsset builds a runnable ingestr asset for a single MongoDB
+// collection. Running the generated asset replicates the collection into the
+// chosen destination. The asset name and file path follow the same lowercased
+// convention as createAsset, but source_table preserves the original database
+// and collection names because MongoDB identifiers are case-sensitive.
+func createIngestrAsset(assetsPath, schemaName, tableName, sourceConnection, destination string, table *ansisql.DBTable) *pipeline.Asset {
+	schemaFolder := filepath.Join(assetsPath, strings.ToLower(schemaName))
+	fileName := strings.ToLower(tableName) + ".asset.yml"
+
+	return &pipeline.Asset{
+		Name: fmt.Sprintf("%s.%s", strings.ToLower(schemaName), strings.ToLower(tableName)),
+		Type: pipeline.AssetTypeIngestr,
+		ExecutableFile: pipeline.ExecutableFile{
+			Name: fileName,
+			Path: filepath.Join(schemaFolder, fileName),
+		},
+		Description: buildEnhancedDescription(table, schemaName, tableName),
+		Parameters: pipeline.ParameterMap{
+			"source_connection": sourceConnection,
+			"source_table":      fmt.Sprintf("%s.%s", schemaName, tableName),
+			"destination":       destination,
+		},
+	}
 }
 
 // getTableTypeDescription returns a human-readable description for the table type.

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -419,7 +419,8 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 			}
 
 			assetName := fmt.Sprintf("%s.%s", strings.ToLower(schemaObj.Name), strings.ToLower(table.Name))
-			if existingAssets[assetName] == nil {
+			switch {
+			case existingAssets[assetName] == nil:
 				schemaFolder := filepath.Join(assetsPath, strings.ToLower(schemaObj.Name))
 				if err := fs.MkdirAll(schemaFolder, 0o755); err != nil {
 					return errors2.Wrapf(err, "failed to create schema directory %s", schemaFolder)
@@ -431,12 +432,12 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 				}
 				existingAssets[assetName] = createdAsset
 				totalTables++
-			} else if asIngestr {
+			case asIngestr:
 				// ingestr assets carry no columns, so there is nothing to merge
 				// into an existing asset; skip it without re-persisting to avoid
 				// a misleading "Merged" count on re-runs.
 				skippedTableCount++
-			} else {
+			default:
 				existingAsset := existingAssets[assetName]
 				existingColumns := make(map[string]pipeline.Column, len(existingAsset.Columns))
 				for _, column := range existingAsset.Columns {

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -179,6 +179,8 @@ type importDatabaseModel struct {
 	environment  string
 	configFile   string
 	fillColumns  bool
+	asIngestr    bool
+	destination  string
 
 	step int
 
@@ -545,6 +547,8 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 	connName := m.selectedConnName
 	conn := m.conn
 	fillColumns := m.fillColumns
+	asIngestr := m.asIngestr
+	destination := m.destination
 	summary := m.dbSummary
 
 	selectedSchemaIdxs := make(map[int]bool)
@@ -585,7 +589,13 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 			for _, table := range schema.Tables {
 				fullName := fmt.Sprintf("%s.%s", schema.Name, table.Name)
 
-				createdAsset, warning := createAsset(ctx, assetsPath, schema.Name, table.Name, assetType, conn, fillColumns, table)
+				var createdAsset *pipeline.Asset
+				var warning string
+				if asIngestr {
+					createdAsset = createIngestrAsset(assetsPath, schema.Name, table.Name, connName, destination, table)
+				} else {
+					createdAsset, warning = createAsset(ctx, assetsPath, schema.Name, table.Name, assetType, conn, fillColumns, table)
+				}
 				if warning != "" {
 					warnings = append(warnings, importWarning{tableName: fullName, message: warning})
 				}
@@ -631,7 +641,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 	}
 }
 
-func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, configFile string, fillColumns bool) error {
+func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, configFile string, fillColumns, asIngestr bool, destination string) error {
 	fs := afero.NewOsFs()
 
 	repoRoot, err := git.FindRepoFromPath(".")
@@ -662,12 +672,21 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 
 	var connItems []importConnectionItem
 	for name, connType := range connSummary {
-		if supportedImportConnectionTypes[connType] {
-			connItems = append(connItems, importConnectionItem{name: name, connType: connType})
+		if !supportedImportConnectionTypes[connType] {
+			continue
 		}
+		// --as-ingestr is only supported for MongoDB connections, so restrict
+		// the selectable connections to mongo / mongo_atlas in that mode.
+		if asIngestr && connType != "mongo" && connType != "mongo_atlas" {
+			continue
+		}
+		connItems = append(connItems, importConnectionItem{name: name, connType: connType})
 	}
 
 	if len(connItems) == 0 {
+		if asIngestr {
+			return errors.New("--as-ingestr requires a MongoDB connection, but none were found")
+		}
 		return errors.New("no database connections found that support import")
 	}
 
@@ -693,6 +712,8 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 		environment:  environment,
 		configFile:   configFile,
 		fillColumns:  fillColumns,
+		asIngestr:    asIngestr,
+		destination:  destination,
 		step:         dbtuiStepConnection,
 		cfg:          cfg,
 		connList:     connList,

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -94,6 +94,7 @@ type dbSummaryLoadedMsg struct {
 type importCompleteMsg struct {
 	importedCount int
 	mergedCount   int
+	skippedCount  int
 	warnings      []importWarning
 	err           error
 }
@@ -200,6 +201,7 @@ type importDatabaseModel struct {
 
 	importedCount  int
 	mergedCount    int
+	skippedCount   int
 	importWarnings []importWarning
 	importError    error
 	importDone     bool
@@ -252,6 +254,7 @@ func (m *importDatabaseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case importCompleteMsg:
 		m.importedCount = msg.importedCount
 		m.mergedCount = msg.mergedCount
+		m.skippedCount = msg.skippedCount
 		m.importWarnings = msg.warnings
 		m.importError = msg.err
 		m.importDone = true
@@ -577,9 +580,10 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 		assetType := determineAssetTypeFromConnection(connName, conn)
 
 		var (
-			totalTables      int
-			mergedTableCount int
-			warnings         []importWarning
+			totalTables       int
+			mergedTableCount  int
+			skippedTableCount int
+			warnings          []importWarning
 		)
 
 		for i, schema := range summary.Schemas {
@@ -614,6 +618,11 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 					}
 					existingAssets[assetName] = createdAsset
 					totalTables++
+				} else if asIngestr {
+					// ingestr assets carry no columns, so there is nothing to
+					// merge into an existing asset; skip it without re-persisting
+					// to avoid a misleading "merged" count on re-runs.
+					skippedTableCount++
 				} else {
 					existingAsset := existingAssets[assetName]
 					existingColumns := make(map[string]pipeline.Column, len(existingAsset.Columns))
@@ -636,6 +645,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 		return importCompleteMsg{
 			importedCount: totalTables,
 			mergedCount:   mergedTableCount,
+			skippedCount:  skippedTableCount,
 			warnings:      warnings,
 		}
 	}
@@ -740,6 +750,10 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 		successStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(colorSuccess)).Bold(true)
 		fmt.Println(successStyle.Render(fmt.Sprintf("✓ Imported %d tables, merged %d from '%s' into '%s'",
 			fm.importedCount, fm.mergedCount, fm.selectedConnName, pipelinePath)))
+
+		if fm.skippedCount > 0 {
+			fmt.Println(dbtuiDimStyle.Render(fmt.Sprintf("  Skipped %d existing assets (already present in the pipeline)", fm.skippedCount)))
+		}
 
 		if len(fm.importWarnings) > 0 {
 			fmt.Printf("\nWarnings (%d):\n", len(fm.importWarnings))

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -608,7 +608,8 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 				}
 
 				assetName := fmt.Sprintf("%s.%s", strings.ToLower(schema.Name), strings.ToLower(table.Name))
-				if existingAssets[assetName] == nil {
+				switch {
+				case existingAssets[assetName] == nil:
 					schemaFolder := filepath.Join(assetsPath, strings.ToLower(schema.Name))
 					if mkErr := fs.MkdirAll(schemaFolder, 0o755); mkErr != nil {
 						return importCompleteMsg{err: fmt.Errorf("failed to create directory %s: %w", schemaFolder, mkErr)}
@@ -618,12 +619,12 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 					}
 					existingAssets[assetName] = createdAsset
 					totalTables++
-				} else if asIngestr {
+				case asIngestr:
 					// ingestr assets carry no columns, so there is nothing to
 					// merge into an existing asset; skip it without re-persisting
 					// to avoid a misleading "merged" count on re-runs.
 					skippedTableCount++
-				} else {
+				default:
 					existingAsset := existingAssets[assetName]
 					existingColumns := make(map[string]pipeline.Column, len(existingAsset.Columns))
 					for _, column := range existingAsset.Columns {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -962,3 +962,108 @@ func TestGetPipelinefromPath(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateIngestrAsset(t *testing.T) {
+	t.Parallel()
+
+	testAssetsPath := filepath.Join("test", "assets")
+
+	// Mixed-case database/collection names verify that the asset name and file
+	// path are lowercased while source_table preserves the original case
+	// (MongoDB identifiers are case-sensitive).
+	table := &ansisql.DBTable{
+		Name: "Users",
+		Type: ansisql.DBTableTypeTable,
+	}
+
+	got := createIngestrAsset(testAssetsPath, "myDB", "Users", "localMongo", "duckdb", table)
+
+	want := &pipeline.Asset{
+		Name: "mydb.users",
+		Type: pipeline.AssetTypeIngestr,
+		ExecutableFile: pipeline.ExecutableFile{
+			Name: "users.asset.yml",
+			Path: filepath.Join(testAssetsPath, "mydb", "users.asset.yml"),
+		},
+		Parameters: pipeline.ParameterMap{
+			"source_connection": "localMongo",
+			"source_table":      "myDB.Users",
+			"destination":       "duckdb",
+		},
+	}
+
+	assert.Contains(t, got.Description, "Imported table: myDB.Users")
+	assert.Contains(t, got.Description, "Extracted at:")
+
+	want.Description = got.Description
+	assert.Equal(t, want, got)
+}
+
+func TestValidateIngestrImportFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		asIngestr   bool
+		destination string
+		wantErr     string
+	}{
+		{
+			name:        "not as-ingestr ignores destination",
+			asIngestr:   false,
+			destination: "",
+		},
+		{
+			name:      "as-ingestr requires destination",
+			asIngestr: true,
+			wantErr:   "--destination is required",
+		},
+		{
+			name:        "as-ingestr rejects unknown destination",
+			asIngestr:   true,
+			destination: "bogus",
+			wantErr:     "invalid --destination",
+		},
+		{
+			name:        "as-ingestr accepts valid destination",
+			asIngestr:   true,
+			destination: "duckdb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateIngestrImportFlags(tt.asIngestr, tt.destination)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsMongoConnection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		conn interface{}
+		want bool
+	}{
+		{name: "mongo connection", conn: &mongo.DB{}, want: true},
+		{name: "mongo atlas connection", conn: &mongoatlas.DB{}, want: true},
+		{name: "mssql connection", conn: &mssql.DB{}, want: false},
+		{name: "nil connection", conn: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isMongoConnection(tt.conn))
+		})
+	}
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1009,9 +1009,15 @@ func TestValidateIngestrImportFlags(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			name:        "not as-ingestr ignores destination",
+			name:        "not as-ingestr with no destination is fine",
 			asIngestr:   false,
 			destination: "",
+		},
+		{
+			name:        "destination without as-ingestr is rejected",
+			asIngestr:   false,
+			destination: "duckdb",
+			wantErr:     "--destination has no effect without --as-ingestr",
 		},
 		{
 			name:      "as-ingestr requires destination",

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -53,6 +53,8 @@ table td:first-child {
 | `--connection`, `-c` | string | - | **Required.** Name of the connection to use as defined in `.bruin.yml` (or other [secrets backend](../secrets/overview.md)) |
 | `--schema`, `-s` | string | - | Filter by specific schema name |
 | `--no-columns`, `-n` | bool | `false` | Skip filling column metadata from database schema |
+| `--as-ingestr` | bool | `false` | Generate runnable [ingestr](../assets/ingestr.md) assets that replicate the source instead of source placeholders. Currently MongoDB only; requires `--destination` |
+| `--destination` | string | - | Destination platform for `--as-ingestr` assets (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`) |
 | `--environment`, `--env` | string | - | Target environment name as defined in `.bruin.yml` |
 | `--config-file` | string | - | Path to the `.bruin.yml` file. Can also be set via `BRUIN_CONFIG_FILE` environment variable |
 
@@ -75,6 +77,31 @@ table td:first-child {
 MongoDB is schemaless and has no `database → schema → table` hierarchy, so it maps as **database → schema** and **collection → table**. The import scans every database on the server (excluding the internal `admin`, `local`, and `config` databases) and creates one `mongo.source` asset per collection under `assets/<database>/`. Use `--schema <database>` to import a single database.
 
 Because collections have no fixed schema, imported MongoDB assets are created **without columns** — they are name + metadata stubs (the `--no-columns` flag has no additional effect). You can add column definitions yourself afterwards, for example when turning a collection into an `ingestr` asset, where columns drive schema enforcement, masking, and primary keys.
+
+##### Replicating MongoDB with `--as-ingestr`
+
+A `mongo.source` asset is a metadata placeholder and is **not runnable** on its own (MongoDB is not SQL). To generate assets that actually replicate the data, add `--as-ingestr` together with a `--destination` platform. Instead of `mongo.source` placeholders, each collection becomes a runnable [ingestr](../assets/ingestr.md) asset:
+
+```bash
+bruin import database --connection localMongo --as-ingestr --destination duckdb ./my-pipeline
+```
+
+For a database `myDB` with a `Users` collection this writes `assets/mydb/users.asset.yml`:
+
+```yaml
+name: mydb.users
+type: ingestr
+parameters:
+  source_connection: localMongo
+  source_table: myDB.Users
+  destination: duckdb
+```
+
+Running the pipeline (`bruin run ./my-pipeline`) then replicates every collection into the destination via ingestr. The destination *connection* is resolved from the pipeline's default connection for that platform. Notes:
+
+- `--destination` is **required** with `--as-ingestr` and must be a supported ingestr destination (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`, `redshift`, `clickhouse`).
+- `--as-ingestr` is currently **MongoDB only**; using it with a non-MongoDB connection is rejected. In the interactive TUI (when `--connection` is omitted) only MongoDB connections are offered.
+- The asset name and file path are lowercased, but `source_table` preserves the original database/collection casing because MongoDB identifiers are case-sensitive.
 
 ### How It Works
 
@@ -126,6 +153,16 @@ Import using a specific environment configuration:
 ```bash
 bruin import database --connection snowflake-prod --environment production ./my-pipeline
 ```
+
+#### Replicate MongoDB as ingestr assets
+
+Generate runnable ingestr assets for every collection so the database can be replicated into a destination (MongoDB only):
+
+```bash
+bruin import database --connection localMongo --as-ingestr --destination duckdb ./my-pipeline
+```
+
+See [MongoDB](#mongodb) above for the generated asset structure.
 
 ### Generated Asset Structure
 

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -99,7 +99,8 @@ parameters:
 
 Running the pipeline (`bruin run ./my-pipeline`) then replicates every collection into the destination via ingestr. The destination *connection* is resolved from the pipeline's default connection for that platform. Notes:
 
-- `--destination` is **required** with `--as-ingestr` and must be a supported ingestr destination (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`, `redshift`, `clickhouse`).
+- `--destination` is **required** with `--as-ingestr` and must be a supported ingestr destination (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`, `redshift`, `clickhouse`). Passing `--destination` without `--as-ingestr` is rejected so a forgotten `--as-ingestr` does not silently produce `mongo.source` placeholders.
+- Re-running the import skips collections whose assets already exist (it never overwrites them); the summary reports how many were skipped.
 - `--as-ingestr` is currently **MongoDB only**; using it with a non-MongoDB connection is rejected. In the interactive TUI (when `--connection` is omitted) only MongoDB connections are offered.
 - The asset name and file path are lowercased, but `source_table` preserves the original database/collection casing because MongoDB identifiers are case-sensitive.
 

--- a/docs/ingestion/mongo.md
+++ b/docs/ingestion/mongo.md
@@ -73,6 +73,15 @@ bruin run assets/mongo_ingestion.yml
 
 As a result of this command, Bruin will ingest data from the given MongoDB table into your Postgres database.
 
+> [!TIP]
+> Instead of writing one asset per collection by hand, you can scaffold them automatically with
+> [`bruin import database --as-ingestr`](/commands/import#mongodb). It scans the MongoDB connection
+> and generates a runnable ingestr asset for every collection, so you can replicate the whole
+> database by running the generated pipeline:
+> ```bash
+> bruin import database --connection localMongo --as-ingestr --destination duckdb ./my-pipeline
+> ```
+
 <img width="1017" alt="image" src="https://github.com/user-attachments/assets/2bad9131-baa1-4f20-8e3d-eed4329e7f90">
 
 ## Querying


### PR DESCRIPTION
Add a --as-ingestr flag to `bruin import database` that generates runnable ingestr assets instead of mongo.source placeholders, so a MongoDB database can be replicated by running the generated pipeline.

- New required --destination flag (validated against IngestrTypeConnectionMapping)
- createIngestrAsset helper: source_table preserves original Mongo casing
- MongoDB-only: guarded in the CLI path and filtered in the interactive TUI
- Unit tests for the helper, flag validation, and the Mongo guard
- Docs in commands/import.md and ingestion/mongo.md