### PR TITLE
feat(starrocks): support StarRocks as an ingestr destination

### DIFF
--- a/docs/ingestion/starrocks.md
+++ b/docs/ingestion/starrocks.md
@@ -2,7 +2,7 @@
 
 [StarRocks](https://www.starrocks.io/) is a high-performance analytical (OLAP) database. Besides its own internal storage, it can query open lakehouse table formats — Apache Iceberg, Hudi, Hive, and Delta Lake — through external catalogs.
 
-Bruin supports StarRocks as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from StarRocks (including lakehouse tables) into your data warehouse.
+Bruin supports StarRocks as both a source and a destination for [Ingestr assets](/assets/ingestr): you can ingest data from StarRocks (including lakehouse tables) into another warehouse, or load data from another source into StarRocks' internal storage.
 
 For more information, please refer [here](https://getbruin.com/docs/ingestr/supported-sources/starrocks.html).
 
@@ -87,3 +87,20 @@ bruin run assets/starrocks_ingestion.yml
 ```
 
 As a result of this command, Bruin will ingest data from the given StarRocks table into your Postgres database.
+
+## Using StarRocks as a destination
+
+StarRocks can also be the destination of an Ingestr asset. Set `destination: starrocks` and point `connection` (or `destination_connection`) at the StarRocks connection; the `name` of the asset is the fully qualified `database.table` written into StarRocks' internal catalog.
+
+```yaml
+name: analytics.events
+type: ingestr
+connection: my_starrocks
+
+parameters:
+  source_connection: my_postgres
+  source_table: 'public.events'
+  destination: starrocks
+```
+
+Bruin creates the destination table if it does not exist and loads rows via StarRocks [Stream Load](https://docs.starrocks.io/docs/loading/StreamLoad/). The `replace`, `append`, and `merge` strategies are supported; `merge` requires a primary key and produces a StarRocks PRIMARY KEY table. Only the internal catalog is writable — external lakehouse catalogs (Iceberg/Hudi/Hive) are read-only, so they can be used as a source but not a destination.

--- a/docs/ingestion/starrocks.md
+++ b/docs/ingestion/starrocks.md
@@ -25,6 +25,8 @@ To connect to StarRocks, you need to add a configuration item to the connections
           database: "analytics"         # optional
           catalog: "iceberg_catalog"    # optional
           ssl: "true"                   # optional
+          http_port: 8030               # optional, destination only
+          replication_num: 1            # optional, destination only
 ```
 
 - `host`: the StarRocks FE (frontend) hostname or IP address. Required.
@@ -34,6 +36,8 @@ To connect to StarRocks, you need to add a configuration item to the connections
 - `database`: the default database for unqualified table names. Optional.
 - `catalog`: the default catalog. Optional, defaults to the internal catalog (`default_catalog`). Set this to an external catalog name (e.g. an Iceberg/Hudi/Hive catalog configured in StarRocks) to read lakehouse tables.
 - `ssl`: enable a TLS-encrypted connection. Optional — use `true` to verify the server certificate, or `skip-verify` for TLS without verification.
+- `http_port`: the FE HTTP port used for Stream Load when StarRocks is the destination. Optional, defaults to `8030`.
+- `replication_num`: the replica count for tables created when StarRocks is the destination. Optional, defaults to the cluster default (set `1` for a single-backend cluster).
 
 ### Step 2: Create an asset file for data ingestion
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -4141,6 +4141,12 @@
         },
         "ssl": {
           "type": "string"
+        },
+        "http_port": {
+          "type": "integer"
+        },
+        "replication_num": {
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1614,14 +1614,16 @@ func (c TrinoConnection) GetName() string {
 }
 
 type StarRocksConnection struct {
-	Name     string `yaml:"name" json:"name" mapstructure:"name"`
-	Host     string `yaml:"host" json:"host" mapstructure:"host"`
-	Username string `yaml:"username" json:"username" mapstructure:"username"`
-	Password string `yaml:"password,omitempty" json:"password,omitempty" mapstructure:"password"`
-	Port     int    `yaml:"port,omitempty" json:"port,omitempty" mapstructure:"port"`
-	Database string `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
-	Catalog  string `yaml:"catalog,omitempty" json:"catalog,omitempty" mapstructure:"catalog"`
-	SSL      string `yaml:"ssl,omitempty" json:"ssl,omitempty" mapstructure:"ssl"`
+	Name           string `yaml:"name" json:"name" mapstructure:"name"`
+	Host           string `yaml:"host" json:"host" mapstructure:"host"`
+	Username       string `yaml:"username" json:"username" mapstructure:"username"`
+	Password       string `yaml:"password,omitempty" json:"password,omitempty" mapstructure:"password"`
+	Port           int    `yaml:"port,omitempty" json:"port,omitempty" mapstructure:"port"`
+	Database       string `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
+	Catalog        string `yaml:"catalog,omitempty" json:"catalog,omitempty" mapstructure:"catalog"`
+	SSL            string `yaml:"ssl,omitempty" json:"ssl,omitempty" mapstructure:"ssl"`
+	HTTPPort       int    `yaml:"http_port,omitempty" json:"http_port,omitempty" mapstructure:"http_port"`
+	ReplicationNum int    `yaml:"replication_num,omitempty" json:"replication_num,omitempty" mapstructure:"replication_num"`
 }
 
 func (c StarRocksConnection) GetName() string {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -3601,13 +3601,15 @@ func (m *Manager) AddStarRocksConnectionFromConfig(connection *config.StarRocksC
 	m.mutex.Unlock()
 
 	client, err := starrocks.NewClient(starrocks.Config{
-		Username: connection.Username,
-		Password: connection.Password,
-		Host:     connection.Host,
-		Port:     connection.Port,
-		Database: connection.Database,
-		Catalog:  connection.Catalog,
-		SSL:      connection.SSL,
+		Username:       connection.Username,
+		Password:       connection.Password,
+		Host:           connection.Host,
+		Port:           connection.Port,
+		Database:       connection.Database,
+		Catalog:        connection.Catalog,
+		SSL:            connection.SSL,
+		HTTPPort:       connection.HTTPPort,
+		ReplicationNum: connection.ReplicationNum,
 	})
 	if err != nil {
 		return err

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -117,6 +117,7 @@ const (
 	AssetTypeSnowflakeSeed             = AssetType("sf.seed")
 	AssetTypeSnowflakeSource           = AssetType("sf.source")
 	AssetTypeSnowflakeTableSensor      = AssetType("sf.sensor.table")
+	AssetTypeStarRocks                 = AssetType("starrocks")
 	AssetTypeSuperset                  = AssetType("superset")
 	AssetTypeSynapseQuery              = AssetType("synapse.sql")
 	AssetTypeSynapseQuerySensor        = AssetType("synapse.sensor.query")
@@ -855,6 +856,7 @@ var AssetTypeConnectionMapping = map[AssetType]string{
 	AssetTypeSnowflakeTableSensor:      "snowflake",
 	AssetTypeSnowflakeSeed:             "snowflake",
 	AssetTypeSnowflakeSource:           "snowflake",
+	AssetTypeStarRocks:                 "starrocks",
 	AssetTypePostgresQuery:             "postgres",
 	AssetTypePostgresSeed:              "postgres",
 	AssetTypePostgresQuerySensor:       "postgres",
@@ -963,6 +965,7 @@ var IngestrTypeConnectionMapping = map[string]AssetType{
 	"synapse":       AssetTypeSynapseQuery,
 	"duckdb":        AssetTypeDuckDBQuery,
 	"clickhouse":    AssetTypeClickHouse,
+	"starrocks":     AssetTypeStarRocks,
 	"oracle":        AssetTypeOracleQuery,
 	"motherduck":    AssetTypeMotherduckQuery,
 	"dynamodb":      AssetTypeDynamoDB,

--- a/pkg/starrocks/config.go
+++ b/pkg/starrocks/config.go
@@ -9,13 +9,15 @@ import (
 const defaultPort = 9030
 
 type Config struct {
-	Username string // Required
-	Password string // Optional
-	Host     string // Required
-	Port     int    // Optional - defaults to 9030 (FE MySQL protocol port)
-	Database string // Optional - default database for unqualified table names
-	Catalog  string // Optional - external lakehouse catalog (Iceberg/Hudi/Hive/...)
-	SSL      string // Optional - "true" or "skip-verify" to enable TLS
+	Username       string // Required
+	Password       string // Optional
+	Host           string // Required
+	Port           int    // Optional - defaults to 9030 (FE MySQL protocol port)
+	Database       string // Optional - default database for unqualified table names
+	Catalog        string // Optional - external lakehouse catalog (Iceberg/Hudi/Hive/...)
+	SSL            string // Optional - "true" or "skip-verify" to enable TLS
+	HTTPPort       int    // Optional - FE HTTP port for Stream Load when used as a destination
+	ReplicationNum int    // Optional - replica count for tables created as a destination
 }
 
 // GetIngestrURI builds starrocks://user:pass@host:port/[catalog/]database?ssl=...
@@ -48,11 +50,18 @@ func (c Config) GetIngestrURI() string {
 		}
 	}
 
+	query := url.Values{}
 	if c.SSL != "" {
-		query := url.Values{}
 		query.Set("ssl", c.SSL)
-		u.RawQuery = query.Encode()
 	}
+	// Destination-only params; the source ignores them.
+	if c.HTTPPort != 0 {
+		query.Set("http_port", strconv.Itoa(c.HTTPPort))
+	}
+	if c.ReplicationNum != 0 {
+		query.Set("replication_num", strconv.Itoa(c.ReplicationNum))
+	}
+	u.RawQuery = query.Encode()
 
 	return u.String()
 }

--- a/pkg/starrocks/config_test.go
+++ b/pkg/starrocks/config_test.go
@@ -40,6 +40,16 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 			config: Config{Username: "root", Host: "fe", Port: 9030, Catalog: "iceberg_catalog"},
 			want:   "starrocks://root@fe:9030",
 		},
+		{
+			name:   "destination params http_port and replication_num",
+			config: Config{Username: "root", Host: "fe", Port: 9030, Database: "db", HTTPPort: 8030, ReplicationNum: 1},
+			want:   "starrocks://root@fe:9030/db?http_port=8030&replication_num=1",
+		},
+		{
+			name:   "destination params combine with ssl",
+			config: Config{Username: "root", Host: "fe", Port: 9030, SSL: "true", HTTPPort: 8040},
+			want:   "starrocks://root@fe:9030?http_port=8040&ssl=true",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

StarRocks was already supported as an ingestr **source** (#2272). This registers it as an ingestr **destination** as well, so a single StarRocks connection can be used on either side of an Ingestr asset.