### PR TITLE
docs(adjust): document attribution_types parameter

### DIFF
--- a/docs/ingestion/adjust.md
+++ b/docs/ingestion/adjust.md
@@ -63,6 +63,28 @@ parameters:
   source_table: 'campaigns:abc123,def456'
 ```
 
+### Attribution Types
+
+The `campaigns` and `creatives` tables default to `click,engaged_ad` attribution. You can override which attribution types are included with the `attribution_types` query parameter. Valid values are `click`, `impression`, and `engaged_ad`, comma-separated.
+
+```yaml
+parameters:
+  source_connection: my_adjust
+  source_table: 'creatives?attribution_types=click,impression,engaged_ad'
+```
+
+```yaml
+# Combined with an app token
+parameters:
+  source_connection: my_adjust
+  source_table: 'creatives?app_token=abc123&attribution_types=click,engaged_ad'
+```
+
+The existing `creatives:abc123` colon form (app token only) continues to work; `attribution_types` can only be set through the query parameter. For custom tables, pass `attribution_types` in the filters section instead.
+
+> [!WARNING]
+> Adjust is changing its API-side default on **July 13, 2026** to include **all** attribution types (including `impression`). ingestr currently pins `click,engaged_ad` for these tables to preserve existing behavior. To keep your metrics stable regardless of Adjust's default, set `attribution_types` explicitly for the behavior you want.
+
 ## Available Source Tables
 
 | Table | PK | Inc Key | Inc Strategy | Details |

--- a/docs/ingestion/adjust.md
+++ b/docs/ingestion/adjust.md
@@ -65,7 +65,7 @@ parameters:
 
 ### Attribution Types
 
-The `campaigns` and `creatives` tables default to `click,engaged_ad` attribution. You can override which attribution types are included with the `attribution_types` query parameter. Valid values are `click`, `impression`, and `engaged_ad`, comma-separated.
+The `campaigns` and `creatives` tables default to `click,engaged_ad` attribution. You can override which attribution types are included with the `attribution_types` query parameter, given as a comma-separated list of the [attribution types supported by Adjust](https://dev.adjust.com/en/api/rs-api/reports/).
 
 ```yaml
 parameters:

--- a/docs/ingestion/adjust.md
+++ b/docs/ingestion/adjust.md
@@ -80,7 +80,7 @@ parameters:
   source_table: 'creatives?app_token=abc123&attribution_types=click,engaged_ad'
 ```
 
-The existing `creatives:abc123` colon form (app token only) continues to work; `attribution_types` can only be set through the query parameter. For custom tables, pass `attribution_types` in the filters section instead.
+The existing `creatives:abc123` colon form (app token only) continues to work. To set `attribution_types`, use the query-parameter form and pass the app token as `app_token` too — the two forms cannot be combined, so `creatives:abc123?attribution_types=...` is **not** valid. For custom tables, pass `attribution_types` in the filters section instead.
 
 > [!WARNING]
 > Adjust is changing its API-side default on **July 13, 2026** to include **all** attribution types (including `impression`). ingestr currently pins `click,engaged_ad` for these tables to preserve existing behavior. To keep your metrics stable regardless of Adjust's default, set `attribution_types` explicitly for the behavior you want.


### PR DESCRIPTION
Documents the new `attribution_types` table parameter for the Adjust `campaigns` and `creatives` sources, added in ingestr ([bruin-data/ingestr#860](https://github.com/bruin-data/ingestr/pull/860)).

## Changes
- New **Attribution Types** section: `attribution_types` query parameter (`creatives?attribution_types=click,impression,engaged_ad`), valid values, and combining with `app_token`.
- Notes that the legacy `creatives:abc123` colon form still works and that custom tables pass it via the filters section.
- Adds a warning about Adjust changing its API-side default on **July 13, 2026** to include all attribution types, and how to keep metrics stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)