### PR TITLE
feat(cloud): print the dashboard link after create

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3106,7 +3106,11 @@ func cloudDashboardsCreate() *cli.Command {
 			if dashboard.Title != nil {
 				title = *dashboard.Title
 			}
-			infoPrinter.Printf("Created dashboard %d (%s) as a draft — publish it from the Bruin Cloud UI.\n", dashboard.ID, title)
+			if dashboard.URL != "" {
+				infoPrinter.Printf("Created dashboard %d (%s) as a draft — open it to review and publish: %s\n", dashboard.ID, title, dashboard.URL)
+			} else {
+				infoPrinter.Printf("Created dashboard %d (%s) as a draft — publish it from the Bruin Cloud UI.\n", dashboard.ID, title)
+			}
 			return nil
 		},
 	}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -793,10 +793,11 @@ func TestCreateDashboard(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		title := "New Dash"
-		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private"})
+		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private", URL: "https://cloud.getbruin.com/acme/dashboards/9?mode=edit"})
 	})
 
 	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", map[string]any{"widgets": []any{}})
 	require.NoError(t, err)
 	assert.Equal(t, 9, dashboard.ID)
+	assert.Equal(t, "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", dashboard.URL)
 }

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -252,5 +252,6 @@ type Dashboard struct {
 	Title      *string         `json:"title"`
 	Visibility string          `json:"visibility"`
 	UpdatedAt  *string         `json:"updated_at"`
+	URL        string          `json:"url"`
 	State      json.RawMessage `json:"state,omitempty"`
 }


### PR DESCRIPTION
Surface the dashboard URL returned by the create endpoint. Plain output links straight to the draft to review and publish; `--output json` carries it once the struct field exists. Depends on the cloud API returning `url`.