### PR TITLE
feat(square): add Square as a Bruin source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -358,6 +358,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Smartsheet", link: "/ingestion/smartsheet"},
                                     {text: "Snapchat Ads", link: "/ingestion/snapchat-ads"},
                                     {text: "Solidgate", link: "/ingestion/solidgate"},
+                                    {text: "Square", link: "/ingestion/square"},
                                     {text: "Stripe", link: "/ingestion/stripe"},
                                     {text: "Slack", link: "/ingestion/slack"},
                                     {text: "Socrata", link: "/ingestion/socrata"},

--- a/docs/ingestion/square.md
+++ b/docs/ingestion/square.md
@@ -1,0 +1,73 @@
+# Square
+
+[Square](https://squareup.com/) is a payments and commerce platform for businesses.
+
+Bruin supports Square as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Square into your data warehouse.
+
+To set up a Square connection, you need a Square access token. For more information, please refer [here](https://getbruin.com/docs/ingestr/supported-sources/square.html)
+
+Follow the steps below to correctly set up Square as a data source and run ingestion:
+
+## Configuration
+
+### Step 1: Add a connection to .bruin.yml file
+
+To connect to Square, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+    connections:
+      square:
+        - name: "my_square"
+          access_token: "YOUR_SQUARE_ACCESS_TOKEN"
+          environment: "production"
+```
+
+- `access_token`: Your Square access token. Required.
+- `environment` (optional): Either `production` (default) or `sandbox`. Use `sandbox` to read from Square's developer sandbox.
+
+### Step 2: Create an asset file for data ingestion
+
+To ingest data from Square, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., square_ingestion.yml) inside the assets folder and add the following content:
+
+```yaml
+name: public.square
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: my_square
+  source_table: 'payments'
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Specifies the type of the asset. It will be always ingestr type for Square.
+- `connection`: This is the destination connection.
+- `source_connection`: The name of the Square connection defined in .bruin.yml.
+- `source_table`: The name of the data table in Square you want to ingest. For example, `payments` would ingest payment records.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| `payments` | id | updated_at | merge | Payments taken by the account. |
+| `refunds` | id | updated_at | merge | Refunds processed against payments. |
+| `orders` | id | updated_at | merge | Orders across all of the account's locations. |
+| `customers` | id | updated_at | merge | Customer profiles. |
+| `catalog_objects` | id | updated_at | merge | All catalog objects (items, variations, categories, taxes, discounts, modifier lists, images, and more). Deletions surface as `is_deleted=true` rows. |
+| `team_members` | id | updated_at | merge | Team members (staff). Soft-deletes appear as `status="INACTIVE"`. |
+| `inventory` | catalog_object_id, location_id, state | calculated_at | merge | Inventory counts per catalog object, location, and state. |
+| `locations` | id | - | replace | The account's locations. |
+| `team_member_wages` | id | - | replace | Hourly wage settings per team member. |
+| `shifts` | id | - | replace | Worked shifts (Labor API). |
+| `bank_accounts` | id | - | replace | Linked bank accounts. |
+| `cash_drawers` | id, location_id | - | replace | Cash drawer shifts across all locations. |
+| `loyalty` | id | - | replace | Loyalty accounts (requires a paid Square Loyalty subscription). |
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run ingestr.square.asset.yml
+```
+
+As a result of this command, Bruin will ingest data from the given Square table into your Postgres database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1227,6 +1227,12 @@
           },
           "type": "array"
         },
+        "square": {
+          "items": {
+            "$ref": "#/$defs/SquareConnection"
+          },
+          "type": "array"
+        },
         "spanner": {
           "items": {
             "$ref": "#/$defs/SpannerConnection"
@@ -4000,6 +4006,25 @@
         "name",
         "public_key",
         "secret_key"
+      ]
+    },
+    "SquareConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "access_token": {
+          "type": "string"
+        },
+        "environment": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "access_token"
       ]
     },
     "SpannerConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1466,6 +1466,16 @@ func (c SolidgateConnection) GetName() string {
 	return c.Name
 }
 
+type SquareConnection struct {
+	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	AccessToken string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token"`
+	Environment string `yaml:"environment,omitempty" json:"environment,omitempty" mapstructure:"environment"`
+}
+
+func (c SquareConnection) GetName() string {
+	return c.Name
+}
+
 type SmartsheetConnection struct {
 	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	AccessToken  string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -121,6 +121,7 @@ type Connections struct {
 	Phantombuster       []PhantombusterConnection       `yaml:"phantombuster,omitempty" json:"phantombuster,omitempty" mapstructure:"phantombuster"`
 	Elasticsearch       []ElasticsearchConnection       `yaml:"elasticsearch,omitempty" json:"elasticsearch,omitempty" mapstructure:"elasticsearch"`
 	Solidgate           []SolidgateConnection           `yaml:"solidgate,omitempty" json:"solidgate,omitempty" mapstructure:"solidgate"`
+	Square              []SquareConnection              `yaml:"square,omitempty" json:"square,omitempty" mapstructure:"square"`
 	Spanner             []SpannerConnection             `yaml:"spanner,omitempty" json:"spanner,omitempty" mapstructure:"spanner"`
 	Smartsheet          []SmartsheetConnection          `yaml:"smartsheet,omitempty" json:"smartsheet,omitempty" mapstructure:"smartsheet"`
 	Attio               []AttioConnection               `yaml:"attio,omitempty" json:"attio,omitempty" mapstructure:"attio"`
@@ -1231,6 +1232,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Solidgate = append(env.Connections.Solidgate, conn)
+	case "square":
+		var conn SquareConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Square = append(env.Connections.Square, conn)
 	case "smartsheet":
 		var conn SmartsheetConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1637,6 +1645,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Spanner = removeConnection(env.Connections.Spanner, connectionName)
 	case "solidgate":
 		env.Connections.Solidgate = removeConnection(env.Connections.Solidgate, connectionName)
+	case "square":
+		env.Connections.Square = removeConnection(env.Connections.Square, connectionName)
 	case "smartsheet":
 		env.Connections.Smartsheet = removeConnection(env.Connections.Smartsheet, connectionName)
 	case "attio":
@@ -1840,6 +1850,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Phantombuster, source.Phantombuster)
 	mergeConnectionList(&c.Elasticsearch, source.Elasticsearch)
 	mergeConnectionList(&c.Solidgate, source.Solidgate)
+	mergeConnectionList(&c.Square, source.Square)
 	mergeConnectionList(&c.Spanner, source.Spanner)
 	mergeConnectionList(&c.Smartsheet, source.Smartsheet)
 	mergeConnectionList(&c.Attio, source.Attio)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -709,6 +709,13 @@ func TestLoadFromFile(t *testing.T) {
 					PublicKey: "public-key-123",
 				},
 			},
+			Square: []SquareConnection{
+				{
+					Name:        "square-1",
+					AccessToken: "EAAA-test-access-token",
+					Environment: "sandbox",
+				},
+			},
 			Smartsheet: []SmartsheetConnection{
 				{
 					Name:         "smartsheet-1",
@@ -2254,6 +2261,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Phantombuster:       []PhantombusterConnection{{Name: "phantombuster1"}},
 				Elasticsearch:       []ElasticsearchConnection{{Name: "elasticsearch1"}},
 				Solidgate:           []SolidgateConnection{{Name: "solidgate1"}},
+				Square:              []SquareConnection{{Name: "square1"}},
 				Spanner:             []SpannerConnection{{Name: "spanner1"}},
 				Smartsheet:          []SmartsheetConnection{{Name: "smartsheet1"}},
 				Attio:               []AttioConnection{{Name: "attio1"}},
@@ -2383,6 +2391,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Phantombuster:       []PhantombusterConnection{{Name: "phantombuster1"}},
 				Elasticsearch:       []ElasticsearchConnection{{Name: "elasticsearch1"}},
 				Solidgate:           []SolidgateConnection{{Name: "solidgate1"}},
+				Square:              []SquareConnection{{Name: "square1"}},
 				Spanner:             []SpannerConnection{{Name: "spanner1"}},
 				Smartsheet:          []SmartsheetConnection{{Name: "smartsheet1"}},
 				Attio:               []AttioConnection{{Name: "attio1"}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -447,6 +447,10 @@ environments:
         - name: "solidgate-1"
           secret_key: "secret-key-123"
           public_key: "public-key-123"
+      square:
+        - name: "square-1"
+          access_token: "EAAA-test-access-token"
+          environment: "sandbox"
       smartsheet:
         - name: "smartsheet-1"
           access_token: "access-token-123"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -448,6 +448,10 @@ environments:
         - name: "solidgate-1"
           secret_key: "secret-key-123"
           public_key: "public-key-123"
+      square:
+        - name: "square-1"
+          access_token: "EAAA-test-access-token"
+          environment: "sandbox"
       smartsheet:
         - name: "smartsheet-1"
           access_token: "access-token-123"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -124,6 +124,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/solidgate"
 	"github.com/bruin-data/bruin/pkg/spanner"
 	"github.com/bruin-data/bruin/pkg/sqlite"
+	"github.com/bruin-data/bruin/pkg/square"
 	"github.com/bruin-data/bruin/pkg/stripe"
 	"github.com/bruin-data/bruin/pkg/surveymonkey"
 	"github.com/bruin-data/bruin/pkg/tableau"
@@ -249,6 +250,7 @@ type Manager struct {
 	Elasticsearch        map[string]*elasticsearch.Client
 	Spanner              map[string]*spanner.Client
 	Solidgate            map[string]*solidgate.Client
+	Square               map[string]*square.Client
 	Smartsheet           map[string]*smartsheet.Client
 	Attio                map[string]*attio.Client
 	Sftp                 map[string]*sftp.Client
@@ -1713,6 +1715,26 @@ func (m *Manager) AddSolidgateConnectionFromConfig(connection *config.SolidgateC
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection
 
+	return nil
+}
+
+func (m *Manager) AddSquareConnectionFromConfig(connection *config.SquareConnection) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.Square == nil {
+		m.Square = make(map[string]*square.Client)
+	}
+
+	client, err := square.NewClient(square.Config{
+		AccessToken: connection.AccessToken,
+		Environment: connection.Environment,
+	})
+	if err != nil {
+		return err
+	}
+	m.Square[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
 	return nil
 }
 
@@ -3779,6 +3801,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Elasticsearch, connectionManager.AddElasticsearchConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Spanner, connectionManager.AddSpannerConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Solidgate, connectionManager.AddSolidgateConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Square, connectionManager.AddSquareConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Smartsheet, connectionManager.AddSmartsheetConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Attio, connectionManager.AddAttioConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Sftp, connectionManager.AddSftpConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -907,6 +907,23 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "financial_entries", PrimaryKey: "id", IncKey: "created_at", IncStrategy: "merge"},
 	},
 
+	// Square - Payments and commerce platform
+	"square": {
+		{Name: "payments", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
+		{Name: "refunds", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
+		{Name: "orders", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
+		{Name: "customers", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
+		{Name: "catalog_objects", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
+		{Name: "team_members", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},
+		{Name: "inventory", PrimaryKey: "catalog_object_id, location_id, state", IncKey: "calculated_at", IncStrategy: "merge"},
+		{Name: "locations", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "team_member_wages", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "shifts", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "bank_accounts", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "cash_drawers", PrimaryKey: "id, location_id", IncKey: "", IncStrategy: "replace"},
+		{Name: "loyalty", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+	},
+
 	// GCP Spanner (user-defined tables)
 	"spanner": {},
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -199,6 +199,7 @@ var defaultMapping = map[string]string{
 	"applovin":              "applovin-default",
 	"salesforce":            "salesforce-default",
 	"solidgate":             "solidgate-default",
+	"square":                "square-default",
 	"smartsheet":            "smartsheet-default",
 	"sftp":                  "sftp-default",
 	"motherduck":            "motherduck-default",

--- a/pkg/square/config.go
+++ b/pkg/square/config.go
@@ -1,0 +1,17 @@
+package square
+
+import "net/url"
+
+type Config struct {
+	AccessToken string
+	Environment string
+}
+
+func (c *Config) GetIngestrURI() string {
+	params := url.Values{}
+	params.Set("access_token", c.AccessToken)
+	if c.Environment != "" {
+		params.Set("environment", c.Environment)
+	}
+	return "square://?" + params.Encode()
+}

--- a/pkg/square/db.go
+++ b/pkg/square/db.go
@@ -1,0 +1,15 @@
+package square
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}


### PR DESCRIPTION
## Summary

Adds end-to-end wiring for **Square** as a Bruin source connection, on top of the new Square source landing in `ingestr` (PR [#877](https://github.com/bruin-data/ingestr/pull/877)).

Connection schema:

\`\`\`yaml
connections:
  square:
    - name: "my_square"
      access_token: "EAAA..."        # required
      environment: "sandbox"         # optional; production (default) or sandbox
\`\`\`

The 13 Square tables (`payments`, `refunds`, `orders`, `customers`, `catalog_objects`, `team_members`, `inventory`, `locations`, `team_member_wages`, `shifts`, `bank_accounts`, `cash_drawers`, `loyalty`) are registered in `pkg/ingestr/sources.go` with their primary keys, incremental keys, and strategies.