### PR TITLE
🔒 Security: Patch CVE-2026-46595 — upgrade golang.org/x/crypto to v0.52.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect


### PR DESCRIPTION
## Security Fix: golang.org/x/crypto v0.51.0 → v0.52.0

### Vulnerabilities Addressed (9 total)

**7 CRITICAL:**
- **CVE-2026-46595** — `VerifiedPublicKeyCallback` permissions skip enforcement
- **CVE-2026-42508** — `ssh/knownhosts` auth bypass via unenforced `@revoked` status
- **CVE-2026-39834** — infinite loop on large channel writes
- **CVE-2026-39831** — FIDO/U2F physical presence check bypass
- **CVE-2026-39830** — client can cause server deadlock on unexpected responses
- **CVE-2026-39832** — `ssh/agent` doesn't drop constraints when forwarding keys
- **CVE-2026-39833** — `ssh/agent` doesn't enforce key constraints

**2 HIGH:**
- **CVE-2026-39829** — pathological RSA/DSA parameters DoS
- **CVE-2026-46597** — byte arithmetic underflow and panic

### What Changed
- Updated `golang.org/x/crypto` from `v0.51.0` to `v0.52.0` in `go.mod`

### After Merge
Run `go mod tidy` to update `go.sum` with the new checksums.

### Linear Ticket
[BRU-5110](https://linear.app/bruin/issue/BRU-5110)

### Advisory Links
- https://github.com/advisories/GHSA-q4h4-gmj2-qvw2
- https://github.com/advisories/GHSA-5cgq-3rg8-m6cv
- https://github.com/advisories/GHSA-rm3j-f69w-wqmq