### PR TITLE
feat(semantic): expose result columns from query compilation

### DIFF
--- a/semantic-engine/engine.go
+++ b/semantic-engine/engine.go
@@ -249,17 +249,52 @@ func (e *Engine) validateRefs(name string, visited map[string]bool) error {
 
 // GenerateSQL produces a SQL query string for the given Query.
 func (e *Engine) GenerateSQL(q *Query) (string, error) {
+	sql, _, err := e.GenerateSQLWithColumns(q)
+	return sql, err
+}
+
+// GenerateSQLWithColumns compiles the query and also returns the result set's
+// columns in SELECT order. Each column carries both the name as it appears in
+// the SQL (Name) and the dimension/metric the query referenced (Field), so
+// callers can map results back to the request without re-deriving the engine's
+// column aliasing (qualified joined dimensions are sanitized, e.g.
+// "customers.country" -> "customers_country").
+func (e *Engine) GenerateSQLWithColumns(q *Query) (string, []QueryColumn, error) {
 	plan, err := e.planQuery(q)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if err := e.validateQuery(q, plan); err != nil {
-		return "", err
+		return "", nil, err
 	}
+
+	var sql string
 	if e.needsWindowWrap(q.Metrics) {
-		return e.generateWrapped(q, plan)
+		sql, err = e.generateWrapped(q, plan)
+	} else {
+		sql, err = e.generateSimple(q, plan)
 	}
-	return e.generateSimple(q, plan)
+	if err != nil {
+		return "", nil, err
+	}
+	return sql, e.outputColumns(q, plan), nil
+}
+
+// outputColumns reports the result columns in the same order the SELECT emits
+// them: dimensions (in query order) followed by metrics (in query order).
+func (e *Engine) outputColumns(q *Query, plan *queryPlan) []QueryColumn {
+	cols := make([]QueryColumn, 0, len(q.Dimensions)+len(q.Metrics))
+	for _, d := range q.Dimensions {
+		name := d.Name
+		if binding := plan.dimensionBinding(d); binding != nil {
+			name = binding.outputAlias
+		}
+		cols = append(cols, QueryColumn{Name: name, Field: d.Name})
+	}
+	for _, name := range q.Metrics {
+		cols = append(cols, QueryColumn{Name: name, Field: name})
+	}
+	return cols
 }
 
 func (e *Engine) validateQuery(q *Query, plan *queryPlan) error {

--- a/semantic-engine/engine_test.go
+++ b/semantic-engine/engine_test.go
@@ -1668,3 +1668,50 @@ func TestRichFixtureSmoke(t *testing.T) {
 		expectContains(t, sql, want)
 	}
 }
+
+func TestGenerateSQLWithColumns_JoinedDimensionAlias(t *testing.T) {
+	t.Parallel()
+
+	customers := &Model{
+		Name:       "customers",
+		Source:     Source{Table: "public.customers"},
+		PrimaryKey: "customer_id",
+		Dimensions: []Dimension{{Name: "country", Type: "string"}},
+	}
+	orders := &Model{
+		Name:       "orders",
+		Source:     Source{Table: "public.orders"},
+		PrimaryKey: "order_id",
+		Joins:      []Join{{Name: "customers", Relationship: "many_to_one", ForeignKey: "customer_id"}},
+		Metrics:    []Metric{{Name: "revenue", Expression: "sum(amount)"}},
+	}
+
+	engine, err := NewEngineWithModels(orders, map[string]*Model{"orders": orders, "customers": customers})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	sql, cols, err := engine.GenerateSQLWithColumns(&Query{
+		Dimensions: []DimensionRef{{Name: "customers.country"}},
+		Metrics:    []string{"revenue"},
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if !strings.Contains(sql, "AS customers_country") {
+		t.Fatalf("expected sanitized alias in SQL, got: %s", sql)
+	}
+
+	want := []QueryColumn{
+		{Name: "customers_country", Field: "customers.country"},
+		{Name: "revenue", Field: "revenue"},
+	}
+	if len(cols) != len(want) {
+		t.Fatalf("expected %d columns, got %d: %+v", len(want), len(cols), cols)
+	}
+	for i, c := range want {
+		if cols[i] != c {
+			t.Fatalf("column %d = %+v, want %+v", i, cols[i], c)
+		}
+	}
+}

--- a/semantic-engine/model.go
+++ b/semantic-engine/model.go
@@ -96,3 +96,15 @@ type SortSpec struct {
 	Name      string `json:"name"`
 	Direction string `json:"direction,omitempty"` // asc, desc
 }
+
+// QueryColumn describes a column in a compiled query's result set.
+//
+// Name is the column name as it appears in the generated SQL (and therefore in
+// the executed result). Qualified dimensions on joined models are sanitized
+// (e.g. "customers.country" becomes "customers_country"), so Name and Field can
+// differ. Field is the name the query referenced — a dimension ref name or a
+// metric name — which callers typically use to map results back to a request.
+type QueryColumn struct {
+	Name  string `json:"name"`
+	Field string `json:"field"`
+}


### PR DESCRIPTION
## What
Adds `GenerateSQLWithColumns(q) (string, []QueryColumn, error)` to the semantic engine. It returns the result set's columns in SELECT order alongside the SQL:

```go
type QueryColumn struct {
    Name  string `json:"name"`  // column name in the generated SQL / result
    Field string `json:"field"` // the dimension ref or metric name the query referenced
}
```

`GenerateSQL` is now a thin wrapper over it, so existing callers are unchanged.

## Why
`GenerateSQL` returned only the SQL string. Qualified dimensions on joined models are sanitized in the SELECT alias — `customers.country` is selected `AS customers_country` — so a consumer that wants to map a result column back to the dimension it requested had to **re-derive the engine's `sanitizeIdentifier` rule**. That's fragile coupling (dac currently does exactly this to keep joined dimensions from rendering blank). Returning the columns lets callers map by what the engine reports instead of guessing.

## Notes
- Purely additive; no behavior change to `GenerateSQL`.
- Known limitation left as-is (not introduced here): a base-model time dimension's granularity is not reflected in its column name, while a joined one's is — selecting the same base dimension at two granularities would collide. Worth a follow-up.

## Tests
`TestGenerateSQLWithColumns_JoinedDimensionAlias` asserts the sanitized alias maps back to `customers.country`; full `semantic-engine` suite passes.