### PR TITLE
Add 'bruin cloud dashboards list' and 'get' commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -35,6 +35,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudGlossary(),
 			CloudAgents(),
 			CloudConnections(),
+			CloudDashboards(),
 		},
 	}
 }
@@ -2698,6 +2699,123 @@ func cloudConnectionsDelete() *cli.Command {
 			}
 
 			printSuccessForOutput(output, fmt.Sprintf("Successfully deleted connection '%s'", name))
+			return nil
+		},
+	}
+}
+
+func CloudDashboards() *cli.Command {
+	return &cli.Command{
+		Name:  "dashboards",
+		Usage: "Manage Bruin Cloud dashboards",
+		Commands: []*cli.Command{
+			cloudDashboardsList(),
+			cloudDashboardsGet(),
+		},
+	}
+}
+
+func cloudDashboardsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List dashboards",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			dashboards, err := client.ListDashboards(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list dashboards")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(dashboards, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Title", "Visibility", "Updated At"})
+			for _, d := range dashboards {
+				title := ""
+				if d.Title != nil {
+					title = *d.Title
+				}
+				updated := ""
+				if d.UpdatedAt != nil {
+					updated = *d.UpdatedAt
+				}
+				t.AppendRow(table.Row{d.ID, title, d.Visibility, updated})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudDashboardsGet() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "Get a dashboard including its published definition",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "dashboard-id",
+				Usage:    "dashboard ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			dashboard, err := client.GetDashboard(ctx, c.Int("dashboard-id"))
+			if err != nil {
+				printError(err, output, "Failed to get dashboard")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(dashboard, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			title := ""
+			if dashboard.Title != nil {
+				title = *dashboard.Title
+			}
+			infoPrinter.Printf("Dashboard %d: %s (visibility: %s)\n", dashboard.ID, title, dashboard.Visibility)
+
+			// Print the definition (state) as pretty JSON so it can be inspected or saved.
+			if len(dashboard.State) > 0 {
+				var obj any
+				if err := json.Unmarshal(dashboard.State, &obj); err == nil {
+					pretty, _ := json.MarshalIndent(obj, "", "  ")
+					fmt.Println(string(pretty))
+				} else {
+					fmt.Println(string(dashboard.State))
+				}
+			}
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -143,7 +143,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 8)
+	assert.Len(t, cmd.Commands, 9)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -157,6 +157,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "glossary")
 	assert.Contains(t, subNames, "agents")
 	assert.Contains(t, subNames, "connections")
+	assert.Contains(t, subNames, "dashboards")
 }
 
 func TestCloudProjectsCommand_Help(t *testing.T) {
@@ -220,6 +221,21 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
 	require.Len(t, cmd.Commands, 8)
+}
+
+func TestCloudDashboardsCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := CloudDashboards()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "dashboards", cmd.Name)
+	require.Len(t, cmd.Commands, 2)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "list")
+	assert.Contains(t, subNames, "get")
 }
 
 func TestExtractErrorLines_ErrorLevel(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -599,6 +599,31 @@ Delete a connection by name:
 bruin cloud connections delete --name my_pg
 ```
 
+### `dashboards`
+
+Read the dashboards in your Bruin Cloud team — useful for inspecting or
+version-controlling a dashboard's definition.
+
+#### `list`
+
+List the team's dashboards (id, title, visibility, last updated):
+
+```bash
+bruin cloud dashboards list
+bruin cloud dashboards list --output json
+```
+
+#### `get`
+
+Get a single dashboard including its published definition (`state`):
+
+```bash
+bruin cloud dashboards get --dashboard-id 42
+
+# Full payload, incl. the definition, as JSON
+bruin cloud dashboards get --dashboard-id 42 --output json
+```
+
 ---
 
 ## Common Workflows

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -540,3 +540,22 @@ func (c *APIClient) CreateConnection(ctx context.Context, name, connType string,
 func (c *APIClient) DeleteConnection(ctx context.Context, name string) error {
 	return c.doRequest(ctx, http.MethodDelete, "/connections/"+url.PathEscape(name), nil, nil)
 }
+
+// --- Dashboards ---
+
+func (c *APIClient) ListDashboards(ctx context.Context) ([]Dashboard, error) {
+	var resp struct {
+		Dashboards []Dashboard `json:"dashboards"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/dashboards", nil, &resp)
+	return resp.Dashboards, err
+}
+
+func (c *APIClient) GetDashboard(ctx context.Context, dashboardID int) (*Dashboard, error) {
+	var result Dashboard
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/dashboards/%d", dashboardID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -703,14 +703,14 @@ func TestTriggerRunWithTags(t *testing.T) {
 
 func TestListDashboards(t *testing.T) {
 	t.Parallel()
-	title := "Revenue"
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/dashboards", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
+		// Match the API's snake_case shape exactly, so the tag mapping is covered.
 		writeJSON(t, w, map[string]any{
-			"dashboards": []Dashboard{
-				{ID: 3, Title: &title, Visibility: "team"},
+			"dashboards": []map[string]any{
+				{"id": 3, "title": "Revenue", "visibility": "team", "updated_at": "2026-07-06T10:00:00+00:00"},
 			},
 		})
 	})
@@ -719,6 +719,8 @@ func TestListDashboards(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dashboards, 1)
 	assert.Equal(t, "Revenue", *dashboards[0].Title)
+	require.NotNil(t, dashboards[0].UpdatedAt)
+	assert.Equal(t, "2026-07-06T10:00:00+00:00", *dashboards[0].UpdatedAt)
 }
 
 func TestGetDashboard(t *testing.T) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -700,3 +700,43 @@ func TestTriggerRunWithTags(t *testing.T) {
 		TriggerRunOptions{Note: "Q1 backfill", Tags: []string{"nightly", "manual"}})
 	require.NoError(t, err)
 }
+
+func TestListDashboards(t *testing.T) {
+	t.Parallel()
+	title := "Revenue"
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/dashboards", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"dashboards": []Dashboard{
+				{ID: 3, Title: &title, Visibility: "team"},
+			},
+		})
+	})
+
+	dashboards, err := client.ListDashboards(t.Context())
+	require.NoError(t, err)
+	require.Len(t, dashboards, 1)
+	assert.Equal(t, "Revenue", *dashboards[0].Title)
+}
+
+func TestGetDashboard(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/dashboards/3", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"id":         3,
+			"title":      "Revenue",
+			"visibility": "team",
+			"state":      map[string]any{"widgets": []any{}},
+		})
+	})
+
+	dashboard, err := client.GetDashboard(t.Context(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, dashboard.ID)
+	assert.JSONEq(t, `{"widgets":[]}`, string(dashboard.State))
+}

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -244,3 +244,13 @@ type Connection struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
+
+// Dashboard represents a Bruin Cloud dashboard. State is only populated by the
+// single-dashboard endpoint and carries the published definition as raw JSON.
+type Dashboard struct {
+	ID         int             `json:"id"`
+	Title      *string         `json:"title"`
+	Visibility string          `json:"visibility"`
+	UpdatedAt  *string         `json:"updated_at"`
+	State      json.RawMessage `json:"state,omitempty"`
+}


### PR DESCRIPTION
Phase 2 of the dashboard work — wraps the read-only dashboard API.

```
bruin cloud dashboards list
bruin cloud dashboards get --dashboard-id N
```

`list` shows id/title/visibility/updated; `get` returns the dashboard incl. its published definition (`state`), with `--output json` for the full payload. Depends on the cloud API (PR #2518) being deployed.