### PR TITLE
fix(dataproc_serverless): stream driver logs from GCS instead of Clou…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ tool (
 require (
 	cloud.google.com/go/bigquery v1.72.0
 	cloud.google.com/go/dataproc/v2 v2.11.2
-	cloud.google.com/go/logging v1.13.0
 	cloud.google.com/go/longrunning v0.6.7
 	cloud.google.com/go/storage v1.56.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,6 @@ github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0kt
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
 github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EOqtpKwwwHI=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -672,8 +670,6 @@ github.com/zeroshade/machine-id v0.0.0-20251223181436-930511047eef/go.mod h1:RHX
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
 go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
-go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
-go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.42.0 h1:kpt2PEJuOuqYkPcktfJqWWDjTEd/FNgrxcniL7kQrXQ=

--- a/pkg/dataproc_serverless/job.go
+++ b/pkg/dataproc_serverless/job.go
@@ -14,7 +14,6 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
-	"cloud.google.com/go/logging/logadmin"
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"cloud.google.com/go/storage"
 	"github.com/bruin-data/bruin/pkg/git"
@@ -105,7 +104,6 @@ type Job struct {
 	logger        *log.Logger
 	batchClient   *dataproc.BatchControllerClient
 	storageClient *storage.Client
-	logClient     *logadmin.Client
 	asset         *pipeline.Asset
 	pipeline      *pipeline.Pipeline
 	params        *JobRunParams
@@ -310,8 +308,14 @@ func (job Job) Run(ctx context.Context) (err error) {
 
 	var (
 		previousState = dataprocpb.Batch_STATE_UNSPECIFIED
-		jobLogs       = job.buildLogConsumer(ctx, req.GetBatchId())
+		jobLogs       = job.buildLogConsumer(ctx)
 	)
+
+	emit := func(lines []LogLine) {
+		for _, line := range lines {
+			job.logger.Printf("%s | %s", line.Source, line.Message)
+		}
+	}
 
 	for {
 		select {
@@ -337,22 +341,21 @@ func (job Job) Run(ctx context.Context) (err error) {
 				previousState = batch.GetState()
 			}
 
-			for _, line := range jobLogs.Next() {
-				job.logger.Printf("%s | %s", line.Source, line.Message)
-			}
+			// Dataproc populates the driver-output location once the batch
+			// starts running; keep feeding it to the consumer until it sticks.
+			jobLogs.SetOutputURI(batch.GetRuntimeInfo().GetOutputUri())
+			emit(jobLogs.Next())
 
 			switch batch.GetState() { //nolint:exhaustive
 			case dataprocpb.Batch_FAILED, dataprocpb.Batch_CANCELLED:
+				emit(job.drainLogs(ctx, jobLogs))
 				return batchError{
 					BatchID: req.GetBatchId(),
 					State:   batch.GetState(),
 					Details: batch.GetStateMessage(),
 				}
 			case dataprocpb.Batch_SUCCEEDED:
-				// Drain remaining logs
-				for _, line := range jobLogs.Next() {
-					job.logger.Printf("%s | %s", line.Source, line.Message)
-				}
+				emit(job.drainLogs(ctx, jobLogs))
 				return nil
 			}
 		}
@@ -360,18 +363,51 @@ func (job Job) Run(ctx context.Context) (err error) {
 }
 
 type LogConsumer interface {
+	// Next returns log lines produced since the previous call.
 	Next() []LogLine
+	// Flush returns any remaining buffered output, including a final line not
+	// terminated by a newline.
+	Flush() []LogLine
+	// SetOutputURI points the consumer at the GCS driver-output location.
+	SetOutputURI(uri string)
 }
 
-func (job Job) buildLogConsumer(ctx context.Context, batchID string) LogConsumer {
-	return &CloudLoggingConsumer{
-		ctx:       ctx,
-		client:    job.logClient,
-		project:   job.params.Project,
-		region:    job.params.Region,
-		batchID:   batchID,
-		lastFetch: time.Now(),
+// drainLogs reads any driver output that is still being flushed to GCS after the
+// batch has reached a terminal state, giving Dataproc a short grace period, then
+// flushes any trailing line that is not newline-terminated.
+func (job Job) drainLogs(ctx context.Context, jobLogs LogConsumer) []LogLine {
+	const (
+		maxRounds = 3
+		graceWait = 2 * time.Second
+	)
+
+	lines := []LogLine{}
+	emptyRounds := 0
+	for i := 0; i < maxRounds; i++ {
+		batch := jobLogs.Next()
+		lines = append(lines, batch...)
+
+		if len(batch) == 0 {
+			emptyRounds++
+			if emptyRounds >= 2 {
+				break
+			}
+		} else {
+			emptyRounds = 0
+		}
+
+		select {
+		case <-ctx.Done():
+			i = maxRounds
+		case <-time.After(graceWait):
+		}
 	}
+
+	return append(lines, jobLogs.Flush()...)
+}
+
+func (job Job) buildLogConsumer(ctx context.Context) LogConsumer {
+	return newGCSLogConsumer(ctx, job.storageClient)
 }
 
 func batchEnvironmentConfig(params *JobRunParams) *dataprocpb.EnvironmentConfig {

--- a/pkg/dataproc_serverless/job.go
+++ b/pkg/dataproc_serverless/job.go
@@ -383,7 +383,8 @@ func (job Job) drainLogs(ctx context.Context, jobLogs LogConsumer) []LogLine {
 
 	lines := []LogLine{}
 	emptyRounds := 0
-	for i := 0; i < maxRounds; i++ {
+drain:
+	for range maxRounds {
 		batch := jobLogs.Next()
 		lines = append(lines, batch...)
 
@@ -398,11 +399,13 @@ func (job Job) drainLogs(ctx context.Context, jobLogs LogConsumer) []LogLine {
 
 		select {
 		case <-ctx.Done():
-			i = maxRounds
+			break drain
 		case <-time.After(graceWait):
 		}
 	}
 
+	// Flush drains any buffered partial line; it works even if ctx is already
+	// cancelled because it falls back to the in-memory buffers.
 	return append(lines, jobLogs.Flush()...)
 }
 

--- a/pkg/dataproc_serverless/logs.go
+++ b/pkg/dataproc_serverless/logs.go
@@ -1,13 +1,15 @@
 package dataprocserverless
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"fmt"
+	"io"
+	"net/url"
+	"sort"
 	"strings"
-	"time"
 
-	"cloud.google.com/go/logging/logadmin"
+	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
 )
 
@@ -16,108 +18,150 @@ type LogLine struct {
 	Source  string
 }
 
-// CloudLoggingConsumer streams logs from Cloud Logging for a Dataproc Serverless batch job.
-type CloudLoggingConsumer struct {
-	ctx       context.Context //nolint:containedctx
-	client    *logadmin.Client
-	project   string
-	region    string
-	batchID   string
-	lastFetch time.Time
-	seenLogs  map[string]bool
+// GCSLogConsumer streams the Spark driver output that Dataproc Serverless writes
+// to the batch's staging bucket (RuntimeInfo.OutputUri). This is the same source
+// that `gcloud dataproc batches wait` streams.
+//
+// We deliberately do not read job logs from Cloud Logging: Dataproc Serverless
+// writes the driver/executor stdout, stderr and log4j output to this GCS
+// location, and that output does not reliably appear in Cloud Logging (only
+// control-plane logs such as the autoscaler do).
+type GCSLogConsumer struct {
+	ctx           context.Context //nolint:containedctx
+	storageClient *storage.Client
+
+	bucket   string
+	prefix   string
+	resolved bool
+
+	// offsets tracks, per output object, how many bytes have already been read.
+	offsets map[string]int64
+	// partial holds bytes that have been read but not yet terminated by a
+	// newline, per output object. They are completed on a subsequent read or
+	// emitted as-is on Flush.
+	partial map[string][]byte
 }
 
-func (l *CloudLoggingConsumer) Next() []LogLine {
-	if l.seenLogs == nil {
-		l.seenLogs = make(map[string]bool)
+func newGCSLogConsumer(ctx context.Context, client *storage.Client) *GCSLogConsumer {
+	return &GCSLogConsumer{
+		ctx:           ctx,
+		storageClient: client,
+		offsets:       map[string]int64{},
+		partial:       map[string][]byte{},
+	}
+}
+
+// SetOutputURI records the GCS location of the driver output. Dataproc only
+// populates RuntimeInfo.OutputUri once the batch starts running, so this is
+// called on every poll until a non-empty URI is observed.
+func (l *GCSLogConsumer) SetOutputURI(uri string) {
+	if uri == "" || l.resolved {
+		return
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return
+	}
+	l.bucket = u.Host
+	l.prefix = strings.TrimPrefix(u.Path, "/")
+	l.resolved = true
+}
+
+// Next returns any complete log lines written since the last call.
+func (l *GCSLogConsumer) Next() []LogLine {
+	return l.read(false)
+}
+
+// Flush returns any remaining buffered output, including a trailing line that is
+// not newline-terminated. It should be called once after the batch reaches a
+// terminal state.
+func (l *GCSLogConsumer) Flush() []LogLine {
+	return l.read(true)
+}
+
+func (l *GCSLogConsumer) read(flush bool) []LogLine {
+	if !l.resolved {
+		return nil
 	}
 
-	lines := []LogLine{}
+	bucket := l.storageClient.Bucket(l.bucket)
 
-	// Build filter for Dataproc Serverless batch logs
-	// Dataproc Serverless logs are written to Cloud Logging with resource type dataproc_batch
-	filter := fmt.Sprintf(
-		`resource.type="cloud_dataproc_batch" `+
-			`resource.labels.batch_id="%s" `+
-			`resource.labels.location="%s" `+
-			`timestamp >= "%s"`,
-		l.batchID,
-		l.region,
-		l.lastFetch.UTC().Format(time.RFC3339),
-	)
-
-	it := l.client.Entries(l.ctx, logadmin.Filter(filter))
-
+	// Driver output is split across objects named "<prefix>.000000000",
+	// "<prefix>.000000001", ... Read them in lexical order, which matches the
+	// order in which Dataproc writes them.
+	names := []string{}
+	it := bucket.Objects(l.ctx, &storage.Query{Prefix: l.prefix})
 	for {
-		entry, err := it.Next()
+		attrs, err := it.Next()
 		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {
-			// Log errors silently and continue - logs are best effort
+			// Listing is best-effort; try again on the next poll.
 			break
 		}
+		names = append(names, attrs.Name)
+	}
+	sort.Strings(names)
 
-		// Create a unique key for this log entry to avoid duplicates
-		logKey := fmt.Sprintf("%s-%s", entry.InsertID, entry.Timestamp.String())
-		if l.seenLogs[logKey] {
+	lines := []LogLine{}
+	for _, name := range names {
+		off := l.offsets[name]
+		obj := bucket.Object(name)
+
+		attrs, err := obj.Attrs(l.ctx)
+		if err != nil {
 			continue
 		}
-		l.seenLogs[logKey] = true
-
-		// Extract the message from the payload
-		message := extractMessage(entry.Payload)
-		if message == "" {
-			continue
-		}
-
-		// Determine the source (driver/executor) from labels
-		source := "SPARK"
-		if entry.Labels != nil {
-			if componentType, ok := entry.Labels["component_type"]; ok {
-				source = strings.ToUpper(componentType)
+		if attrs.Size > off {
+			reader, err := obj.NewRangeReader(l.ctx, off, -1)
+			if err != nil {
+				continue
 			}
+			data, err := io.ReadAll(reader)
+			reader.Close()
+			if err != nil {
+				continue
+			}
+			l.offsets[name] = off + int64(len(data))
+			l.partial[name] = append(l.partial[name], data...)
 		}
 
-		lines = append(lines, LogLine{
-			Message: message,
-			Source:  source,
-		})
-
-		// Update last fetch time to the latest entry we've seen
-		if entry.Timestamp.After(l.lastFetch) {
-			l.lastFetch = entry.Timestamp
+		complete, rest := splitLines(l.partial[name], flush)
+		l.partial[name] = rest
+		for _, msg := range complete {
+			lines = append(lines, LogLine{Source: "DRIVER", Message: msg})
 		}
 	}
 
 	return lines
 }
 
-func extractMessage(payload interface{}) string {
-	switch p := payload.(type) {
-	case string:
-		return strings.TrimSpace(p)
-	case map[string]interface{}:
-		// Try common message fields
-		if msg, ok := p["message"].(string); ok {
-			return strings.TrimSpace(msg)
+// splitLines splits buffered bytes into complete (newline-terminated) lines.
+// When flush is false, bytes after the final newline are returned as rest so
+// they can be completed on a later read. When flush is true, any trailing bytes
+// are emitted as a final line.
+func splitLines(buf []byte, flush bool) (lines []string, rest []byte) {
+	for {
+		idx := bytes.IndexByte(buf, '\n')
+		if idx < 0 {
+			break
 		}
-		if msg, ok := p["textPayload"].(string); ok {
-			return strings.TrimSpace(msg)
-		}
-		// For structured logs, try to get the full content
-		if jsonPayload, ok := p["jsonPayload"].(map[string]interface{}); ok {
-			if msg, ok := jsonPayload["message"].(string); ok {
-				return strings.TrimSpace(msg)
-			}
-		}
+		lines = append(lines, strings.TrimRight(string(buf[:idx]), "\r"))
+		buf = buf[idx+1:]
 	}
-	return ""
+	if flush && len(buf) > 0 {
+		lines = append(lines, strings.TrimRight(string(buf), "\r"))
+		buf = nil
+	}
+	return lines, buf
 }
 
 // NoOpLogConsumer is a log consumer that does nothing.
 type NoOpLogConsumer struct{}
 
-func (l *NoOpLogConsumer) Next() []LogLine {
-	return nil
-}
+func (l *NoOpLogConsumer) Next() []LogLine { return nil }
+
+func (l *NoOpLogConsumer) Flush() []LogLine { return nil }
+
+func (l *NoOpLogConsumer) SetOutputURI(string) {}

--- a/pkg/dataproc_serverless/logs.go
+++ b/pkg/dataproc_serverless/logs.go
@@ -87,9 +87,14 @@ func (l *GCSLogConsumer) read(flush bool) []LogLine {
 	bucket := l.storageClient.Bucket(l.bucket)
 
 	// Driver output is split across objects named "<prefix>.000000000",
-	// "<prefix>.000000001", ... Read them in lexical order, which matches the
-	// order in which Dataproc writes them.
-	names := []string{}
+	// "<prefix>.000000001", ... List them and pull any new bytes into the
+	// per-object buffers. The listing already reports each object's size, so we
+	// avoid a second Attrs call per object on every poll.
+	//
+	// Listing is best-effort: if it fails (e.g. the context was cancelled), we
+	// still fall through to drainBuffers so that any bytes already buffered are
+	// emitted — in particular a final Flush must never drop a buffered partial
+	// line just because the listing failed.
 	it := bucket.Objects(l.ctx, &storage.Query{Prefix: l.prefix})
 	for {
 		attrs, err := it.Next()
@@ -97,38 +102,55 @@ func (l *GCSLogConsumer) read(flush bool) []LogLine {
 			break
 		}
 		if err != nil {
-			// Listing is best-effort; try again on the next poll.
 			break
 		}
-		names = append(names, attrs.Name)
+		l.fetch(bucket, attrs.Name, attrs.Size)
+	}
+
+	return l.drainBuffers(flush)
+}
+
+// fetch reads the bytes appended to an output object since the last read into
+// the per-object buffer, advancing the object's offset.
+func (l *GCSLogConsumer) fetch(bucket *storage.BucketHandle, name string, size int64) {
+	off := l.offsets[name]
+	if size <= off {
+		return
+	}
+
+	reader, err := bucket.Object(name).NewRangeReader(l.ctx, off, -1)
+	if err != nil {
+		return
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return
+	}
+
+	l.offsets[name] = off + int64(len(data))
+	l.partial[name] = append(l.partial[name], data...)
+}
+
+// drainBuffers emits complete lines from every buffered object in lexical order
+// (which matches the order Dataproc writes them). It does not touch GCS, so it
+// always flushes whatever is buffered regardless of listing failures.
+func (l *GCSLogConsumer) drainBuffers(flush bool) []LogLine {
+	names := make([]string, 0, len(l.partial))
+	for name := range l.partial {
+		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	lines := []LogLine{}
 	for _, name := range names {
-		off := l.offsets[name]
-		obj := bucket.Object(name)
-
-		attrs, err := obj.Attrs(l.ctx)
-		if err != nil {
-			continue
-		}
-		if attrs.Size > off {
-			reader, err := obj.NewRangeReader(l.ctx, off, -1)
-			if err != nil {
-				continue
-			}
-			data, err := io.ReadAll(reader)
-			reader.Close()
-			if err != nil {
-				continue
-			}
-			l.offsets[name] = off + int64(len(data))
-			l.partial[name] = append(l.partial[name], data...)
-		}
-
 		complete, rest := splitLines(l.partial[name], flush)
-		l.partial[name] = rest
+		if len(rest) == 0 {
+			delete(l.partial, name)
+		} else {
+			l.partial[name] = rest
+		}
 		for _, msg := range complete {
 			lines = append(lines, LogLine{Source: "DRIVER", Message: msg})
 		}

--- a/pkg/dataproc_serverless/logs_test.go
+++ b/pkg/dataproc_serverless/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitLines(t *testing.T) {
@@ -110,5 +111,50 @@ func TestGCSLogConsumer_SetOutputURI(t *testing.T) {
 		c := newGCSLogConsumer(t.Context(), nil)
 		assert.Nil(t, c.Next())
 		assert.Nil(t, c.Flush())
+	})
+}
+
+// TestGCSLogConsumer_DrainBuffers covers the buffer-draining path that runs
+// regardless of GCS access. This is what guarantees a final Flush emits any
+// buffered partial line even when the object listing fails (e.g. the context
+// has been cancelled).
+func TestGCSLogConsumer_DrainBuffers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("emits complete lines in lexical order, keeps partial tail", func(t *testing.T) {
+		t.Parallel()
+		c := newGCSLogConsumer(t.Context(), nil)
+		c.partial = map[string][]byte{
+			"driveroutput.000000001": []byte("two\n"),
+			"driveroutput.000000000": []byte("one\npartial"),
+		}
+
+		lines := c.drainBuffers(false)
+
+		got := make([]string, len(lines))
+		for i, l := range lines {
+			assert.Equal(t, "DRIVER", l.Source)
+			got[i] = l.Message
+		}
+		assert.Equal(t, []string{"one", "two"}, got)
+		// The non-terminated tail is held back for a later read.
+		assert.Equal(t, "partial", string(c.partial["driveroutput.000000000"]))
+		// A fully consumed buffer is dropped.
+		_, ok := c.partial["driveroutput.000000001"]
+		assert.False(t, ok)
+	})
+
+	t.Run("flush emits the buffered partial tail without touching GCS", func(t *testing.T) {
+		t.Parallel()
+		c := newGCSLogConsumer(t.Context(), nil)
+		c.partial = map[string][]byte{"driveroutput.000000000": []byte("last line no newline")}
+
+		// drainBuffers is the GCS-free path read() falls through to; on a final
+		// Flush it must emit the buffered partial even when the listing failed.
+		lines := c.drainBuffers(true)
+
+		require.Len(t, lines, 1)
+		assert.Equal(t, "last line no newline", lines[0].Message)
+		assert.Empty(t, c.partial)
 	})
 }

--- a/pkg/dataproc_serverless/logs_test.go
+++ b/pkg/dataproc_serverless/logs_test.go
@@ -1,0 +1,114 @@
+package dataprocserverless
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		buf       string
+		flush     bool
+		wantLines []string
+		wantRest  string
+	}{
+		{
+			name:      "complete lines, no trailing partial",
+			buf:       "alpha\nbeta\n",
+			flush:     false,
+			wantLines: []string{"alpha", "beta"},
+			wantRest:  "",
+		},
+		{
+			name:      "trailing partial is held back when not flushing",
+			buf:       "alpha\nbeta\ngam",
+			flush:     false,
+			wantLines: []string{"alpha", "beta"},
+			wantRest:  "gam",
+		},
+		{
+			name:      "trailing partial is emitted on flush",
+			buf:       "alpha\ngam",
+			flush:     true,
+			wantLines: []string{"alpha", "gam"},
+			wantRest:  "",
+		},
+		{
+			name:      "carriage returns are trimmed",
+			buf:       "alpha\r\nbeta\r\n",
+			flush:     false,
+			wantLines: []string{"alpha", "beta"},
+			wantRest:  "",
+		},
+		{
+			name:      "blank lines are preserved",
+			buf:       "a\n\nb\n",
+			flush:     false,
+			wantLines: []string{"a", "", "b"},
+			wantRest:  "",
+		},
+		{
+			name:      "empty buffer yields nothing",
+			buf:       "",
+			flush:     false,
+			wantLines: nil,
+			wantRest:  "",
+		},
+		{
+			name:      "empty buffer on flush yields nothing",
+			buf:       "",
+			flush:     true,
+			wantLines: nil,
+			wantRest:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lines, rest := splitLines([]byte(tt.buf), tt.flush)
+			assert.Equal(t, tt.wantLines, lines)
+			assert.Equal(t, tt.wantRest, string(rest))
+		})
+	}
+}
+
+func TestGCSLogConsumer_SetOutputURI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses bucket and prefix", func(t *testing.T) {
+		t.Parallel()
+		c := newGCSLogConsumer(t.Context(), nil)
+		c.SetOutputURI("gs://my-bucket/path/to/jobs/srvls-batch-123/driveroutput")
+		assert.True(t, c.resolved)
+		assert.Equal(t, "my-bucket", c.bucket)
+		assert.Equal(t, "path/to/jobs/srvls-batch-123/driveroutput", c.prefix)
+	})
+
+	t.Run("empty URI is ignored", func(t *testing.T) {
+		t.Parallel()
+		c := newGCSLogConsumer(t.Context(), nil)
+		c.SetOutputURI("")
+		assert.False(t, c.resolved)
+	})
+
+	t.Run("first non-empty URI wins", func(t *testing.T) {
+		t.Parallel()
+		c := newGCSLogConsumer(t.Context(), nil)
+		c.SetOutputURI("gs://first/driveroutput")
+		c.SetOutputURI("gs://second/driveroutput")
+		assert.Equal(t, "first", c.bucket)
+	})
+
+	t.Run("not resolved returns no lines", func(t *testing.T) {
+		t.Parallel()
+		c := newGCSLogConsumer(t.Context(), nil)
+		assert.Nil(t, c.Next())
+		assert.Nil(t, c.Flush())
+	})
+}

--- a/pkg/dataproc_serverless/operator.go
+++ b/pkg/dataproc_serverless/operator.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
-	"cloud.google.com/go/logging/logadmin"
 	"cloud.google.com/go/storage"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/env"
@@ -62,12 +61,6 @@ func (op *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) err
 	}
 	defer storageClient.Close()
 
-	logClient, err := logadmin.NewClient(ctx, conn.ProjectID, clientOptions...)
-	if err != nil {
-		return fmt.Errorf("error creating logging client: %w", err)
-	}
-	defer logClient.Close()
-
 	envVars, err := env.SetupVariables(ctx, ti.GetPipeline(), asset, cloneEnv(op.env))
 	if err != nil {
 		return fmt.Errorf("error setting up environment variables: %w", err)
@@ -77,7 +70,6 @@ func (op *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) err
 		logger:        logger,
 		batchClient:   batchClient,
 		storageClient: storageClient,
-		logClient:     logClient,
 		params:        params,
 		asset:         asset,
 		pipeline:      ti.GetPipeline(),


### PR DESCRIPTION
…d Logging

Dataproc Serverless assets streamed back no job logs. Verified against real batches: the Spark driver/executor stdout, stderr and log4j output is written to the batch's staging bucket (RuntimeInfo.OutputUri, .../driveroutput.NNN) and does not reliably appear in Cloud Logging — only control-plane logs (e.g. the autoscaler) do. The previous CloudLoggingConsumer read exclusively from Cloud Logging, so it found nothing to stream.

A second, latent bug compounded this: extractMessage only handled `string` and `map[string]interface{}` payloads, but logadmin returns jsonPayload entries as `*structpb.Struct`, so every structured entry was dropped as "".

Replace the Cloud Logging consumer with a GCSLogConsumer that tails the driver output objects by byte offset (the same source `gcloud dataproc batches wait` streams), draining with a short grace window and flushing any trailing partial line on terminal state. Drop the now-unused logadmin client/dependency.

Verified end-to-end against a real batch: 100% of the driver-output lines now stream back, matching the GCS driveroutput exactly.