### PR TITLE
Add 'bruin cloud agents get' and 'update' commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2030,12 +2030,114 @@ func CloudAgents() *cli.Command {
 		Commands: []*cli.Command{
 			cloudAgentsList(),
 			cloudAgentsCreate(),
+			cloudAgentsGet(),
+			cloudAgentsUpdate(),
 			cloudAgentsSend(),
 			cloudAgentsStatus(),
 			cloudAgentsThreads(),
 			cloudAgentsMessages(),
 			cloudAgentsGetPrompt(),
 			cloudAgentsSetPrompt(),
+		},
+	}
+}
+
+func cloudAgentsGet() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "Get a single agent's details",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			agent, err := client.GetAgent(ctx, c.Int("agent-id"))
+			if err != nil {
+				printError(err, output, "Failed to get agent")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(agent, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Agent %d: %s (visibility: %s)\n", agent.ID, agent.Name, agent.Visibility)
+			return nil
+		},
+	}
+}
+
+func cloudAgentsUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Update an agent's name, description or visibility",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "name",
+				Usage: "the new agent name",
+			},
+			&cli.StringFlag{
+				Name:  "description",
+				Usage: "the new agent description",
+			},
+			&cli.StringFlag{
+				Name:  "visibility",
+				Usage: "agent visibility: team or private",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			visibility := c.String("visibility")
+			if visibility != "" && visibility != "team" && visibility != "private" {
+				printError(fmt.Errorf("visibility must be 'team' or 'private', got %q", visibility), output, "Invalid --visibility")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			agent, err := client.UpdateAgent(ctx, c.Int("agent-id"), c.String("name"), c.String("description"), visibility)
+			if err != nil {
+				printError(err, output, "Failed to update agent")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(agent, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Updated agent %d (%s)\n", agent.ID, agent.Name)
+			return nil
 		},
 	}
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2130,7 +2130,7 @@ func cloudAgentsUpdate() *cli.Command {
 				fields["visibility"] = visibility
 			}
 			if len(fields) == 0 {
-				printError(fmt.Errorf("provide at least one of --name, --description or --visibility"), output, "Nothing to update")
+				printError(errors.New("provide at least one of --name, --description or --visibility"), output, "Nothing to update")
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2112,9 +2112,25 @@ func cloudAgentsUpdate() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
-			visibility := c.String("visibility")
-			if visibility != "" && visibility != "team" && visibility != "private" {
-				printError(fmt.Errorf("visibility must be 'team' or 'private', got %q", visibility), output, "Invalid --visibility")
+			// Build the patch from the flags the user actually set, so an explicit
+			// empty value (e.g. --description "") is sent rather than dropped.
+			fields := map[string]any{}
+			if c.IsSet("name") {
+				fields["name"] = c.String("name")
+			}
+			if c.IsSet("description") {
+				fields["description"] = c.String("description")
+			}
+			if c.IsSet("visibility") {
+				visibility := c.String("visibility")
+				if visibility != "team" && visibility != "private" {
+					printError(fmt.Errorf("visibility must be 'team' or 'private', got %q", visibility), output, "Invalid --visibility")
+					return cli.Exit("", 1)
+				}
+				fields["visibility"] = visibility
+			}
+			if len(fields) == 0 {
+				printError(fmt.Errorf("provide at least one of --name, --description or --visibility"), output, "Nothing to update")
 				return cli.Exit("", 1)
 			}
 
@@ -2124,7 +2140,7 @@ func cloudAgentsUpdate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			agent, err := client.UpdateAgent(ctx, c.Int("agent-id"), c.String("name"), c.String("description"), visibility)
+			agent, err := client.UpdateAgent(ctx, c.Int("agent-id"), fields)
 			if err != nil {
 				printError(err, output, "Failed to update agent")
 				return cli.Exit("", 1)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -219,7 +219,7 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 8)
+	require.Len(t, cmd.Commands, 10)
 }
 
 func TestExtractErrorLines_ErrorLevel(t *testing.T) {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -440,6 +440,37 @@ func (c *APIClient) CreateAgent(ctx context.Context, name, description, systemPr
 	return &result, nil
 }
 
+// GetAgent returns a single agent's details.
+func (c *APIClient) GetAgent(ctx context.Context, agentID int) (*Agent, error) {
+	var result Agent
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%d", agentID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateAgent updates an agent. Only non-empty fields are sent, so the server
+// changes just those; omitted fields are left unchanged.
+func (c *APIClient) UpdateAgent(ctx context.Context, agentID int, name, description, visibility string) (*Agent, error) {
+	body := map[string]any{}
+	if name != "" {
+		body["name"] = name
+	}
+	if description != "" {
+		body["description"] = description
+	}
+	if visibility != "" {
+		body["visibility"] = visibility
+	}
+	var result Agent
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/agents/%d", agentID), body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *APIClient) SendAgentMessage(ctx context.Context, agentID int, message string, threadID *int) (json.RawMessage, error) {
 	body := map[string]any{
 		"message": message,

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -450,21 +450,12 @@ func (c *APIClient) GetAgent(ctx context.Context, agentID int) (*Agent, error) {
 	return &result, nil
 }
 
-// UpdateAgent updates an agent. Only non-empty fields are sent, so the server
-// changes just those; omitted fields are left unchanged.
-func (c *APIClient) UpdateAgent(ctx context.Context, agentID int, name, description, visibility string) (*Agent, error) {
-	body := map[string]any{}
-	if name != "" {
-		body["name"] = name
-	}
-	if description != "" {
-		body["description"] = description
-	}
-	if visibility != "" {
-		body["visibility"] = visibility
-	}
+// UpdateAgent patches an agent with the given fields. The caller decides which
+// fields to include (based on which flags were set), so an explicit empty value
+// is sent and can clear a field.
+func (c *APIClient) UpdateAgent(ctx context.Context, agentID int, fields map[string]any) (*Agent, error) {
 	var result Agent
-	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/agents/%d", agentID), body, &result)
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/agents/%d", agentID), fields, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -512,6 +512,42 @@ func TestCreateAgent(t *testing.T) {
 	assert.Equal(t, "private", agent.Visibility)
 }
 
+func TestGetAgent(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/agents/7", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, Agent{ID: 7, Name: "an-agent", Visibility: "team"})
+	})
+
+	agent, err := client.GetAgent(t.Context(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, "an-agent", agent.Name)
+}
+
+func TestUpdateAgent(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/agents/7", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "renamed", body["name"])
+		// empty fields are omitted so the server leaves them unchanged
+		_, hasVisibility := body["visibility"]
+		assert.False(t, hasVisibility)
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, Agent{ID: 7, Name: "renamed", Visibility: "team"})
+	})
+
+	agent, err := client.UpdateAgent(t.Context(), 7, "renamed", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", agent.Name)
+}
+
 func TestListAgentThreads(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -543,7 +543,7 @@ func TestUpdateAgent(t *testing.T) {
 		writeJSON(t, w, Agent{ID: 7, Name: "renamed", Visibility: "team"})
 	})
 
-	agent, err := client.UpdateAgent(t.Context(), 7, "renamed", "", "")
+	agent, err := client.UpdateAgent(t.Context(), 7, map[string]any{"name": "renamed"})
 	require.NoError(t, err)
 	assert.Equal(t, "renamed", agent.Name)
 }


### PR DESCRIPTION
Wraps the new `GET`/`PATCH /api/v1/agents/{id}` endpoints.

```
bruin cloud agents get --agent-id N
bruin cloud agents update --agent-id N [--name ...] [--description ...] [--visibility team|private]
```

update sends only the non-empty flags (server leaves the rest unchanged); visibility validated client-side. Completes create → get → update → set-prompt → list.