### PR TITLE
Accept YAML for dashboard create --state/--state-file

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/afero"
 	"github.com/urfave/cli/v3"
+	"gopkg.in/yaml.v3"
 )
 
 var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
@@ -2958,11 +2959,11 @@ func cloudDashboardsCreate() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "state",
-				Usage: "the dashboard definition as a JSON string",
+				Usage: "the dashboard definition as a JSON or YAML string",
 			},
 			&cli.StringFlag{
 				Name:  "state-file",
-				Usage: "path to a file containing the dashboard definition as JSON",
+				Usage: "path to a file containing the dashboard definition as JSON or YAML",
 			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
@@ -2998,15 +2999,17 @@ func cloudDashboardsCreate() *cli.Command {
 			// Validate whenever a state flag was provided (even if empty), so an
 			// explicit --state '' or empty --state-file is rejected rather than
 			// silently creating an empty draft. Omitting both is title-only, which is fine.
+			// Accept JSON or YAML — dashboards are YAML-native and JSON is valid YAML,
+			// so one parser handles both.
 			var state map[string]any
 			if c.IsSet("state") || c.IsSet("state-file") {
-				if err := json.Unmarshal([]byte(raw), &state); err != nil {
-					printError(fmt.Errorf("invalid dashboard definition JSON: %w", err), output, "Invalid state")
+				if err := yaml.Unmarshal([]byte(raw), &state); err != nil {
+					printError(fmt.Errorf("invalid dashboard definition (expected a JSON or YAML object): %w", err), output, "Invalid state")
 					return cli.Exit("", 1)
 				}
-				// A JSON object is required; null/scalars/arrays are not a definition.
+				// A mapping is required; null/scalars/arrays are not a definition.
 				if state == nil {
-					printError(errors.New("dashboard definition must be a JSON object"), output, "Invalid state")
+					printError(errors.New("dashboard definition must be a JSON or YAML object"), output, "Invalid state")
 					return cli.Exit("", 1)
 				}
 			}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2941,6 +2941,75 @@ func cloudDashboardsGet() *cli.Command {
 	}
 }
 
+// parseDashboardState decodes a dashboard definition from JSON or YAML into a
+// map. It walks the YAML node tree rather than decoding straight into a map so
+// that timestamp-like scalars (e.g. an unquoted `2024-01-01`) are preserved as
+// their original string — yaml.v3 would otherwise resolve them to time.Time,
+// which JSON-encodes as an RFC3339 timestamp and changes the value. Returns a
+// nil map (no error) when the document is empty or not a mapping; the caller
+// rejects that as "must be an object".
+func parseDashboardState(raw []byte) (map[string]any, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	if len(doc.Content) == 0 {
+		return nil, nil
+	}
+	v, err := yamlNodeToValue(doc.Content[0])
+	if err != nil {
+		return nil, err
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	return m, nil
+}
+
+func yamlNodeToValue(n *yaml.Node) (any, error) {
+	switch n.Kind {
+	case yaml.DocumentNode:
+		if len(n.Content) == 0 {
+			return nil, nil
+		}
+		return yamlNodeToValue(n.Content[0])
+	case yaml.AliasNode:
+		return yamlNodeToValue(n.Alias)
+	case yaml.MappingNode:
+		m := make(map[string]any, len(n.Content)/2)
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			val, err := yamlNodeToValue(n.Content[i+1])
+			if err != nil {
+				return nil, err
+			}
+			m[n.Content[i].Value] = val
+		}
+		return m, nil
+	case yaml.SequenceNode:
+		s := make([]any, 0, len(n.Content))
+		for _, c := range n.Content {
+			val, err := yamlNodeToValue(c)
+			if err != nil {
+				return nil, err
+			}
+			s = append(s, val)
+		}
+		return s, nil
+	default: // ScalarNode
+		// Keep timestamp-like scalars as their raw string so the value shape is
+		// preserved through the JSON request to the API.
+		if n.Tag == "!!timestamp" {
+			return n.Value, nil
+		}
+		var v any
+		if err := n.Decode(&v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	}
+}
+
 func cloudDashboardsCreate() *cli.Command {
 	return &cli.Command{
 		Name:  "create",
@@ -2999,14 +3068,15 @@ func cloudDashboardsCreate() *cli.Command {
 			// Validate whenever a state flag was provided (even if empty), so an
 			// explicit --state '' or empty --state-file is rejected rather than
 			// silently creating an empty draft. Omitting both is title-only, which is fine.
-			// Accept JSON or YAML — dashboards are YAML-native and JSON is valid YAML,
-			// so one parser handles both.
+			// Accept JSON or YAML — dashboards are YAML-native and JSON is valid YAML.
 			var state map[string]any
 			if c.IsSet("state") || c.IsSet("state-file") {
-				if err := yaml.Unmarshal([]byte(raw), &state); err != nil {
+				parsed, err := parseDashboardState([]byte(raw))
+				if err != nil {
 					printError(fmt.Errorf("invalid dashboard definition (expected a JSON or YAML object): %w", err), output, "Invalid state")
 					return cli.Exit("", 1)
 				}
+				state = parsed
 				// A mapping is required; null/scalars/arrays are not a definition.
 				if state == nil {
 					printError(errors.New("dashboard definition must be a JSON or YAML object"), output, "Invalid state")

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -239,6 +239,46 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "create")
 }
 
+func TestParseDashboardState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses a JSON object", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseDashboardState([]byte(`{"name":"d","rows":[]}`))
+		require.NoError(t, err)
+		assert.Equal(t, "d", got["name"])
+	})
+
+	t.Run("parses a YAML object", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseDashboardState([]byte("name: d\nrows: []\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "d", got["name"])
+	})
+
+	t.Run("preserves an unquoted date-like scalar as a string", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseDashboardState([]byte("default: 2024-01-01\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "2024-01-01", got["default"])
+	})
+
+	t.Run("returns nil for non-object documents", func(t *testing.T) {
+		t.Parallel()
+		for _, in := range []string{"", "null", `"scalar"`, "[1, 2]"} {
+			got, err := parseDashboardState([]byte(in))
+			require.NoError(t, err, "input %q", in)
+			assert.Nil(t, got, "input %q", in)
+		}
+	})
+
+	t.Run("errors on malformed YAML", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseDashboardState([]byte("name: [unclosed"))
+		require.Error(t, err)
+	})
+}
+
 func TestExtractErrorLines_ErrorLevel(t *testing.T) {
 	t.Parallel()
 	logJSON := json.RawMessage(`{


### PR DESCRIPTION
Dashboards are YAML-native (multi-line `sql: |` blocks), so hand-authoring the definition as escaped JSON is painful and error-prone — the main way agent-created dashboards come out malformed. JSON is valid YAML, so this parses both flags with the YAML decoder. Null/scalar/array/empty inputs are still rejected exactly as before.