### PR TITLE
python: bump ingestr to v1.0.65

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -43,7 +43,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.63"
+	IngestrVersionV1 = "1.0.65"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
## Summary
- Bump the default v1 ingestr package version from 1.0.63 to 1.0.65.
- Keep default and parameters.version=v1 ingestr assets aligned with the latest ingestr release tag.