### PR TITLE
snowflake warehouse size

### DIFF
--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -375,7 +375,9 @@ order by start_time desc;
 
 ## Overriding the warehouse per asset
 
-By default, Bruin runs every query on the warehouse configured on the connection. You can override the warehouse for a specific asset with the `snowflake.warehouse` field. When set, Bruin issues a `USE WAREHOUSE <name>` in the same session before running the asset's query, so it applies only to that asset without changing the connection.
+By default, Bruin runs every query on the warehouse configured on the connection. You can override the warehouse for a specific asset with a `warehouse` parameter. When set, Bruin runs that asset on a dedicated Snowflake connection whose warehouse is the overridden one, without changing the connection default used by other assets.
+
+If the overridden warehouse can't be used (for example the role lacks `USAGE` on it, or the account can't resume it), Bruin logs a warning and falls back to the connection's default warehouse so the run isn't broken by the override.
 
 ```bruin-sql
 /* @bruin
@@ -384,7 +386,7 @@ type: sf.sql
 materialization:
     type: table
 
-snowflake:
+parameters:
     warehouse: BIG_WH
 @bruin */
 
@@ -393,19 +395,11 @@ from analytics.events
 where event_name = 'install'
 ```
 
-You can also set a default warehouse for the whole pipeline under `defaults` in `pipeline.yml`; individual assets can still override it:
-
-```yaml
-defaults:
-    snowflake:
-        warehouse: COMPUTE_WH
-```
-
 ### Overriding the warehouse at run time (urgent reruns)
 
-The `snowflake.warehouse` field supports Jinja templating, so you can drive it from a [pipeline variable](../assets/templating/templating.md) and override it at run time.
+The `warehouse` parameter supports Jinja templating, so you can drive it from a [pipeline variable](../assets/templating/templating.md) and override it at run time for one-off urgent reruns on a larger warehouse — without editing the asset.
 
-Reference a variable in the asset (with a sensible default):
+Reference a `warehouse` variable in the asset and declare its default in `pipeline.yml`:
 
 ```bruin-sql
 /* @bruin
@@ -414,23 +408,22 @@ type: sf.sql
 materialization:
     type: table
 
-snowflake:
+parameters:
     warehouse: "{{ var.warehouse }}"
 @bruin */
 
 select user_id, ts, platform, country from analytics.events
 ```
 
-Declare the variable's default in `pipeline.yml`:
-
 ```yaml
+# pipeline.yml
 variables:
     warehouse:
         type: string
         default: COMPUTE_WH
 ```
 
-Then override it for a single run with `--var`:
+Normal runs use the default (`COMPUTE_WH`). For an urgent rerun, override it for that single run with `--var`:
 
 ```bash
 bruin run --var '{"warehouse":"BIG_WH"}' ./my-pipeline

--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -373,6 +373,70 @@ where try_parse_json(query_tag):asset is not null
 order by start_time desc;
 ```
 
+## Overriding the warehouse per asset
+
+By default, Bruin runs every query on the warehouse configured on the connection. You can override the warehouse for a specific asset with the `snowflake.warehouse` field. When set, Bruin issues a `USE WAREHOUSE <name>` in the same session before running the asset's query, so it applies only to that asset without changing the connection.
+
+```bruin-sql
+/* @bruin
+name: events.install
+type: sf.sql
+materialization:
+    type: table
+
+snowflake:
+    warehouse: BIG_WH
+@bruin */
+
+select user_id, ts, platform, country
+from analytics.events
+where event_name = 'install'
+```
+
+You can also set a default warehouse for the whole pipeline under `defaults` in `pipeline.yml`; individual assets can still override it:
+
+```yaml
+defaults:
+    snowflake:
+        warehouse: COMPUTE_WH
+```
+
+### Overriding the warehouse at run time (urgent reruns)
+
+The `snowflake.warehouse` field supports Jinja templating, so you can drive it from a [pipeline variable](../assets/templating/templating.md) and override it at run time.
+
+Reference a variable in the asset (with a sensible default):
+
+```bruin-sql
+/* @bruin
+name: events.install
+type: sf.sql
+materialization:
+    type: table
+
+snowflake:
+    warehouse: "{{ var.warehouse }}"
+@bruin */
+
+select user_id, ts, platform, country from analytics.events
+```
+
+Declare the variable's default in `pipeline.yml`:
+
+```yaml
+variables:
+    warehouse:
+        type: string
+        default: COMPUTE_WH
+```
+
+Then override it for a single run with `--var`:
+
+```bash
+bruin run --var '{"warehouse":"BIG_WH"}' ./my-pipeline
+```
+
+
 ## Snowflake Assets
 
 ### `sf.sql`

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -397,13 +397,7 @@ func (m *Manager) AddBqConnectionFromConfig(connection *config.GoogleCloudPlatfo
 	return nil
 }
 
-func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnection) error {
-	m.mutex.Lock()
-	if m.Snowflake == nil {
-		m.Snowflake = make(map[string]*snowflake.DB)
-	}
-	m.mutex.Unlock()
-
+func newSnowflakeDBFromConnection(connection *config.SnowflakeConnection) (*snowflake.DB, error) {
 	privateKey := ""
 
 	// Prioritize the direct PrivateKey field over PrivateKeyPath
@@ -412,7 +406,7 @@ func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnecti
 	} else if connection.PrivateKeyPath != "" {
 		privateKeyBytes, err := os.ReadFile(connection.PrivateKeyPath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		privateKey = string(privateKeyBytes)
 	}
@@ -422,7 +416,7 @@ func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnecti
 		privateKey = convertPKCS1ToPKCS8(privateKey)
 	}
 
-	db, err := snowflake.NewDB(&snowflake.Config{
+	return snowflake.NewDB(&snowflake.Config{
 		Account:    connection.Account,
 		Username:   connection.Username,
 		Password:   connection.Password,
@@ -433,6 +427,16 @@ func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnecti
 		Warehouse:  connection.Warehouse,
 		PrivateKey: privateKey,
 	})
+}
+
+func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnection) error {
+	m.mutex.Lock()
+	if m.Snowflake == nil {
+		m.Snowflake = make(map[string]*snowflake.DB)
+	}
+	m.mutex.Unlock()
+
+	db, err := newSnowflakeDBFromConnection(connection)
 	if err != nil {
 		return err
 	}
@@ -444,6 +448,36 @@ func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnecti
 	m.AllConnectionDetails[connection.Name] = connection
 
 	return nil
+}
+
+// GetSfConnectionWithWarehouse returns a Snowflake client for the named
+// connection whose warehouse is overridden. When warehouse is empty it returns
+// the default connection unchanged; otherwise it builds a client by cloning the
+// connection config with a different warehouse. The returned client is not
+// pinged here; callers that need to fall back on failure should validate it.
+func (m *Manager) GetSfConnectionWithWarehouse(name, warehouse string) (snowflake.SfClient, error) {
+	base, ok := m.Snowflake[name]
+	if !ok || base == nil {
+		return nil, errors.Errorf("snowflake connection '%s' does not exist", name)
+	}
+
+	if strings.TrimSpace(warehouse) == "" {
+		return base, nil
+	}
+
+	detail, ok := m.AllConnectionDetails[name].(*config.SnowflakeConnection)
+	if !ok {
+		return nil, errors.Errorf("connection '%s' is not a snowflake connection", name)
+	}
+
+	override := *detail
+	override.Warehouse = warehouse
+	db, err := newSnowflakeDBFromConnection(&override)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create snowflake connection '%s' with warehouse '%s'", name, warehouse)
+	}
+
+	return db, nil
 }
 
 func (m *Manager) AddAthenaConnectionFromConfig(connection *config.AthenaConnection) error {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -288,6 +288,10 @@ type Manager struct {
 	Generic              map[string]*config.GenericConnection
 	mutex                sync.Mutex
 	availableConnections map[string]any
+	// snowflakeWarehouseOverrides caches per-warehouse Snowflake clients, keyed
+	// by "<connection name>\x00<warehouse>", so a warehouse override reuses one
+	// client instead of opening a new connection pool for every asset.
+	snowflakeWarehouseOverrides map[string]*snowflake.DB
 }
 
 func (m *Manager) GetConnection(name string) any {
@@ -456,18 +460,28 @@ func (m *Manager) AddSfConnectionFromConfig(connection *config.SnowflakeConnecti
 // connection config with a different warehouse. The returned client is not
 // pinged here; callers that need to fall back on failure should validate it.
 func (m *Manager) GetSfConnectionWithWarehouse(name, warehouse string) (snowflake.SfClient, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	base, ok := m.Snowflake[name]
 	if !ok || base == nil {
 		return nil, errors.Errorf("snowflake connection '%s' does not exist", name)
 	}
 
-	if strings.TrimSpace(warehouse) == "" {
-		return base, nil
-	}
-
 	detail, ok := m.AllConnectionDetails[name].(*config.SnowflakeConnection)
 	if !ok {
 		return nil, errors.Errorf("connection '%s' is not a snowflake connection", name)
+	}
+
+	// No override, or the override matches the connection's own warehouse.
+	warehouse = strings.TrimSpace(warehouse)
+	if warehouse == "" || strings.EqualFold(warehouse, detail.Warehouse) {
+		return base, nil
+	}
+
+	key := name + "\x00" + warehouse
+	if db, ok := m.snowflakeWarehouseOverrides[key]; ok {
+		return db, nil
 	}
 
 	override := *detail
@@ -477,6 +491,10 @@ func (m *Manager) GetSfConnectionWithWarehouse(name, warehouse string) (snowflak
 		return nil, errors.Wrapf(err, "failed to create snowflake connection '%s' with warehouse '%s'", name, warehouse)
 	}
 
+	if m.snowflakeWarehouseOverrides == nil {
+		m.snowflakeWarehouseOverrides = make(map[string]*snowflake.DB)
+	}
+	m.snowflakeWarehouseOverrides[key] = db
 	return db, nil
 }
 

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -634,6 +634,46 @@ func TestManager_GetSfConnection(t *testing.T) {
 	}
 }
 
+func TestManager_GetSfConnectionWithWarehouse(t *testing.T) {
+	t.Parallel()
+
+	m := Manager{
+		AllConnectionDetails: map[string]any{},
+		availableConnections: map[string]any{},
+	}
+	require.NoError(t, m.AddSfConnectionFromConfig(&config.SnowflakeConnection{
+		ConnectionMetadata: config.ConnectionMetadata{Name: "sf"},
+		Account:            "acc",
+		Username:           "user",
+		Password:           "pass",
+		Region:             "eu-west1",
+		Warehouse:          "DEFAULT_WH",
+	}))
+
+	base := m.Snowflake["sf"]
+
+	t.Run("empty warehouse returns the default connection", func(t *testing.T) {
+		t.Parallel()
+		got, err := m.GetSfConnectionWithWarehouse("sf", "")
+		require.NoError(t, err)
+		assert.Same(t, base, got)
+	})
+
+	t.Run("override returns a distinct connection", func(t *testing.T) {
+		t.Parallel()
+		override, err := m.GetSfConnectionWithWarehouse("sf", "BIG_WH")
+		require.NoError(t, err)
+		require.NotNil(t, override)
+		assert.NotSame(t, base, override)
+	})
+
+	t.Run("unknown connection returns an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := m.GetSfConnectionWithWarehouse("missing", "BIG_WH")
+		require.Error(t, err)
+	})
+}
+
 func TestManager_AddGenericConnectionFromConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -659,12 +659,23 @@ func TestManager_GetSfConnectionWithWarehouse(t *testing.T) {
 		assert.Same(t, base, got)
 	})
 
-	t.Run("override returns a distinct connection", func(t *testing.T) {
+	t.Run("warehouse equal to the default returns the default connection", func(t *testing.T) {
+		t.Parallel()
+		got, err := m.GetSfConnectionWithWarehouse("sf", "default_wh") // case-insensitive match of DEFAULT_WH
+		require.NoError(t, err)
+		assert.Same(t, base, got)
+	})
+
+	t.Run("override returns a distinct, cached connection", func(t *testing.T) {
 		t.Parallel()
 		override, err := m.GetSfConnectionWithWarehouse("sf", "BIG_WH")
 		require.NoError(t, err)
 		require.NotNil(t, override)
 		assert.NotSame(t, base, override)
+
+		again, err := m.GetSfConnectionWithWarehouse("sf", "BIG_WH")
+		require.NoError(t, err)
+		assert.Same(t, override, again, "the overridden connection should be cached and reused")
 	})
 
 	t.Run("unknown connection returns an error", func(t *testing.T) {

--- a/pkg/snowflake/checks_test.go
+++ b/pkg/snowflake/checks_test.go
@@ -84,6 +84,16 @@ func (m *mockConnectionFetcher) GetConnection(name string) any {
 	return get.(SfClient)
 }
 
+func (m *mockConnectionFetcher) GetSfConnectionWithWarehouse(name, warehouse string) (SfClient, error) {
+	args := m.Called(name, warehouse)
+	get := args.Get(0)
+	if get == nil {
+		return nil, args.Error(1)
+	}
+
+	return get.(SfClient), args.Error(1)
+}
+
 func TestAcceptedValuesCheck_Check(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -3,6 +3,8 @@ package snowflake
 import (
 	"context"
 	"io"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -17,6 +19,25 @@ import (
 	"github.com/pkg/errors"
 	"github.com/snowflakedb/gosnowflake"
 )
+
+// Snowflake identifiers are case-insensitive unless they are double-quoted.
+// This regex matches simple identifiers that do not require quoting.
+var safeSnowflakeIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$]*$`)
+
+func withWarehouse(q *query.Query, warehouse string) *query.Query {
+	warehouse = strings.TrimSpace(warehouse)
+	if warehouse == "" {
+		return q
+	}
+
+	if !safeSnowflakeIdentifier.MatchString(warehouse) {
+		warehouse = `"` + strings.ReplaceAll(warehouse, `"`, `""`) + `"`
+	}
+
+	cloned := *q
+	cloned.Query = "USE WAREHOUSE " + warehouse + ";\n" + q.Query
+	return &cloned
+}
 
 type materializer interface {
 	Render(task *pipeline.Asset, query string) (string, error)
@@ -155,8 +176,9 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	if o.devEnv == nil {
-		ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
-		return conn.RunQueryWithoutResult(ctx, q)
+		runQuery := withWarehouse(q, t.Snowflake.Warehouse)
+		ansisql.LogQueryIfVerbose(ctx, writer, runQuery.Query)
+		return conn.RunQueryWithoutResult(ctx, runQuery)
 	}
 
 	q, err = o.devEnv.Modify(ctx, p, t, q)
@@ -164,9 +186,10 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return err
 	}
 
-	ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
+	runQuery := withWarehouse(q, t.Snowflake.Warehouse)
+	ansisql.LogQueryIfVerbose(ctx, writer, runQuery.Query)
 
-	err = conn.RunQueryWithoutResult(ctx, q)
+	err = conn.RunQueryWithoutResult(ctx, runQuery)
 	if err != nil {
 		return err
 	}

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -2,9 +2,8 @@ package snowflake
 
 import (
 	"context"
+	"fmt"
 	"io"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -20,23 +19,8 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-// Snowflake identifiers are case-insensitive unless they are double-quoted.
-// This regex matches simple identifiers that do not require quoting.
-var safeSnowflakeIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$]*$`)
-
-func withWarehouse(q *query.Query, warehouse string) *query.Query {
-	warehouse = strings.TrimSpace(warehouse)
-	if warehouse == "" {
-		return q
-	}
-
-	if !safeSnowflakeIdentifier.MatchString(warehouse) {
-		warehouse = `"` + strings.ReplaceAll(warehouse, `"`, `""`) + `"`
-	}
-
-	cloned := *q
-	cloned.Query = "USE WAREHOUSE " + warehouse + ";\n" + q.Query
-	return &cloned
+type warehouseConnectionGetter interface {
+	GetSfConnectionWithWarehouse(name, warehouse string) (SfClient, error)
 }
 
 type materializer interface {
@@ -142,6 +126,10 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return errors.Errorf("connection '%s' is not a snowflake connection", connName)
 	}
 
+	if warehouse, ok := t.Parameters.GetString("warehouse"); ok && warehouse != "" {
+		conn = o.connectionForWarehouse(ctx, ctx.Value(executor.KeyPrinter), conn, connName, warehouse)
+	}
+
 	if t.Materialization.Type != pipeline.MaterializationTypeNone {
 		err = conn.CreateSchemaIfNotExist(ctx, t)
 		if err != nil {
@@ -176,9 +164,8 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	if o.devEnv == nil {
-		runQuery := withWarehouse(q, t.Snowflake.Warehouse)
-		ansisql.LogQueryIfVerbose(ctx, writer, runQuery.Query)
-		return conn.RunQueryWithoutResult(ctx, runQuery)
+		ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
+		return conn.RunQueryWithoutResult(ctx, q)
 	}
 
 	q, err = o.devEnv.Modify(ctx, p, t, q)
@@ -186,10 +173,9 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		return err
 	}
 
-	runQuery := withWarehouse(q, t.Snowflake.Warehouse)
-	ansisql.LogQueryIfVerbose(ctx, writer, runQuery.Query)
+	ansisql.LogQueryIfVerbose(ctx, writer, q.Query)
 
-	err = conn.RunQueryWithoutResult(ctx, runQuery)
+	err = conn.RunQueryWithoutResult(ctx, q)
 	if err != nil {
 		return err
 	}
@@ -200,6 +186,38 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	return nil
+}
+
+// connectionForWarehouse returns a Snowflake client bound to the overridden
+// warehouse. If the connection getter can't provide one, or the overridden
+// client can't run a query (e.g. the warehouse is inaccessible or the account
+// can't resume it), it logs a warning and falls back to the default client.
+func (o BasicOperator) connectionForWarehouse(ctx context.Context, writer interface{}, fallback SfClient, connName, warehouse string) SfClient {
+	getter, ok := o.connection.(warehouseConnectionGetter)
+	if !ok {
+		return fallback
+	}
+
+	overridden, err := getter.GetSfConnectionWithWarehouse(connName, warehouse)
+	if err != nil {
+		logWarehouseFallback(writer, warehouse, err)
+		return fallback
+	}
+
+	if err := overridden.Ping(ctx); err != nil {
+		logWarehouseFallback(writer, warehouse, err)
+		return fallback
+	}
+
+	return overridden
+}
+
+func logWarehouseFallback(writer interface{}, warehouse string, err error) {
+	w, ok := writer.(io.Writer)
+	if !ok || w == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "warning: could not use warehouse override '%s', falling back to the connection's default warehouse: %v\n", warehouse, err)
 }
 
 func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnCheckOperator {

--- a/pkg/snowflake/operator_test.go
+++ b/pkg/snowflake/operator_test.go
@@ -176,31 +176,6 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "warehouse override prepends USE WAREHOUSE",
-			setup: func(f *fields) {
-				f.e.On("ExtractQueriesFromString", "some content").
-					Return([]*query.Query{
-						{Query: "select * from users"},
-					}, nil)
-
-				f.m.On("Render", mock.Anything, "select * from users").
-					Return("select * from users", nil)
-				f.q.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "USE WAREHOUSE BIG_WH;\nselect * from users"}).
-					Return(nil)
-			},
-			args: args{
-				t: &pipeline.Asset{
-					Type: pipeline.AssetTypeSnowflakeQuery,
-					ExecutableFile: pipeline.ExecutableFile{
-						Path:    "test-file.sql",
-						Content: "some content",
-					},
-					Snowflake: pipeline.SnowflakeConfig{Warehouse: "BIG_WH"},
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "query successfully executed with materialization",
 			setup: func(f *fields) {
 				f.e.On("ExtractQueriesFromString", "some content").
@@ -267,39 +242,79 @@ func TestBasicOperator_RunTask(t *testing.T) {
 	}
 }
 
-func TestWithWarehouse(t *testing.T) {
+func TestBasicOperator_RunTask_WarehouseOverride(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		warehouse string
-		want      string // "" means the original query is returned unchanged
-	}{
-		{name: "empty warehouse returns original", warehouse: "", want: ""},
-		{name: "whitespace-only warehouse returns original", warehouse: "   ", want: ""},
-		{name: "simple identifier injected as-is", warehouse: "BIG_WH", want: "USE WAREHOUSE BIG_WH;\nselect 1"},
-		{name: "lowercase identifier preserved", warehouse: "compute_wh", want: "USE WAREHOUSE compute_wh;\nselect 1"},
-		{name: "surrounding whitespace trimmed", warehouse: "  BIG_WH  ", want: "USE WAREHOUSE BIG_WH;\nselect 1"},
-		{name: "name with space is quoted", warehouse: "my warehouse", want: "USE WAREHOUSE \"my warehouse\";\nselect 1"},
-		{name: "embedded double quote is escaped", warehouse: `odd"name`, want: "USE WAREHOUSE \"odd\"\"name\";\nselect 1"},
+	newAsset := func() *pipeline.Asset {
+		return &pipeline.Asset{
+			Type: pipeline.AssetTypeSnowflakeQuery,
+			ExecutableFile: pipeline.ExecutableFile{
+				Path:    "test-file.sql",
+				Content: "some content",
+			},
+			Parameters: pipeline.ParameterMap{"warehouse": "BIG_WH"},
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			base := &query.Query{Query: "select 1"}
-			got := withWarehouse(base, tt.warehouse)
-
-			if tt.want == "" {
-				assert.Same(t, base, got)
-				return
-			}
-
-			assert.NotSame(t, base, got)
-			assert.Equal(t, tt.want, got.Query)
-			assert.Equal(t, "select 1", base.Query, "original query must not be mutated")
-		})
+	setupExtractorAndMaterializer := func(e *mockExtractor, m *mockMaterializer) {
+		e.On("ExtractQueriesFromString", "some content").
+			Return([]*query.Query{{Query: "select * from users"}}, nil)
+		m.On("Render", mock.Anything, "select * from users").
+			Return("select * from users", nil)
+		m.On("IsFullRefresh").Return(false)
 	}
+
+	newExtractors := func() (*mockExtractor, *mockExtractor, *mockMaterializer) {
+		extractor := new(mockExtractor)
+		preExtractor := new(mockExtractor)
+		preExtractor.On("CloneForAsset", mock.Anything, mock.Anything, mock.Anything).Return(extractor, nil)
+		mat := new(mockMaterializer)
+		setupExtractorAndMaterializer(extractor, mat)
+		return preExtractor, extractor, mat
+	}
+
+	t.Run("runs on the overridden warehouse when reachable", func(t *testing.T) {
+		t.Parallel()
+
+		defaultClient := new(mockQuerierWithResult)
+		overrideClient := new(mockQuerierWithResult)
+		overrideClient.On("Ping", mock.Anything).Return(nil)
+		overrideClient.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "select * from users"}).Return(nil)
+
+		preExtractor, _, mat := newExtractors()
+
+		conn := new(mockConnectionFetcher)
+		conn.On("GetConnection", mock.Anything).Return(defaultClient)
+		conn.On("GetSfConnectionWithWarehouse", mock.Anything, "BIG_WH").Return(overrideClient, nil)
+
+		o := BasicOperator{connection: conn, extractor: preExtractor, materializer: mat}
+		require.NoError(t, o.RunTask(t.Context(), &pipeline.Pipeline{}, newAsset()))
+
+		overrideClient.AssertExpectations(t)
+		defaultClient.AssertNotCalled(t, "RunQueryWithoutResult", mock.Anything, mock.Anything)
+	})
+
+	t.Run("falls back to the default warehouse when the override is unreachable", func(t *testing.T) {
+		t.Parallel()
+
+		defaultClient := new(mockQuerierWithResult)
+		defaultClient.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "select * from users"}).Return(nil)
+		overrideClient := new(mockQuerierWithResult)
+		overrideClient.On("Ping", mock.Anything).Return(errors.New("account suspended"))
+
+		preExtractor, _, mat := newExtractors()
+
+		conn := new(mockConnectionFetcher)
+		conn.On("GetConnection", mock.Anything).Return(defaultClient)
+		conn.On("GetSfConnectionWithWarehouse", mock.Anything, "BIG_WH").Return(overrideClient, nil)
+
+		o := BasicOperator{connection: conn, extractor: preExtractor, materializer: mat}
+		require.NoError(t, o.RunTask(t.Context(), &pipeline.Pipeline{}, newAsset()))
+
+		overrideClient.AssertCalled(t, "Ping", mock.Anything)
+		overrideClient.AssertNotCalled(t, "RunQueryWithoutResult", mock.Anything, mock.Anything)
+		defaultClient.AssertExpectations(t)
+	})
 }
 
 func TestQuerySensorTimesOutWhenConfigured(t *testing.T) {

--- a/pkg/snowflake/operator_test.go
+++ b/pkg/snowflake/operator_test.go
@@ -176,6 +176,31 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "warehouse override prepends USE WAREHOUSE",
+			setup: func(f *fields) {
+				f.e.On("ExtractQueriesFromString", "some content").
+					Return([]*query.Query{
+						{Query: "select * from users"},
+					}, nil)
+
+				f.m.On("Render", mock.Anything, "select * from users").
+					Return("select * from users", nil)
+				f.q.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "USE WAREHOUSE BIG_WH;\nselect * from users"}).
+					Return(nil)
+			},
+			args: args{
+				t: &pipeline.Asset{
+					Type: pipeline.AssetTypeSnowflakeQuery,
+					ExecutableFile: pipeline.ExecutableFile{
+						Path:    "test-file.sql",
+						Content: "some content",
+					},
+					Snowflake: pipeline.SnowflakeConfig{Warehouse: "BIG_WH"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "query successfully executed with materialization",
 			setup: func(f *fields) {
 				f.e.On("ExtractQueriesFromString", "some content").
@@ -238,6 +263,41 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestWithWarehouse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		warehouse string
+		want      string // "" means the original query is returned unchanged
+	}{
+		{name: "empty warehouse returns original", warehouse: "", want: ""},
+		{name: "whitespace-only warehouse returns original", warehouse: "   ", want: ""},
+		{name: "simple identifier injected as-is", warehouse: "BIG_WH", want: "USE WAREHOUSE BIG_WH;\nselect 1"},
+		{name: "lowercase identifier preserved", warehouse: "compute_wh", want: "USE WAREHOUSE compute_wh;\nselect 1"},
+		{name: "surrounding whitespace trimmed", warehouse: "  BIG_WH  ", want: "USE WAREHOUSE BIG_WH;\nselect 1"},
+		{name: "name with space is quoted", warehouse: "my warehouse", want: "USE WAREHOUSE \"my warehouse\";\nselect 1"},
+		{name: "embedded double quote is escaped", warehouse: `odd"name`, want: "USE WAREHOUSE \"odd\"\"name\";\nselect 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base := &query.Query{Query: "select 1"}
+			got := withWarehouse(base, tt.warehouse)
+
+			if tt.want == "" {
+				assert.Same(t, base, got)
+				return
+			}
+
+			assert.NotSame(t, base, got)
+			assert.Equal(t, tt.want, got.Query)
+			assert.Equal(t, "select 1", base.Query, "original query must not be mutated")
 		})
 	}
 }


### PR DESCRIPTION
Adds a warehouse parameter to Snowflake assets. When set, Bruin runs that asset on a dedicated connection whose warehouse is the overridden one. set at the connection/DSN level. If the overridden warehouse can’t be used (role lacks USAGE, account can’t resume it, etc.), Bruin logs a warning and falls back to the connection’s default warehouse so the run isn’t broken.