### PR TITLE
[codex] Add AI init templates

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -265,6 +265,10 @@ func Init() *cli.Command {
 				}
 			}
 
+			if isAITemplateArgument(templateName) {
+				return handleAIInit(ctx, c, selectedViaInteractive)
+			}
+
 			_, err = templates.Templates.ReadDir(templateName)
 			if err != nil || !slices.Contains(templateList, templateName) {
 				errorPrinter.Printf("Template '%s' not found\n", templateName)

--- a/cmd/init_ai.go
+++ b/cmd/init_ai.go
@@ -1,0 +1,561 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	fs2 "io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/git"
+	"github.com/bruin-data/bruin/pkg/telemetry"
+	"github.com/bruin-data/bruin/templates"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/manifoldco/promptui"
+	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	aiCategoryTemplateName = "ai"
+	aiAgentsTemplateName   = "ai-agents-md"
+	aiSelfHealTemplateName = "ai-skill-self-heal"
+
+	aiAgentsSectionStart = "<!-- BEGIN BRUIN AI AGENTS -->"
+	aiAgentsSectionEnd   = "<!-- END BRUIN AI AGENTS -->"
+)
+
+type aiTemplate struct {
+	Name                string
+	TemplateDir         string
+	RequiredConnections []aiConnectionType
+}
+
+type aiConnectionType string
+
+const (
+	aiConnectionBruinCloud aiConnectionType = "bruin"
+	aiConnectionGitHub     aiConnectionType = "github"
+)
+
+type aiConflictAction string
+
+const (
+	aiConflictOverwrite aiConflictAction = "overwrite"
+	aiConflictAdd       aiConflictAction = "add"
+	aiConflictSkip      aiConflictAction = "skip"
+)
+
+type aiInstallOptions struct {
+	conflictResolver   func(path string) (aiConflictAction, error)
+	connectionResolver func(connection aiConnectionType) (bool, error)
+}
+
+var aiTemplates = []aiTemplate{
+	{
+		Name:        aiAgentsTemplateName,
+		TemplateDir: "agents-md",
+	},
+	{
+		Name:                aiSelfHealTemplateName,
+		TemplateDir:         "skill-self-heal",
+		RequiredConnections: []aiConnectionType{aiConnectionBruinCloud, aiConnectionGitHub},
+	},
+}
+
+const (
+	aiBruinCloudTokenPlaceholder = "${BRUIN_CLOUD_API_TOKEN}" //nolint:gosec // Environment variable reference, not a credential.
+	aiGitHubTokenPlaceholder     = "${GITHUB_TOKEN}"          //nolint:gosec // Environment variable reference, not a credential.
+)
+
+var aiGitHubPathPartPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+func isAITemplateArgument(templateName string) bool {
+	return templateName == aiCategoryTemplateName || lookupAITemplate(templateName) != nil
+}
+
+func handleAIInit(ctx context.Context, c *cli.Command, selectedViaInteractive bool) error {
+	templateName := c.Args().Get(0)
+	if c.Args().Get(1) != "" {
+		errorPrinter.Printf("AI templates install into the repository root and do not accept a folder argument.\n")
+		return cli.Exit("", 1)
+	}
+	if c.IsSet("in-place") {
+		errorPrinter.Printf("AI templates always install into the repository root or current directory; --in-place is not supported.\n")
+		return cli.Exit("", 1)
+	}
+
+	if templateName == aiCategoryTemplateName {
+		selected, cancelled, err := runAISelector()
+		if err != nil {
+			errorPrinter.Printf("Error running the AI template selector: %v\n", err)
+			return cli.Exit("", 1)
+		}
+		if cancelled {
+			return nil
+		}
+		templateName = selected
+		selectedViaInteractive = true
+	}
+
+	template := lookupAITemplate(templateName)
+	if template == nil {
+		errorPrinter.Printf("AI template '%s' not found\n", templateName)
+		return cli.Exit("", 1)
+	}
+
+	targetRoot, err := aiTargetRoot()
+	if err != nil {
+		errorPrinter.Printf("Could not find target directory: %v\n", err)
+		return cli.Exit("", 1)
+	}
+
+	result, err := installAITemplate(ctx, *template, targetRoot, aiInstallOptions{})
+	if err != nil {
+		errorPrinter.Printf("%v\n", err)
+		return cli.Exit("", 1)
+	}
+
+	telemetry.SetTemplateName(template.Name)
+	telemetry.SendEvent("template_selected", map[string]interface{}{
+		"template_name":       template.Name,
+		"template_category":   aiCategoryTemplateName,
+		"interactive":         selectedViaInteractive,
+		"created_files":       len(result.Created),
+		"updated_files":       len(result.Updated),
+		"skipped_conflicts":   len(result.Skipped),
+		"connections_added":   len(result.ConnectionsAdded),
+		"connections_skipped": len(result.ConnectionsSkipped),
+	})
+
+	successPrinter.Printf("\n\nAI template '%s' installed in '%s'.\n", template.Name, targetRoot)
+	if len(result.ConnectionsAdded) > 0 {
+		infoPrinter.Printf("Added placeholder connections to .bruin.yml: %s\n", strings.Join(result.ConnectionsAdded, ", "))
+	}
+	if len(result.ConnectionsSkipped) > 0 {
+		infoPrinter.Printf("Skipped optional connection setup: %s\n", strings.Join(result.ConnectionsSkipped, ", "))
+	}
+	if len(result.Skipped) > 0 {
+		infoPrinter.Printf("Skipped existing paths: %s\n", strings.Join(result.Skipped, ", "))
+	}
+	infoPrinter.Print("\nYou can review the installed files and customize them for this repository.\n\n")
+
+	return nil
+}
+
+type aiInstallResult struct {
+	Created            []string
+	Updated            []string
+	Skipped            []string
+	ConnectionsAdded   []string
+	ConnectionsSkipped []string
+}
+
+func installAITemplate(ctx context.Context, template aiTemplate, targetRoot string, opts aiInstallOptions) (*aiInstallResult, error) {
+	result := &aiInstallResult{}
+	sourceRoot := filepath.ToSlash(filepath.Join(aiCategoryTemplateName, template.TemplateDir))
+
+	if err := fs2.WalkDir(templates.Templates, sourceRoot, func(path string, d fs2.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == sourceRoot || d.IsDir() {
+			return nil
+		}
+
+		content, err := templates.Templates.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		relPath := strings.TrimPrefix(path, sourceRoot+"/")
+		targetPath := filepath.Join(targetRoot, filepath.FromSlash(relPath))
+
+		outcome, err := writeAIFile(targetPath, content, opts)
+		if err != nil {
+			return err
+		}
+		switch outcome {
+		case aiWriteCreated:
+			result.Created = append(result.Created, targetPath)
+		case aiWriteUpdated:
+			result.Updated = append(result.Updated, targetPath)
+		case aiWriteSkipped:
+			result.Skipped = append(result.Skipped, targetPath)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("could not install AI template %s: %w", template.Name, err)
+	}
+
+	if err := ensureAIConnections(ctx, targetRoot, template.RequiredConnections, opts, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+type aiWriteOutcome string
+
+const (
+	aiWriteCreated aiWriteOutcome = "created"
+	aiWriteUpdated aiWriteOutcome = "updated"
+	aiWriteSkipped aiWriteOutcome = "skipped"
+)
+
+func writeAIFile(targetPath string, content []byte, opts aiInstallOptions) (aiWriteOutcome, error) {
+	if _, err := os.Stat(targetPath); errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return "", err
+		}
+		return aiWriteCreated, os.WriteFile(targetPath, content, 0o644) //nolint:gosec
+	} else if err != nil {
+		return "", err
+	}
+
+	action, err := resolveAIConflict(targetPath, opts)
+	if err != nil {
+		return "", err
+	}
+
+	switch action {
+	case aiConflictOverwrite:
+		return aiWriteUpdated, os.WriteFile(targetPath, content, 0o644) //nolint:gosec
+	case aiConflictAdd:
+		if filepath.Base(targetPath) == "AGENTS.md" {
+			return aiWriteUpdated, addOrUpdateAgentsSection(targetPath, string(content))
+		}
+		return aiWriteSkipped, nil
+	case aiConflictSkip:
+		return aiWriteSkipped, nil
+	default:
+		return "", fmt.Errorf("unknown conflict action %q", action)
+	}
+}
+
+func resolveAIConflict(path string, opts aiInstallOptions) (aiConflictAction, error) {
+	if opts.conflictResolver != nil {
+		return opts.conflictResolver(path)
+	}
+	if !isStdinTerminal() {
+		return "", fmt.Errorf("AI template target already exists: %s. Re-run in an interactive terminal and choose overwrite, add, or skip", path)
+	}
+
+	prompt := promptui.Select{
+		Label: path + " already exists. What would you like to do?",
+		Items: []string{string(aiConflictAdd), string(aiConflictOverwrite), string(aiConflictSkip)},
+	}
+	_, selected, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return aiConflictAction(selected), nil
+}
+
+func addOrUpdateAgentsSection(path, templateContent string) error {
+	section, err := extractAgentsSection(templateContent)
+	if err != nil {
+		return err
+	}
+
+	existingBytes, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	existing := string(existingBytes)
+
+	start := strings.Index(existing, aiAgentsSectionStart)
+	end := strings.Index(existing, aiAgentsSectionEnd)
+	if start >= 0 && end >= start {
+		end += len(aiAgentsSectionEnd)
+		updated := existing[:start] + strings.TrimSpace(section) + existing[end:]
+		return os.WriteFile(path, []byte(ensureTrailingNewline(updated)), 0o644) //nolint:gosec
+	}
+
+	updated := strings.TrimRight(existing, "\n") + "\n\n" + strings.TrimSpace(section) + "\n"
+	return os.WriteFile(path, []byte(updated), 0o644) //nolint:gosec
+}
+
+func extractAgentsSection(content string) (string, error) {
+	start := strings.Index(content, aiAgentsSectionStart)
+	end := strings.Index(content, aiAgentsSectionEnd)
+	if start < 0 || end < start {
+		return "", errors.New("AGENTS.md template does not contain Bruin AI section markers")
+	}
+
+	return content[start : end+len(aiAgentsSectionEnd)], nil
+}
+
+func ensureTrailingNewline(value string) string {
+	if strings.HasSuffix(value, "\n") {
+		return value
+	}
+	return value + "\n"
+}
+
+func ensureAIConnections(ctx context.Context, targetRoot string, required []aiConnectionType, opts aiInstallOptions, result *aiInstallResult) error {
+	if len(required) == 0 {
+		return nil
+	}
+
+	configPath := filepath.Join(targetRoot, ".bruin.yml")
+	cm, err := loadAIConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	for _, connection := range required {
+		if aiConfigHasConnection(cm, connection) {
+			continue
+		}
+
+		shouldAdd, err := resolveAIConnectionPrompt(connection, opts)
+		if err != nil {
+			return err
+		}
+		if !shouldAdd {
+			result.ConnectionsSkipped = append(result.ConnectionsSkipped, string(connection))
+			continue
+		}
+
+		if err := addAIConnection(ctx, cm, connection, targetRoot); err != nil {
+			return err
+		}
+		result.ConnectionsAdded = append(result.ConnectionsAdded, string(connection))
+	}
+
+	if len(result.ConnectionsAdded) == 0 {
+		return nil
+	}
+
+	configBytes, err := yaml.Marshal(cm)
+	if err != nil {
+		return fmt.Errorf("could not marshal .bruin.yml: %w", err)
+	}
+	if err := os.WriteFile(configPath, configBytes, 0o644); err != nil { //nolint:gosec
+		return fmt.Errorf("could not write .bruin.yml: %w", err)
+	}
+
+	return nil
+}
+
+func loadAIConfig(configPath string) (*config.Config, error) {
+	content, err := os.ReadFile(configPath) //nolint:gosec
+	if errors.Is(err, os.ErrNotExist) {
+		defaultEnv := config.Environment{Connections: &config.Connections{}}
+		return &config.Config{
+			DefaultEnvironmentName: "default",
+			Environments: map[string]config.Environment{
+				"default": defaultEnv,
+			},
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not read .bruin.yml: %w", err)
+	}
+
+	var cm config.Config
+	if err := yaml.Unmarshal(content, &cm); err != nil {
+		return nil, fmt.Errorf("could not parse .bruin.yml: %w", err)
+	}
+	if cm.DefaultEnvironmentName == "" {
+		cm.DefaultEnvironmentName = "default"
+	}
+	if cm.Environments == nil {
+		cm.Environments = map[string]config.Environment{}
+	}
+	if _, ok := cm.Environments[cm.DefaultEnvironmentName]; !ok {
+		cm.Environments[cm.DefaultEnvironmentName] = config.Environment{Connections: &config.Connections{}}
+	}
+
+	return &cm, nil
+}
+
+func aiConfigHasConnection(cm *config.Config, connection aiConnectionType) bool {
+	for _, env := range cm.Environments {
+		if env.Connections == nil {
+			continue
+		}
+		switch connection {
+		case aiConnectionBruinCloud:
+			if len(env.Connections.BruinCloud) > 0 {
+				return true
+			}
+		case aiConnectionGitHub:
+			if len(env.Connections.GitHub) > 0 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func resolveAIConnectionPrompt(connection aiConnectionType, opts aiInstallOptions) (bool, error) {
+	if opts.connectionResolver != nil {
+		return opts.connectionResolver(connection)
+	}
+	if !isStdinTerminal() {
+		return false, nil
+	}
+
+	prompt := promptui.Prompt{
+		Label:     fmt.Sprintf("No %s connection found in .bruin.yml. Add a placeholder connection?", connection),
+		IsConfirm: true,
+	}
+	_, err := prompt.Run()
+	if err != nil {
+		if errors.Is(err, promptui.ErrAbort) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func addAIConnection(ctx context.Context, cm *config.Config, connection aiConnectionType, targetRoot string) error {
+	envName := cm.DefaultEnvironmentName
+	if envName == "" {
+		envName = "default"
+		cm.DefaultEnvironmentName = envName
+	}
+
+	env := cm.Environments[envName]
+	if env.Connections == nil {
+		env.Connections = &config.Connections{}
+	}
+
+	switch connection {
+	case aiConnectionBruinCloud:
+		env.Connections.BruinCloud = append(env.Connections.BruinCloud, config.BruinCloudConnection{
+			ConnectionMetadata: config.ConnectionMetadata{Name: "bruin-cloud"},
+			APIToken:           aiBruinCloudTokenPlaceholder,
+		})
+	case aiConnectionGitHub:
+		owner, repo := inferGitHubOwnerRepo(ctx, targetRoot)
+		env.Connections.GitHub = append(env.Connections.GitHub, config.GitHubConnection{
+			ConnectionMetadata: config.ConnectionMetadata{Name: "github"},
+			AccessToken:        aiGitHubTokenPlaceholder,
+			Owner:              owner,
+			Repo:               repo,
+		})
+	default:
+		return fmt.Errorf("unsupported AI connection type %q", connection)
+	}
+
+	cm.Environments[envName] = env
+	return nil
+}
+
+func inferGitHubOwnerRepo(ctx context.Context, targetRoot string) (string, string) {
+	cmd := exec.CommandContext(ctx, "git", "config", "--get", "remote.origin.url")
+	cmd.Dir = targetRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return "<github-owner>", "<github-repo>"
+	}
+
+	owner, repo := parseGitHubRemote(strings.TrimSpace(string(output)))
+	if owner == "" || repo == "" {
+		return "<github-owner>", "<github-repo>"
+	}
+
+	return owner, repo
+}
+
+func parseGitHubRemote(remote string) (string, string) {
+	remote = strings.TrimSuffix(remote, ".git")
+	if strings.HasPrefix(remote, "git@") {
+		parts := strings.SplitN(remote, ":", 2)
+		if len(parts) != 2 {
+			return "", ""
+		}
+		return ownerRepoFromPath(parts[1])
+	}
+
+	parsed, err := url.Parse(remote)
+	if err == nil && parsed.Path != "" {
+		return ownerRepoFromPath(parsed.Path)
+	}
+
+	return ownerRepoFromPath(remote)
+}
+
+func ownerRepoFromPath(path string) (string, string) {
+	path = strings.Trim(path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return "", ""
+	}
+
+	owner := parts[len(parts)-2]
+	repo := parts[len(parts)-1]
+	if !isGitHubPathPart(owner) || !isGitHubPathPart(repo) {
+		return "", ""
+	}
+
+	return owner, repo
+}
+
+func isGitHubPathPart(value string) bool {
+	return aiGitHubPathPartPattern.MatchString(value)
+}
+
+func isStdinTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // os.File.Fd returns the process file descriptor expected by term.IsTerminal.
+}
+
+func aiTargetRoot() (string, error) {
+	repoRoot, err := git.FindRepoFromPath(".")
+	if err == nil {
+		return repoRoot.Path, nil
+	}
+
+	return os.Getwd()
+}
+
+func lookupAITemplate(name string) *aiTemplate {
+	for i := range aiTemplates {
+		if aiTemplates[i].Name == name {
+			return &aiTemplates[i]
+		}
+	}
+
+	return nil
+}
+
+func runAISelector() (string, bool, error) {
+	originalChoices := choices
+	choices = make([]string, 0, len(aiTemplates))
+	for _, template := range aiTemplates {
+		choices = append(choices, template.Name)
+	}
+	defer func() {
+		choices = originalChoices
+	}()
+
+	p := tea.NewProgram(model{height: getTerminalHeight()})
+	m, err := p.Run()
+	if err != nil {
+		return "", false, err
+	}
+
+	if m, ok := m.(model); ok {
+		if m.quitting {
+			return "", true, nil
+		}
+		return m.choice, false, nil
+	}
+
+	return "", false, errors.New("AI template selector returned an unexpected model")
+}

--- a/cmd/init_ai_test.go
+++ b/cmd/init_ai_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestIsAITemplateArgument(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isAITemplateArgument("ai"))
+	require.True(t, isAITemplateArgument("ai-agents-md"))
+	require.True(t, isAITemplateArgument("ai-skill-self-heal"))
+	require.False(t, isAITemplateArgument("default"))
+}
+
+func TestInstallAITemplateCreatesAgentsFile(t *testing.T) {
+	t.Parallel()
+
+	targetRoot := t.TempDir()
+	template := lookupAITemplate(aiAgentsTemplateName)
+	require.NotNil(t, template)
+
+	result, err := installAITemplate(t.Context(), *template, targetRoot, aiInstallOptions{})
+	require.NoError(t, err)
+
+	agentsPath := filepath.Join(targetRoot, "AGENTS.md")
+	require.Contains(t, result.Created, agentsPath)
+
+	content, err := os.ReadFile(agentsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), aiAgentsSectionStart)
+	require.Contains(t, string(content), "Bruin Pipeline Agent Guidance")
+	require.NoFileExists(t, filepath.Join(targetRoot, ".bruin.yml"))
+}
+
+func TestInstallAITemplateAddsAgentsSectionToExistingFile(t *testing.T) {
+	t.Parallel()
+
+	targetRoot := t.TempDir()
+	agentsPath := filepath.Join(targetRoot, "AGENTS.md")
+	require.NoError(t, os.WriteFile(agentsPath, []byte("# Existing\n\nKeep this.\n"), 0o644))
+
+	template := lookupAITemplate(aiAgentsTemplateName)
+	require.NotNil(t, template)
+
+	result, err := installAITemplate(t.Context(), *template, targetRoot, aiInstallOptions{
+		conflictResolver: func(path string) (aiConflictAction, error) {
+			require.Equal(t, agentsPath, path)
+			return aiConflictAdd, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, result.Updated, agentsPath)
+
+	content, err := os.ReadFile(agentsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "# Existing")
+	require.Contains(t, string(content), "Keep this.")
+	require.Equal(t, 1, strings.Count(string(content), aiAgentsSectionStart))
+	require.Equal(t, 1, strings.Count(string(content), aiAgentsSectionEnd))
+}
+
+func TestInstallAITemplateSelfHealCreatesSkillsAndConnections(t *testing.T) {
+	t.Parallel()
+
+	targetRoot := t.TempDir()
+	template := lookupAITemplate(aiSelfHealTemplateName)
+	require.NotNil(t, template)
+
+	result, err := installAITemplate(t.Context(), *template, targetRoot, aiInstallOptions{
+		connectionResolver: func(connection aiConnectionType) (bool, error) {
+			return true, nil
+		},
+	})
+	require.NoError(t, err)
+
+	expectedSkills := []string{
+		"duplicate-investigate",
+		"freshness-check",
+		"maintenance-action",
+		"pipeline-diagnose",
+		"quality-check-investigate",
+		"schema-drift-check",
+	}
+	for _, skill := range expectedSkills {
+		require.FileExists(t, filepath.Join(targetRoot, ".agents", "skills", skill, "SKILL.md"))
+	}
+	require.Len(t, result.Created, len(expectedSkills))
+	require.ElementsMatch(t, []string{"bruin", "github"}, result.ConnectionsAdded)
+
+	cm := readTestBruinConfig(t, filepath.Join(targetRoot, ".bruin.yml"))
+	env := cm.Environments["default"]
+	require.Len(t, env.Connections.BruinCloud, 1)
+	require.Equal(t, "bruin-cloud", env.Connections.BruinCloud[0].Name)
+	require.Equal(t, "${BRUIN_CLOUD_API_TOKEN}", env.Connections.BruinCloud[0].APIToken)
+	require.Len(t, env.Connections.GitHub, 1)
+	require.Equal(t, "github", env.Connections.GitHub[0].Name)
+	require.Equal(t, "${GITHUB_TOKEN}", env.Connections.GitHub[0].AccessToken)
+	require.Equal(t, "<github-owner>", env.Connections.GitHub[0].Owner)
+	require.Equal(t, "<github-repo>", env.Connections.GitHub[0].Repo)
+}
+
+func TestInstallAITemplateDoesNotDuplicateExistingConnections(t *testing.T) {
+	t.Parallel()
+
+	targetRoot := t.TempDir()
+	configPath := filepath.Join(targetRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`default_environment: default
+environments:
+    default:
+        connections:
+            github:
+                - name: existing-github
+                  access_token: "${EXISTING_GITHUB_TOKEN}"
+                  owner: existing
+                  repo: repo
+`), 0o644))
+
+	template := lookupAITemplate(aiSelfHealTemplateName)
+	require.NotNil(t, template)
+
+	result, err := installAITemplate(context.Background(), *template, targetRoot, aiInstallOptions{
+		connectionResolver: func(connection aiConnectionType) (bool, error) {
+			return true, nil
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"bruin"}, result.ConnectionsAdded)
+
+	cm := readTestBruinConfig(t, configPath)
+	env := cm.Environments["default"]
+	require.Len(t, env.Connections.GitHub, 1)
+	require.Equal(t, "existing-github", env.Connections.GitHub[0].Name)
+	require.Len(t, env.Connections.BruinCloud, 1)
+}
+
+func TestParseGitHubRemote(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string][2]string{
+		"git@github.com:bruin-data/bruin.git":       {"bruin-data", "bruin"},
+		"https://github.com/bruin-data/bruin.git":   {"bruin-data", "bruin"},
+		"ssh://git@github.com/bruin-data/bruin.git": {"bruin-data", "bruin"},
+	}
+
+	for remote, want := range tests {
+		owner, repo := parseGitHubRemote(remote)
+		require.Equal(t, want[0], owner)
+		require.Equal(t, want[1], repo)
+	}
+}
+
+func readTestBruinConfig(t *testing.T, path string) config.Config {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cm config.Config
+	require.NoError(t, yaml.Unmarshal(content, &cm))
+	return cm
+}

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -390,6 +390,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     {text: "Validate", link: "/commands/validate"},
                     {text: "Unit Test", link: "/commands/unit-test"},
                     {text: "Init", link: "/commands/init"},
+                    {text: "AI Templates", link: "/commands/ai-templates"},
                     {text: "Clean", link: "/commands/clean"},
                     {text: "Connections", link: "/commands/connections"},
                     {text: "Data Diff", link: "/commands/data-diff"},
@@ -481,6 +482,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 collapsed: false,
                 items: [
                     {text: "Overview", link: "/getting-started/templates"},
+                    {text: "AI Templates", link: "/commands/ai-templates"},
                     {
                         text: "Analytics Demos",
                         collapsed: false,

--- a/docs/commands/ai-templates.md
+++ b/docs/commands/ai-templates.md
@@ -1,0 +1,443 @@
+# AI Templates
+
+AI templates install starter files for AI agents that work on Bruin repositories. They are installed with [`bruin init`](/commands/init), but they are not pipeline templates.
+
+AI templates install files into the Git repository root when Bruin can find one, otherwise into the current directory. They do not create a pipeline folder, initialize Git, or create `.bruin.yml` by default. They also do not accept a folder argument or `--in-place`.
+
+```bash
+# Open the AI template selector
+bruin init ai
+
+# Install AGENTS.md directly
+bruin init ai-agents-md
+
+# Install the troubleshooting skill pack directly
+bruin init ai-skill-self-heal
+```
+
+## Available AI Templates
+
+| Template | What it installs |
+| --- | --- |
+| `ai-agents-md` | A generic `AGENTS.md` starter with Bruin-oriented agent instructions. |
+| `ai-skill-self-heal` | Starter troubleshooting skills under `.agents/skills/`. |
+
+The self-healing starter is a pack of focused skills:
+
+* `pipeline-diagnose`
+* `schema-drift-check`
+* `duplicate-investigate`
+* `freshness-check`
+* `quality-check-investigate`
+* `maintenance-action`
+
+Each skill includes a placeholder `Actions` section for repository-specific behavior. Until customized, the skills only diagnose and report findings.
+
+## Runtime Expectations
+
+The starter skills are primarily meant for AI agents configured inside Bruin Cloud. In that environment, agents should use Bruin Cloud MCP tools when available. If they use the CLI, the relevant Cloud commands include:
+
+```bash
+# Diagnose the latest failed or recent run
+bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest
+
+# Read run and asset logs
+bruin cloud runs get --project-id <project-id> --run-id <run-id>
+bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>
+bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>
+
+# Create or rerun Cloud runs
+bruin cloud runs trigger --project-id <project-id> --pipeline <pipeline-name>
+bruin cloud runs rerun --project-id <project-id> --run-id <run-id> --only-failed
+
+# Enable or disable Cloud pipelines
+bruin cloud pipelines enable --project-id <project-id> --pipeline <pipeline-name>
+bruin cloud pipelines disable --project-id <project-id> --pipeline <pipeline-name>
+```
+
+For local development, the skills should rely on local terminal commands such as `bruin validate`, `bruin render`, `bruin query`, and `bruin run`. Local troubleshooting should read terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Local runs should be created with `bruin run` rather than Bruin Cloud run commands.
+
+When troubleshooting data issues, the skills guide agents to find one specific failing row, key, partition, or timestamp first and keep upstream queries filtered to that example. For layered pipelines such as bronze, silver, and gold, agents should start at the asset where the issue appears, trace upstream through lineage until the issue first appears, then inspect that asset's SQL or Python logic to isolate the likely join, filter, cast, incremental condition, function, or transformation step. If the user has allowed fixes, agents should change only the isolated logic, verify the same bad example first, and only then run the broader quality check, freshness check, duplicate check, or pipeline command.
+
+If investigation or verification requires actual asset or pipeline runs, agents should prefer a dev or shadow environment. If one is not available, they should ask whether to run in production or create temporary copies of affected tables to reproduce and test the issue.
+
+For any other agent runtime or orchestrator, customize the installed skills with the correct log source and action mechanism before using them to read logs, trigger runs, enable or disable pipelines, mark statuses, or change external systems.
+
+## Safe Sample Copies
+
+When an agent needs to investigate real data issues, instruct it to reproduce the smallest useful slice of the problem outside production before changing pipeline logic. The safest pattern is:
+
+* Find one failing row, key, partition, timestamp, or column first.
+* Create dev, shadow, or temporary copies of only the affected upstream and downstream tables.
+* Prefer a small sample filtered to the failing example plus a small amount of surrounding context, such as the same date partition, tenant, customer, order, or batch.
+* Preserve enough lineage to reproduce the issue locally or in a dev warehouse: source sample, intermediate sample, final asset sample, and the SQL or Python logic under test.
+* Run the suspected fix against the sampled copies first.
+* Verify the known bad example before running broader checks, reruns, or backfills.
+
+For large tables, avoid full-table copies unless the user explicitly approves the cost and blast radius. A useful agent instruction is:
+
+```text
+Before changing production logic, create the smallest safe dev sample that reproduces the issue.
+Copy only the affected keys, partitions, or time window from each upstream table needed for lineage.
+Run the current logic against the sample, prove the failure, apply the proposed fix to the sample, and prove the same key or partition is fixed before touching the real asset.
+```
+
+## Sample Pipeline and Test
+
+This section is a fully mocked local demo. It creates a dummy DuckDB pipeline, deliberately introduces common data and pipeline issues, then gives agent prompts and proof commands for testing the installed self-healing skills end to end.
+
+Use a throwaway local DuckDB project so agents can safely investigate, run assets, and test fixes without production data. Recreate the fixture before each scenario unless you intentionally want to test multiple failures at once.
+
+### Create the Sample Pipeline
+
+```bash
+BRUIN=${BRUIN:-bruin}
+WORKDIR=$(mktemp -d)
+cd "$WORKDIR"
+git init
+
+$BRUIN init ai-skill-self-heal
+mkdir -p assets
+
+cat > .bruin.yml <<'YAML'
+default_environment: default
+environments:
+  default:
+    connections:
+      duckdb:
+        - name: duckdb-skill-test
+          path: skill-test.duckdb
+YAML
+
+cat > pipeline.yml <<'YAML'
+name: ai-skill-test
+default_connections:
+  duckdb: duckdb-skill-test
+YAML
+
+cat > assets/bronze_orders.sql <<'SQL'
+/* @bruin
+name: bronze_orders
+type: duckdb.sql
+materialization:
+  type: table
+columns:
+  - name: order_id
+    type: INTEGER
+  - name: user_id
+    type: INTEGER
+  - name: transaction_date
+    type: DATE
+  - name: amount
+    type: DOUBLE
+  - name: status
+    type: VARCHAR
+@bruin */
+
+SELECT 1001 AS order_id, 501 AS user_id, DATE '2025-01-01' AS transaction_date, 25.00 AS amount, 'paid' AS status
+UNION ALL
+SELECT 1002 AS order_id, 502 AS user_id, DATE '2025-01-01' AS transaction_date, 35.00 AS amount, 'paid' AS status
+UNION ALL
+SELECT 1003 AS order_id, 503 AS user_id, DATE '2025-01-02' AS transaction_date, 40.00 AS amount, 'paid' AS status
+UNION ALL
+SELECT 1004 AS order_id, 504 AS user_id, DATE '2025-01-03' AS transaction_date, 50.00 AS amount, 'paid' AS status;
+SQL
+
+cat > assets/silver_orders.sql <<'SQL'
+/* @bruin
+name: silver_orders
+type: duckdb.sql
+materialization:
+  type: table
+depends:
+  - bronze_orders
+columns:
+  - name: order_id
+    type: INTEGER
+  - name: user_id
+    type: INTEGER
+  - name: transaction_date
+    type: DATE
+  - name: amount
+    type: DOUBLE
+  - name: status
+    type: VARCHAR
+@bruin */
+
+WITH typed_orders AS (
+    SELECT
+        order_id,
+        user_id,
+        transaction_date,
+        amount AS amount,
+        status
+    FROM bronze_orders
+    WHERE status <> 'cancelled'
+)
+
+SELECT * FROM typed_orders
+UNION ALL
+SELECT * FROM typed_orders WHERE order_id = 1002;
+SQL
+
+cat > assets/gold_order_report.sql <<'SQL'
+/* @bruin
+name: gold_order_report
+type: duckdb.sql
+materialization:
+  type: table
+depends:
+  - silver_orders
+columns:
+  - name: order_id
+    type: INTEGER
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: user_id
+    type: INTEGER
+  - name: transaction_date
+    type: DATE
+    checks:
+      - name: not_null
+  - name: amount
+    type: DOUBLE
+    checks:
+      - name: positive
+  - name: status
+    type: VARCHAR
+custom_checks:
+  - name: latest partition exists
+    query: SELECT CASE WHEN max(transaction_date) = DATE '2025-01-03' THEN 1 ELSE 0 END FROM gold_order_report
+    value: 1
+@bruin */
+
+SELECT
+    order_id,
+    user_id,
+    transaction_date,
+    amount,
+    status
+FROM silver_orders;
+SQL
+
+$BRUIN validate .
+$BRUIN render assets/gold_order_report.sql
+$BRUIN query --connection duckdb-skill-test --query "SELECT current_database() AS duckdb_database;"
+```
+
+The setup should print a successful validation for three assets, render SQL that reads from `silver_orders`, and return the active DuckDB database. That proves the skills, pipeline files, and DuckDB connection are in place before you create any issue.
+
+### Run Agent Test Scenarios
+
+Use one fresh copy of the fixture for each scenario. If you are testing with an agent runner that supports parallel work, create one sub-agent per scenario and give each sub-agent its own copy of the throwaway directory. Ask every agent to read the named skill file under `.agents/skills/`, print the commands it runs, capture the row or error that proves the issue exists, isolate the smallest upstream cause, apply only the approved fix, and print the rerun/backfill proof.
+
+Use this prompt shape for each scenario:
+
+```text
+Use .agents/skills/<skill-name>/SKILL.md.
+Create the documented issue in this throwaway DuckDB pipeline.
+Prove the tables were created and prove the issue exists with a filtered query or failing Bruin command.
+Trace lineage from gold_order_report to silver_orders to bronze_orders, keeping queries filtered to the failing key, date, or column.
+Fix only the isolated cause.
+Rerun with bruin run --full-refresh --backfill-id <scenario>-fix --backfill-total 1 .
+Verify the specific bad example first, then run bruin run --only checks .
+Report the commands, important output, changed file, and final status.
+```
+
+For these local table-materialization tests, `--full-refresh` makes reruns deterministic after an agent edits SQL. It is not a requirement for every real pipeline fix.
+
+### Mock Duplicate Investigation
+
+The base fixture already contains a duplicate row for `order_id = 1002` in `silver_orders`.
+
+```bash
+$BRUIN run . || true
+$BRUIN query --connection duckdb-skill-test --query "SHOW TABLES;"
+$BRUIN query --connection duckdb-skill-test --query "SELECT order_id, count(*) AS row_count FROM gold_order_report GROUP BY 1 HAVING count(*) > 1;"
+$BRUIN query --connection duckdb-skill-test --query "SELECT 'gold' AS layer, count(*) AS row_count FROM gold_order_report WHERE order_id = 1002 UNION ALL SELECT 'silver' AS layer, count(*) AS row_count FROM silver_orders WHERE order_id = 1002 UNION ALL SELECT 'bronze' AS layer, count(*) AS row_count FROM bronze_orders WHERE order_id = 1002;"
+```
+
+Expected proof:
+
+* `bruin run` fails `gold_order_report:order_id:unique`.
+* `SHOW TABLES` lists `bronze_orders`, `silver_orders`, and `gold_order_report`.
+* The duplicate query returns `1002` with `row_count = 2`.
+* The lineage query shows the duplicate first appears in `silver_orders`, not `bronze_orders`.
+
+Ask the agent to use `duplicate-investigate`, start from `order_id = 1002`, trace upstream through `gold_order_report -> silver_orders -> bronze_orders`, isolate the extra `UNION ALL` in `assets/silver_orders.sql`, and fix it only if you explicitly allow fixes. After the fix, verify the specific key first, then run the broader check and a tagged rerun:
+
+```bash
+$BRUIN run --full-refresh --backfill-id duplicate-fix --backfill-total 1 .
+$BRUIN query --connection duckdb-skill-test --query "SELECT order_id, count(*) AS row_count FROM gold_order_report WHERE order_id = 1002 GROUP BY 1 HAVING count(*) > 1;"
+$BRUIN run --only checks .
+```
+
+The filtered duplicate query should return no rows, and the check-only run should pass.
+
+### Mock Quality Check Investigation
+
+Create a negative amount after removing the duplicate from the base fixture:
+
+```bash
+perl -0pi -e 's/\nUNION ALL\nSELECT \* FROM typed_orders WHERE order_id = 1002;//' assets/silver_orders.sql
+perl -0pi -e 's/amount AS amount/CASE WHEN order_id = 1003 THEN -amount ELSE amount END AS amount/' assets/silver_orders.sql
+$BRUIN run --full-refresh . || true
+$BRUIN query --connection duckdb-skill-test --query "SHOW TABLES;"
+$BRUIN query --connection duckdb-skill-test --query "SELECT order_id, amount FROM gold_order_report WHERE order_id = 1003;"
+$BRUIN query --connection duckdb-skill-test --query "SELECT 'gold' AS layer, amount FROM gold_order_report WHERE order_id = 1003 UNION ALL SELECT 'silver' AS layer, amount FROM silver_orders WHERE order_id = 1003 UNION ALL SELECT 'bronze' AS layer, amount FROM bronze_orders WHERE order_id = 1003;"
+```
+
+Expected proof:
+
+* `bruin run` fails `gold_order_report:amount:positive`.
+* `SHOW TABLES` lists `bronze_orders`, `silver_orders`, and `gold_order_report`.
+* `order_id = 1003` has a negative amount in `gold_order_report`.
+* The lineage query shows the negative amount first appears in `silver_orders`.
+
+Ask the agent to use `quality-check-investigate`, start from `order_id = 1003`, trace the negative amount upstream, isolate the expression in `silver_orders`, and fix only that expression if fixes are allowed. Verify the row, then rerun:
+
+```bash
+$BRUIN run --full-refresh --backfill-id quality-fix --backfill-total 1 .
+$BRUIN query --connection duckdb-skill-test --query "SELECT order_id, amount FROM gold_order_report WHERE order_id = 1003;"
+$BRUIN run --only checks .
+```
+
+The row should show a positive amount, and the check-only run should pass.
+
+### Mock Freshness Check
+
+Create a stale latest partition after removing the duplicate from the base fixture:
+
+```bash
+perl -0pi -e 's/\nUNION ALL\nSELECT \* FROM typed_orders WHERE order_id = 1002;//' assets/silver_orders.sql
+perl -0pi -e "s/WHERE status <> 'cancelled'/WHERE status <> 'cancelled' AND transaction_date < DATE '2025-01-03'/" assets/silver_orders.sql
+$BRUIN run . || true
+$BRUIN query --connection duckdb-skill-test --query "SHOW TABLES;"
+$BRUIN query --connection duckdb-skill-test --query "SELECT max(transaction_date) AS max_transaction_date FROM gold_order_report;"
+$BRUIN query --connection duckdb-skill-test --query "SELECT 'gold' AS layer, count(*) AS row_count FROM gold_order_report WHERE transaction_date = DATE '2025-01-03' UNION ALL SELECT 'silver' AS layer, count(*) AS row_count FROM silver_orders WHERE transaction_date = DATE '2025-01-03' UNION ALL SELECT 'bronze' AS layer, count(*) AS row_count FROM bronze_orders WHERE transaction_date = DATE '2025-01-03';"
+```
+
+Expected proof:
+
+* `bruin run` fails the `latest partition exists` custom check.
+* `SHOW TABLES` lists `bronze_orders`, `silver_orders`, and `gold_order_report`.
+* `max(transaction_date)` is `2025-01-02`.
+* The lineage query shows `2025-01-03` exists in `bronze_orders` but not in `silver_orders` or `gold_order_report`.
+
+Ask the agent to use `freshness-check`, start from the missing `transaction_date = DATE '2025-01-03'`, trace upstream, isolate the stale filter in `silver_orders`, and fix it only if allowed. Verify the date, then rerun:
+
+```bash
+$BRUIN run --full-refresh --backfill-id freshness-fix --backfill-total 1 .
+$BRUIN query --connection duckdb-skill-test --query "SELECT max(transaction_date) AS max_transaction_date FROM gold_order_report;"
+$BRUIN run --only checks .
+```
+
+The max date should be `2025-01-03`, and the check-only run should pass.
+
+### Mock Schema Drift Check
+
+Create a source column rename after removing the duplicate from the base fixture:
+
+```bash
+perl -0pi -e 's/\nUNION ALL\nSELECT \* FROM typed_orders WHERE order_id = 1002;//' assets/silver_orders.sql
+perl -0pi -e 's/ AS amount/ AS gross_amount/g' assets/bronze_orders.sql
+$BRUIN render assets/bronze_orders.sql --raw-query
+$BRUIN render assets/silver_orders.sql --raw-query
+$BRUIN run --full-refresh . || true
+$BRUIN query --connection duckdb-skill-test --query "DESCRIBE bronze_orders;"
+```
+
+Expected proof:
+
+* `bruin run` fails while executing `silver_orders`.
+* The error says the `amount` column cannot be found and suggests `gross_amount`.
+* Rendered SQL shows `assets/bronze_orders.sql` now emits `gross_amount` while `assets/silver_orders.sql` still selects `amount AS amount`.
+* `DESCRIBE bronze_orders` shows `gross_amount`.
+
+Ask the agent to use `schema-drift-check`, identify that `bronze_orders.amount` became `gross_amount`, confirm `silver_orders` still references `amount`, and update only the affected mapping if fixes are allowed. Verify with render or the smallest failing command, then rerun:
+
+```bash
+$BRUIN render assets/silver_orders.sql
+$BRUIN run --full-refresh --backfill-id schema-drift-fix --backfill-total 1 .
+$BRUIN query --connection duckdb-skill-test --query "DESCRIBE silver_orders;"
+$BRUIN run --only checks .
+```
+
+The run should rebuild all three tables, `DESCRIBE silver_orders` should show the downstream `amount` column again, and the check-only run should pass.
+
+### Mock Pipeline Diagnose and Maintenance Action
+
+Create a broken table reference after removing the duplicate from the base fixture:
+
+```bash
+perl -0pi -e 's/\nUNION ALL\nSELECT \* FROM typed_orders WHERE order_id = 1002;//' assets/silver_orders.sql
+perl -0pi -e 's/FROM silver_orders/FROM missing_table/' assets/gold_order_report.sql
+$BRUIN run . || true
+$BRUIN render assets/gold_order_report.sql
+```
+
+Expected proof:
+
+* `bruin run` fails while executing `gold_order_report`.
+* The error says `missing_table` does not exist.
+* `bruin render assets/gold_order_report.sql` shows `FROM missing_table`.
+
+Ask the agent to use `pipeline-diagnose`, classify the failure, inspect the failing asset, and isolate the broken table reference. Then explicitly approve `maintenance-action` to fix only that reference. Verify the specific command, then rerun:
+
+```bash
+$BRUIN render assets/gold_order_report.sql
+$BRUIN validate .
+$BRUIN run --full-refresh --backfill-id pipeline-diagnose-fix --backfill-total 1 .
+$BRUIN run --only checks .
+```
+
+The rendered SQL should read from `silver_orders`, validation should pass, and both reruns should pass.
+
+## Publish the Fix
+
+In a real repository, have the agent show its diff and publish the fix after the focused verification passes:
+
+```bash
+git diff
+git status --short
+git add assets/<fixed-asset>.sql
+git commit -m "Fix <scenario> in ai skill test pipeline"
+
+# Only when the repository has a remote:
+git push -u origin <branch-name>
+```
+
+The proof to save in the agent's final report is the failing command output, the filtered investigation query, the fixed diff, the `bruin run --backfill-id ...` output, the `bruin run --only checks .` output, and the commit or push reference.
+
+## AI Template Conflicts
+
+If an AI template target already exists, Bruin asks what to do:
+
+* `add`: append or update the marked Bruin AI section in `AGENTS.md`; for skill files, keep existing files.
+* `overwrite`: replace the existing target file.
+* `skip`: leave the existing target unchanged.
+
+In non-interactive shells, existing targets fail safely and Bruin prints the path that needs a choice.
+
+## Optional AI Connections
+
+Some AI starter skills can use Bruin Cloud or GitHub context. If `bruin init ai-skill-self-heal` does not find matching connections in `.bruin.yml`, Bruin asks whether to add placeholder connections:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      bruin:
+        - name: bruin-cloud
+          api_token: "${BRUIN_CLOUD_API_TOKEN}"
+      github:
+        - name: github
+          access_token: "${GITHUB_TOKEN}"
+          owner: "<github-owner>"
+          repo: "<github-repo>"
+```
+
+Bruin infers `owner` and `repo` from the `origin` remote when possible. Existing connections are never duplicated.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -52,7 +52,7 @@ When you run `bruin init`, it:
 
 ## AI Templates
 
-AI templates are not pipeline templates. They install files into the Git repository root when Bruin can find one, otherwise into the current directory.
+`bruin init` also installs AI starter templates for agent instructions and troubleshooting skills.
 
 ```bash
 # Open the AI template selector
@@ -67,80 +67,7 @@ bruin init ai-skill-self-heal
 
 AI templates do not create a pipeline folder, initialize Git, or create `.bruin.yml` by default. They also do not accept a folder argument or `--in-place`.
 
-### Available AI Templates
-
-| Template | What it installs |
-| --- | --- |
-| `ai-agents-md` | A generic `AGENTS.md` starter with Bruin-oriented agent instructions. |
-| `ai-skill-self-heal` | Starter troubleshooting skills under `.agents/skills/`. |
-
-The self-healing starter is a pack of focused skills:
-
-* `pipeline-diagnose`
-* `schema-drift-check`
-* `duplicate-investigate`
-* `freshness-check`
-* `quality-check-investigate`
-* `maintenance-action`
-
-Each skill includes a placeholder `Actions` section for repository-specific behavior. Until customized, the skills only diagnose and report findings.
-
-### AI Skill Runtime Expectations
-
-The starter skills are primarily meant for AI agents configured inside Bruin Cloud. In that environment, agents should use Bruin Cloud MCP tools when available. If they use the CLI, the relevant Cloud commands include:
-
-```bash
-# Diagnose the latest failed or recent run
-bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest
-
-# Read run and asset logs
-bruin cloud runs get --project-id <project-id> --run-id <run-id>
-bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>
-bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>
-
-# Create or rerun Cloud runs
-bruin cloud runs trigger --project-id <project-id> --pipeline <pipeline-name>
-bruin cloud runs rerun --project-id <project-id> --run-id <run-id> --only-failed
-
-# Enable or disable Cloud pipelines
-bruin cloud pipelines enable --project-id <project-id> --pipeline <pipeline-name>
-bruin cloud pipelines disable --project-id <project-id> --pipeline <pipeline-name>
-```
-
-For local development, the skills should rely on local terminal commands such as `bruin validate`, `bruin render`, `bruin query`, and `bruin run`. Local troubleshooting should read terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Local runs should be created with `bruin run` rather than Bruin Cloud run commands.
-
-For any other agent runtime or orchestrator, customize the installed skills with the correct log source and action mechanism before using them to read logs, trigger runs, enable or disable pipelines, mark statuses, or change external systems.
-
-### AI Template Conflicts
-
-If an AI template target already exists, Bruin asks what to do:
-
-* `add`: append or update the marked Bruin AI section in `AGENTS.md`; for skill files, keep existing files.
-* `overwrite`: replace the existing target file.
-* `skip`: leave the existing target unchanged.
-
-In non-interactive shells, existing targets fail safely and Bruin prints the path that needs a choice.
-
-### Optional AI Connections
-
-Some AI starter skills can use Bruin Cloud or GitHub context. If `bruin init ai-skill-self-heal` does not find matching connections in `.bruin.yml`, Bruin asks whether to add placeholder connections:
-
-```yaml
-default_environment: default
-environments:
-  default:
-    connections:
-      bruin:
-        - name: bruin-cloud
-          api_token: "${BRUIN_CLOUD_API_TOKEN}"
-      github:
-        - name: github
-          access_token: "${GITHUB_TOKEN}"
-          owner: "<github-owner>"
-          repo: "<github-repo>"
-```
-
-Bruin infers `owner` and `repo` from the `origin` remote when possible. Existing connections are never duplicated.
+See [AI Templates](/commands/ai-templates) for the available templates, runtime expectations, optional connection setup, and an end-to-end DuckDB self-healing test workflow.
 
 ## Folder Structure
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -7,6 +7,8 @@ It automatically sets up the folder structure, initializes configuration files, 
 
 You can use it to start a new data pipeline project quickly, or to add a new pipeline inside an existing repository.
 
+`bruin init` also includes an `ai` template category for adding generic AI agent starter files to an existing repository.
+
 ## Usage
 
 ```bash
@@ -24,6 +26,15 @@ bruin init default ecommerce-pipeline
 
 # Create a pipeline in the current directory (no parent folder)
 bruin init default --in-place
+
+# Choose an AI starter template
+bruin init ai
+
+# Install a generic AGENTS.md file
+bruin init ai-agents-md
+
+# Install starter troubleshooting skills
+bruin init ai-skill-self-heal
 ```
 
 ## How It Works
@@ -38,6 +49,98 @@ When you run `bruin init`, it:
 5. Outputs next steps, such as validating or running your new pipeline.
 
 ---
+
+## AI Templates
+
+AI templates are not pipeline templates. They install files into the Git repository root when Bruin can find one, otherwise into the current directory.
+
+```bash
+# Open the AI template selector
+bruin init ai
+
+# Install AGENTS.md directly
+bruin init ai-agents-md
+
+# Install the troubleshooting skill pack directly
+bruin init ai-skill-self-heal
+```
+
+AI templates do not create a pipeline folder, initialize Git, or create `.bruin.yml` by default. They also do not accept a folder argument or `--in-place`.
+
+### Available AI Templates
+
+| Template | What it installs |
+| --- | --- |
+| `ai-agents-md` | A generic `AGENTS.md` starter with Bruin-oriented agent instructions. |
+| `ai-skill-self-heal` | Starter troubleshooting skills under `.agents/skills/`. |
+
+The self-healing starter is a pack of focused skills:
+
+* `pipeline-diagnose`
+* `schema-drift-check`
+* `duplicate-investigate`
+* `freshness-check`
+* `quality-check-investigate`
+* `maintenance-action`
+
+Each skill includes a placeholder `Actions` section for repository-specific behavior. Until customized, the skills only diagnose and report findings.
+
+### AI Skill Runtime Expectations
+
+The starter skills are primarily meant for AI agents configured inside Bruin Cloud. In that environment, agents should use Bruin Cloud MCP tools when available. If they use the CLI, the relevant Cloud commands include:
+
+```bash
+# Diagnose the latest failed or recent run
+bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest
+
+# Read run and asset logs
+bruin cloud runs get --project-id <project-id> --run-id <run-id>
+bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>
+bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>
+
+# Create or rerun Cloud runs
+bruin cloud runs trigger --project-id <project-id> --pipeline <pipeline-name>
+bruin cloud runs rerun --project-id <project-id> --run-id <run-id> --only-failed
+
+# Enable or disable Cloud pipelines
+bruin cloud pipelines enable --project-id <project-id> --pipeline <pipeline-name>
+bruin cloud pipelines disable --project-id <project-id> --pipeline <pipeline-name>
+```
+
+For local development, the skills should rely on local terminal commands such as `bruin validate`, `bruin render`, `bruin query`, and `bruin run`. Local troubleshooting should read terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Local runs should be created with `bruin run` rather than Bruin Cloud run commands.
+
+For any other agent runtime or orchestrator, customize the installed skills with the correct log source and action mechanism before using them to read logs, trigger runs, enable or disable pipelines, mark statuses, or change external systems.
+
+### AI Template Conflicts
+
+If an AI template target already exists, Bruin asks what to do:
+
+* `add`: append or update the marked Bruin AI section in `AGENTS.md`; for skill files, keep existing files.
+* `overwrite`: replace the existing target file.
+* `skip`: leave the existing target unchanged.
+
+In non-interactive shells, existing targets fail safely and Bruin prints the path that needs a choice.
+
+### Optional AI Connections
+
+Some AI starter skills can use Bruin Cloud or GitHub context. If `bruin init ai-skill-self-heal` does not find matching connections in `.bruin.yml`, Bruin asks whether to add placeholder connections:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      bruin:
+        - name: bruin-cloud
+          api_token: "${BRUIN_CLOUD_API_TOKEN}"
+      github:
+        - name: github
+          access_token: "${GITHUB_TOKEN}"
+          owner: "<github-owner>"
+          repo: "<github-repo>"
+```
+
+Bruin infers `owner` and `repo` from the `origin` remote when possible. Existing connections are never duplicated.
 
 ## Folder Structure
 

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -31,6 +31,7 @@ bruin validate --help
 | Command | Description |
 |---------|-------------|
 | [`init`](/commands/init) | Create a new Bruin project from a template |
+| [`ai templates`](/commands/ai-templates) | Install AI agent instructions and troubleshooting skills with `bruin init ai` |
 | [`clean`](/commands/clean) | Remove temporary files and build artifacts |
 | [`format`](/commands/format) | Format asset files for consistency |
 

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -35,6 +35,23 @@ bruin init --help
 
 These bundled templates are grouped by the job they help you start. Use the docs search for template names, sources, warehouses, or tags such as `DuckDB`, `Snowflake`, `Shopify`, `Python`, or `demo`.
 
+### AI templates
+
+<div class="template-grid">
+  <a class="template-card" href="../commands/ai-templates.html">
+    <span class="template-card__category">Agent setup</span>
+    <strong>ai-skill-self-heal</strong>
+    <span>Installs Bruin-oriented agent skills for diagnosing failed runs, schema drift, duplicates, freshness issues, quality checks, and approved maintenance actions.</span>
+    <span class="template-card__tags"><code>AI agents</code><code>skills</code><code>DuckDB test</code></span>
+  </a>
+  <a class="template-card" href="../commands/ai-templates.html">
+    <span class="template-card__category">Agent instructions</span>
+    <strong>ai-agents-md</strong>
+    <span>Installs a starter AGENTS.md file with repository guidance for AI agents working on Bruin pipelines.</span>
+    <span class="template-card__tags"><code>AGENTS.md</code><code>repo setup</code></span>
+  </a>
+</div>
+
 ### Analytics demos
 
 <div class="template-grid">

--- a/templates/ai/agents-md/AGENTS.md
+++ b/templates/ai/agents-md/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+This file gives AI agents the repo-specific context they need for Bruin pipeline development, data analysis, and troubleshooting.
+
+<!-- BEGIN BRUIN AI AGENTS -->
+## Bruin Pipeline Agent Guidance
+
+### Scope
+
+- Use this file for Bruin pipeline development, asset work, data analysis, and troubleshooting.
+- Do not treat this as a general application-code instruction file.
+- Prefer existing Bruin CLI commands, pipeline patterns, and project conventions over ad hoc scripts.
+
+### Bruin MCP and Docs
+
+- Use Bruin MCP when it is available to inspect Bruin docs and project context.
+- Local Bruin MCP runs with `bruin mcp`.
+- If configuring an AI client, register the command as `bruin mcp` and then use the exposed Bruin docs tools.
+- Use the docs tree first, then fetch the specific doc page you need. Prefer docs such as `commands/run`, `commands/query`, `commands/validate`, `commands/connections`, `assets/sql`, `assets/ingestr`, `assets/definition-schema`, and platform-specific docs.
+- When MCP is not available, use `bruin --help`, `bruin <command> --help`, and the repository docs.
+
+### Navigating Pipelines and Assets
+
+- Start from the nearest `pipeline.yml` to understand pipeline name, schedule, defaults, and asset layout.
+- Inspect asset definitions before editing SQL or Python. SQL assets usually include Bruin metadata between `/* @bruin` and `@bruin */`.
+- Follow dependencies through `depends`, upstream asset names, source tables, and materialization settings.
+- Use `bruin validate <path>` on the affected pipeline or asset after changes.
+- Use `bruin render <asset>` to inspect rendered SQL before running it.
+- Keep changes scoped to the affected pipeline, asset, checks, or documentation.
+
+### Environments and Secrets
+
+- Treat `.bruin.yml` as a local development config file. Do not commit real credentials, tokens, passwords, private keys, or personal connection details.
+- In Bruin Cloud and other server environments, connections and secrets may be initialized from environment variables instead of a local `.bruin.yml`.
+- Prefer environment-variable references in local config, such as `${MY_SECRET}`, over literal secret values.
+- If `.bruin.yml` defines both `dev` and `prod` environments, run commands in `dev` unless the user explicitly asks for `prod`.
+- Never run against `prod` by assumption. State the environment you are using in your response.
+- Before `--full-refresh`, backfills, destructive operations, or commands that can replace data, get explicit user confirmation unless the user already gave specific instructions.
+
+### Querying Data
+
+- Prefer `bruin query` and the connections already configured in `.bruin.yml` when querying data.
+- Use read-only, narrow queries first: select only needed columns, include limits, and filter partitions or date ranges where possible.
+- Avoid large scans, full table reads, exports, or expensive joins unless the user confirms the scope.
+- Do not query sensitive columns unless needed for the task. Mask or aggregate sensitive results in summaries.
+- When investigating an asset, prefer rendering the asset query and running a limited diagnostic query before changing logic.
+- Save useful diagnostic SQL only when it belongs in the repository; otherwise report the query and result.
+
+### Skills
+
+- Check `.agents/skills/` for repository-specific skills before starting specialized work.
+- Open the relevant `SKILL.md` and follow its workflow when the task matches its purpose.
+- Use the smallest applicable skill. Do not run broad maintenance or action skills when a diagnosis skill is enough.
+- If a skill has an `Actions` placeholder, treat it as a policy gap: report findings and stop before modifying data, source systems, production settings, credentials, or repo files.
+- When a skill and Bruin docs disagree, verify with the current Bruin CLI help or MCP docs and report the discrepancy.
+
+### Reporting
+
+- Summarize commands run, environment used, files changed, and validation results.
+- If validation cannot be run, say why and provide the exact command the user can run.
+- If a fix requires warehouse, source-system, or Bruin Cloud action, document the exact follow-up instead of guessing.
+<!-- END BRUIN AI AGENTS -->

--- a/templates/ai/agents-md/AGENTS.md
+++ b/templates/ai/agents-md/AGENTS.md
@@ -24,6 +24,7 @@ This file gives AI agents the repo-specific context they need for Bruin pipeline
 - Start from the nearest `pipeline.yml` to understand pipeline name, schedule, defaults, and asset layout.
 - Inspect asset definitions before editing SQL or Python. SQL assets usually include Bruin metadata between `/* @bruin` and `@bruin */`.
 - Follow dependencies through `depends`, upstream asset names, source tables, and materialization settings.
+- Prefer a `README.md` inside each pipeline folder that explains the pipeline purpose, key source tables, asset dependencies, environment assumptions, operating notes, and how agents should run or troubleshoot the pipeline.
 - Use `bruin validate <path>` on the affected pipeline or asset after changes.
 - Use `bruin render <asset>` to inspect rendered SQL before running it.
 - Keep changes scoped to the affected pipeline, asset, checks, or documentation.
@@ -44,7 +45,17 @@ This file gives AI agents the repo-specific context they need for Bruin pipeline
 - Avoid large scans, full table reads, exports, or expensive joins unless the user confirms the scope.
 - Do not query sensitive columns unless needed for the task. Mask or aggregate sensitive results in summaries.
 - When investigating an asset, prefer rendering the asset query and running a limited diagnostic query before changing logic.
+- Query warehouse admin or metadata tables when permissions allow it, such as `INFORMATION_SCHEMA` or platform-specific account usage views, to inspect schemas, row counts, table sizes, partitions, clustering, freshness, and downstream dependencies.
 - Save useful diagnostic SQL only when it belongs in the repository; otherwise report the query and result.
+
+### Creating and Updating SQL Assets
+
+- Query and analyze the source and target data before making assumptions about grain, freshness, nullability, uniqueness, or business meaning. Clarify material assumptions with the user before encoding them in SQL or checks.
+- Use `bruin render <asset>` to inspect rendered SQL before execution. Use `bruin validate <path>` at regular intervals after meaningful changes, but do not overuse validation after every small edit.
+- Filter exploratory and validation queries by partition, clustering columns, date ranges, tenant, or other selective predicates whenever possible.
+- Add or preserve partitioning and clustering when the database or warehouse supports it and the expected table size, query pattern, or incremental strategy warrants it. Discuss backfill and cost implications with the user before changing physical layout on large tables.
+- When exploring unfamiliar tables, consider asking the user for permission to run `bruin ai enhance` to generate table-level and column-level descriptions as a starting point. Review generated descriptions instead of treating them as authoritative.
+- When creating or changing quality checks, run the affected checks or validation to verify they work. If a check fails, assess whether the SQL, data, or check expectation is wrong, and clarify with the user when the intended rule is uncertain.
 
 ### Skills
 

--- a/templates/ai/skill-self-heal/.agents/skills/duplicate-investigate/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/duplicate-investigate/SKILL.md
@@ -1,0 +1,53 @@
+# Duplicate Investigate
+
+## When to Use
+
+Use this skill when duplicate rows, unstable primary keys, repeated ingestion, or failed uniqueness checks appear in a Bruin asset.
+
+## Inputs
+
+- Affected asset name or table.
+- Key columns or uniqueness checks.
+- Error output, sample duplicate keys, or row counts.
+
+## Operating Context
+
+- These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
+- In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, inspect failures with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, fetch failed logs with `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>`, and inspect a specific asset with `bruin cloud assets get --project-id <project-id> --pipeline <pipeline-name> --asset <asset-name>`.
+- In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Use `bruin query` with existing `.bruin.yml` connections for read-only duplicate checks.
+- For other agent runtimes or orchestrators, customize this skill with the correct log source, query mechanism, and action mechanism before using it.
+
+## Context to Gather
+
+- Inspect quality checks and declared primary or unique keys.
+- Find the ingestion or transformation logic that creates the affected rows.
+- Compare source row counts, destination row counts, and recent run history when available.
+- Check whether incremental logic can replay the same source records.
+- Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Decision Tree
+
+- If duplicates share the same business key and timestamp, suspect replay or missing deduplication.
+- If duplicates differ only by load metadata, inspect incremental merge logic.
+- If the declared key is incomplete, identify additional columns needed for uniqueness.
+- If duplicates originate upstream, report the source and avoid masking the issue silently.
+
+## Actions
+
+Define repository-specific actions here. Until customized, this skill must report findings and stop before deleting rows, changing deduplication logic, or modifying source systems.
+
+## Verification
+
+- Re-run the duplicate detection query.
+- Re-run the affected quality check if available.
+- Confirm whether the duplicate count changed after any reviewed fix.
+
+## Output
+
+Return:
+
+- Duplicate pattern.
+- Suspected source.
+- Keys or columns involved.
+- Recommended remediation.
+- Commands or queries run.

--- a/templates/ai/skill-self-heal/.agents/skills/duplicate-investigate/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/duplicate-investigate/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when duplicate rows, unstable primary keys, repeated ingestion, o
 - These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
 - In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, inspect failures with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, fetch failed logs with `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>`, and inspect a specific asset with `bruin cloud assets get --project-id <project-id> --pipeline <pipeline-name> --asset <asset-name>`.
 - In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Use `bruin query` with existing `.bruin.yml` connections for read-only duplicate checks.
+- If investigation or fix verification requires running an asset or pipeline, prefer a dev or shadow environment. If none exists, ask whether to run in production or create temporary copies of the affected tables to reproduce and test the issue.
 - For other agent runtimes or orchestrators, customize this skill with the correct log source, query mechanism, and action mechanism before using it.
 
 ## Context to Gather
@@ -24,6 +25,14 @@ Use this skill when duplicate rows, unstable primary keys, repeated ingestion, o
 - Compare source row counts, destination row counts, and recent run history when available.
 - Check whether incremental logic can replay the same source records.
 - Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Lineage Investigation
+
+- Find one specific duplicate key or bad row pattern first, then keep every upstream query filtered to that instance. For example, prove `COUNT(*) > 1` for one `user_id` and `transaction_date` before broad scans.
+- If the data has bronze, silver, gold, or other tiers, start at the asset where the duplicate appears and trace upstream through lineage one asset at a time.
+- Query the filtered duplicate instance in each upstream asset until you find the first asset where the duplicate appears.
+- Once the first bad asset is identified, read its SQL query or Python script and isolate the specific join, union, incremental filter, merge key, deduplication step, or function that likely introduced the duplicate.
+- If the user has allowed fixes, change only that specific logic, then run the smallest asset-level validation in dev or shadow first. Recheck the same duplicate instance after the fix; only after that passes, run the full duplicate check or affected quality check.
 
 ## Decision Tree
 
@@ -41,6 +50,12 @@ Define repository-specific actions here. Until customized, this skill must repor
 - Re-run the duplicate detection query.
 - Re-run the affected quality check if available.
 - Confirm whether the duplicate count changed after any reviewed fix.
+
+## Testing This Skill
+
+- Use the local self-heal fixture from the Bruin `init` command docs.
+- Run the duplicate scenario and verify the agent starts with `order_id = 1002`, traces the duplicate from `gold_order_report` to `silver_orders`, and identifies the extra `UNION ALL` as the likely cause.
+- If fixes are allowed, verify the agent removes or corrects only that logic, checks `order_id = 1002` first, then runs the full duplicate check.
 
 ## Output
 

--- a/templates/ai/skill-self-heal/.agents/skills/freshness-check/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/freshness-check/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when data is stale, a scheduled run is missing, or freshness chec
 - These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
 - In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, list recent runs with `bruin cloud runs list --project-id <project-id> --pipeline <pipeline-name>`, diagnose the latest run with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, and inspect failed logs with `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>`.
 - In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Create local runs with `bruin run <path>` and explicit dates when needed.
+- If investigation or fix verification requires running an asset or pipeline, prefer a dev or shadow environment. If none exists, ask whether to run in production or create temporary copies of the affected tables to reproduce and test the issue.
 - For other agent runtimes or orchestrators, customize this skill with the correct scheduler, log source, and run trigger mechanism before using it.
 
 ## Context to Gather
@@ -24,6 +25,14 @@ Use this skill when data is stale, a scheduled run is missing, or freshness chec
 - Compare expected partitions or timestamps with the latest available data.
 - Confirm timezone assumptions for schedules and freshness thresholds.
 - Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Lineage Investigation
+
+- Find one specific stale partition, timestamp, date, tenant, or key first, then keep every upstream query filtered to that instance.
+- If the data has bronze, silver, gold, or other tiers, start at the stale asset and trace upstream through lineage one asset at a time.
+- Query the filtered instance in each upstream asset until you find the first asset or source where the expected data is missing, late, or filtered out.
+- Once the first stale asset is identified, read its SQL query or Python script and isolate the specific schedule dependency, incremental filter, date predicate, timezone conversion, source extraction, or function that likely caused the lag.
+- If the user has allowed fixes, change only that specific logic, then run the smallest asset-level validation in dev or shadow first. Recheck the same stale instance after the fix; only after that passes, run the full freshness check or affected pipeline check.
 
 ## Decision Tree
 
@@ -41,6 +50,12 @@ Define repository-specific actions here. Until customized, this skill must repor
 - Re-run the freshness check or equivalent query.
 - Confirm the latest source and destination timestamps.
 - Verify the expected schedule against the current date and timezone.
+
+## Testing This Skill
+
+- Use the local self-heal fixture from the Bruin `init` command docs.
+- Run the freshness scenario and verify the agent starts with the missing `transaction_date = DATE '2025-01-03'`, traces the date upstream, and identifies the stale filter in `silver_orders`.
+- If fixes are allowed, verify the agent changes only the isolated filter, checks the missing date first, then runs the full freshness check.
 
 ## Output
 

--- a/templates/ai/skill-self-heal/.agents/skills/freshness-check/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/freshness-check/SKILL.md
@@ -1,0 +1,53 @@
+# Freshness Check
+
+## When to Use
+
+Use this skill when data is stale, a scheduled run is missing, or freshness checks fail.
+
+## Inputs
+
+- Affected pipeline, asset, or freshness check.
+- Expected schedule or freshness threshold.
+- Last successful run time, if known.
+
+## Operating Context
+
+- These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
+- In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, list recent runs with `bruin cloud runs list --project-id <project-id> --pipeline <pipeline-name>`, diagnose the latest run with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, and inspect failed logs with `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>`.
+- In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Create local runs with `bruin run <path>` and explicit dates when needed.
+- For other agent runtimes or orchestrators, customize this skill with the correct scheduler, log source, and run trigger mechanism before using it.
+
+## Context to Gather
+
+- Inspect pipeline schedules, asset dependencies, and freshness checks.
+- Check recent run logs and whether upstream assets completed.
+- Compare expected partitions or timestamps with the latest available data.
+- Confirm timezone assumptions for schedules and freshness thresholds.
+- Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Decision Tree
+
+- If the pipeline did not run, inspect scheduler or CI status.
+- If the run failed before the asset, diagnose the upstream blocker first.
+- If the run succeeded but data is stale, inspect source availability and incremental filters.
+- If timestamps look stale only in one timezone, verify timezone conversion and display logic.
+
+## Actions
+
+Define repository-specific actions here. Until customized, this skill must report findings and stop before triggering backfills, changing schedules, or modifying data.
+
+## Verification
+
+- Re-run the freshness check or equivalent query.
+- Confirm the latest source and destination timestamps.
+- Verify the expected schedule against the current date and timezone.
+
+## Output
+
+Return:
+
+- Freshness status.
+- Expected vs actual timestamps.
+- Blocker category.
+- Recommended next action.
+- Commands or queries run.

--- a/templates/ai/skill-self-heal/.agents/skills/maintenance-action/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/maintenance-action/SKILL.md
@@ -1,0 +1,54 @@
+# Maintenance Action
+
+## When to Use
+
+Use this skill after a diagnosis skill has identified a likely fix and the repository owner wants to define a controlled action.
+
+## Inputs
+
+- Diagnosis summary.
+- Exact action requested by the repository owner.
+- Files, assets, connections, or systems in scope.
+- Required approval process.
+
+## Operating Context
+
+- These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
+- In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, supported operational commands include `bruin cloud runs trigger --project-id <project-id> --pipeline <pipeline-name>`, `bruin cloud runs rerun --project-id <project-id> --run-id <run-id> --only-failed`, `bruin cloud pipelines enable --project-id <project-id> --pipeline <pipeline-name>`, and `bruin cloud pipelines disable --project-id <project-id> --pipeline <pipeline-name>`.
+- In local development, create runs with direct terminal commands such as `bruin run <path>`, `bruin run <asset>`, `bruin validate <path>`, and `bruin query`. Read troubleshooting context from terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist.
+- For other agent runtimes or orchestrators, customize this skill with the correct log source and action mechanism before using it to trigger runs, enable or disable schedules, mark statuses, or change external systems.
+
+## Context to Gather
+
+- Confirm the action is explicitly requested and scoped.
+- Inspect affected files and downstream dependencies.
+- Identify whether the action touches data, source systems, credentials, or production environments.
+- Determine the smallest validation command that proves the action worked.
+- Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Decision Tree
+
+- If the action touches production data or credentials, stop unless explicit approval is present.
+- If the action changes repo files, make a minimal diff and run validation.
+- If the action requires a pull request, prepare a clear summary and verification notes.
+- If the action is not yet defined, return the diagnosis and ask for the missing policy.
+
+## Actions
+
+Define repository-specific actions here. Until customized, this skill must not modify data, source systems, production settings, credentials, repo files, Bruin Cloud pipeline state, or run state.
+
+## Verification
+
+- Run the smallest relevant Bruin validation command.
+- For Cloud actions, verify the resulting state with `bruin cloud runs get`, `bruin cloud runs list`, or `bruin cloud pipelines get`.
+- For local actions, verify with the local command output, `bruin validate <path>`, and local `logs/` files when present.
+- Record any command that could not be run.
+
+## Output
+
+Return:
+
+- Action taken or reason no action was taken.
+- Files or systems touched.
+- Validation results.
+- Remaining manual approval or follow-up.

--- a/templates/ai/skill-self-heal/.agents/skills/maintenance-action/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/maintenance-action/SKILL.md
@@ -16,6 +16,7 @@ Use this skill after a diagnosis skill has identified a likely fix and the repos
 - These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
 - In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, supported operational commands include `bruin cloud runs trigger --project-id <project-id> --pipeline <pipeline-name>`, `bruin cloud runs rerun --project-id <project-id> --run-id <run-id> --only-failed`, `bruin cloud pipelines enable --project-id <project-id> --pipeline <pipeline-name>`, and `bruin cloud pipelines disable --project-id <project-id> --pipeline <pipeline-name>`.
 - In local development, create runs with direct terminal commands such as `bruin run <path>`, `bruin run <asset>`, `bruin validate <path>`, and `bruin query`. Read troubleshooting context from terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist.
+- If action verification requires running an asset or pipeline, prefer a dev or shadow environment. If none exists, ask whether to run in production or create temporary copies of the affected tables to reproduce and test the issue.
 - For other agent runtimes or orchestrators, customize this skill with the correct log source and action mechanism before using it to trigger runs, enable or disable schedules, mark statuses, or change external systems.
 
 ## Context to Gather
@@ -30,6 +31,7 @@ Use this skill after a diagnosis skill has identified a likely fix and the repos
 
 - If the action touches production data or credentials, stop unless explicit approval is present.
 - If the action changes repo files, make a minimal diff and run validation.
+- If the action fixes data logic, first verify the known bad row, key, partition, or timestamp, then run the broader validation only after the specific example is resolved.
 - If the action requires a pull request, prepare a clear summary and verification notes.
 - If the action is not yet defined, return the diagnosis and ask for the missing policy.
 
@@ -43,6 +45,12 @@ Define repository-specific actions here. Until customized, this skill must not m
 - For Cloud actions, verify the resulting state with `bruin cloud runs get`, `bruin cloud runs list`, or `bruin cloud pipelines get`.
 - For local actions, verify with the local command output, `bruin validate <path>`, and local `logs/` files when present.
 - Record any command that could not be run.
+
+## Testing This Skill
+
+- Use the local self-heal fixture from the Bruin `init` command docs after a diagnosis skill has found an isolated issue.
+- Give explicit permission to fix one scenario and verify the agent changes only the approved asset logic.
+- Verify the agent checks the known bad row, key, partition, or timestamp first, then runs the broader validation only after the specific example is resolved.
 
 ## Output
 

--- a/templates/ai/skill-self-heal/.agents/skills/pipeline-diagnose/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/pipeline-diagnose/SKILL.md
@@ -1,0 +1,53 @@
+# Pipeline Diagnose
+
+## When to Use
+
+Use this skill when a Bruin pipeline, asset, or command fails and the cause is not yet clear.
+
+## Inputs
+
+- Failing command and full error output.
+- Pipeline or asset path.
+- Environment name, if one was used.
+- Recent code or configuration changes, if known.
+
+## Operating Context
+
+- These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
+- In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, prefer `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, `bruin cloud runs get --project-id <project-id> --run-id <run-id>`, `bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>`, and `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>` for logs and run context.
+- In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Create local runs with `bruin run <path>` rather than Bruin Cloud run commands.
+- For other agent runtimes or orchestrators, customize this skill with the correct log source and action mechanism before using it to read logs or trigger changes.
+
+## Context to Gather
+
+- Run `bruin validate <path>` for the affected pipeline or asset.
+- Check `pipeline.yml`, asset definitions, and connection names referenced by the failing task.
+- Inspect recent logs, stack traces, and changed files.
+- Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+- Confirm whether the failure is parse-time, compile-time, connection-time, or execution-time.
+
+## Decision Tree
+
+- If validation fails, fix the configuration or asset definition first.
+- If the connection is missing or invalid, report the missing connection and required fields.
+- If rendering fails, inspect Jinja variables, macros, and included files.
+- If execution fails after rendering, isolate the failing query or script and summarize the warehouse/runtime error.
+
+## Actions
+
+Define repository-specific actions here. Until customized, this skill must report findings and stop before modifying data, source systems, or repo files.
+
+## Verification
+
+- Re-run the smallest failing command.
+- Run `bruin validate <path>` when files were changed.
+- Capture the final command output or remaining error.
+
+## Output
+
+Return a concise diagnosis with:
+
+- Root cause or strongest hypothesis.
+- Evidence used.
+- Recommended next action.
+- Commands run and their result.

--- a/templates/ai/skill-self-heal/.agents/skills/pipeline-diagnose/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/pipeline-diagnose/SKILL.md
@@ -16,6 +16,7 @@ Use this skill when a Bruin pipeline, asset, or command fails and the cause is n
 - These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
 - In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, prefer `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, `bruin cloud runs get --project-id <project-id> --run-id <run-id>`, `bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>`, and `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>` for logs and run context.
 - In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Create local runs with `bruin run <path>` rather than Bruin Cloud run commands.
+- If investigation or fix verification requires running an asset or pipeline, prefer a dev or shadow environment. If none exists, ask whether to run in production or create temporary copies of the affected tables to reproduce and test the issue.
 - For other agent runtimes or orchestrators, customize this skill with the correct log source and action mechanism before using it to read logs or trigger changes.
 
 ## Context to Gather
@@ -25,6 +26,14 @@ Use this skill when a Bruin pipeline, asset, or command fails and the cause is n
 - Inspect recent logs, stack traces, and changed files.
 - Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
 - Confirm whether the failure is parse-time, compile-time, connection-time, or execution-time.
+
+## Data Failure Investigation
+
+- If the failure is caused by bad data and there are bronze, silver, gold, or other tiers, start at the asset where the problem appears and trace upstream through lineage one asset at a time.
+- Find one specific failing row, key, partition, or timestamp first, then keep every upstream query filtered to that instance.
+- Query the filtered instance in upstream assets until you find the first asset where the problem appears.
+- Once the first bad asset is identified, read its SQL query or Python script and isolate the specific function, join, filter, cast, incremental condition, or transformation step that likely caused the problem.
+- If the user has allowed fixes, change only that specific logic, then run the smallest asset-level validation in dev or shadow first. Recheck the same failing instance after the fix; only after that passes, run the broader failing command or check.
 
 ## Decision Tree
 
@@ -42,6 +51,12 @@ Define repository-specific actions here. Until customized, this skill must repor
 - Re-run the smallest failing command.
 - Run `bruin validate <path>` when files were changed.
 - Capture the final command output or remaining error.
+
+## Testing This Skill
+
+- Use the local self-heal fixture from the Bruin `init` command docs.
+- Run the pipeline-diagnose scenario and verify the agent classifies the failure, reads the affected asset, and identifies the exact missing table reference or broken SQL step.
+- If fixes are allowed, verify the agent changes only the isolated failing reference, reruns the smallest failing command, then runs validation.
 
 ## Output
 

--- a/templates/ai/skill-self-heal/.agents/skills/quality-check-investigate/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/quality-check-investigate/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when a Bruin quality check fails or starts warning unexpectedly.
 - These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
 - In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, inspect failures with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, fetch an asset instance with `bruin cloud instances get --project-id <project-id> --run-id <run-id> --asset <asset-name>`, and fetch logs with `bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>`.
 - In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Use `bruin run --only checks <path>` or a limited `bruin query` where appropriate.
+- If investigation or fix verification requires running an asset or pipeline, prefer a dev or shadow environment. If none exists, ask whether to run in production or create temporary copies of the affected tables to reproduce and test the issue.
 - For other agent runtimes or orchestrators, customize this skill with the correct check-result source, log source, and action mechanism before using it.
 
 ## Context to Gather
@@ -24,6 +25,14 @@ Use this skill when a Bruin quality check fails or starts warning unexpectedly.
 - Compare recent upstream changes with the first failing run.
 - Sample failing rows only when it is safe and allowed by repository policy.
 - Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Lineage Investigation
+
+- Find one specific failing example first, then keep every upstream query filtered to that row, key, partition, or time window. Use the full failing set only after the specific example is understood.
+- If the data has bronze, silver, gold, or other tiers, start at the asset where the quality check fails and trace upstream through lineage one asset at a time.
+- Query the filtered example in each upstream asset until you find the first asset where the invalid value, missing row, duplicate, stale timestamp, or unexpected aggregate appears.
+- Once the first bad asset is identified, read its SQL query or Python script and isolate the specific calculation, join, filter, cast, window function, incremental condition, or Python function that likely caused the failure.
+- If the user has allowed fixes, change only that specific logic, then run the smallest asset-level or check-level validation in dev or shadow first. Recheck the same failing example after the fix; only after that passes, run the full quality check.
 
 ## Decision Tree
 
@@ -41,6 +50,12 @@ Define repository-specific actions here. Until customized, this skill must repor
 - Re-run the failed quality check or the smallest equivalent query.
 - Re-run `bruin validate <path>` if files were changed.
 - Confirm whether failing row counts and examples match the diagnosis.
+
+## Testing This Skill
+
+- Use the local self-heal fixture from the Bruin `init` command docs.
+- Run the quality-check scenario and verify the agent starts with `order_id = 1003`, traces the negative `amount` upstream, and identifies the specific calculation in `silver_orders`.
+- If fixes are allowed, verify the agent changes only the isolated expression, checks `order_id = 1003` first, then runs the full quality check.
 
 ## Output
 

--- a/templates/ai/skill-self-heal/.agents/skills/quality-check-investigate/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/quality-check-investigate/SKILL.md
@@ -1,0 +1,53 @@
+# Quality Check Investigate
+
+## When to Use
+
+Use this skill when a Bruin quality check fails or starts warning unexpectedly.
+
+## Inputs
+
+- Affected asset and check name.
+- Check SQL or check definition.
+- Failure output and sample rows, if available.
+
+## Operating Context
+
+- These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
+- In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, inspect failures with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, fetch an asset instance with `bruin cloud instances get --project-id <project-id> --run-id <run-id> --asset <asset-name>`, and fetch logs with `bruin cloud instances logs --project-id <project-id> --run-id <run-id> --asset <asset-name>`.
+- In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Use `bruin run --only checks <path>` or a limited `bruin query` where appropriate.
+- For other agent runtimes or orchestrators, customize this skill with the correct check-result source, log source, and action mechanism before using it.
+
+## Context to Gather
+
+- Inspect the asset definition and check configuration.
+- Determine whether the check tests completeness, uniqueness, freshness, accepted values, ranges, or custom SQL.
+- Compare recent upstream changes with the first failing run.
+- Sample failing rows only when it is safe and allowed by repository policy.
+- Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+
+## Decision Tree
+
+- If the check definition is wrong, identify the intended rule and affected files.
+- If the data violates a valid rule, locate the upstream source or transformation that introduced it.
+- If the threshold is outdated, document why the threshold changed and who should approve it.
+- If the check is flaky, inspect nondeterministic ordering, time windows, and incremental logic.
+
+## Actions
+
+Define repository-specific actions here. Until customized, this skill must report findings and stop before changing thresholds, deleting rows, or modifying data.
+
+## Verification
+
+- Re-run the failed quality check or the smallest equivalent query.
+- Re-run `bruin validate <path>` if files were changed.
+- Confirm whether failing row counts and examples match the diagnosis.
+
+## Output
+
+Return:
+
+- Failed rule.
+- Evidence and sample pattern.
+- Root cause or strongest hypothesis.
+- Recommended fix.
+- Verification commands and results.

--- a/templates/ai/skill-self-heal/.agents/skills/schema-drift-check/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/schema-drift-check/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when a pipeline fails because source, destination, or declared as
 - These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
 - In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, inspect runs with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, fetch run details with `bruin cloud runs get --project-id <project-id> --run-id <run-id>`, and fetch failed asset logs with `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>`.
 - In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Use `bruin render <asset>`, `bruin validate <path>`, and `bruin query` with existing `.bruin.yml` connections for schema investigation.
+- If investigation or fix verification requires running an asset or pipeline, prefer a dev or shadow environment. If none exists, ask whether to run in production or create temporary copies of the affected tables to reproduce and test the issue.
 - For other agent runtimes or orchestrators, customize this skill with the correct log source, schema inspection mechanism, and action mechanism before using it.
 
 ## Context to Gather
@@ -24,6 +25,14 @@ Use this skill when a pipeline fails because source, destination, or declared as
 - Check recent upstream changes, ingestion sync logs, and warehouse table metadata when available.
 - Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
 - Identify downstream assets that reference changed columns.
+
+## Lineage Investigation
+
+- Find one specific missing, renamed, type-changed, or malformed column example first, then keep every upstream schema or data query scoped to the affected table, column, partition, or row.
+- If the data has bronze, silver, gold, or other tiers, start at the failing asset and trace upstream through lineage one asset at a time.
+- Compare the filtered data and schema metadata in each upstream asset until you find the first asset or source where the schema drift appears.
+- Once the first drifted asset is identified, read its SQL query, ingestion config, or Python script and isolate the specific select list, cast, rename, source mapping, union, model contract, or function that likely introduced the mismatch.
+- If the user has allowed fixes, change only that specific logic, then run the smallest render, schema inspection, or asset-level validation in dev or shadow first. Recheck the same column example after the fix; only after that passes, run the broader schema validation.
 
 ## Decision Tree
 
@@ -41,6 +50,12 @@ Define repository-specific actions here. Until customized, this skill must repor
 - Re-run validation for the affected asset.
 - Re-run the smallest schema inspection or render command used in diagnosis.
 - Confirm whether downstream references are accounted for.
+
+## Testing This Skill
+
+- Use the local self-heal fixture from the Bruin `init` command docs.
+- Run the schema-drift scenario and verify the agent identifies that `bronze_orders.amount` was renamed to `gross_amount` while `silver_orders` still references `amount`.
+- If fixes are allowed, verify the agent updates only the affected select list or mapping, then runs render/schema validation before broader checks.
 
 ## Output
 

--- a/templates/ai/skill-self-heal/.agents/skills/schema-drift-check/SKILL.md
+++ b/templates/ai/skill-self-heal/.agents/skills/schema-drift-check/SKILL.md
@@ -1,0 +1,52 @@
+# Schema Drift Check
+
+## When to Use
+
+Use this skill when a pipeline fails because source, destination, or declared asset columns may have changed.
+
+## Inputs
+
+- Affected asset name or path.
+- Error output mentioning missing columns, extra columns, type changes, or schema mismatch.
+- Connection and environment names, if available.
+
+## Operating Context
+
+- These starter skills are primarily meant for AI agents configured inside Bruin Cloud.
+- In Bruin Cloud, use Bruin Cloud MCP tools when available. If using the CLI, inspect runs with `bruin cloud runs diagnose --project-id <project-id> --pipeline <pipeline-name> --latest`, fetch run details with `bruin cloud runs get --project-id <project-id> --run-id <run-id>`, and fetch failed asset logs with `bruin cloud instances failed-logs --project-id <project-id> --run-id <run-id>`.
+- In local development, inspect terminal output and the local `logs/` folder, especially `logs/runs`, query logs, and export logs when they exist. Use `bruin render <asset>`, `bruin validate <path>`, and `bruin query` with existing `.bruin.yml` connections for schema investigation.
+- For other agent runtimes or orchestrators, customize this skill with the correct log source, schema inspection mechanism, and action mechanism before using it.
+
+## Context to Gather
+
+- Inspect the asset definition for declared columns and checks.
+- Compare the rendered query or ingestion config with the current source schema.
+- Check recent upstream changes, ingestion sync logs, and warehouse table metadata when available.
+- Use Bruin MCP docs tools or `bruin <command> --help` to confirm the current command syntax before running Cloud or local CLI commands.
+- Identify downstream assets that reference changed columns.
+
+## Decision Tree
+
+- If a column was added upstream, classify whether it is safe to ignore, declare, or propagate.
+- If a column was removed or renamed, identify every asset that still references it.
+- If a type changed, check whether casts or quality checks now fail.
+- If only column order changed, verify whether the affected task depends on positional columns.
+
+## Actions
+
+Define repository-specific actions here. Until customized, this skill must report findings and stop before modifying schemas, source systems, warehouse tables, or repo files.
+
+## Verification
+
+- Re-run validation for the affected asset.
+- Re-run the smallest schema inspection or render command used in diagnosis.
+- Confirm whether downstream references are accounted for.
+
+## Output
+
+Return:
+
+- Drift type: added, removed, renamed, type-changed, or unknown.
+- Affected columns and assets.
+- Recommended action.
+- Verification commands and results.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -6,4 +6,6 @@ import (
 
 //go:embed *
 //go:embed */.bruin.yml
+//go:embed ai/agents-md/AGENTS.md
+//go:embed ai/skill-self-heal/.agents/skills/*/SKILL.md
 var Templates embed.FS


### PR DESCRIPTION
## Summary

Adds a new AI template category to `bruin init` for installing agent starter files instead of pipeline scaffolding.

- Adds `bruin init ai` for an AI template selector.
- Adds direct aliases `bruin init ai-agents-md` and `bruin init ai-skill-self-heal`.
- Installs a generic `AGENTS.md` starter and a focused self-healing/troubleshooting skill pack under `.agents/skills/`.
- Handles existing targets with overwrite/add/skip choices, with safe non-interactive failure for conflicts.
- Optionally adds placeholder Bruin Cloud and GitHub connections when requested.
- Documents the new AI template behavior in the init command docs.

## Validation

- `make build`
- Temp-repo E2E checks for:
  - direct `ai-agents-md` install
  - non-interactive conflict failure
  - direct `ai-skill-self-heal` install
  - interactive `bruin init ai` selector
  - interactive placeholder connection prompts with GitHub owner/repo inference
  - folder argument and `--in-place` rejection
- `PATH="$(go env GOPATH)/bin:$PATH" make format`
- `PATH="$(go env GOPATH)/bin:$PATH" make test`
- `npm run docs:build`

## Notes

The docs dev server (`vitepress dev`) fails under local Node `v25.4.0` with esbuild transform errors in dependencies, but the production docs build succeeds.