### PR TITLE
feat(trello): add Trello connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -369,6 +369,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "SQLite", link: "/ingestion/sqlite"},
                                     {text: "SurveyMonkey", link: "/ingestion/surveymonkey"},
                                     {text: "TikTok Ads", link: "/ingestion/tiktokads"},
+                                    {text: "Trello", link: "/ingestion/trello"},
                                     {text: "Twilio", link: "/ingestion/twilio"},
                                     {text: "Vitess", link: "/ingestion/vitess"},
                                     {text: "Wise", link: "/ingestion/wise"},

--- a/docs/ingestion/trello.md
+++ b/docs/ingestion/trello.md
@@ -1,0 +1,84 @@
+# Trello
+
+[Trello](https://trello.com/) is a visual work-management tool that organizes projects into boards, lists, and cards.
+
+Bruin supports Trello as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Trello into your data warehouse.
+
+In order to set up Trello connection, you need to add a configuration item in the `.bruin.yml` file and in `asset` file. You need an `api_key` and a `token` for authentication. For details on how to obtain them, please refer to the [Obtaining credentials](#obtaining-credentials) section below.
+
+Follow the steps below to correctly set up Trello as a data source and run ingestion.
+
+## Step 1: Add a connection to .bruin.yml file
+
+To connect to Trello, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+connections:
+  trello:
+    - name: "my_trello"
+      api_key: "your_api_key"
+      token: "your_token"
+```
+
+- `api_key`: Your Trello Power-Up API key (required)
+- `token`: A Trello token authorizing access to your account's data (required)
+
+## Step 2: Create an asset file for data ingestion
+
+To ingest data from Trello, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., trello_ingestion.yml) inside the assets folder and add the following content:
+
+```yaml
+name: public.trello
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: my_trello
+  source_table: 'cards'
+
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
+- `connection`: This is the destination connection, which defines where the data should be stored. For example: "postgres" indicates that the ingested data will be stored in a PostgreSQL database.
+- `source_connection`: The name of the Trello connection defined in .bruin.yml.
+- `source_table`: The name of the data table in Trello you want to ingest. You can find the available source tables below.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------|---------|
+| `boards` | id | - | replace | All boards the account can access. |
+| `organizations` | id | - | replace | Workspaces (organizations) the account belongs to. |
+| `lists` | id | - | replace | Lists across all accessible boards. |
+| `members` | id | - | replace | Members across all accessible boards, de-duplicated. |
+| `labels` | id | - | replace | Labels defined on each board. |
+| `checklists` | id | - | replace | Checklists across all accessible boards. |
+| `cards` | id | dateLastActivity | merge | Cards across all accessible boards. |
+| `actions` | id | date | merge | Activity log (actions) across all accessible boards. |
+
+## Scoping to specific boards
+
+By default the board-scoped tables (`lists`, `members`, `labels`, `checklists`, `cards`, `actions`) fetch data from every board the account can access. To scope a run to specific boards, append a comma-separated list of board IDs after the table name with a colon, e.g. `source_table: 'cards:5f2a1c,60b1d2'`.
+
+## Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/trello_ingestion.yml
+```
+
+As a result of this command, Bruin will ingest data from the given Trello table into your Postgres database.
+
+## Obtaining credentials
+
+Trello's REST API authenticates with an API key and a token:
+
+1. Log in to Trello and open the [Power-Ups admin](https://trello.com/power-ups/admin).
+2. Create a Power-Up (or open an existing one) and generate an **API key** on its "API key" page.
+3. From the same page, use the **Token** link to authorize your account and generate a token.
+
+## Notes
+
+- **Authentication**: The Trello REST API uses an API key + token passed as query parameters.
+- **Incremental Loading**: Supported for `cards` (by `dateLastActivity`) and `actions` (by `date`).

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1434,6 +1434,12 @@
           },
           "type": "array"
         },
+        "trello": {
+          "items": {
+            "$ref": "#/$defs/TrelloConnection"
+          },
+          "type": "array"
+        },
         "jira": {
           "items": {
             "$ref": "#/$defs/JiraConnection"
@@ -4774,6 +4780,29 @@
         "name",
         "access_token",
         "advertiser_ids"
+      ]
+    },
+    "TrelloConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "api_key": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "api_key",
+        "token"
       ]
     },
     "TrinoConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1872,6 +1872,16 @@ func (c FirefliesConnection) GetName() string {
 	return c.Name
 }
 
+type TrelloConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	APIKey             string `yaml:"api_key,omitempty" json:"api_key" mapstructure:"api_key" sensitive:"true"`
+	Token              string `yaml:"token,omitempty" json:"token" mapstructure:"token" sensitive:"true"`
+}
+
+func (c TrelloConnection) GetName() string {
+	return c.Name
+}
+
 type WistiaConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	AccessToken        string `yaml:"access_token,omitempty" json:"access_token" mapstructure:"access_token" sensitive:"true"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -144,6 +144,7 @@ type Connections struct {
 	Freshdesk           []FreshdeskConnection           `yaml:"freshdesk,omitempty" json:"freshdesk,omitempty" mapstructure:"freshdesk"`
 	FundraiseUp         []FundraiseUpConnection         `yaml:"fundraiseup,omitempty" json:"fundraiseup,omitempty" mapstructure:"fundraiseup"`
 	Fireflies           []FirefliesConnection           `yaml:"fireflies,omitempty" json:"fireflies,omitempty" mapstructure:"fireflies"`
+	Trello              []TrelloConnection              `yaml:"trello,omitempty" json:"trello,omitempty" mapstructure:"trello"`
 	Jira                []JiraConnection                `yaml:"jira,omitempty" json:"jira,omitempty" mapstructure:"jira"`
 	Monday              []MondayConnection              `yaml:"monday,omitempty" json:"monday,omitempty" mapstructure:"monday"`
 	PlusVibeAI          []PlusVibeAIConnection          `yaml:"plusvibeai,omitempty" json:"plusvibeai,omitempty" mapstructure:"plusvibeai"`
@@ -1558,6 +1559,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Fireflies = append(env.Connections.Fireflies, conn)
+	case "trello":
+		var conn TrelloConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Trello = append(env.Connections.Trello, conn)
 	case "plusvibeai":
 		var conn PlusVibeAIConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1981,6 +1989,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.FundraiseUp = removeConnection(env.Connections.FundraiseUp, connectionName)
 	case "fireflies":
 		env.Connections.Fireflies = removeConnection(env.Connections.Fireflies, connectionName)
+	case "trello":
+		env.Connections.Trello = removeConnection(env.Connections.Trello, connectionName)
 	case "plusvibeai":
 		env.Connections.PlusVibeAI = removeConnection(env.Connections.PlusVibeAI, connectionName)
 	case "bruin":
@@ -2232,6 +2242,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Freshdesk, source.Freshdesk)
 	mergeConnectionList(&c.FundraiseUp, source.FundraiseUp)
 	mergeConnectionList(&c.Fireflies, source.Fireflies)
+	mergeConnectionList(&c.Trello, source.Trello)
 	mergeConnectionList(&c.Jira, source.Jira)
 	mergeConnectionList(&c.Monday, source.Monday)
 	mergeConnectionList(&c.PlusVibeAI, source.PlusVibeAI)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -809,6 +809,13 @@ func TestLoadFromFile(t *testing.T) {
 					APIKey:             "test-api-key",
 				},
 			},
+			Trello: []TrelloConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "trello-1"},
+					APIKey:             "test-api-key",
+					Token:              "test-token",
+				},
+			},
 			Jira: []JiraConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "jira-1"},
@@ -1442,6 +1449,17 @@ func TestConfig_AddConnection(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:     "Add Trello connection",
+			envName:  "default",
+			connType: "trello",
+			connName: "trello-conn",
+			creds: map[string]interface{}{
+				"api_key": "test-api-key",
+				"token":   "test-token",
+			},
+			expectedErr: false,
+		},
+		{
 			name:     "Add Fabric connection",
 			envName:  "default",
 			connType: "fabric",
@@ -1550,6 +1568,11 @@ func TestConfig_AddConnection(t *testing.T) {
 					assert.Len(t, env.Connections.Fireflies, 1)
 					assert.Equal(t, tt.connName, env.Connections.Fireflies[0].Name)
 					assert.Equal(t, tt.creds["api_key"], env.Connections.Fireflies[0].APIKey)
+				case "trello":
+					assert.Len(t, env.Connections.Trello, 1)
+					assert.Equal(t, tt.connName, env.Connections.Trello[0].Name)
+					assert.Equal(t, tt.creds["api_key"], env.Connections.Trello[0].APIKey)
+					assert.Equal(t, tt.creds["token"], env.Connections.Trello[0].Token)
 				case "fabric":
 					assert.Len(t, env.Connections.Fabric, 1)
 					assert.Equal(t, tt.connName, env.Connections.Fabric[0].Name)
@@ -2503,6 +2526,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Freshdesk:           []FreshdeskConnection{{ConnectionMetadata: ConnectionMetadata{Name: "freshdesk1"}}},
 				FundraiseUp:         []FundraiseUpConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fundraiseup1"}}},
 				Fireflies:           []FirefliesConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fireflies1"}}},
+				Trello:              []TrelloConnection{{ConnectionMetadata: ConnectionMetadata{Name: "trello1"}}},
 				Jira:                []JiraConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jira1"}}},
 				Monday:              []MondayConnection{{ConnectionMetadata: ConnectionMetadata{Name: "monday1"}}},
 				PlusVibeAI:          []PlusVibeAIConnection{{ConnectionMetadata: ConnectionMetadata{Name: "plusvibeai1"}}},
@@ -2636,6 +2660,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Freshdesk:           []FreshdeskConnection{{ConnectionMetadata: ConnectionMetadata{Name: "freshdesk1"}}},
 				FundraiseUp:         []FundraiseUpConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fundraiseup1"}}},
 				Fireflies:           []FirefliesConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fireflies1"}}},
+				Trello:              []TrelloConnection{{ConnectionMetadata: ConnectionMetadata{Name: "trello1"}}},
 				Jira:                []JiraConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jira1"}}},
 				Monday:              []MondayConnection{{ConnectionMetadata: ConnectionMetadata{Name: "monday1"}}},
 				PlusVibeAI:          []PlusVibeAIConnection{{ConnectionMetadata: ConnectionMetadata{Name: "plusvibeai1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -510,6 +510,10 @@ environments:
       fireflies:
         - name: "fireflies-1"
           api_key: "test-api-key"
+      trello:
+        - name: "trello-1"
+          api_key: "test-api-key"
+          token: "test-token"
       jira:
         - name: "jira-1"
           domain: "company.atlassian.net"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -511,6 +511,10 @@ environments:
       fireflies:
         - name: "fireflies-1"
           api_key: "test-api-key"
+      trello:
+        - name: "trello-1"
+          api_key: "test-api-key"
+          token: "test-token"
       jira:
         - name: "jira-1"
           domain: "company.atlassian.net"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -133,6 +133,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/surveymonkey"
 	"github.com/bruin-data/bruin/pkg/tableau"
 	"github.com/bruin-data/bruin/pkg/tiktokads"
+	"github.com/bruin-data/bruin/pkg/trello"
 	"github.com/bruin-data/bruin/pkg/trino"
 	"github.com/bruin-data/bruin/pkg/trustpilot"
 	"github.com/bruin-data/bruin/pkg/twilio"
@@ -240,6 +241,7 @@ type Manager struct {
 	Freshdesk            map[string]*freshdesk.Client
 	FundraiseUp          map[string]*fundraiseup.Client
 	Fireflies            map[string]*fireflies.Client
+	Trello               map[string]*trello.Client
 	Jira                 map[string]*jira.Client
 	Monday               map[string]*monday.Client
 	PlusVibeAI           map[string]*plusvibeai.Client
@@ -3188,6 +3190,28 @@ func (m *Manager) AddFirefliesConnectionFromConfig(connection *config.FirefliesC
 	return nil
 }
 
+func (m *Manager) AddTrelloConnectionFromConfig(connection *config.TrelloConnection) error {
+	m.mutex.Lock()
+	if m.Trello == nil {
+		m.Trello = make(map[string]*trello.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := trello.NewClient(trello.Config{
+		APIKey: connection.APIKey,
+		Token:  connection.Token,
+	})
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Trello[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddJiraConnectionFromConfig(connection *config.JiraConnection) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -3947,6 +3971,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Freshdesk, connectionManager.AddFreshdeskConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.FundraiseUp, connectionManager.AddFundraiseUpConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Fireflies, connectionManager.AddFirefliesConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Trello, connectionManager.AddTrelloConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Jira, connectionManager.AddJiraConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Monday, connectionManager.AddMondayConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.PlusVibeAI, connectionManager.AddPlusVibeAIConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -343,6 +343,18 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "contacts", PrimaryKey: "", IncKey: "", IncStrategy: "replace"},
 	},
 
+	// Trello - Project management (boards, lists, cards)
+	"trello": {
+		{Name: "boards", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "organizations", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "lists", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "members", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "labels", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "checklists", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "cards", PrimaryKey: "id", IncKey: "dateLastActivity", IncStrategy: "merge"},
+		{Name: "actions", PrimaryKey: "id", IncKey: "date", IncStrategy: "merge"},
+	},
+
 	// Fluxx - Grants management platform
 	"fluxx": {
 		{Name: "claim", PrimaryKey: "id", IncKey: "updated_at", IncStrategy: "merge"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -233,6 +233,7 @@ var defaultMapping = map[string]string{
 	"dune":                  "dune-default",
 	"espn":                  "espn-default",
 	"fireflies":             "fireflies-default",
+	"trello":                "trello-default",
 	"fluxx":                 "fluxx-default",
 	"footballdata":          "footballdata-default",
 	"frankfurter":           "frankfurter-default",

--- a/pkg/trello/config.go
+++ b/pkg/trello/config.go
@@ -1,0 +1,20 @@
+package trello
+
+import "net/url"
+
+type Config struct {
+	APIKey string
+	Token  string
+}
+
+func (c *Config) GetIngestrURI() string {
+	params := url.Values{}
+	params.Set("api_key", c.APIKey)
+	params.Set("token", c.Token)
+
+	uri := url.URL{
+		Scheme:   "trello",
+		RawQuery: params.Encode(),
+	}
+	return uri.String()
+}

--- a/pkg/trello/db.go
+++ b/pkg/trello/db.go
@@ -1,0 +1,19 @@
+package trello
+
+type Client struct {
+	config Config
+}
+
+type TrelloConfig interface {
+	GetIngestrURI() string
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}


### PR DESCRIPTION
Adds **Trello** as an ingestr-backed source connection.

Trello's REST API authenticates with an **API key + token** (both query-string params), so the connection exposes both — `api_key` and `token`, both required and marked `sensitive`.
