### PR TITLE
[codex] clarify materialization scope

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -4,6 +4,9 @@ Materialization is the idea of taking a simple `SELECT` query, and applying the 
 
 Bruin supports various materialization strategies catered to different use cases.
 
+> [!WARNING]
+> The materialization behavior described on this page applies to SQL assets only. It is not applied to `ingestr` assets; use `ingestr` parameters such as `incremental_strategy` and `incremental_key` instead. Python assets have their own [materialization workflow](./python.md#materialization).
+
 Here's a sample asset with materialization:
 
 ```bruin-sql

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -156,6 +156,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "ingestr-materialization-ignored",
+			Fast:             true,
+			Severity:         ValidatorSeverityWarning,
+			AssetValidator:   WarnIngestrAssetMaterializationIgnored,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "valid-pipeline-start-date",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -62,6 +62,7 @@ const (
 	materializationPartitionByNotSupportedForViews    = "Materialization partition by is not supported for views because views cannot be partitioned"
 	materializationIncrementalKeyNotSupportedForViews = "Materialization incremental key is not supported for views because views cannot be updated incrementally"
 	materializationClusterByNotSupportedForViews      = "Materialization cluster by is not supported for views because views cannot be clustered"
+	ingestrMaterializationIgnored                     = "The `materialization` block is ignored for ingestr assets. Use `parameters.incremental_strategy` and `parameters.incremental_key` instead."
 )
 
 var validIDRegexCompiled = regexp.MustCompile(validIDRegex)
@@ -326,6 +327,19 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 	}
 
 	return issues, nil
+}
+
+func WarnIngestrAssetMaterializationIgnored(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	if asset.Type != pipeline.AssetTypeIngestr || !hasMaterializationConfig(asset.Materialization) {
+		return []*Issue{}, nil
+	}
+
+	return []*Issue{
+		{
+			Task:        asset,
+			Description: ingestrMaterializationIgnored,
+		},
+	}, nil
 }
 
 func isFileExecutable(mode os.FileMode) bool {
@@ -1178,7 +1192,7 @@ func EnsureAssetNotificationsAreValid(ctx context.Context, p *pipeline.Pipeline,
 
 func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
-	if asset.Type == pipeline.AssetTypePython {
+	if asset.Type == pipeline.AssetTypePython || asset.Type == pipeline.AssetTypeIngestr {
 		return issues, nil
 	}
 
@@ -1343,6 +1357,15 @@ func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *p
 	}
 
 	return issues, nil
+}
+
+func hasMaterializationConfig(mat pipeline.Materialization) bool {
+	return mat.Type != pipeline.MaterializationTypeNone ||
+		mat.Strategy != pipeline.MaterializationStrategyNone ||
+		mat.PartitionBy != "" ||
+		len(mat.ClusterBy) > 0 ||
+		mat.IncrementalKey != "" ||
+		mat.TimeGranularity != ""
 }
 
 func ensureDataVaultHubColumnsAreValid(asset *pipeline.Asset) []*Issue {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1257,6 +1257,21 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "ingestr materialization is ignored",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Type: pipeline.AssetTypeIngestr,
+					Materialization: pipeline.Materialization{
+						Type:           pipeline.MaterializationTypeTable,
+						Strategy:       "whatever",
+						IncrementalKey: "dt",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "view materialization has extra fields",
 			assets: []*pipeline.Asset{
 				{
@@ -2238,6 +2253,76 @@ func TestEnsurePipelineStartDateIsValid(t *testing.T) {
 			got, err := EnsurePipelineStartDateIsValid(ctx, tt.p)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWarnIngestrAssetMaterializationIgnored(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		asset     *pipeline.Asset
+		wantIssue bool
+	}{
+		{
+			name: "ingestr asset with materialization warns",
+			asset: &pipeline.Asset{
+				Name: "raw.orders",
+				Type: pipeline.AssetTypeIngestr,
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+			},
+			wantIssue: true,
+		},
+		{
+			name: "ingestr asset with incremental key materialization warns",
+			asset: &pipeline.Asset{
+				Name: "raw.orders",
+				Type: pipeline.AssetTypeIngestr,
+				Materialization: pipeline.Materialization{
+					IncrementalKey: "updated_at",
+				},
+			},
+			wantIssue: true,
+		},
+		{
+			name: "ingestr asset without materialization does not warn",
+			asset: &pipeline.Asset{
+				Name: "raw.orders",
+				Type: pipeline.AssetTypeIngestr,
+			},
+		},
+		{
+			name: "sql asset with materialization does not warn",
+			asset: &pipeline.Asset{
+				Name: "raw.orders",
+				Type: pipeline.AssetTypeDuckDBQuery,
+				Materialization: pipeline.Materialization{
+					Type: pipeline.MaterializationTypeTable,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &pipeline.Pipeline{Assets: []*pipeline.Asset{tt.asset}}
+			got, err := WarnIngestrAssetMaterializationIgnored(t.Context(), p, tt.asset)
+			require.NoError(t, err)
+
+			if !tt.wantIssue {
+				assert.Empty(t, got)
+				return
+			}
+
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.asset, got[0].Task)
+			assert.Equal(t, ingestrMaterializationIgnored, got[0].Description)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add a warning that the materialization docs apply to SQL assets only.
- Add a warning lint rule for `ingestr` assets that define a `materialization` block, pointing users to `parameters.incremental_strategy` and `parameters.incremental_key` instead.
- Skip generic materialization config validation for `ingestr` assets because the block is ignored at runtime.

## Validation

- `git diff --check`

Not run: Go formatter/tests (`go`/`gofmt` are unavailable in this environment).