### PR TITLE
ingestr: add dedicated vitess and planetscale connection types

### DIFF
--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -34,6 +34,21 @@ environments:
           password: "pass"
           database: "db"
           port: 3306
+      vitess:
+        - name: "vitess_conn"
+          host: "vtgate.internal"
+          username: "user"
+          password: "pass"
+          database: "commerce"
+          port: 15306
+          grpc_port: 15991
+      planetscale:
+        - name: "planetscale_conn"
+          host: "aws.connect.psdb.cloud"
+          username: "user"
+          password: "pass"
+          database: "psdb"
+          port: 3306
     schema_prefix: "dev_"
   prod:
     connections:

--- a/docs/ingestion/planetscale.md
+++ b/docs/ingestion/planetscale.md
@@ -1,6 +1,6 @@
 # PlanetScale
 
-[PlanetScale](https://planetscale.com/) is a managed, MySQL-compatible database platform built on [Vitess](https://vitess.io/). Because it speaks the MySQL wire protocol, Bruin connects to PlanetScale through a regular [`mysql` connection](/platforms/mysql), and it can be used as both a **source** and a **destination** for [Ingestr assets](/assets/ingestr). PlanetScale [change data capture](#change-data-capture-cdc) is also supported.
+[PlanetScale](https://planetscale.com/) is a managed, MySQL-compatible database platform built on [Vitess](https://vitess.io/). Bruin connects to it through a dedicated `planetscale` connection, and it can be used as both a **source** and a **destination** for [Ingestr assets](/assets/ingestr). PlanetScale [change data capture](#change-data-capture-cdc) is also supported.
 
 Follow the steps below to set up PlanetScale and run ingestion.
 
@@ -8,10 +8,10 @@ Follow the steps below to set up PlanetScale and run ingestion.
 
 ### Step 1: Add a connection to .bruin.yml file
 
-PlanetScale uses the MySQL connector, so add a `mysql` connection to the `connections` section of your `.bruin.yml` file. Use the connection details from your PlanetScale branch's password:
+Add a `planetscale` connection to the `connections` section of your `.bruin.yml` file. Use the connection details from your PlanetScale branch's password:
 
 ```yaml
-  mysql:
+  planetscale:
     - name: "planetscale"
       username: "xxxxxxxxxxxxx"
       password: "pscale_pw_xxxxxxxxxxxx"
@@ -28,7 +28,7 @@ PlanetScale uses the MySQL connector, so add a `mysql` connection to the `connec
 - `database`: The PlanetScale database (keyspace) name
 
 > [!NOTE]
-> PlanetScale requires encrypted connections. TLS is enabled automatically for `*.psdb.cloud` hosts, so you do not need any extra configuration. For a custom domain or private endpoint that does not end in `.psdb.cloud`, set `?tls=true` on the connection or ingest through CDC's `cdc_backend`.
+> PlanetScale requires encrypted connections. TLS is enabled automatically for the `planetscale` connection, so you do not need any extra configuration.
 
 ### Step 2: Create an asset file for data ingestion
 
@@ -48,7 +48,7 @@ parameters:
 - `name`: The name of the asset.
 - `type`: Set this to `ingestr` to use the ingestr data pipeline.
 - `connection`: The destination connection where the data should be stored.
-- `source_connection`: The name of the PlanetScale (`mysql`) connection defined in `.bruin.yml`.
+- `source_connection`: The name of the PlanetScale connection defined in `.bruin.yml`.
 - `source_table`: The name of the table in PlanetScale that you want to ingest.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
@@ -61,7 +61,7 @@ As a result of this command, Bruin will ingest data from the given PlanetScale t
 
 ## PlanetScale as a destination
 
-Because PlanetScale speaks MySQL, you can also use it as a destination by pointing an ingestr asset's `connection` and `destination` at a PlanetScale `mysql` connection:
+You can also use PlanetScale as a destination by pointing an ingestr asset's `connection` and `destination` at a PlanetScale connection:
 
 ```yaml
 name: orders
@@ -81,14 +81,13 @@ When loading into PlanetScale, keep two things in mind:
 
 ## Change data capture (CDC)
 
-PlanetScale CDC streams inserts, updates, and deletes through PlanetScale's hosted `psdbconnect` API over TLS. It reuses the database credentials already in the connection — no separate token is required — and is selected automatically for `*.psdb.cloud` hosts.
+PlanetScale CDC streams inserts, updates, and deletes through PlanetScale's hosted `psdbconnect` API over TLS. It reuses the database credentials already in the connection — no separate token is required — and TLS is handled automatically.
 
-CDC is enabled by setting `cdc: "true"` on an ingestr asset with a PlanetScale (`mysql`) source connection.
+CDC is enabled by setting `cdc: "true"` on an ingestr asset with a PlanetScale source connection.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `cdc` | Yes | Set to `"true"` to enable CDC mode |
-| `cdc_backend` | No | Force the backend: `planetscale` selects psdbconnect (useful for custom domains / private endpoints), `vstream` selects the self-hosted Vitess VStream path |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
 | `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
 
@@ -113,23 +112,6 @@ parameters:
   source_table: 'orders'
   destination: bigquery
   cdc: "true"
-```
-
-### Example: CDC on a custom domain
-
-For a custom domain or private endpoint that does not end in `.psdb.cloud`, force the psdbconnect backend explicitly:
-
-```yaml
-name: orders
-type: ingestr
-connection: bigquery
-
-parameters:
-  source_connection: planetscale
-  source_table: 'orders'
-  destination: bigquery
-  cdc: "true"
-  cdc_backend: planetscale
 ```
 
 > [!NOTE]

--- a/docs/ingestion/vitess.md
+++ b/docs/ingestion/vitess.md
@@ -1,6 +1,6 @@
 # Vitess
 
-[Vitess](https://vitess.io/) is a MySQL-compatible database clustering and sharding system originally built at YouTube. Because it speaks the MySQL wire protocol through vtgate, Bruin connects to Vitess through a regular [`mysql` connection](/platforms/mysql), and it can be used as both a **source** and a **destination** for [Ingestr assets](/assets/ingestr). Vitess [change data capture](#change-data-capture-cdc) is also supported through VStream.
+[Vitess](https://vitess.io/) is a MySQL-compatible database clustering and sharding system originally built at YouTube. It speaks the MySQL wire protocol through vtgate, and Bruin connects to it through a dedicated `vitess` connection. Vitess can be used as both a **source** and a **destination** for [Ingestr assets](/assets/ingestr), and Vitess [change data capture](#change-data-capture-cdc) is also supported through VStream.
 
 > [!TIP]
 > If you use the managed [PlanetScale](/ingestion/planetscale) platform, follow the PlanetScale guide instead — it uses the hosted `psdbconnect` API rather than a directly reachable vtgate gRPC port.
@@ -11,16 +11,18 @@ Follow the steps below to set up Vitess and run ingestion.
 
 ### Step 1: Add a connection to .bruin.yml file
 
-Vitess uses the MySQL connector, so add a `mysql` connection to the `connections` section of your `.bruin.yml` file, pointing at your vtgate endpoint:
+Add a `vitess` connection to the `connections` section of your `.bruin.yml` file, pointing at your vtgate endpoint:
 
 ```yaml
-  mysql:
+  vitess:
     - name: "vitess"
       username: "user"
       password: "password"
       host: "vtgate.internal"
       port: 15306
       database: "commerce"
+      # Optional, required only for change data capture:
+      grpc_port: 15991
 ```
 
 - `name`: The name to identify this connection
@@ -29,6 +31,12 @@ Vitess uses the MySQL connector, so add a `mysql` connection to the `connections
 - `host`: The vtgate host
 - `port`: The vtgate MySQL protocol port (e.g. `15306`)
 - `database`: The Vitess keyspace to connect to
+- `grpc_port`: (Optional) vtgate's gRPC port, used by [CDC](#change-data-capture-cdc) (e.g. `15991`)
+- `grpc_host`: (Optional) Host override for the gRPC connection when it differs from the MySQL host
+- `grpc_tls`: (Optional) Set to `true` to use TLS for the gRPC connection
+- `ssl_ca_path`: (Optional) The path to the CA certificate file
+- `ssl_cert_path`: (Optional) The path to the client certificate file
+- `ssl_key_path`: (Optional) The path to the client key file
 
 ### Step 2: Create an asset file for data ingestion
 
@@ -48,7 +56,7 @@ parameters:
 - `name`: The name of the asset.
 - `type`: Set this to `ingestr` to use the ingestr data pipeline.
 - `connection`: The destination connection where the data should be stored.
-- `source_connection`: The name of the Vitess (`mysql`) connection defined in `.bruin.yml`.
+- `source_connection`: The name of the Vitess connection defined in `.bruin.yml`.
 - `source_table`: The name of the table in the keyspace that you want to ingest.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
@@ -61,7 +69,7 @@ As a result of this command, Bruin will ingest data from the given Vitess table 
 
 ## Vitess as a destination
 
-You can also use Vitess as a destination by pointing an ingestr asset's `connection` and `destination` at a Vitess `mysql` connection:
+You can also use Vitess as a destination by pointing an ingestr asset's `connection` and `destination` at a Vitess connection:
 
 ```yaml
 name: orders
@@ -81,15 +89,14 @@ When loading into Vitess, keep two things in mind:
 
 ## Change data capture (CDC)
 
-Vitess CDC streams inserts, updates, and deletes through vtgate's VStream gRPC API. It is enabled by setting `cdc: "true"` on an ingestr asset with a Vitess (`mysql`) source connection, and requires the vtgate gRPC port.
+Vitess CDC streams inserts, updates, and deletes through vtgate's VStream gRPC API. It is enabled by setting `cdc: "true"` on an ingestr asset with a Vitess source connection, and requires the vtgate gRPC port — configure it once as `grpc_port` on the connection (see [Step 1](#step-1-add-a-connection-to-bruin-yml-file)).
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `cdc` | Yes | Set to `"true"` to enable CDC mode |
-| `cdc_grpc_port` | Yes (for VStream) | vtgate's gRPC port (e.g. `15991`) |
-| `cdc_grpc_host` | No | Host override for the gRPC connection when it differs from the MySQL host |
-| `cdc_grpc_tls` | No | Set to `"true"` to use TLS for the gRPC connection |
-| `cdc_backend` | No | Force the backend: `vstream` selects the self-hosted Vitess VStream path, `planetscale` selects PlanetScale's psdbconnect API |
+| `cdc_grpc_port` | No | Overrides the connection's `grpc_port` for this asset |
+| `cdc_grpc_host` | No | Overrides the connection's `grpc_host` for this asset |
+| `cdc_grpc_tls` | No | Overrides the connection's `grpc_tls` for this asset |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
 | `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
 
@@ -114,7 +121,6 @@ parameters:
   source_table: 'orders'
   destination: bigquery
   cdc: "true"
-  cdc_grpc_port: "15991"
 ```
 
-For the managed PlanetScale platform, see [PlanetScale](/ingestion/planetscale).
+The example above relies on `grpc_port` being set on the `vitess` connection. For the managed PlanetScale platform, see [PlanetScale](/ingestion/planetscale).

--- a/docs/platforms/mysql.md
+++ b/docs/platforms/mysql.md
@@ -153,19 +153,15 @@ parameters:
 
 ## CDC (Change Data Capture)
 
-Bruin supports MySQL-family CDC via the `ingestr` asset type. CDC captures row-level changes (inserts, updates, deletes) and replicates them to a destination. The same mechanism powers MySQL binary-log replication as well as [Vitess](/ingestion/vitess) (VStream) and [PlanetScale](/ingestion/planetscale) (psdbconnect).
+Bruin supports MySQL CDC via the `ingestr` asset type. CDC captures row-level changes (inserts, updates, deletes) via MySQL binary-log replication and replicates them to a destination. [Vitess](/ingestion/vitess) (VStream) and [PlanetScale](/ingestion/planetscale) (psdbconnect) are MySQL-compatible but use their own dedicated connection types — see their ingestion guides for CDC.
 
-CDC is enabled by setting `cdc: "true"` on an ingestr asset with a MySQL (or Vitess/PlanetScale) source connection.
+CDC is enabled by setting `cdc: "true"` on an ingestr asset with a MySQL source connection.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `cdc` | Yes | Set to `"true"` to enable CDC mode |
 | `cdc_mode` | No | `"stream"` for real-time streaming or `"batch"` for batch replication |
 | `cdc_server_id` | No | Replication server identifier for MySQL binary-log CDC |
-| `cdc_grpc_port` | No | vtgate's gRPC port for Vitess VStream CDC (e.g. `15991`) |
-| `cdc_grpc_host` | No | Host override for the Vitess VStream gRPC connection |
-| `cdc_grpc_tls` | No | Set to `"true"` to use TLS for the Vitess VStream gRPC connection |
-| `cdc_backend` | No | Force the CDC backend: `vstream` (self-hosted Vitess) or `planetscale` (psdbconnect) |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
 | `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -759,6 +759,18 @@
           },
           "type": "array"
         },
+        "vitess": {
+          "items": {
+            "$ref": "#/$defs/VitessConnection"
+          },
+          "type": "array"
+        },
+        "planetscale": {
+          "items": {
+            "$ref": "#/$defs/PlanetScaleConnection"
+          },
+          "type": "array"
+        },
         "notion": {
           "items": {
             "$ref": "#/$defs/NotionConnection"
@@ -3234,6 +3246,39 @@
         "api_token"
       ]
     },
+    "PlanetScaleConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "default": 3306
+        },
+        "database": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "username",
+        "password",
+        "host",
+        "port",
+        "database"
+      ]
+    },
     "PlusVibeAIConnection": {
       "properties": {
         "name": {
@@ -4449,6 +4494,57 @@
           "type": "string"
         },
         "schema": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "username",
+        "password",
+        "host",
+        "port",
+        "database"
+      ]
+    },
+    "VitessConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "default": 15306
+        },
+        "database": {
+          "type": "string"
+        },
+        "grpc_port": {
+          "type": "integer"
+        },
+        "grpc_host": {
+          "type": "string"
+        },
+        "grpc_tls": {
+          "type": "boolean"
+        },
+        "ssl_ca_path": {
+          "type": "string"
+        },
+        "ssl_cert_path": {
+          "type": "string"
+        },
+        "ssl_key_path": {
           "type": "string"
         }
       },

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -384,6 +384,45 @@ func (c MySQLConnection) GetName() string {
 	return c.Name
 }
 
+// VitessConnection describes a connection to a Vitess cluster via vtgate. Vitess speaks the MySQL
+// wire protocol, but ingestr now routes it through its own "vitess" scheme, so it is a dedicated
+// connection type rather than a MySQL connection. The grpc_* fields point at vtgate's VStream gRPC
+// endpoint and are only needed for change data capture.
+type VitessConnection struct {
+	Name        string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	Username    string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
+	Password    string `yaml:"password,omitempty" json:"password" mapstructure:"password"`
+	Host        string `yaml:"host,omitempty"     json:"host" mapstructure:"host"`
+	Port        int    `yaml:"port,omitempty"     json:"port" mapstructure:"port" jsonschema:"default=15306"`
+	Database    string `yaml:"database,omitempty" json:"database" mapstructure:"database"`
+	GrpcPort    int    `yaml:"grpc_port,omitempty" json:"grpc_port,omitempty" mapstructure:"grpc_port"`
+	GrpcHost    string `yaml:"grpc_host,omitempty" json:"grpc_host,omitempty" mapstructure:"grpc_host"`
+	GrpcTLS     bool   `yaml:"grpc_tls,omitempty" json:"grpc_tls,omitempty" mapstructure:"grpc_tls"`
+	SslCaPath   string `yaml:"ssl_ca_path,omitempty" json:"ssl_ca_path,omitempty" mapstructure:"ssl_ca_path"`
+	SslCertPath string `yaml:"ssl_cert_path,omitempty" json:"ssl_cert_path,omitempty" mapstructure:"ssl_cert_path"`
+	SslKeyPath  string `yaml:"ssl_key_path,omitempty" json:"ssl_key_path,omitempty" mapstructure:"ssl_key_path"`
+}
+
+func (c VitessConnection) GetName() string {
+	return c.Name
+}
+
+// PlanetScaleConnection describes a connection to PlanetScale, the managed Vitess platform. ingestr
+// routes it through its own "planetscale" scheme (hosted psdbconnect API) and enables TLS
+// automatically, so no SSL configuration is required.
+type PlanetScaleConnection struct {
+	Name     string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
+	Username string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
+	Password string `yaml:"password,omitempty" json:"password" mapstructure:"password"`
+	Host     string `yaml:"host,omitempty"     json:"host" mapstructure:"host"`
+	Port     int    `yaml:"port,omitempty"     json:"port" mapstructure:"port" jsonschema:"default=3306"`
+	Database string `yaml:"database,omitempty" json:"database" mapstructure:"database"`
+}
+
+func (c PlanetScaleConnection) GetName() string {
+	return c.Name
+}
+
 type PostgresConnection struct {
 	Name         string `yaml:"name,omitempty" json:"name" mapstructure:"name"`
 	Username     string `yaml:"username,omitempty" json:"username" mapstructure:"username"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -43,6 +43,8 @@ type Connections struct {
 	Cursor              []CursorConnection              `yaml:"cursor,omitempty" json:"cursor,omitempty" mapstructure:"cursor"`
 	MongoAtlas          []MongoAtlasConnection          `yaml:"mongo_atlas,omitempty" json:"mongo_atlas,omitempty" mapstructure:"mongo_atlas"`
 	MySQL               []MySQLConnection               `yaml:"mysql,omitempty" json:"mysql,omitempty" mapstructure:"mysql"`
+	Vitess              []VitessConnection              `yaml:"vitess,omitempty" json:"vitess,omitempty" mapstructure:"vitess"`
+	Planetscale         []PlanetScaleConnection         `yaml:"planetscale,omitempty" json:"planetscale,omitempty" mapstructure:"planetscale"`
 	Notion              []NotionConnection              `yaml:"notion,omitempty" json:"notion,omitempty" mapstructure:"notion"`
 	Allium              []AlliumConnection              `yaml:"allium,omitempty" json:"allium,omitempty" mapstructure:"allium"`
 	HANA                []HANAConnection                `yaml:"hana,omitempty" json:"hana,omitempty" mapstructure:"hana"`
@@ -405,6 +407,21 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 			}
 		}
 
+		// Make Vitess SSL file paths absolute
+		for i, conn := range env.Connections.Vitess {
+			if conn.SslCaPath != "" && !filepath.IsAbs(conn.SslCaPath) {
+				env.Connections.Vitess[i].SslCaPath = filepath.Join(configLocation, conn.SslCaPath)
+			}
+
+			if conn.SslCertPath != "" && !filepath.IsAbs(conn.SslCertPath) {
+				env.Connections.Vitess[i].SslCertPath = filepath.Join(configLocation, conn.SslCertPath)
+			}
+
+			if conn.SslKeyPath != "" && !filepath.IsAbs(conn.SslKeyPath) {
+				env.Connections.Vitess[i].SslKeyPath = filepath.Join(configLocation, conn.SslKeyPath)
+			}
+		}
+
 		// Make Snowflake private key path absolute
 		for i, conn := range env.Connections.Snowflake {
 			if conn.PrivateKeyPath == "" {
@@ -659,6 +676,20 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.MySQL = append(env.Connections.MySQL, conn)
+	case "vitess":
+		var conn VitessConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Vitess = append(env.Connections.Vitess, conn)
+	case "planetscale":
+		var conn PlanetScaleConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Planetscale = append(env.Connections.Planetscale, conn)
 	case "notion":
 		var conn NotionConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1499,6 +1530,10 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Monday = removeConnection(env.Connections.Monday, connectionName)
 	case "mysql":
 		env.Connections.MySQL = removeConnection(env.Connections.MySQL, connectionName)
+	case "vitess":
+		env.Connections.Vitess = removeConnection(env.Connections.Vitess, connectionName)
+	case "planetscale":
+		env.Connections.Planetscale = removeConnection(env.Connections.Planetscale, connectionName)
 	case "notion":
 		env.Connections.Notion = removeConnection(env.Connections.Notion, connectionName)
 	case "hana":
@@ -1802,6 +1837,8 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Cursor, source.Cursor)
 	mergeConnectionList(&c.MongoAtlas, source.MongoAtlas)
 	mergeConnectionList(&c.MySQL, source.MySQL)
+	mergeConnectionList(&c.Vitess, source.Vitess)
+	mergeConnectionList(&c.Planetscale, source.Planetscale)
 	mergeConnectionList(&c.Notion, source.Notion)
 	mergeConnectionList(&c.Allium, source.Allium)
 	mergeConnectionList(&c.HANA, source.HANA)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -143,6 +143,27 @@ func TestLoadFromFile(t *testing.T) {
 					Port:     3306,
 				},
 			},
+			Vitess: []VitessConnection{
+				{
+					Name:     "conn8b",
+					Host:     "vtgatehost",
+					Username: "vitessuser",
+					Password: "vitesspass",
+					Database: "commerce",
+					Port:     15306,
+					GrpcPort: 15991,
+				},
+			},
+			Planetscale: []PlanetScaleConnection{
+				{
+					Name:     "conn8c",
+					Host:     "aws.connect.psdb.cloud",
+					Username: "psuser",
+					Password: "pspass",
+					Database: "psdb",
+					Port:     3306,
+				},
+			},
 			Notion: []NotionConnection{
 				{
 					Name:   "conn9",

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -91,6 +91,23 @@ environments:
           port: 3306
           database: "mysqldb"
 
+      vitess:
+        - name: conn8b
+          username: "vitessuser"
+          password: "vitesspass"
+          host: "vtgatehost"
+          port: 15306
+          database: "commerce"
+          grpc_port: 15991
+
+      planetscale:
+        - name: conn8c
+          username: "psuser"
+          password: "pspass"
+          host: "aws.connect.psdb.cloud"
+          port: 3306
+          database: "psdb"
+
       notion:
         - name: conn9
           api_key: "XXXXYYYYZZZZ"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -91,6 +91,23 @@ environments:
           port: 3306
           database: "mysqldb"
 
+      vitess:
+        - name: conn8b
+          username: "vitessuser"
+          password: "vitesspass"
+          host: "vtgatehost"
+          port: 15306
+          database: "commerce"
+          grpc_port: 15991
+
+      planetscale:
+        - name: conn8c
+          username: "psuser"
+          password: "pspass"
+          host: "aws.connect.psdb.cloud"
+          port: 3306
+          database: "psdb"
+
       notion:
         - name: conn9
           api_key: "XXXXYYYYZZZZ"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -100,6 +100,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/phantombuster"
 	"github.com/bruin-data/bruin/pkg/pinterest"
 	"github.com/bruin-data/bruin/pkg/pipedrive"
+	"github.com/bruin-data/bruin/pkg/planetscale"
 	"github.com/bruin-data/bruin/pkg/plusvibeai"
 	"github.com/bruin-data/bruin/pkg/polymarket"
 	"github.com/bruin-data/bruin/pkg/postgres"
@@ -136,6 +137,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/trustpilot"
 	"github.com/bruin-data/bruin/pkg/twilio"
 	"github.com/bruin-data/bruin/pkg/vertica"
+	"github.com/bruin-data/bruin/pkg/vitess"
 	"github.com/bruin-data/bruin/pkg/wise"
 	"github.com/bruin-data/bruin/pkg/wistia"
 	"github.com/bruin-data/bruin/pkg/zendesk"
@@ -163,6 +165,8 @@ type Manager struct {
 	Cursor               map[string]*cursor.Client
 	MongoAtlas           map[string]*mongoatlas.DB
 	Mysql                map[string]*mysql.Client
+	Vitess               map[string]*mysql.Client
+	Planetscale          map[string]*mysql.Client
 	Notion               map[string]*notion.Client
 	Allium               map[string]*allium.Client
 	HANA                 map[string]*hana.Client
@@ -1220,6 +1224,72 @@ func (m *Manager) AddMySQLConnectionFromConfig(connection *config.MySQLConnectio
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.Mysql[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
+// AddVitessConnectionFromConfig registers a Vitess connection. Vitess speaks the MySQL wire
+// protocol, so it reuses the shared mysql.Client for direct connectivity (e.g. `connections test`)
+// while emitting ingestr's dedicated "vitess" scheme via vitess.Config.GetIngestrURI.
+func (m *Manager) AddVitessConnectionFromConfig(connection *config.VitessConnection) error {
+	m.mutex.Lock()
+	if m.Vitess == nil {
+		m.Vitess = make(map[string]*mysql.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := mysql.NewClient(&vitess.Config{
+		Username:    connection.Username,
+		Password:    connection.Password,
+		Host:        connection.Host,
+		Port:        connection.Port,
+		Database:    connection.Database,
+		GrpcPort:    connection.GrpcPort,
+		GrpcHost:    connection.GrpcHost,
+		GrpcTLS:     connection.GrpcTLS,
+		SslCaPath:   connection.SslCaPath,
+		SslCertPath: connection.SslCertPath,
+		SslKeyPath:  connection.SslKeyPath,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Vitess[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
+// AddPlanetScaleConnectionFromConfig registers a PlanetScale connection. It reuses the shared
+// mysql.Client for direct connectivity (TLS is always on) while emitting ingestr's dedicated
+// "planetscale" scheme via planetscale.Config.GetIngestrURI.
+func (m *Manager) AddPlanetScaleConnectionFromConfig(connection *config.PlanetScaleConnection) error {
+	m.mutex.Lock()
+	if m.Planetscale == nil {
+		m.Planetscale = make(map[string]*mysql.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := mysql.NewClient(&planetscale.Config{
+		Username: connection.Username,
+		Password: connection.Password,
+		Host:     connection.Host,
+		Port:     connection.Port,
+		Database: connection.Database,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Planetscale[connection.Name] = client
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection
 
@@ -3797,6 +3867,8 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Cursor, connectionManager.AddCursorConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.MongoAtlas, connectionManager.AddMongoAtlasConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.MySQL, connectionManager.AddMySQLConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Vitess, connectionManager.AddVitessConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Planetscale, connectionManager.AddPlanetScaleConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Notion, connectionManager.AddNotionConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Allium, connectionManager.AddAlliumConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.HANA, connectionManager.AddHANAConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -256,6 +256,67 @@ func TestManager_AddMySqlConnectionFromConfigConnectionFromConfig(t *testing.T) 
 	assert.NotNil(t, res)
 }
 
+func TestManager_AddVitessConnectionFromConfig(t *testing.T) {
+	t.Parallel()
+
+	m := Manager{
+		AllConnectionDetails: map[string]any{},
+		availableConnections: make(map[string]any),
+	}
+
+	configuration := &config.VitessConnection{
+		Name:     "test",
+		Host:     "vtgate.internal",
+		Username: "user",
+		Password: "pass",
+		Database: "commerce",
+		Port:     15306,
+		GrpcPort: 15991,
+	}
+
+	err := m.AddVitessConnectionFromConfig(configuration)
+	require.NoError(t, err)
+
+	res, ok := m.GetConnection("test").(*mysql.Client)
+	require.True(t, ok)
+	require.NotNil(t, res)
+
+	uri, err := res.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "vitess://user:pass@vtgate.internal:15306/commerce?grpc_port=15991", uri)
+	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
+}
+
+func TestManager_AddPlanetScaleConnectionFromConfig(t *testing.T) {
+	t.Parallel()
+
+	m := Manager{
+		AllConnectionDetails: map[string]any{},
+		availableConnections: make(map[string]any),
+	}
+
+	configuration := &config.PlanetScaleConnection{
+		Name:     "test",
+		Host:     "aws.connect.psdb.cloud",
+		Username: "user",
+		Password: "pass",
+		Database: "psdb",
+		Port:     3306,
+	}
+
+	err := m.AddPlanetScaleConnectionFromConfig(configuration)
+	require.NoError(t, err)
+
+	res, ok := m.GetConnection("test").(*mysql.Client)
+	require.True(t, ok)
+	require.NotNil(t, res)
+
+	uri, err := res.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "planetscale://user:pass@aws.connect.psdb.cloud:3306/psdb", uri)
+	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
+}
+
 func TestManager_AddNotionConnectionFromConfigConnectionFromConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -236,8 +236,8 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 	}
 
 	// Handle CDC mode - transform the source URI into ingestr's CDC scheme and auto-set merge strategy.
-	// Supported today: PostgreSQL (postgres+cdc) and the MySQL family (mysql+cdc / mariadb+cdc),
-	// which also covers Vitess (VStream) and PlanetScale (psdbconnect).
+	// Supported today: PostgreSQL (postgres+cdc), the MySQL family (mysql+cdc / mariadb+cdc),
+	// Vitess (vitess+cdc, VStream) and PlanetScale (planetscale+cdc, psdbconnect).
 	if cdcVal, _ := asset.Parameters.GetString("cdc"); cdcVal == "true" {
 		parsedURI, err := url.Parse(sourceURI)
 		if err != nil {
@@ -247,8 +247,9 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		switch {
 		case strings.Contains(parsedURI.Scheme, "postgresql"):
 			parsedURI.Scheme = strings.ReplaceAll(parsedURI.Scheme, "postgresql", "postgres+cdc")
-		case strings.HasPrefix(parsedURI.Scheme, "mysql"), strings.HasPrefix(parsedURI.Scheme, "mariadb"):
-			// mysql+cdc / mysql+pymysql+cdc / mariadb+cdc are all valid CDC schemes.
+		case strings.HasPrefix(parsedURI.Scheme, "mysql"), strings.HasPrefix(parsedURI.Scheme, "mariadb"),
+			strings.HasPrefix(parsedURI.Scheme, "vitess"), strings.HasPrefix(parsedURI.Scheme, "planetscale"):
+			// mysql+cdc / mariadb+cdc / vitess+cdc / planetscale+cdc are all valid CDC schemes.
 			if !strings.HasSuffix(parsedURI.Scheme, "+cdc") {
 				parsedURI.Scheme += "+cdc"
 			}

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1068,8 +1068,10 @@ func TestBasicOperator_CDCMode(t *testing.T) {
 func TestBasicOperator_MySQLCDCMode(t *testing.T) {
 	t.Parallel()
 
-	// A bruin MySQL connection emits a mysql+pymysql:// URI; Vitess and PlanetScale
-	// use the same MySQL wire protocol, so they reuse a mysql connection.
+	// A bruin MySQL connection emits a mysql+pymysql:// URI. These cases also exercise the
+	// operator's generic CDC parameter plumbing (grpc_* / cdc_backend) on the MySQL family;
+	// the dedicated vitess:// / planetscale:// schemes are covered by
+	// TestBasicOperator_VitessPlanetScaleCDCMode.
 	mockMy := new(mockConnection)
 	mockMy.On("GetIngestrURI").Return("mysql+pymysql://user:pass@localhost:3306/db", nil)
 	mockBq := new(mockConnection)
@@ -1154,6 +1156,134 @@ func TestBasicOperator_MySQLCDCMode(t *testing.T) {
 			want: []string{
 				"ingest",
 				"--source-uri", "mysql+pymysql+cdc://user:pass@localhost:3306/db?cdc_backend=planetscale",
+				"--source-table", "orders",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "cdc-planetscale-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := new(mockRunner)
+			runner.On("RunIngestr", mock.Anything, tt.want, []string(nil), repo).Return(nil)
+
+			startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			executionDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			o := &BasicOperator{
+				conn:          &fetcher,
+				finder:        finder,
+				runner:        runner,
+				jinjaRenderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, &executionDate, "ingestr-test", "ingestr-test", nil),
+			}
+
+			ti := scheduler.AssetInstance{
+				Pipeline: &pipeline.Pipeline{},
+				Asset:    tt.asset,
+			}
+
+			ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+			err := o.Run(ctx, &ti)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestBasicOperator_VitessPlanetScaleCDCMode(t *testing.T) {
+	t.Parallel()
+
+	// Dedicated Vitess/PlanetScale connections emit the vitess:// / planetscale:// schemes.
+	// The vitess connection carries the vtgate gRPC port in the URI (from its config builder),
+	// so it survives into the derived vitess+cdc:// scheme without any asset-level parameters.
+	mockVitess := new(mockConnection)
+	mockVitess.On("GetIngestrURI").Return("vitess://user:pass@vtgate.internal:15306/commerce?grpc_port=15991", nil)
+	mockPS := new(mockConnection)
+	mockPS.On("GetIngestrURI").Return("planetscale://user:pass@aws.connect.psdb.cloud:3306/my_database", nil)
+	mockBq := new(mockConnection)
+	mockBq.On("GetIngestrURI").Return("bigquery://uri-here", nil)
+
+	fetcher := simpleConnectionFetcher{
+		connections: map[string]*mockConnection{
+			"vitess":      mockVitess,
+			"planetscale": mockPS,
+			"bq":          mockBq,
+		},
+	}
+
+	finder := new(mockFinder)
+
+	tests := []struct {
+		name  string
+		asset *pipeline.Asset
+		want  []string
+	}{
+		{
+			name: "Vitess source is left untouched when CDC is disabled",
+			asset: &pipeline.Asset{
+				Name:       "vitess-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "vitess",
+					"source_table":      "orders",
+					"destination":       "bigquery",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "vitess://user:pass@vtgate.internal:15306/commerce?grpc_port=15991",
+				"--source-table", "orders",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "vitess-asset",
+				"--yes",
+				"--progress", "log",
+			},
+		},
+		{
+			name: "Vitess CDC derives the vitess+cdc scheme and keeps grpc_port",
+			asset: &pipeline.Asset{
+				Name:       "cdc-vitess-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "vitess",
+					"source_table":      "orders",
+					"destination":       "bigquery",
+					"cdc":               "true",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "vitess+cdc://user:pass@vtgate.internal:15306/commerce?grpc_port=15991",
+				"--source-table", "orders",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "cdc-vitess-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			name: "PlanetScale CDC derives the planetscale+cdc scheme",
+			asset: &pipeline.Asset{
+				Name:       "cdc-planetscale-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "planetscale",
+					"source_table":      "orders",
+					"destination":       "bigquery",
+					"cdc":               "true",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "planetscale+cdc://user:pass@aws.connect.psdb.cloud:3306/my_database",
 				"--source-table", "orders",
 				"--dest-uri", "bigquery://uri-here",
 				"--dest-table", "cdc-planetscale-asset",

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -676,6 +676,12 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 	// MySQL - Relational database (user-defined tables)
 	"mysql": {},
 
+	// Vitess - MySQL-compatible sharded database (user-defined tables)
+	"vitess": {},
+
+	// PlanetScale - Managed Vitess platform (user-defined tables)
+	"planetscale": {},
+
 	// Notion - Workspace
 	"notion": {
 		{Name: "<database_id>", PrimaryKey: "", IncKey: "", IncStrategy: "replace"},

--- a/pkg/planetscale/config.go
+++ b/pkg/planetscale/config.go
@@ -1,0 +1,64 @@
+package planetscale
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// defaultPort is PlanetScale's MySQL-protocol port.
+const defaultPort = 3306
+
+// Config describes a connection to PlanetScale, the managed Vitess platform. PlanetScale speaks the
+// MySQL wire protocol, so the direct database connection reuses the MySQL driver; the ingestr URI
+// uses the dedicated "planetscale" scheme, which ingestr routes through its hosted psdbconnect API
+// (TLS is enabled automatically, so no SSL configuration is required).
+type Config struct {
+	Username string
+	Password string
+	Host     string
+	Port     int
+	Database string
+}
+
+// GetIngestrURI builds the ingestr source/destination URI using the dedicated "planetscale" scheme.
+// ingestr enables TLS automatically for this scheme, and the ingestr operator derives the CDC scheme
+// (planetscale+cdc://) by appending "+cdc".
+func (c Config) GetIngestrURI() string {
+	if c.Port == 0 {
+		c.Port = defaultPort
+	}
+
+	u := &url.URL{
+		Scheme: "planetscale",
+		User:   url.UserPassword(c.Username, c.Password),
+		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Path:   c.Database,
+	}
+
+	return u.String()
+}
+
+// ToDBConnectionURI builds the go-sql-driver/mysql DSN used to open a direct connection (e.g. for
+// `bruin connections test`). PlanetScale requires encrypted connections, so TLS is always enabled;
+// go-sql-driver's tls=true verifies the server certificate against the system root CAs, which is
+// valid for the public *.psdb.cloud endpoints.
+func (c Config) ToDBConnectionURI() string {
+	if c.Port == 0 {
+		c.Port = defaultPort
+	}
+
+	return fmt.Sprintf(
+		"%s:%s@tcp(%s:%d)/%s?tls=true&multiStatements=true",
+		c.Username,
+		c.Password,
+		c.Host,
+		c.Port,
+		c.Database,
+	)
+}
+
+// interface guard: the shared mysql.Client accepts any config exposing these two methods.
+var _ interface {
+	GetIngestrURI() string
+	ToDBConnectionURI() string
+} = Config{}

--- a/pkg/planetscale/config_test.go
+++ b/pkg/planetscale/config_test.go
@@ -1,0 +1,37 @@
+package planetscale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	c := Config{
+		Username: "user",
+		Password: "pscale_pw_secret",
+		Host:     "aws.connect.psdb.cloud",
+		Port:     3306,
+		Database: "my_database",
+	}
+	assert.Equal(t, "planetscale://user:pscale_pw_secret@aws.connect.psdb.cloud:3306/my_database", c.GetIngestrURI())
+
+	// Default port is applied when unset.
+	c.Port = 0
+	assert.Equal(t, "planetscale://user:pscale_pw_secret@aws.connect.psdb.cloud:3306/my_database", c.GetIngestrURI())
+}
+
+func TestConfig_ToDBConnectionURI(t *testing.T) {
+	t.Parallel()
+
+	c := Config{
+		Username: "user",
+		Password: "pscale_pw_secret",
+		Host:     "aws.connect.psdb.cloud",
+		Port:     3306,
+		Database: "my_database",
+	}
+	assert.Equal(t, "user:pscale_pw_secret@tcp(aws.connect.psdb.cloud:3306)/my_database?tls=true&multiStatements=true", c.ToDBConnectionURI())
+}

--- a/pkg/vitess/config.go
+++ b/pkg/vitess/config.go
@@ -84,7 +84,11 @@ func (c Config) ToDBConnectionURI() string {
 		c.Database,
 	)
 
-	if c.GrpcTLS || c.SslCaPath != "" || c.SslCertPath != "" || c.SslKeyPath != "" {
+	// Only the MySQL-protocol SSL settings govern TLS on this DSN. GrpcTLS is intentionally
+	// excluded: it configures the independent vtgate gRPC (VStream) transport, which has a
+	// separate port and TLS setup, so honoring it here would wrongly force TLS on the
+	// MySQL-protocol connection used by `bruin connections test`.
+	if c.SslCaPath != "" || c.SslCertPath != "" || c.SslKeyPath != "" {
 		dsn += "&tls=true"
 	}
 

--- a/pkg/vitess/config.go
+++ b/pkg/vitess/config.go
@@ -1,0 +1,98 @@
+package vitess
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// defaultPort is vtgate's default MySQL-protocol port.
+const defaultPort = 15306
+
+// Config describes a connection to a Vitess cluster through vtgate. Vitess speaks the MySQL wire
+// protocol, so the actual database connection reuses the MySQL driver; only the ingestr URI scheme
+// differs (ingestr now routes Vitess purely by the "vitess" scheme).
+type Config struct {
+	Username    string
+	Password    string
+	Host        string
+	Port        int
+	Database    string
+	GrpcPort    int
+	GrpcHost    string
+	GrpcTLS     bool
+	SslCaPath   string
+	SslCertPath string
+	SslKeyPath  string
+}
+
+// GetIngestrURI builds the ingestr source/destination URI. It emits the dedicated "vitess" scheme
+// (not "mysql"); ingestr rejects "mysql://" pointed at a Vitess server. The vtgate gRPC settings and
+// SSL paths are carried as query params so they survive into ingestr's CDC scheme (vitess+cdc://),
+// which the ingestr operator derives by appending "+cdc" to this scheme.
+func (c Config) GetIngestrURI() string {
+	if c.Port == 0 {
+		c.Port = defaultPort
+	}
+
+	u := &url.URL{
+		Scheme: "vitess",
+		User:   url.UserPassword(c.Username, c.Password),
+		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Path:   c.Database,
+	}
+
+	q := u.Query()
+	if c.GrpcPort != 0 {
+		q.Set("grpc_port", strconv.Itoa(c.GrpcPort))
+	}
+	if c.GrpcHost != "" {
+		q.Set("grpc_host", c.GrpcHost)
+	}
+	if c.GrpcTLS {
+		q.Set("grpc_tls", "true")
+	}
+	if c.SslCaPath != "" {
+		q.Set("ssl_ca", c.SslCaPath)
+	}
+	if c.SslCertPath != "" {
+		q.Set("ssl_cert", c.SslCertPath)
+	}
+	if c.SslKeyPath != "" {
+		q.Set("ssl_key", c.SslKeyPath)
+	}
+	if encoded := q.Encode(); encoded != "" {
+		u.RawQuery = encoded
+	}
+
+	return u.String()
+}
+
+// ToDBConnectionURI builds the go-sql-driver/mysql DSN used to open a direct connection (e.g. for
+// `bruin connections test`). Vitess is reached over vtgate's MySQL-protocol port.
+func (c Config) ToDBConnectionURI() string {
+	if c.Port == 0 {
+		c.Port = defaultPort
+	}
+
+	dsn := fmt.Sprintf(
+		"%s:%s@tcp(%s:%d)/%s?multiStatements=true",
+		c.Username,
+		c.Password,
+		c.Host,
+		c.Port,
+		c.Database,
+	)
+
+	if c.GrpcTLS || c.SslCaPath != "" || c.SslCertPath != "" || c.SslKeyPath != "" {
+		dsn += "&tls=true"
+	}
+
+	return dsn
+}
+
+// interface guard: the shared mysql.Client accepts any config exposing these two methods.
+var _ interface {
+	GetIngestrURI() string
+	ToDBConnectionURI() string
+} = Config{}

--- a/pkg/vitess/config_test.go
+++ b/pkg/vitess/config_test.go
@@ -1,0 +1,91 @@
+package vitess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config Config
+		want   string
+	}{
+		{
+			name: "basic uri uses the vitess scheme",
+			config: Config{
+				Username: "user",
+				Password: "password",
+				Host:     "vtgate.internal",
+				Port:     15306,
+				Database: "commerce",
+			},
+			want: "vitess://user:password@vtgate.internal:15306/commerce",
+		},
+		{
+			name: "default port is applied when unset",
+			config: Config{
+				Username: "user",
+				Password: "password",
+				Host:     "vtgate.internal",
+				Database: "commerce",
+			},
+			want: "vitess://user:password@vtgate.internal:15306/commerce",
+		},
+		{
+			name: "grpc settings are carried as query params",
+			config: Config{
+				Username: "user",
+				Password: "password",
+				Host:     "vtgate.internal",
+				Port:     15306,
+				Database: "commerce",
+				GrpcPort: 15991,
+				GrpcHost: "vtgate.grpc.internal",
+				GrpcTLS:  true,
+			},
+			want: "vitess://user:password@vtgate.internal:15306/commerce?grpc_host=vtgate.grpc.internal&grpc_port=15991&grpc_tls=true",
+		},
+		{
+			name: "ssl paths are carried as query params",
+			config: Config{
+				Username:    "user",
+				Password:    "password",
+				Host:        "vtgate.internal",
+				Port:        15306,
+				Database:    "commerce",
+				SslCaPath:   "/path/to/ca.pem",
+				SslCertPath: "/path/to/cert.pem",
+				SslKeyPath:  "/path/to/key.pem",
+			},
+			want: "vitess://user:password@vtgate.internal:15306/commerce?ssl_ca=%2Fpath%2Fto%2Fca.pem&ssl_cert=%2Fpath%2Fto%2Fcert.pem&ssl_key=%2Fpath%2Fto%2Fkey.pem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.config.GetIngestrURI())
+		})
+	}
+}
+
+func TestConfig_ToDBConnectionURI(t *testing.T) {
+	t.Parallel()
+
+	c := Config{
+		Username: "user",
+		Password: "password",
+		Host:     "vtgate.internal",
+		Port:     15306,
+		Database: "commerce",
+	}
+	assert.Equal(t, "user:password@tcp(vtgate.internal:15306)/commerce?multiStatements=true", c.ToDBConnectionURI())
+
+	// TLS is requested when grpc TLS or any SSL path is configured.
+	c.GrpcTLS = true
+	assert.Equal(t, "user:password@tcp(vtgate.internal:15306)/commerce?multiStatements=true&tls=true", c.ToDBConnectionURI())
+}

--- a/pkg/vitess/config_test.go
+++ b/pkg/vitess/config_test.go
@@ -85,7 +85,12 @@ func TestConfig_ToDBConnectionURI(t *testing.T) {
 	}
 	assert.Equal(t, "user:password@tcp(vtgate.internal:15306)/commerce?multiStatements=true", c.ToDBConnectionURI())
 
-	// TLS is requested when grpc TLS or any SSL path is configured.
+	// grpc_tls governs the vtgate gRPC transport, not the MySQL-protocol port, so it must not
+	// force TLS on the direct connection used by `connections test`.
 	c.GrpcTLS = true
+	assert.Equal(t, "user:password@tcp(vtgate.internal:15306)/commerce?multiStatements=true", c.ToDBConnectionURI())
+
+	// A MySQL-protocol SSL path does enable TLS on the DSN.
+	c.SslCaPath = "/path/to/ca.pem"
 	assert.Equal(t, "user:password@tcp(vtgate.internal:15306)/commerce?multiStatements=true&tls=true", c.ToDBConnectionURI())
 }


### PR DESCRIPTION
ingestr split its shared MySQL URI scheme into dedicated schemes and now routes purely by scheme, failing fast when a mysql:// URI points at a Vitess or PlanetScale server. Until now Bruin made Vitess/PlanetScale users configure a mysql: connection, which emitted mysql:// and is now rejected.

Add first-class vitess and planetscale connection types that emit the correct ingestr schemes:

  - New pkg/vitess and pkg/planetscale URI builders emit bare vitess:// and planetscale:// (default ports 15306/3306). They implement the mysql.MySQLConfig interface, so the connection manager reuses mysql.Client for direct connectivity and "connections test" without duplicating the client.
  - Vitess carries grpc_port/grpc_host/grpc_tls connection fields for vtgate VStream CDC, folded into the URI; PlanetScale enables TLS automatically via psdbconnect.
  - Register the types in the config Connections struct plus the add/delete/merge and SSL-path-normalize paths; listing and the .bruin.yml JSON schema are reflection-driven and pick them up.
  - The ingestr operator's per-asset CDC transform now appends +cdc for the vitess/planetscale schemes (vitess+cdc://, planetscale+cdc://).

These are ingestion-only connections; no SQL query/seed/sensor asset types are added. Docs for Vitess and PlanetScale are updated to the new connection blocks, and the MySQL platform CDC section is refocused on MySQL with pointers to the dedicated guides.