### PR TITLE
Add ingestr destination table override

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -47,9 +47,10 @@ parameters:
   source: string # optional, used when inferring the source from connection is not enough, e.g. GCP connection + GSheets source
   source_connection: string
   source_table: string
-  destination: bigquery | snowflake | redshift | synapse
+  destination: bigquery | snowflake | redshift | synapse | onelake
   
   # optional
+  destination_table: string # overrides the --dest-table value; defaults to name
   version: v0 | v1 | v1.x.y
   incremental_strategy: replace | append | merge | delete+insert # legacy alternative to materialization.strategy
   incremental_key: string # legacy alternative to materialization.incremental_key
@@ -86,6 +87,7 @@ parameters:
 | `version` | No | _n/a_  | Selects the version of ingestr to install and use.. Valid options are `v1` (latest), `v0` (legacy) or `v1.x.y` (full version specifer) | 
 | `materialization` | No | `--incremental-*`, `--partition-by`, `--cluster-by` | Preferred way to define destination write behavior. Supports `type: table` with `create+replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`. |
 | `destination` | Yes | `--dest-uri` | Logical destination used to select the target connection; Bruin converts it into the URI supplied to Ingestr. |
+| `destination_table` | No | `--dest-table` | Overrides the destination table/path passed to Ingestr. Defaults to the asset `name`; useful when the destination path cannot be represented as a Bruin asset name, such as OneLake `Tables/<schema>/<table>`. |
 | `incremental_strategy` | No | `--incremental-strategy` | Passes the incremental loading strategy (`replace`, `append`, `merge`, `delete+insert`) to Ingestr. |
 | `incremental_key` | No | `--incremental-key` | Column that determines incremental progress. When the column is defined with type `date`, Bruin also forwards it through the `--columns` option so Ingestr treats it as a date field. |
 | `partition_by` | No | `--partition-by` | Comma-separated list of destination columns to partition by. |

--- a/docs/ingestion/onelake.md
+++ b/docs/ingestion/onelake.md
@@ -45,7 +45,7 @@ OneLake requires Microsoft Entra ID authentication — shared account keys are n
 To ingest data to OneLake, you need to create an [asset configuration](/assets/ingestr.html#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., `stripe_onelake.yml`) inside the assets folder and add the following content:
 
 ```yaml
-name: Tables/events
+name: onelake.events
 type: ingestr
 connection: my-onelake
 
@@ -54,20 +54,23 @@ parameters:
   source_table: 'event'
 
   destination: onelake
+  destination_table: Tables/events
 ```
 
-- `name`: The name of the asset. This is also used as the destination table (`--dest-table`) in the lakehouse — see [Storage modes](#storage-modes) below.
+- `name`: The Bruin asset name used for orchestration, lineage, and checks.
 - `type`: Specifies the type of the asset. Set this to `ingestr` to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. Here `my-onelake` points at the OneLake connection defined in `.bruin.yml`.
 - `source_connection`: The name of the source connection defined in `.bruin.yml`.
 - `source_table`: The table to ingest from the source.
 - `destination`: Set to `onelake`.
+- `destination_table`: The OneLake table or file path passed to ingestr as `--dest-table` - see [Storage modes](#storage-modes) below.
 
 ### Storage modes
 
-The asset name is passed to ingestr as the destination table, and its prefix determines how data is stored in the lakehouse:
+Bruin passes `parameters.destination_table` to ingestr as the destination table. If `destination_table` is not set, Bruin falls back to the asset `name`. The destination prefix determines how data is stored in the lakehouse:
 
 - `Tables/<name>` → a Delta Lake table that is queryable in Fabric.
+- `Tables/<schema>/<name>` → a Delta Lake table under a schema-enabled Fabric lakehouse schema.
 - `Files/<path>` → raw Parquet files.
 - A bare name (e.g. `events`) defaults to `Tables/`.
 

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -343,7 +343,7 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		destURI = applyClickHouseEngineParams(destURI, asset.Parameters)
 	}
 
-	destTable := asset.Name
+	destTable := resolveDestinationTableName(asset)
 
 	extraPackages = python.AddExtraPackages(destURI, sourceURI, extraPackages)
 
@@ -596,6 +596,16 @@ func normalizeMaterializationParameter(key, value string) string {
 		}
 	}
 	return strings.Join(cleaned, ",")
+}
+
+func resolveDestinationTableName(asset *pipeline.Asset) string {
+	if value, exists := asset.Parameters.GetString("destination_table"); exists {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+
+	return asset.Name
 }
 
 func NewSeedOperator(conn config.ConnectionGetter, j jinja.RendererInterface) (*SeedOperator, error) {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -331,13 +331,16 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 	mockDuck.On("GetIngestrURI").Return("duckdb:////some/path", nil)
 	mockCh := new(mockConnection)
 	mockCh.On("GetIngestrURI").Return("clickhouse://user:pass@localhost:9000", nil)
+	mockOneLake := new(mockConnection)
+	mockOneLake.On("GetIngestrURI").Return("onelake://workspace/lakehouse", nil)
 
 	fetcher := simpleConnectionFetcher{
 		connections: map[string]*mockConnection{
-			"bq":   mockBq,
-			"sf":   mockSf,
-			"duck": mockDuck,
-			"ch":   mockCh,
+			"bq":      mockBq,
+			"sf":      mockSf,
+			"duck":    mockDuck,
+			"ch":      mockCh,
+			"onelake": mockOneLake,
 		},
 	}
 
@@ -384,6 +387,20 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 				},
 			},
 			want: []string{"ingest", "--source-uri", "snowflake://uri-here", "--source-table", "source-table", "--dest-uri", "bigquery://uri-here", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "destination table override",
+			asset: &pipeline.Asset{
+				Name:       "onelake.events",
+				Connection: "onelake",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "sf",
+					"source_table":      "source-table",
+					"destination":       "onelake",
+					"destination_table": "Tables/myschema/events",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "snowflake://uri-here", "--source-table", "source-table", "--dest-uri", "onelake://workspace/lakehouse", "--dest-table", "Tables/myschema/events", "--yes", "--progress", "log"},
 		},
 		{
 			name: "trim whitespace",


### PR DESCRIPTION
## Summary

- add `parameters.destination_table` support for ingestr assets and use it for the `--dest-table` argument
- keep the asset `name` as the default destination table for existing assets
- document the override in the ingestr asset reference and update OneLake docs to avoid slash-containing asset names

## Root Cause

Bruin was always passing `asset.Name` to ingestr as `--dest-table`. That prevents destinations such as schema-enabled Fabric Lakehouses from receiving paths like `Tables/<schema>/<table>`, because Bruin asset names do not allow `/`.

## Testing

- `go test ./pkg/ingestr`

Fixes bruin-data/ingestr#926