### PR TITLE
Fix config env var interpolation

### DIFF
--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -466,50 +466,75 @@ func decodeConfigYAML(buf []byte, config *Config) error {
 		return err
 	}
 
-	expandEnvVarsInYAMLValues(&node)
+	if err := expandEnvVarsInYAMLValues(&node); err != nil {
+		return err
+	}
+
 	return node.Decode(config)
 }
 
-func expandEnvVarsInYAMLValues(node *yaml.Node) {
+func expandEnvVarsInYAMLValues(node *yaml.Node) error {
 	if node == nil {
-		return
+		return nil
 	}
 
 	switch node.Kind {
 	case yaml.DocumentNode, yaml.SequenceNode:
 		for _, child := range node.Content {
-			expandEnvVarsInYAMLValues(child)
+			if err := expandEnvVarsInYAMLValues(child); err != nil {
+				return err
+			}
 		}
 	case yaml.MappingNode:
 		for i := 1; i < len(node.Content); i += 2 {
-			expandEnvVarsInYAMLValues(node.Content[i])
+			if err := expandEnvVarsInYAMLValues(node.Content[i]); err != nil {
+				return err
+			}
 		}
 	case yaml.AliasNode:
-		expandEnvVarsInYAMLValues(node.Alias)
+		if err := expandEnvVarsInYAMLValues(node.Alias); err != nil {
+			return err
+		}
 	case yaml.ScalarNode:
-		expanded, ok := expandEnvVarReferences(node.Value)
+		expanded, ok, err := expandEnvVarReferences(node.Value)
+		if err != nil {
+			return err
+		}
 		if !ok {
-			return
+			return nil
 		}
 
 		node.Value = expanded
 		node.Tag = ""
 	}
+
+	return nil
 }
 
-func expandEnvVarReferences(value string) (string, bool) {
+func expandEnvVarReferences(value string) (string, bool, error) {
 	matched := false
+	var missing []string
 	expanded := configEnvVarRegex.ReplaceAllStringFunc(value, func(match string) string {
 		matches := configEnvVarRegex.FindStringSubmatch(match)
 		if len(matches) != 2 {
 			return match
 		}
 
+		envValue, ok := os.LookupEnv(matches[1])
+		if !ok {
+			missing = append(missing, matches[1])
+			return match
+		}
+
 		matched = true
-		return os.Getenv(matches[1])
+		return envValue
 	})
 
-	return expanded, matched
+	if len(missing) > 0 {
+		return "", false, fmt.Errorf("environment variable %q is not set", missing[0])
+	}
+
+	return expanded, matched, nil
 }
 
 func LoadOrCreate(fs afero.Fs, path string) (*Config, error) {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -20,7 +21,7 @@ import (
 	"github.com/invopop/jsonschema"
 	errors2 "github.com/pkg/errors"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 type Connections struct {
@@ -282,6 +283,8 @@ type Config struct {
 	Environments            map[string]Environment `yaml:"environments" json:"environments" mapstructure:"environments"`
 }
 
+var configEnvVarRegex = regexp.MustCompile(`\${([^}]+)}`)
+
 func (c *Config) Path() string {
 	return c.path
 }
@@ -344,16 +347,19 @@ func (c *Config) SelectEnvironment(name string) error {
 
 func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 	var config Config
-	var err error
 	envConfig := os.Getenv("BRUIN_CONFIG_FILE_CONTENT")
 	if envConfig != "" {
-		err = yaml.Unmarshal([]byte(envConfig), &config)
+		if err := decodeConfigYAML([]byte(envConfig), &config); err != nil {
+			return nil, err
+		}
 	} else {
-		err = path2.ReadYaml(fs, path, &config)
-	}
-
-	if err != nil {
-		return nil, err
+		buf, err := readConfigYAML(fs, path)
+		if err != nil {
+			return nil, err
+		}
+		if err := decodeConfigYAML(buf, &config); err != nil {
+			return nil, err
+		}
 	}
 
 	config.fs = fs
@@ -445,6 +451,67 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 	return &config, nil
 }
 
+func readConfigYAML(fs afero.Fs, path string) ([]byte, error) {
+	buf, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return nil, errors2.Wrapf(err, "failed to read file %s", path)
+	}
+
+	return buf, nil
+}
+
+func decodeConfigYAML(buf []byte, config *Config) error {
+	var node yaml.Node
+	if err := yaml.Unmarshal(buf, &node); err != nil {
+		return err
+	}
+
+	expandEnvVarsInYAMLValues(&node)
+	return node.Decode(config)
+}
+
+func expandEnvVarsInYAMLValues(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for _, child := range node.Content {
+			expandEnvVarsInYAMLValues(child)
+		}
+	case yaml.MappingNode:
+		for i := 1; i < len(node.Content); i += 2 {
+			expandEnvVarsInYAMLValues(node.Content[i])
+		}
+	case yaml.AliasNode:
+		expandEnvVarsInYAMLValues(node.Alias)
+	case yaml.ScalarNode:
+		expanded, ok := expandEnvVarReferences(node.Value)
+		if !ok {
+			return
+		}
+
+		node.Value = expanded
+		node.Tag = ""
+	}
+}
+
+func expandEnvVarReferences(value string) (string, bool) {
+	matched := false
+	expanded := configEnvVarRegex.ReplaceAllStringFunc(value, func(match string) string {
+		matches := configEnvVarRegex.FindStringSubmatch(match)
+		if len(matches) != 2 {
+			return match
+		}
+
+		matched = true
+		return os.Getenv(matches[1])
+	})
+
+	return expanded, matched
+}
+
 func LoadOrCreate(fs afero.Fs, path string) (*Config, error) {
 	config, err := LoadFromFileOrEnv(fs, path)
 	if err != nil && !errors.Is(err, fs2.ErrNotExist) {
@@ -487,7 +554,10 @@ func ensureConfigIsInGitignore(fs afero.Fs, filePath string) error {
 func LoadOrCreateWithoutPathAbsolutization(fs afero.Fs, path string) (*Config, error) {
 	var config Config
 
-	err := path2.ReadYaml(fs, path, &config)
+	buf, err := readConfigYAML(fs, path)
+	if err == nil {
+		err = decodeConfigYAML(buf, &config)
+	}
 	if err != nil && !errors.Is(err, fs2.ErrNotExist) {
 		return nil, err
 	}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -498,10 +498,7 @@ func expandEnvVarsInYAMLValues(node *yaml.Node, targetType reflect.Type) error {
 			return err
 		}
 	case yaml.ScalarNode:
-		expanded, ok, err := expandEnvVarReferences(node.Value)
-		if err != nil {
-			return err
-		}
+		expanded, ok := expandEnvVarReferences(node.Value)
 		if !ok {
 			return nil
 		}
@@ -607,9 +604,8 @@ func yamlTagName(field reflect.StructField) (string, bool) {
 	return name, inline
 }
 
-func expandEnvVarReferences(value string) (string, bool, error) {
+func expandEnvVarReferences(value string) (string, bool) {
 	matched := false
-	var missing []string
 	expanded := configEnvVarRegex.ReplaceAllStringFunc(value, func(match string) string {
 		matches := configEnvVarRegex.FindStringSubmatch(match)
 		if len(matches) != 2 {
@@ -618,7 +614,6 @@ func expandEnvVarReferences(value string) (string, bool, error) {
 
 		envValue, ok := os.LookupEnv(matches[1])
 		if !ok {
-			missing = append(missing, matches[1])
 			return match
 		}
 
@@ -626,11 +621,7 @@ func expandEnvVarReferences(value string) (string, bool, error) {
 		return envValue
 	})
 
-	if len(missing) > 0 {
-		return "", false, fmt.Errorf("environment variable %q is not set", missing[0])
-	}
-
-	return expanded, matched, nil
+	return expanded, matched
 }
 
 func LoadOrCreate(fs afero.Fs, path string) (*Config, error) {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -466,33 +466,35 @@ func decodeConfigYAML(buf []byte, config *Config) error {
 		return err
 	}
 
-	if err := expandEnvVarsInYAMLValues(&node); err != nil {
+	if err := expandEnvVarsInYAMLValues(&node, reflect.TypeOf(*config)); err != nil {
 		return err
 	}
 
 	return node.Decode(config)
 }
 
-func expandEnvVarsInYAMLValues(node *yaml.Node) error {
+func expandEnvVarsInYAMLValues(node *yaml.Node, targetType reflect.Type) error {
 	if node == nil {
 		return nil
 	}
+	targetType = dereferenceType(targetType)
 
 	switch node.Kind {
 	case yaml.DocumentNode, yaml.SequenceNode:
+		elementType := sequenceElementType(targetType)
 		for _, child := range node.Content {
-			if err := expandEnvVarsInYAMLValues(child); err != nil {
+			if err := expandEnvVarsInYAMLValues(child, elementType); err != nil {
 				return err
 			}
 		}
 	case yaml.MappingNode:
 		for i := 1; i < len(node.Content); i += 2 {
-			if err := expandEnvVarsInYAMLValues(node.Content[i]); err != nil {
+			if err := expandEnvVarsInYAMLValues(node.Content[i], mappingValueType(targetType, node.Content[i-1].Value)); err != nil {
 				return err
 			}
 		}
 	case yaml.AliasNode:
-		if err := expandEnvVarsInYAMLValues(node.Alias); err != nil {
+		if err := expandEnvVarsInYAMLValues(node.Alias, targetType); err != nil {
 			return err
 		}
 	case yaml.ScalarNode:
@@ -505,10 +507,104 @@ func expandEnvVarsInYAMLValues(node *yaml.Node) error {
 		}
 
 		node.Value = expanded
-		node.Tag = ""
+		if targetType != nil && targetType.Kind() == reflect.String {
+			node.Tag = "!!str"
+		} else {
+			node.Tag = ""
+			node.Style = 0
+		}
 	}
 
 	return nil
+}
+
+func dereferenceType(targetType reflect.Type) reflect.Type {
+	for targetType != nil && targetType.Kind() == reflect.Ptr {
+		targetType = targetType.Elem()
+	}
+
+	return targetType
+}
+
+func sequenceElementType(targetType reflect.Type) reflect.Type {
+	if targetType == nil {
+		return nil
+	}
+
+	switch targetType.Kind() {
+	case reflect.Slice, reflect.Array:
+		return targetType.Elem()
+	default:
+		return targetType
+	}
+}
+
+func mappingValueType(targetType reflect.Type, key string) reflect.Type {
+	if targetType == nil {
+		return nil
+	}
+
+	switch targetType.Kind() {
+	case reflect.Map:
+		return targetType.Elem()
+	case reflect.Struct:
+		fieldType, ok := yamlFieldType(targetType, key)
+		if !ok {
+			return nil
+		}
+		return fieldType
+	default:
+		return nil
+	}
+}
+
+func yamlFieldType(targetType reflect.Type, key string) (reflect.Type, bool) {
+	for i := range targetType.NumField() {
+		field := targetType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		tagName, inline := yamlTagName(field)
+		if tagName == "-" {
+			continue
+		}
+
+		if tagName == key {
+			return field.Type, true
+		}
+
+		if inline {
+			if fieldType, ok := yamlFieldType(dereferenceType(field.Type), key); ok {
+				return fieldType, true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func yamlTagName(field reflect.StructField) (string, bool) {
+	tag := field.Tag.Get("yaml")
+	if tag == "-" {
+		return "-", false
+	}
+
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+	inline := false
+	for _, option := range parts[1:] {
+		if option == "inline" {
+			inline = true
+			break
+		}
+	}
+
+	if name == "" && !inline {
+		name = strings.ToLower(field.Name)
+	}
+
+	return name, inline
 }
 
 func expandEnvVarReferences(value string) (string, bool, error) {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -2968,6 +2968,32 @@ environments:
 	assert.Equal(t, "dummy_secret", conn.Lakehouse.Storage.Auth.SecretKey)
 }
 
+func TestLoadFromFileOrEnv_ErrorsForMissingEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	configPath := filepath.Join("repo", ".bruin.yml")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(`default_environment: production
+environments:
+  production:
+    connections:
+      postgres:
+        - name: missing-env
+          host: localhost
+          username: bruin
+          password: secret
+          database: analytics
+          port: ${POSTGRES_PORT}
+`), 0o644))
+
+	got, err := LoadFromFileOrEnv(fs, configPath)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), `environment variable "POSTGRES_PORT" is not set`)
+}
+
 func TestSnowflakeConnection_MarshalYAML_PrivateKey(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -2907,7 +2907,7 @@ func TestLoadFromFileOrEnv_ExpandsEnvironmentVariablesBeforeDecode(t *testing.T)
 	t.Setenv("POSTGRES_PORT", "5433")
 	t.Setenv("POSTGRES_DB", "dummy")
 	t.Setenv("POSTGRES_USER", "dummy_user")
-	t.Setenv("POSTGRES_PASSWORD", "dummy_password")
+	t.Setenv("POSTGRES_PASSWORD", "null")
 	t.Setenv("DUCKLAKE_DATA_PATH", "s3://dummy/warehouse")
 	t.Setenv("AWS_REGION", "auto")
 	t.Setenv("R2_S3_ENDPOINT", "dummy.r2.cloudflarestorage.com")
@@ -2929,7 +2929,7 @@ environments:
             catalog:
               type: postgres
               host: "${POSTGRES_HOST}"
-              port: ${POSTGRES_PORT}
+              port: "${POSTGRES_PORT}"
               database: "${POSTGRES_DB}"
               auth:
                 username: "${POSTGRES_USER}"
@@ -2958,7 +2958,7 @@ environments:
 	assert.Equal(t, 5433, conn.Lakehouse.Catalog.Port)
 	assert.Equal(t, "dummy", conn.Lakehouse.Catalog.Database)
 	assert.Equal(t, "dummy_user", conn.Lakehouse.Catalog.Auth.Username)
-	assert.Equal(t, "dummy_password", conn.Lakehouse.Catalog.Auth.Password)
+	assert.Equal(t, "null", conn.Lakehouse.Catalog.Auth.Password)
 	assert.Equal(t, StorageTypeS3, conn.Lakehouse.Storage.Type)
 	assert.Equal(t, "s3://dummy/warehouse", conn.Lakehouse.Storage.Path)
 	assert.Equal(t, "auto", conn.Lakehouse.Storage.Region)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -2968,7 +2968,7 @@ environments:
 	assert.Equal(t, "dummy_secret", conn.Lakehouse.Storage.Auth.SecretKey)
 }
 
-func TestLoadFromFileOrEnv_ErrorsForMissingEnvironmentVariables(t *testing.T) {
+func TestLoadFromFileOrEnv_LeavesUnsetEnvironmentVariablesLiteral(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewMemMapFs()
@@ -2979,19 +2979,21 @@ environments:
   production:
     connections:
       postgres:
-        - name: missing-env
+        - name: literal-env
           host: localhost
           username: bruin
-          password: secret
+          password: "secret-${BRUIN_TEST_UNSET_CONFIG_PASSWORD}"
           database: analytics
-          port: ${POSTGRES_PORT}
+          port: 5432
 `), 0o644))
 
 	got, err := LoadFromFileOrEnv(fs, configPath)
 
-	require.Error(t, err)
-	assert.Nil(t, got)
-	assert.Contains(t, err.Error(), `environment variable "POSTGRES_PORT" is not set`)
+	require.NoError(t, err)
+	require.Len(t, got.SelectedEnvironment.Connections.Postgres, 1)
+	conn := got.SelectedEnvironment.Connections.Postgres[0]
+	assert.Equal(t, "secret-${BRUIN_TEST_UNSET_CONFIG_PASSWORD}", conn.Password)
+	assert.Equal(t, 5432, conn.Port)
 }
 
 func TestSnowflakeConnection_MarshalYAML_PrivateKey(t *testing.T) {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -2899,6 +2900,72 @@ environments:
 	require.NotNil(t, got.SelectedEnvironment.Config)
 	assert.True(t, got.SelectedEnvironment.Config.RefreshRestricted)
 	assert.True(t, got.Environments["prod"].Config.RefreshRestricted)
+}
+
+func TestLoadFromFileOrEnv_ExpandsEnvironmentVariablesBeforeDecode(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "placeholder-host.invalid")
+	t.Setenv("POSTGRES_PORT", "5433")
+	t.Setenv("POSTGRES_DB", "dummy")
+	t.Setenv("POSTGRES_USER", "dummy_user")
+	t.Setenv("POSTGRES_PASSWORD", "dummy_password")
+	t.Setenv("DUCKLAKE_DATA_PATH", "s3://dummy/warehouse")
+	t.Setenv("AWS_REGION", "auto")
+	t.Setenv("R2_S3_ENDPOINT", "dummy.r2.cloudflarestorage.com")
+	t.Setenv("AWS_ACCESS_KEY_ID", "access:key # hash")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy_secret")
+
+	fs := afero.NewMemMapFs()
+	configPath := filepath.Join("repo", ".bruin.yml")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(`default_environment: production
+environments:
+  production:
+    connections:
+      duckdb:
+        - name: ducklake
+          path: repro-ducklake.duckdb
+          lakehouse:
+            format: ducklake
+            catalog:
+              type: postgres
+              host: "${POSTGRES_HOST}"
+              port: ${POSTGRES_PORT}
+              database: "${POSTGRES_DB}"
+              auth:
+                username: "${POSTGRES_USER}"
+                password: "${POSTGRES_PASSWORD}"
+            storage:
+              type: s3
+              path: "${DUCKLAKE_DATA_PATH}"
+              region: "${AWS_REGION}"
+              endpoint: "${R2_S3_ENDPOINT}"
+              url_style: path
+              auth:
+                access_key: ${AWS_ACCESS_KEY_ID}
+                secret_key: "${AWS_SECRET_ACCESS_KEY}"
+`), 0o644))
+
+	got, err := LoadFromFileOrEnv(fs, configPath)
+	require.NoError(t, err)
+
+	require.Len(t, got.SelectedEnvironment.Connections.DuckDB, 1)
+	conn := got.SelectedEnvironment.Connections.DuckDB[0]
+	require.NotNil(t, conn.Lakehouse)
+
+	assert.Equal(t, LakehouseFormatDuckLake, conn.Lakehouse.Format)
+	assert.Equal(t, CatalogTypePostgres, conn.Lakehouse.Catalog.Type)
+	assert.Equal(t, "placeholder-host.invalid", conn.Lakehouse.Catalog.Host)
+	assert.Equal(t, 5433, conn.Lakehouse.Catalog.Port)
+	assert.Equal(t, "dummy", conn.Lakehouse.Catalog.Database)
+	assert.Equal(t, "dummy_user", conn.Lakehouse.Catalog.Auth.Username)
+	assert.Equal(t, "dummy_password", conn.Lakehouse.Catalog.Auth.Password)
+	assert.Equal(t, StorageTypeS3, conn.Lakehouse.Storage.Type)
+	assert.Equal(t, "s3://dummy/warehouse", conn.Lakehouse.Storage.Path)
+	assert.Equal(t, "auto", conn.Lakehouse.Storage.Region)
+	assert.Equal(t, "dummy.r2.cloudflarestorage.com", conn.Lakehouse.Storage.Endpoint)
+	assert.Equal(t, "path", conn.Lakehouse.Storage.URLStyle)
+	assert.Equal(t, "access:key # hash", conn.Lakehouse.Storage.Auth.AccessKey)
+	assert.Equal(t, "dummy_secret", conn.Lakehouse.Storage.Auth.SecretKey)
 }
 
 func TestSnowflakeConnection_MarshalYAML_PrivateKey(t *testing.T) {


### PR DESCRIPTION
Fixes #2304.

Expands env vars in .bruin.yml before typed config decoding so nested DuckDB lakehouse values and integer fields like port work correctly.

Validated with make format and make test.