### PR TITLE
ci(release): only run CLI release for v* version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      # CLI version tags only (e.g. v0.11.656). Prefixed tags for nested
+      # modules such as semantic-engine/v0.1.0 must NOT trigger a CLI release.
+      - 'v[0-9]*'
 
 permissions:
   contents: write


### PR DESCRIPTION
## What
Restrict the Release workflow trigger from `tags: ['*']` to `tags: ['v[0-9]*']`.

## Why
`release.yml` runs GoReleaser with `VERSION=${{ github.ref_name }}` on **any** tag push. Now that the repo has a nested module (`semantic-engine`, added in #2277), its versions are cut as prefixed tags like `semantic-engine/v0.1.0`. Under the old `'*'` filter, pushing such a tag would trigger a full **CLI** release named `semantic-engine/v0.1.0` — a broken/garbage GoReleaser run.

All existing CLI release tags (`v0.11.x`) match `v[0-9]*`; module tags do not. So this preserves current release behavior exactly while making it safe to tag nested modules.

## Follow-up
Once merged, `semantic-engine/v0.1.0` can be tagged so dac can pin the engine module.