### PR TITLE
docs(lakehouse): align lakehouse docs with implementation

### DIFF
--- a/docs/getting-started/lakehouse.md
+++ b/docs/getting-started/lakehouse.md
@@ -30,16 +30,16 @@ MySQL catalogs are currently not supported for DuckLake in Bruin due to limitati
 
 #### Iceberg
 
-Iceberg uses the AWS Glue Data Catalog ([AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-data-catalog.html)). The table shows supported storage + catalog combinations.
+Iceberg uses the [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-data-catalog.html). The table shows supported storage + catalog combinations.
 
-| Catalog | S3 |
-|-------------------|----|
-| Glue | <span class="lh-check" aria-label="supported"></span> |
+| Catalog | S3 | GCS |
+|-------------------|----|-----|
+| Glue | <span class="lh-check" aria-label="supported"></span> | <span class="lh-check" aria-label="supported"></span> |
 
 
 ### Trino [↗](../platforms/trino.md#lakehouse-support)
 
-Trino supports lakehouse access via the [Iceberg connector](https://trino.io/docs/current/connector/iceberg.html) with [Glue](https://aws.amazon.com/glue/) and [Nessie](https://projectnessie.org/) catalogs. Configuration happens in Trino, while Bruin connection config remains unchanged. See [Trino lakehouse support](../platforms/trino.md#lakehouse-support), [Trino + GCS (general)](../platforms/trino.md#guide-trino-gcs-general), [Glue + S3 guide](../platforms/trino.md#guide-glue-s3), [Nessie (in-memory) + S3 guide](../platforms/trino.md#guide-nessie-in-memory-s3), and [Nessie (in-memory) + GCS guide](../platforms/trino.md#guide-nessie-in-memory-gcs).
+Trino supports lakehouse access via the [Iceberg connector](https://trino.io/docs/current/connector/iceberg.html) with [Glue](https://aws.amazon.com/glue/) and [Nessie](https://projectnessie.org/) catalogs. Configuration happens in Trino, while Bruin connection config remains unchanged. See [Trino lakehouse support](../platforms/trino.md#lakehouse-support), [Glue + S3 guide](../platforms/trino.md#guide-glue-s3), [Nessie (in-memory) + S3 guide](../platforms/trino.md#guide-nessie-in-memory-s3), and [Nessie (in-memory) + GCS guide](../platforms/trino.md#guide-nessie-in-memory-gcs).
 
 | Catalog | S3 | GCS |
 |-------------------|----|-----|
@@ -86,7 +86,7 @@ connections:
             secret_key: "..."
 ```
 
-Then query your Iceberg tables (defaults to the `main` schema):
+Then query your DuckLake tables (defaults to the `main` schema):
 
 ```Bruin-sql
 /* @Bruin

--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -193,7 +193,7 @@ connections:
 |-------|------|----------|-------------|
 | `format` | string | Yes | Table format: `iceberg` or `ducklake` |
 | `catalog` | object | Yes | Catalog configuration (Glue for Iceberg, DuckDB/SQLite/Postgres for DuckLake) |
-| `storage` | object | No | Storage configuration (required for DuckLake) |
+| `storage` | object | Yes | Storage configuration (`type` and `auth` required for both formats; `path` is required for DuckLake and optional for Iceberg) |
 
 ---
 ### Supported Lakehouse Formats
@@ -213,9 +213,9 @@ MySQL catalogs are currently not supported for DuckLake in Bruin due to limitati
 
 #### Iceberg
 
-| Catalog | S3 |
-|-------------------|----|
-| Glue | <span class="lh-check" aria-label="supported"></span> |
+| Catalog | S3 | GCS |
+|-------------------|----|-----|
+| Glue | <span class="lh-check" aria-label="supported"></span> | <span class="lh-check" aria-label="supported"></span> |
 
 
 For background, see DuckDB's [lakehouse format overview](https://duckdb.org/docs/stable/lakehouse_formats).


### PR DESCRIPTION
## What

Fixes inaccuracies in the lakehouse docs so they match the actual Bruin implementation. Verified against `pkg/config/lakehouse.go`, `pkg/duckdb/lakehouse.go` (+ tests), and the `DuckDBConnection`/`TrinoConnection` structs.
