### PR TITLE
Support ingestr destination_table override

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -50,6 +50,7 @@ parameters:
   destination: bigquery | snowflake | redshift | synapse
   
   # optional
+  destination_table: string # defaults to the asset name
   version: v0 | v1 | v1.x.y
   incremental_strategy: replace | append | merge | delete+insert # legacy alternative to materialization.strategy
   incremental_key: string # legacy alternative to materialization.incremental_key
@@ -83,6 +84,7 @@ parameters:
 | `source` | No | _n/a_ | Overrides the inferred source type. For example, set `gsheets` when reusing a BigQuery connection for Google Sheets. |
 | `source_table` | Yes | `--source-table` | Table, sheet, or resource identifier to pull from the source. |
 | `file_type` | No | `--source-table` suffix | Appended to the `source_table` as `table#type` for connectors that need a file format hint (`csv`, `jsonl`, `parquet`). |
+| `destination_table` | No | `--dest-table` | Destination table, index, collection, or path passed to Ingestr. Defaults to the asset name. Use this when the target cannot be represented as a Bruin asset name, such as OneLake `Tables/<schema>/<table>` paths. |
 | `version` | No | _n/a_  | Selects the version of ingestr to install and use.. Valid options are `v1` (latest), `v0` (legacy) or `v1.x.y` (full version specifer) | 
 | `materialization` | No | `--incremental-*`, `--partition-by`, `--cluster-by` | Preferred way to define destination write behavior. Supports `type: table` with `create+replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`. |
 | `destination` | Yes | `--dest-uri` | Logical destination used to select the target connection; Bruin converts it into the URI supplied to Ingestr. |

--- a/docs/ingestion/onelake.md
+++ b/docs/ingestion/onelake.md
@@ -45,7 +45,7 @@ OneLake requires Microsoft Entra ID authentication — shared account keys are n
 To ingest data to OneLake, you need to create an [asset configuration](/assets/ingestr.html#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., `stripe_onelake.yml`) inside the assets folder and add the following content:
 
 ```yaml
-name: Tables/events
+name: stripe_events
 type: ingestr
 connection: my-onelake
 
@@ -54,20 +54,23 @@ parameters:
   source_table: 'event'
 
   destination: onelake
+  destination_table: Tables/events
 ```
 
-- `name`: The name of the asset. This is also used as the destination table (`--dest-table`) in the lakehouse — see [Storage modes](#storage-modes) below.
+- `name`: The Bruin asset name. It must use only alphanumeric characters, dashes, dots, and underscores.
 - `type`: Specifies the type of the asset. Set this to `ingestr` to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. Here `my-onelake` points at the OneLake connection defined in `.bruin.yml`.
 - `source_connection`: The name of the source connection defined in `.bruin.yml`.
 - `source_table`: The table to ingest from the source.
 - `destination`: Set to `onelake`.
+- `destination_table`: The OneLake path passed to ingestr as `--dest-table` — see [Storage modes](#storage-modes) below. If omitted, Bruin uses the asset name.
 
 ### Storage modes
 
-The asset name is passed to ingestr as the destination table, and its prefix determines how data is stored in the lakehouse:
+The `destination_table` value is passed to ingestr as the destination table, and its prefix determines how data is stored in the lakehouse:
 
 - `Tables/<name>` → a Delta Lake table that is queryable in Fabric.
+- `Tables/<schema>/<name>` → a Delta Lake table in a schema-enabled Fabric lakehouse.
 - `Files/<path>` → raw Parquet files.
 - A bare name (e.g. `events`) defaults to `Tables/`.
 

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -343,7 +343,7 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		destURI = applyClickHouseEngineParams(destURI, asset.Parameters)
 	}
 
-	destTable := asset.Name
+	destTable := resolveDestinationTableName(asset)
 
 	extraPackages = python.AddExtraPackages(destURI, sourceURI, extraPackages)
 
@@ -480,6 +480,16 @@ func applyClickHouseEngineParams(destURI string, params pipeline.ParameterMap) s
 
 	parsedURI.RawQuery = q.Encode()
 	return parsedURI.String()
+}
+
+func resolveDestinationTableName(asset *pipeline.Asset) string {
+	if destTable, exists := asset.Parameters.GetString("destination_table"); exists {
+		if destTable = strings.TrimSpace(destTable); destTable != "" {
+			return destTable
+		}
+	}
+
+	return asset.Name
 }
 
 func applyMaterializationParameters(asset *pipeline.Asset) error {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -331,13 +331,16 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 	mockDuck.On("GetIngestrURI").Return("duckdb:////some/path", nil)
 	mockCh := new(mockConnection)
 	mockCh.On("GetIngestrURI").Return("clickhouse://user:pass@localhost:9000", nil)
+	mockOneLake := new(mockConnection)
+	mockOneLake.On("GetIngestrURI").Return("onelake://workspace/lakehouse", nil)
 
 	fetcher := simpleConnectionFetcher{
 		connections: map[string]*mockConnection{
-			"bq":   mockBq,
-			"sf":   mockSf,
-			"duck": mockDuck,
-			"ch":   mockCh,
+			"bq":      mockBq,
+			"sf":      mockSf,
+			"duck":    mockDuck,
+			"ch":      mockCh,
+			"onelake": mockOneLake,
 		},
 	}
 
@@ -384,6 +387,20 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 				},
 			},
 			want: []string{"ingest", "--source-uri", "snowflake://uri-here", "--source-table", "source-table", "--dest-uri", "bigquery://uri-here", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "destination_table overrides asset name",
+			asset: &pipeline.Asset{
+				Name:       "fabric_events",
+				Connection: "onelake",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "sf",
+					"source_table":      "source-table",
+					"destination":       "onelake",
+					"destination_table": "Tables/sales/events",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "snowflake://uri-here", "--source-table", "source-table", "--dest-uri", "onelake://workspace/lakehouse", "--dest-table", "Tables/sales/events", "--yes", "--progress", "log"},
 		},
 		{
 			name: "trim whitespace",


### PR DESCRIPTION
## Summary
- use `parameters.destination_table` as the ingestr `--dest-table` value when it is set
- keep the existing asset-name fallback when `destination_table` is omitted or blank
- document `destination_table` for ingestr assets and update the OneLake docs for schema-enabled Fabric lakehouses

Fixes bruin-data/ingestr#926.

## Tests
- `/tmp/go1.25.0/bin/go test ./pkg/ingestr`
