### PR TITLE
mssql: honor typed columns in create-replace

### DIFF
--- a/docs/platforms/mssql.md
+++ b/docs/platforms/mssql.md
@@ -125,6 +125,8 @@ Runs a materialized SQL Server asset or an SQL script. For detailed parameters, 
 
 Asset names may be `table`, `schema.table`, or `database.schema.table`. A three-part name lets you target a database other than the one in your connection config.
 
+For table assets using the default or `create+replace` materialization strategy, Bruin honors the asset's `columns` schema when every column defines a `type`: it creates the table with the declared column types and then inserts the query result. If any declared column has no type, Bruin keeps SQL Server's `SELECT INTO` behavior so column metadata used only for checks or documentation can still rely on SQL Server type inference.
+
 ::: warning Three-part `ddl` assets across databases
 With the `ddl` materialization strategy, Bruin auto-creates the asset's schema in the connection's *current* database. If a `database.schema.table` asset targets a different database, the schema must already exist there or the run fails with a "schema does not exist" error. Other strategies (e.g. `create+replace`) create the table directly and are unaffected.
 :::

--- a/pkg/mssql/materialization.go
+++ b/pkg/mssql/materialization.go
@@ -51,11 +51,50 @@ func buildCreateReplaceQuery(task *pipeline.Asset, query string) (string, error)
 	if len(mat.ClusterBy) > 0 {
 		return "", errors.New("MsSQL assets do not support `cluster_by`")
 	}
+	if hasTypedColumns(task) {
+		return buildCreateReplaceQueryWithTypedColumns(task, query)
+	}
+
 	query = strings.TrimSuffix(query, ";")
 	queries := []string{
 		"BEGIN TRANSACTION",
 		"DROP TABLE IF EXISTS " + task.Name,
 		fmt.Sprintf("SELECT tmp.* INTO %s FROM (%s) AS tmp", task.Name, query),
+		"COMMIT",
+	}
+
+	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func hasTypedColumns(asset *pipeline.Asset) bool {
+	if len(asset.Columns) == 0 {
+		return false
+	}
+	for _, col := range asset.Columns {
+		if strings.TrimSpace(col.Name) == "" || strings.TrimSpace(col.Type) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func buildCreateReplaceQueryWithTypedColumns(asset *pipeline.Asset, query string) (string, error) {
+	createTable, err := buildCreateTableStatement(asset)
+	if err != nil {
+		return "", err
+	}
+
+	quotedColumnNames := make([]string, 0, len(asset.Columns))
+	for _, col := range asset.Columns {
+		quotedColumnNames = append(quotedColumnNames, quoteIdentifier(col.Name))
+	}
+
+	query = strings.TrimSuffix(query, ";")
+	queries := []string{
+		"BEGIN TRANSACTION",
+		"DROP TABLE IF EXISTS " + quoteIdentifier(asset.Name),
+		createTable,
+		fmt.Sprintf("INSERT INTO %s (%s) %s", quoteIdentifier(asset.Name), strings.Join(quotedColumnNames, ", "), query),
 		"COMMIT",
 	}
 
@@ -185,38 +224,13 @@ func sqlStringLiteral(value string) string {
 	return "N'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
-func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
-	if len(asset.Columns) == 0 {
-		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
-	}
-
-	// Derive the schema component, which is the second-to-last for both
-	// `schema.table` and `database.schema.table`. The schema is created in the
-	// session's current database, so a three-part name's schema is auto-created
-	// only when the database component is the connection's current database.
-	cb, ok := tablename.For("mssql")
-	if !ok {
-		return "", errors.New("mssql table-name capability not found")
-	}
-	tn, err := cb.Parse(asset.Name, tablename.Defaults{})
-	if err != nil {
-		return "", err
-	}
-	queries := make([]string, 0, 2)
-	if tn.Schema != "" {
-		queries = append(queries, fmt.Sprintf(
-			"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
-			sqlStringLiteral(tn.Schema),
-			strings.ReplaceAll(quoteIdentifier(tn.Schema), "'", "''"),
-		))
-	}
-
+func buildColumnDefinitions(asset *pipeline.Asset) ([]string, error) {
 	columnDefs := make([]string, 0, len(asset.Columns)+1)
 	primaryKeys := make([]string, 0)
 	foreignKeys := make([]string, 0)
 	for _, col := range asset.Columns {
 		if col.Type == "" {
-			return "", fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
+			return nil, fmt.Errorf("materialization strategy %s requires column %q to have a type", asset.Materialization.Strategy, col.Name)
 		}
 
 		def := fmt.Sprintf("    %s %s", quoteIdentifier(col.Name), col.SQLType())
@@ -246,11 +260,61 @@ func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
 
 	columnDefs = append(columnDefs, foreignKeys...)
 
-	createTable := fmt.Sprintf(
-		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\nCREATE TABLE %s (\n%s\n)\nEND",
-		sqlStringLiteral(asset.Name),
+	return columnDefs, nil
+}
+
+func buildCreateTableStatement(asset *pipeline.Asset) (string, error) {
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	columnDefs, err := buildColumnDefinitions(asset)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(
+		"CREATE TABLE %s (\n%s\n)",
 		quoteIdentifier(asset.Name),
 		strings.Join(columnDefs, ",\n"),
+	), nil
+}
+
+func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {
+	if len(asset.Columns) == 0 {
+		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
+	}
+
+	// Derive the schema component, which is the second-to-last for both
+	// `schema.table` and `database.schema.table`. The schema is created in the
+	// session's current database, so a three-part name's schema is auto-created
+	// only when the database component is the connection's current database.
+	cb, ok := tablename.For("mssql")
+	if !ok {
+		return "", errors.New("mssql table-name capability not found")
+	}
+	tn, err := cb.Parse(asset.Name, tablename.Defaults{})
+	if err != nil {
+		return "", err
+	}
+	queries := make([]string, 0, 2)
+	if tn.Schema != "" {
+		queries = append(queries, fmt.Sprintf(
+			"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
+			sqlStringLiteral(tn.Schema),
+			strings.ReplaceAll(quoteIdentifier(tn.Schema), "'", "''"),
+		))
+	}
+
+	createTableStatement, err := buildCreateTableStatement(asset)
+	if err != nil {
+		return "", err
+	}
+
+	createTable := fmt.Sprintf(
+		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\n%s\nEND",
+		sqlStringLiteral(asset.Name),
+		createTableStatement,
 	)
 	queries = append(queries, createTable)
 

--- a/pkg/mssql/materialization_test.go
+++ b/pkg/mssql/materialization_test.go
@@ -383,6 +383,56 @@ func TestMaterializer_Render(t *testing.T) {
 	}
 }
 
+func TestCreateReplaceWithTypedColumns(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "dbo.customer_dim",
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyCreateReplace,
+		},
+		Columns: []pipeline.Column{
+			{Name: "id", Type: "int", PrimaryKey: true},
+			{Name: "customer_name", Type: "varchar", Length: intp(50)},
+			{Name: "is_active", Type: "bit", Default: "1"},
+		},
+	}
+
+	render, err := NewMaterializer(false).Render(asset, "SELECT id, customer_name, is_active FROM src.customers;")
+	require.NoError(t, err)
+
+	assert.NotContains(t, render, "SELECT tmp.* INTO")
+	assert.Contains(t, render, "DROP TABLE IF EXISTS [dbo].[customer_dim]")
+	assert.Contains(t, render, "CREATE TABLE [dbo].[customer_dim] (")
+	assert.Contains(t, render, "[customer_name] varchar(50)")
+	assert.Contains(t, render, "[is_active] bit DEFAULT 1")
+	assert.Contains(t, render, "PRIMARY KEY ([id])")
+	assert.Contains(t, render, "INSERT INTO [dbo].[customer_dim] ([id], [customer_name], [is_active]) SELECT id, customer_name, is_active FROM src.customers")
+}
+
+func TestCreateReplaceFallsBackToSelectIntoWithoutTypedColumns(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "dbo.customer_dim",
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyCreateReplace,
+		},
+		Columns: []pipeline.Column{
+			{Name: "id", Type: "int"},
+			{Name: "customer_name"},
+		},
+	}
+
+	render, err := NewMaterializer(false).Render(asset, "SELECT id, customer_name FROM src.customers;")
+	require.NoError(t, err)
+
+	assert.Contains(t, render, "SELECT tmp.* INTO dbo.customer_dim")
+	assert.NotContains(t, render, "CREATE TABLE [dbo].[customer_dim]")
+}
+
 func intp(i int) *int { return &i }
 
 func TestColumnMetadataDDL(t *testing.T) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -2759,6 +2759,46 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 	assert.Equal(t, "#default", got.Notifications.Slack[1].Channel)
 }
 
+func TestBuilder_SetupDefaultsFromPipelineKeepsExplicitMSSQLAssetDefinitions(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "dbo.customer_dim",
+		Type: pipeline.AssetTypeMsSQLQuery,
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyDDL,
+		},
+		Columns: []pipeline.Column{
+			{Name: "customer_name", Type: "varchar", Length: ptrInt(50)},
+		},
+	}
+	defaults := &pipeline.DefaultValues{
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyCreateReplace,
+		},
+		Columns: []pipeline.Column{
+			{Name: "customer_name", Type: "nvarchar", Length: ptrInt(4000)},
+			{Name: "loaded_at", Type: "datetime2"},
+		},
+	}
+
+	builder := &pipeline.Builder{}
+	got, err := builder.SetupDefaultsFromPipeline(t.Context(), asset, &pipeline.Pipeline{DefaultValues: defaults})
+	require.NoError(t, err)
+
+	assert.Equal(t, pipeline.MaterializationTypeTable, got.Materialization.Type)
+	assert.Equal(t, pipeline.MaterializationStrategyDDL, got.Materialization.Strategy)
+	require.Len(t, got.Columns, 2)
+	assert.Equal(t, "customer_name", got.Columns[0].Name)
+	assert.Equal(t, "varchar", got.Columns[0].Type)
+	require.NotNil(t, got.Columns[0].Length)
+	assert.Equal(t, 50, *got.Columns[0].Length)
+	assert.Equal(t, "loaded_at", got.Columns[1].Name)
+	assert.Equal(t, "datetime2", got.Columns[1].Type)
+}
+
 func TestBuilder_InjectConnectionAsSecret(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary:
- create typed MSSQL tables for create+replace materialization when asset columns all declare types
- reuse MSSQL DDL column-definition rendering for create+replace table creation
- add regression coverage for typed create+replace rendering and pipeline default precedence
- document the typed-column behavior for ms.sql assets

Local verification:
- git diff --check: passed
- make format: ran; Python ruff, go vet/gci/gofumpt started, but golangci-lint is not installed in PATH in this environment
- go test -tags="no_duckdb_arrow" ./pkg/mssql: not completed locally because libbruin_rustsqlparser.a is not built in this worktree
