### PR TITLE
feat(starrocks): add StarRocks as a Bruin source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -360,6 +360,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Snapchat Ads", link: "/ingestion/snapchat-ads"},
                                     {text: "Solidgate", link: "/ingestion/solidgate"},
                                     {text: "Square", link: "/ingestion/square"},
+                                    {text: "StarRocks", link: "/ingestion/starrocks"},
                                     {text: "Stripe", link: "/ingestion/stripe"},
                                     {text: "Slack", link: "/ingestion/slack"},
                                     {text: "Socrata", link: "/ingestion/socrata"},

--- a/docs/ingestion/starrocks.md
+++ b/docs/ingestion/starrocks.md
@@ -1,0 +1,87 @@
+# StarRocks
+
+[StarRocks](https://www.starrocks.io/) is a high-performance analytical (OLAP) database. Besides its own internal storage, it can query open lakehouse table formats — Apache Iceberg, Hudi, Hive, and Delta Lake — through external catalogs.
+
+Bruin supports StarRocks as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from StarRocks (including lakehouse tables) into your data warehouse.
+
+For more information, please refer [here](https://getbruin.com/docs/ingestr/supported-sources/starrocks.html).
+
+Follow the steps below to correctly set up StarRocks as a data source and run ingestion:
+
+## Configuration
+
+### Step 1: Add a connection to .bruin.yml file
+
+To connect to StarRocks, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+    connections:
+      starrocks:
+        - name: "my_starrocks"
+          host: "localhost"
+          port: 9030
+          username: "root"
+          password: "YOUR_PASSWORD"
+          database: "analytics"
+          catalog: "iceberg_catalog"
+          ssl: "true"
+```
+
+- `host`: the StarRocks FE (frontend) hostname or IP address. Required.
+- `username`: the StarRocks user. Required.
+- `port`: the FE query port that speaks the MySQL protocol. Optional, defaults to `9030`.
+- `password`: the password for the user. Optional.
+- `database`: the default database for unqualified table names. Optional.
+- `catalog`: the default catalog. Optional, defaults to the internal catalog (`default_catalog`). Set this to an external catalog name (e.g. an Iceberg/Hudi/Hive catalog configured in StarRocks) to read lakehouse tables.
+- `ssl`: enable a TLS-encrypted connection. Optional — use `true` to verify the server certificate, or `skip-verify` for TLS without verification.
+
+### Step 2: Create an asset file for data ingestion
+
+To ingest data from StarRocks, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., starrocks_ingestion.yml) inside the assets folder and add the following content:
+
+```yaml
+name: public.events
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: my_starrocks
+  source_table: 'analytics.events'
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Specifies the type of the asset. It will be always ingestr type for StarRocks.
+- `connection`: This is the destination connection.
+- `source_connection`: The name of the StarRocks connection defined in .bruin.yml.
+- `source_table`: The table in StarRocks to ingest.
+
+## Source tables
+
+StarRocks organizes tables as `catalog.database.table`. The `source_table` accepts any of these forms:
+
+| Format | Description |
+|--------|-------------|
+| `table` | uses the default catalog and database from the connection |
+| `database.table` | uses the default catalog from the connection |
+| `catalog.database.table` | fully qualified — reads from any internal or external catalog |
+
+Examples:
+
+- `analytics.events` — the `events` table in the `analytics` database (internal catalog).
+- `iceberg_catalog.lakehouse.trips` — an Apache Iceberg table reached through the `iceberg_catalog` external catalog.
+- `hudi_catalog.lakehouse.payments` — an Apache Hudi table reached through the `hudi_catalog` external catalog.
+
+Because StarRocks federates lakehouse formats through external catalogs, reading an Iceberg/Hudi/Hive/Delta table uses the same `catalog.database.table` form — no extra configuration is needed on the Bruin side.
+
+## Incremental loading
+
+Provide `incremental_key` together with an interval to pull only the rows in that window, and use the `merge` strategy with a primary key to upsert them. Without an interval, ingestr reads all rows and merges on the primary key (an idempotent full refresh).
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/starrocks_ingestion.yml
+```
+
+As a result of this command, Bruin will ingest data from the given StarRocks table into your Postgres database.

--- a/docs/ingestion/starrocks.md
+++ b/docs/ingestion/starrocks.md
@@ -19,12 +19,12 @@ To connect to StarRocks, you need to add a configuration item to the connections
       starrocks:
         - name: "my_starrocks"
           host: "localhost"
-          port: 9030
           username: "root"
-          password: "YOUR_PASSWORD"
-          database: "analytics"
-          catalog: "iceberg_catalog"
-          ssl: "true"
+          port: 9030                    # optional, defaults to 9030
+          password: "YOUR_PASSWORD"     # optional
+          database: "analytics"         # optional
+          catalog: "iceberg_catalog"    # optional
+          ssl: "true"                   # optional
 ```
 
 - `host`: the StarRocks FE (frontend) hostname or IP address. Required.

--- a/docs/ingestion/starrocks.md
+++ b/docs/ingestion/starrocks.md
@@ -66,6 +66,8 @@ StarRocks organizes tables as `catalog.database.table`. The `source_table` accep
 | `database.table` | uses the default catalog from the connection |
 | `catalog.database.table` | fully qualified — reads from any internal or external catalog |
 
+Anything specified in the `source_table` takes priority over the catalog/database defaults from the connection.
+
 Examples:
 
 - `analytics.events` — the `events` table in the `analytics` database (internal catalog).

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1293,6 +1293,12 @@
           },
           "type": "array"
         },
+        "starrocks": {
+          "items": {
+            "$ref": "#/$defs/StarRocksConnection"
+          },
+          "type": "array"
+        },
         "dremio": {
           "items": {
             "$ref": "#/$defs/DremioConnection"
@@ -4050,6 +4056,41 @@
       "required": [
         "name",
         "access_token"
+      ]
+    },
+    "StarRocksConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "database": {
+          "type": "string"
+        },
+        "catalog": {
+          "type": "string"
+        },
+        "ssl": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "username"
       ]
     },
     "SpannerConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1602,6 +1602,21 @@ func (c TrinoConnection) GetName() string {
 	return c.Name
 }
 
+type StarRocksConnection struct {
+	Name     string `yaml:"name" json:"name" mapstructure:"name"`
+	Host     string `yaml:"host" json:"host" mapstructure:"host"`
+	Username string `yaml:"username" json:"username" mapstructure:"username"`
+	Password string `yaml:"password,omitempty" json:"password,omitempty" mapstructure:"password"`
+	Port     int    `yaml:"port,omitempty" json:"port,omitempty" mapstructure:"port"`
+	Database string `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
+	Catalog  string `yaml:"catalog,omitempty" json:"catalog,omitempty" mapstructure:"catalog"`
+	SSL      string `yaml:"ssl,omitempty" json:"ssl,omitempty" mapstructure:"ssl"`
+}
+
+func (c StarRocksConnection) GetName() string {
+	return c.Name
+}
+
 type KalshiConnection struct {
 	Name        string            `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	QueryParams map[string]string `yaml:"query_params,omitempty" json:"query_params,omitempty" mapstructure:"query_params"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -132,6 +132,7 @@ type Connections struct {
 	Tableau             []TableauConnection             `yaml:"tableau,omitempty" json:"tableau,omitempty" mapstructure:"tableau"`
 	QuickSight          []QuickSightConnection          `yaml:"quicksight,omitempty" json:"quicksight,omitempty" mapstructure:"quicksight"`
 	Trino               []TrinoConnection               `yaml:"trino,omitempty" json:"trino,omitempty" mapstructure:"trino"`
+	StarRocks           []StarRocksConnection           `yaml:"starrocks,omitempty" json:"starrocks,omitempty" mapstructure:"starrocks"`
 	Dremio              []DremioConnection              `yaml:"dremio,omitempty" json:"dremio,omitempty" mapstructure:"dremio"`
 	Sail                []SailConnection                `yaml:"sail,omitempty" json:"sail,omitempty" mapstructure:"sail"`
 	Fluxx               []FluxxConnection               `yaml:"fluxx,omitempty" json:"fluxx,omitempty" mapstructure:"fluxx"`
@@ -1105,6 +1106,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Trino = append(env.Connections.Trino, conn)
+	case "starrocks":
+		var conn StarRocksConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.StarRocks = append(env.Connections.StarRocks, conn)
 	case "dremio":
 		var conn DremioConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1613,6 +1621,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Pinterest = removeConnection(env.Connections.Pinterest, connectionName)
 	case "trino":
 		env.Connections.Trino = removeConnection(env.Connections.Trino, connectionName)
+	case "starrocks":
+		env.Connections.StarRocks = removeConnection(env.Connections.StarRocks, connectionName)
 	case "dremio":
 		env.Connections.Dremio = removeConnection(env.Connections.Dremio, connectionName)
 	case "sail":
@@ -1871,6 +1881,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Tableau, source.Tableau)
 	mergeConnectionList(&c.QuickSight, source.QuickSight)
 	mergeConnectionList(&c.Trino, source.Trino)
+	mergeConnectionList(&c.StarRocks, source.StarRocks)
 	mergeConnectionList(&c.Dremio, source.Dremio)
 	mergeConnectionList(&c.Sail, source.Sail)
 	mergeConnectionList(&c.Fluxx, source.Fluxx)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -904,6 +904,18 @@ func TestLoadFromFile(t *testing.T) {
 					Season: "2026",
 				},
 			},
+			StarRocks: []StarRocksConnection{
+				{
+					Name:     "starrocks-1",
+					Host:     "localhost",
+					Port:     9030,
+					Username: "root",
+					Password: "pass123",
+					Database: "analytics",
+					Catalog:  "iceberg_catalog",
+					SSL:      "true",
+				},
+			},
 		},
 	}
 
@@ -2279,6 +2291,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Tableau:             []TableauConnection{{Name: "tableau1"}},
 				QuickSight:          []QuickSightConnection{{Name: "quicksight1"}},
 				Trino:               []TrinoConnection{{Name: "trino1"}},
+				StarRocks:           []StarRocksConnection{{Name: "starrocks1"}},
 				Fluxx:               []FluxxConnection{{Name: "fluxx1"}},
 				Freshdesk:           []FreshdeskConnection{{Name: "freshdesk1"}},
 				FundraiseUp:         []FundraiseUpConnection{{Name: "fundraiseup1"}},
@@ -2410,6 +2423,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Tableau:             []TableauConnection{{Name: "tableau1"}},
 				QuickSight:          []QuickSightConnection{{Name: "quicksight1"}},
 				Trino:               []TrinoConnection{{Name: "trino1"}},
+				StarRocks:           []StarRocksConnection{{Name: "starrocks1"}},
 				Fluxx:               []FluxxConnection{{Name: "fluxx1"}},
 				Freshdesk:           []FreshdeskConnection{{Name: "freshdesk1"}},
 				FundraiseUp:         []FundraiseUpConnection{{Name: "fundraiseup1"}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -566,6 +566,15 @@ environments:
         - name: "balldontlie-1"
           api_key: "test-api-key"
           season: "2026"
+      starrocks:
+        - name: "starrocks-1"
+          host: "localhost"
+          port: 9030
+          username: "root"
+          password: "pass123"
+          database: "analytics"
+          catalog: "iceberg_catalog"
+          ssl: "true"
 
   prod:
     connections:

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -567,6 +567,15 @@ environments:
         - name: "balldontlie-1"
           api_key: "test-api-key"
           season: "2026"
+      starrocks:
+        - name: "starrocks-1"
+          host: "localhost"
+          port: 9030
+          username: "root"
+          password: "pass123"
+          database: "analytics"
+          catalog: "iceberg_catalog"
+          ssl: "true"
 
   prod:
     connections:

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -126,6 +126,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/spanner"
 	"github.com/bruin-data/bruin/pkg/sqlite"
 	"github.com/bruin-data/bruin/pkg/square"
+	"github.com/bruin-data/bruin/pkg/starrocks"
 	"github.com/bruin-data/bruin/pkg/stripe"
 	"github.com/bruin-data/bruin/pkg/surveymonkey"
 	"github.com/bruin-data/bruin/pkg/tableau"
@@ -261,6 +262,7 @@ type Manager struct {
 	Tableau              map[string]*tableau.Client
 	QuickSight           map[string]*quicksight.Client
 	Trino                map[string]*trino.Client
+	StarRocks            map[string]*starrocks.Client
 	Dremio               map[string]*dremio.Client
 	Sail                 map[string]*sail.Client
 	Dune                 map[string]*dune.Client
@@ -3565,6 +3567,35 @@ func (m *Manager) AddTrinoConnectionFromConfig(connection *config.TrinoConnectio
 	return nil
 }
 
+func (m *Manager) AddStarRocksConnectionFromConfig(connection *config.StarRocksConnection) error {
+	m.mutex.Lock()
+	if m.StarRocks == nil {
+		m.StarRocks = make(map[string]*starrocks.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := starrocks.NewClient(starrocks.Config{
+		Username: connection.Username,
+		Password: connection.Password,
+		Host:     connection.Host,
+		Port:     connection.Port,
+		Database: connection.Database,
+		Catalog:  connection.Catalog,
+		SSL:      connection.SSL,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.StarRocks[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
 func (m *Manager) AddDremioConnectionFromConfig(connection *config.DremioConnection) error {
 	m.mutex.Lock()
 	if m.Dremio == nil {
@@ -3838,6 +3869,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.QuickSight, connectionManager.AddQuickSightConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Generic, connectionManager.AddGenericConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Trino, connectionManager.AddTrinoConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.StarRocks, connectionManager.AddStarRocksConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Dremio, connectionManager.AddDremioConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Sail, connectionManager.AddSailConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Vertica, connectionManager.AddVerticaConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -1034,6 +1034,9 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 	// Trino - Distributed SQL query engine (user-defined tables)
 	"trino": {},
 
+	// StarRocks - OLAP database, incl. lakehouse catalogs (user-defined tables)
+	"starrocks": {},
+
 	// Wise - Money transfers
 	"wise": {
 		{Name: "profiles", PrimaryKey: "id", IncKey: "", IncStrategy: "merge"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -193,6 +193,7 @@ var defaultMapping = map[string]string{
 	"emr_serverless":        "emr_serverless-default",
 	"dataproc_serverless":   "dataproc_serverless-default",
 	"trino":                 "trino-default",
+	"starrocks":             "starrocks-default",
 	"dremio":                "dremio-default",
 	"sail":                  "sail-default",
 	"oracle":                "oracle-default",

--- a/pkg/starrocks/config.go
+++ b/pkg/starrocks/config.go
@@ -1,0 +1,58 @@
+package starrocks
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+)
+
+const defaultPort = 9030
+
+type Config struct {
+	Username string // Required
+	Password string // Optional
+	Host     string // Required
+	Port     int    // Optional - defaults to 9030 (FE MySQL protocol port)
+	Database string // Optional - default database for unqualified table names
+	Catalog  string // Optional - external lakehouse catalog (Iceberg/Hudi/Hive/...)
+	SSL      string // Optional - "true" or "skip-verify" to enable TLS
+}
+
+// GetIngestrURI builds starrocks://user:pass@host:port/[catalog/]database?ssl=...
+// A lone database maps to the internal catalog; catalog is prefixed only when a
+// database is also set, matching ingestr's [catalog/]database path handling.
+func (c Config) GetIngestrURI() string {
+	port := c.Port
+	if port == 0 {
+		port = defaultPort
+	}
+
+	u := &url.URL{
+		Scheme: "starrocks",
+		Host:   net.JoinHostPort(c.Host, strconv.Itoa(port)),
+	}
+
+	if c.Username != "" {
+		if c.Password != "" {
+			u.User = url.UserPassword(c.Username, c.Password)
+		} else {
+			u.User = url.User(c.Username)
+		}
+	}
+
+	if c.Database != "" {
+		if c.Catalog != "" {
+			u.Path = "/" + c.Catalog + "/" + c.Database
+		} else {
+			u.Path = "/" + c.Database
+		}
+	}
+
+	if c.SSL != "" {
+		query := url.Values{}
+		query.Set("ssl", c.SSL)
+		u.RawQuery = query.Encode()
+	}
+
+	return u.String()
+}

--- a/pkg/starrocks/config_test.go
+++ b/pkg/starrocks/config_test.go
@@ -1,0 +1,53 @@
+package starrocks
+
+import "testing"
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config Config
+		want   string
+	}{
+		{
+			name:   "minimal with default port",
+			config: Config{Username: "root", Host: "localhost"},
+			want:   "starrocks://root@localhost:9030",
+		},
+		{
+			name:   "user and password",
+			config: Config{Username: "root", Password: "secret", Host: "fe", Port: 9030, Database: "analytics"},
+			want:   "starrocks://root:secret@fe:9030/analytics",
+		},
+		{
+			name:   "catalog and database",
+			config: Config{Username: "root", Host: "fe", Port: 9030, Catalog: "iceberg_catalog", Database: "lake"},
+			want:   "starrocks://root@fe:9030/iceberg_catalog/lake",
+		},
+		{
+			name:   "ssl enabled",
+			config: Config{Username: "root", Host: "fe", Port: 9030, Database: "db", SSL: "true"},
+			want:   "starrocks://root@fe:9030/db?ssl=true",
+		},
+		{
+			name:   "ssl skip-verify",
+			config: Config{Username: "root", Host: "fe", Port: 9030, SSL: "skip-verify"},
+			want:   "starrocks://root@fe:9030?ssl=skip-verify",
+		},
+		{
+			name:   "catalog without database is omitted from the path",
+			config: Config{Username: "root", Host: "fe", Port: 9030, Catalog: "iceberg_catalog"},
+			want:   "starrocks://root@fe:9030",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.config.GetIngestrURI(); got != tt.want {
+				t.Errorf("GetIngestrURI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/starrocks/db.go
+++ b/pkg/starrocks/db.go
@@ -1,0 +1,13 @@
+package starrocks
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{config: c}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}


### PR DESCRIPTION
## Summary

Adds **StarRocks** as a Bruin source connection, wiring the ingestr StarRocks source end-to-end. StarRocks federates open lakehouse table formats (Apache Iceberg, Hudi, Hive, Delta Lake) through external catalogs addressed as `catalog.database.table`, so those tables are readable through this connection too.

## Connection fields

`StarRocksConnection` exposes every parameter of the ingestr URI `starrocks://user:pass@host:port/[catalog/]database?ssl=...`:

| Field | Required | Notes |
|-------|----------|-------|
| `host` | ✅ | FE hostname/IP |
| `username` | ✅ | |
| `port` | optional | defaults to `9030` (FE MySQL protocol port) |
| `password` | optional | |
| `database` | optional | default database for unqualified tables |
| `catalog` | optional | external lakehouse catalog; prefixed only alongside a database, matching ingestr's `[catalog/]database` path rule |
| `ssl` | optional | `true` (verify) or `skip-verify` |