### PR TITLE
feat(gsheets): support Google Sheets as an ingestr destination

### DIFF
--- a/docs/ingestion/google_sheets.md
+++ b/docs/ingestion/google_sheets.md
@@ -2,7 +2,7 @@
 
 [Google Sheets](https://www.google.com/sheets/about/) is a web-based spreadsheet program that is part of Google's free, web-based Google Docs Editors suite.
 
-Bruin supports Google Sheets as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Google Sheets into your data warehouse.
+Bruin supports Google Sheets as both a source and a destination for [Ingestr assets](/assets/ingestr): you can ingest data from Google Sheets into your data warehouse, or write data from any supported source into a Google Sheets spreadsheet.
 
 To set up a Google Sheets connection, you need to add a configuration item in the `.bruin.yml` file and the `asset` file. You can provide either the `service_account_file` or the `service_account_json`; if you omit both, Application Default Credentials are used (e.g. after running `gcloud auth application-default login`). For more information, please follow the [guide](https://dlthub.com/docs/dlt-ecosystem/verified-sources/google_sheets#google-service-account-credentials). Once you complete the guide, you should have a `service account JSON` file.
 
@@ -61,3 +61,27 @@ bruin run assets/gsheets_ingestion.yml
 As a result of this command, Bruin will ingest data from the given Google Sheets table into your Postgres database.
 
 <img width="1140" alt="google_sheets" src="https://github.com/user-attachments/assets/8ee4e055-15e8-4439-a94c-26e124bfd5a7">
+
+## Google Sheets as a destination
+
+You can also write data into a Google Sheets spreadsheet by using a Google Sheets connection as the ingestr destination. The connection is configured exactly as above (Step 1), but the credentials must grant **write** access — share the target spreadsheet with the service account's `client_email` as an **Editor**.
+
+Set `destination: gsheets` and point the asset `connection` at your Google Sheets connection. The asset `name` is used as the target and must follow the `spreadsheet_id.sheet_name` format; the sheet (tab) is created automatically if it does not exist.
+
+```yaml
+name: '16UY6EQ_6jkdUdasdNfUq2CA.Sheet1'
+type: ingestr
+connection: my-gsheets
+
+parameters:
+  source_connection: my-postgres
+  source_table: 'public.users'
+
+  destination: gsheets
+```
+
+- `name`: The target spreadsheet and sheet, in `spreadsheet_id.sheet_name` format.
+- `connection`: The name of the Google Sheets connection (Editor access) defined in `.bruin.yml`.
+- `destination`: Set to `gsheets` to write into Google Sheets.
+
+Only the `replace` (default) and `append` incremental strategies are supported for the Google Sheets destination.

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -43,6 +43,15 @@ func TestGetIngestrDestinationType(t *testing.T) {
 			want: pipeline.AssetTypeBigqueryQuery,
 		},
 		{
+			name: "google_sheets",
+			asset: &pipeline.Asset{
+				Parameters: pipeline.ParameterMap{
+					"destination": "gsheets",
+				},
+			},
+			want: pipeline.AssetTypeGoogleSheets,
+		},
+		{
 			name: "not found",
 			asset: &pipeline.Asset{
 				Parameters: pipeline.ParameterMap{

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -64,6 +64,7 @@ const (
 	AssetTypeEMRServerlessPyspark      = AssetType("emr_serverless.pyspark")
 	AssetTypeEMRServerlessSpark        = AssetType("emr_serverless.spark")
 	AssetTypeGoodData                  = AssetType("gooddata")
+	AssetTypeGoogleSheets              = AssetType("gsheets")
 	AssetTypeGrafana                   = AssetType("grafana")
 	AssetTypeIngestr                   = AssetType("ingestr")
 	AssetTypeLooker                    = AssetType("looker")
@@ -922,6 +923,7 @@ var AssetTypeConnectionMapping = map[AssetType]string{
 	AssetTypeS3KeySensor:               "aws",
 	AssetTypeDynamoDB:                  "dynamodb",
 	AssetTypeElasticsearch:             "elasticsearch",
+	AssetTypeGoogleSheets:              "google_sheets",
 	AssetTypeVerticaQuery:              "vertica",
 	AssetTypeVerticaSeed:               "vertica",
 	AssetTypeVerticaQuerySensor:        "vertica",
@@ -967,6 +969,7 @@ var IngestrTypeConnectionMapping = map[string]AssetType{
 	"motherduck":    AssetTypeMotherduckQuery,
 	"dynamodb":      AssetTypeDynamoDB,
 	"elasticsearch": AssetTypeElasticsearch,
+	"gsheets":       AssetTypeGoogleSheets,
 	"vertica":       AssetTypeVerticaQuery,
 }
 


### PR DESCRIPTION
Register google_sheets as a valid ingestr destination by adding the AssetTypeGoogleSheets asset type and wiring it into the ingestr and asset-type connection mappings.