### PR TITLE
feat(semantic): accept legacy dac schema id for backward compatibility

### DIFF
--- a/semantic-engine/engine_test.go
+++ b/semantic-engine/engine_test.go
@@ -195,6 +195,27 @@ func TestLoadFile_DefaultsModelSchemaToV1(t *testing.T) {
 	}
 }
 
+func TestLoadFile_AcceptsLegacyDacSchemaID(t *testing.T) {
+	t.Parallel()
+
+	// dac models written before the engine was shared declared this URL as
+	// their schema id; the engine must keep accepting it so those files do
+	// not need to be migrated.
+	path := filepath.Join(t.TempDir(), "sales.yml")
+	body := "schema: https://getbruin.com/schemas/dac/semantic-model/v1\nname: sales\nsource:\n  table: sales\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	model, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("load model with legacy schema id: %v", err)
+	}
+	if model.Schema != "https://getbruin.com/schemas/dac/semantic-model/v1" {
+		t.Fatalf("expected legacy schema id preserved, got %q", model.Schema)
+	}
+}
+
 func TestLoadDir_EmptyDirIsOk(t *testing.T) {
 	t.Parallel()
 

--- a/semantic-engine/schemas/semantic-model/v1/schema.json
+++ b/semantic-engine/schemas/semantic-model/v1/schema.json
@@ -6,7 +6,11 @@
   "required": ["name", "source"],
   "properties": {
     "schema": {
-      "const": "v1"
+      "comment": "v1 is canonical; the getbruin.com URL is the legacy dac identifier, accepted for backward compatibility.",
+      "enum": [
+        "v1",
+        "https://getbruin.com/schemas/dac/semantic-model/v1"
+      ]
     },
     "name": {
       "type": "string",


### PR DESCRIPTION
## What
The shared semantic-model schema pinned the `schema` field to `const: "v1"`. Models authored before the engine was extracted (in dac) declared `schema: https://getbruin.com/schemas/dac/semantic-model/v1`, so they now fail validation and have to be hand-edited.

This changes the constraint to an `enum` accepting both ids (`v1` stays canonical):

```json
"schema": {
  "enum": ["v1", "https://getbruin.com/schemas/dac/semantic-model/v1"]
}
```

## Why
Both the bruin CLI and dac load semantic models through this schema. Without this, every pre-existing dac semantic file is a breaking change. Accepting the legacy id as an alias means those files load unchanged — no migration required.

## Tests
Added `TestLoadFile_AcceptsLegacyDacSchemaID`; full `semantic-engine` module suite passes.