### PR TITLE
Add 'bruin cloud agents create' command (BRU-4735)

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2029,12 +2029,66 @@ func CloudAgents() *cli.Command {
 		Usage: "Manage Bruin Cloud agents",
 		Commands: []*cli.Command{
 			cloudAgentsList(),
+			cloudAgentsCreate(),
 			cloudAgentsSend(),
 			cloudAgentsStatus(),
 			cloudAgentsThreads(),
 			cloudAgentsMessages(),
 			cloudAgentsGetPrompt(),
 			cloudAgentsSetPrompt(),
+		},
+	}
+}
+
+func cloudAgentsCreate() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a new agent",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.StringFlag{
+				Name:     "name",
+				Usage:    "the agent name",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "description",
+				Usage: "the agent description",
+			},
+			&cli.StringFlag{
+				Name:  "prompt",
+				Usage: "the agent's system prompt",
+			},
+			&cli.StringFlag{
+				Name:  "visibility",
+				Usage: "agent visibility: team or private (default: team)",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			agent, err := client.CreateAgent(ctx, c.String("name"), c.String("description"), c.String("prompt"), c.String("visibility"))
+			if err != nil {
+				printError(err, output, "Failed to create agent")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(agent, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Created agent %d (%s)\n", agent.ID, agent.Name)
+			return nil
 		},
 	}
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2069,13 +2069,19 @@ func cloudAgentsCreate() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
+			visibility := c.String("visibility")
+			if visibility != "" && visibility != "team" && visibility != "private" {
+				printError(fmt.Errorf("visibility must be 'team' or 'private', got %q", visibility), output, "Invalid --visibility")
+				return cli.Exit("", 1)
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
 				return cli.Exit("", 1)
 			}
 
-			agent, err := client.CreateAgent(ctx, c.String("name"), c.String("description"), c.String("prompt"), c.String("visibility"))
+			agent, err := client.CreateAgent(ctx, c.String("name"), c.String("description"), c.String("prompt"), visibility)
 			if err != nil {
 				printError(err, output, "Failed to create agent")
 				return cli.Exit("", 1)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -219,7 +219,7 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 7)
+	require.Len(t, cmd.Commands, 8)
 }
 
 func TestExtractErrorLines_ErrorLevel(t *testing.T) {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -419,6 +419,27 @@ func (c *APIClient) ListAgents(ctx context.Context) ([]Agent, error) {
 	return resp.Agents, err
 }
 
+// CreateAgent creates a new agent. Optional fields are omitted when empty so the
+// server applies its defaults (null description/prompt, "team" visibility).
+func (c *APIClient) CreateAgent(ctx context.Context, name, description, systemPrompt, visibility string) (*Agent, error) {
+	body := map[string]any{"name": name}
+	if description != "" {
+		body["description"] = description
+	}
+	if systemPrompt != "" {
+		body["system_prompt"] = systemPrompt
+	}
+	if visibility != "" {
+		body["visibility"] = visibility
+	}
+	var result Agent
+	err := c.doRequest(ctx, http.MethodPost, "/agents", body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *APIClient) SendAgentMessage(ctx context.Context, agentID int, message string, threadID *int) (json.RawMessage, error) {
 	body := map[string]any{
 		"message": message,

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -488,6 +488,30 @@ func TestListAgents(t *testing.T) {
 	assert.Equal(t, "test-agent", agents[0].Name)
 }
 
+func TestCreateAgent(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/agents", r.URL.Path)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "new-agent", body["name"])
+		assert.Equal(t, "private", body["visibility"])
+		// empty optional fields are omitted so the server applies its defaults
+		_, hasDesc := body["description"]
+		assert.False(t, hasDesc)
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, Agent{ID: 7, Name: "new-agent", Visibility: "private"})
+	})
+
+	agent, err := client.CreateAgent(t.Context(), "new-agent", "", "", "private")
+	require.NoError(t, err)
+	assert.Equal(t, 7, agent.ID)
+	assert.Equal(t, "private", agent.Visibility)
+}
+
 func TestListAgentThreads(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -495,7 +495,7 @@ func TestCreateAgent(t *testing.T) {
 		assert.Equal(t, "/agents", r.URL.Path)
 
 		var body map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		assert.Equal(t, "new-agent", body["name"])
 		assert.Equal(t, "private", body["visibility"])
 		// empty optional fields are omitted so the server applies its defaults

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -102,6 +102,7 @@ type Agent struct {
 	ID          int     `json:"id"`
 	Name        string  `json:"name"`
 	Description *string `json:"description"`
+	Visibility  string  `json:"visibility"`
 }
 
 // AgentThread represents a thread for an agent.


### PR DESCRIPTION
Adds `bruin cloud agents create`, wrapping the new `POST /api/v1/agents` endpoint.

```
bruin cloud agents create --name "My Agent" [--description ...] [--prompt ...] [--visibility team|private]
```

`--name` is required; the optional fields are omitted from the request when empty so the server applies its defaults (null description/prompt, `team` visibility). Supports `--output json`.