### PR TITLE
[codex] add deployment overview docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -430,6 +430,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 items: [
                     {
                         text: "Deployment",
+                        link: "/deployment/overview",
                         collapsed: false,
                         items: [
                             {text: "Ubuntu VM with Cron", link: "/deployment/vm-deployment"},

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -127,3 +127,68 @@ html:not(.dark) .vp-code-dark {
   border-radius: 6px;
   font-size: 0.75rem;
 }
+
+.deployment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+  margin: 22px 0 30px;
+}
+
+.deployment-card {
+  display: flex;
+  min-height: 230px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  text-decoration: none !important;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+}
+
+.deployment-card:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-alt);
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-1px);
+}
+
+.deployment-card--featured {
+  border-color: var(--vp-c-brand-1);
+}
+
+.deployment-card strong {
+  color: var(--vp-c-text-1);
+  font-size: 1.08rem;
+  line-height: 1.25;
+}
+
+.deployment-card span {
+  color: var(--vp-c-text-2);
+  line-height: 1.45;
+}
+
+.deployment-card__eyebrow {
+  color: var(--vp-c-brand-1) !important;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.deployment-card__button {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  margin-top: auto;
+  padding: 7px 11px;
+  color: var(--vp-c-brand-1) !important;
+  background: var(--vp-c-brand-soft);
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 6px;
+  font-size: 0.84rem;
+  font-weight: 700;
+}

--- a/docs/core-concepts/overview.md
+++ b/docs/core-concepts/overview.md
@@ -21,5 +21,5 @@ Bruin orchestrates pipeline execution through several features that work togethe
 - **[Lineage](/commands/lineage)**: The dependency graph forms a lineage that lets you trace how data flows through your pipeline. You can visualize it via the [`lineage` command](/commands/lineage) or the [VS Code lineage panel](/vscode-extension/panels/lineage-panel). In Bruin Cloud, lineage extends [across pipelines](/cloud/cross-pipeline).
 - **[Scheduling](/pipelines/definition#schedule)**: Pipelines can be scheduled using cron expressions in `pipeline.yml`, defining when and how often they run.
 - **[Concurrency](/getting-started/concurrency)**: Control how many assets run simultaneously (`--workers`) and how many pipeline runs can overlap (`concurrency` setting in Bruin Cloud).
-- **[Deployment](/deployment/vm-deployment)**: Run pipelines locally, on VMs with cron, via CI/CD (GitHub Actions, GitLab), or on cloud infrastructure (AWS Lambda, ECS, Google Cloud Run).
+- **[Deployment](/deployment/overview)**: Run pipelines with Bruin Cloud, on VMs with cron, via CI/CD (GitHub Actions, GitLab), or on cloud infrastructure (AWS Lambda, ECS, Google Cloud Run).
 - **[Bruin Cloud](/cloud/overview)**: Managed orchestration with scheduling, monitoring, notifications, and cross-pipeline dependencies — no infrastructure to manage.

--- a/docs/core-concepts/project.md
+++ b/docs/core-concepts/project.md
@@ -152,7 +152,7 @@ When deploying to Bruin Cloud or other environments, you have several options:
 2. **Secret Providers**: Use external secret managers like [HashiCorp Vault](/secrets/vault), [Doppler](/secrets/doppler), or [AWS Secrets Manager](/secrets/aws-secrets-manager)
 3. **CI/CD Integration**: Inject secrets during CI/CD pipeline execution
 
-See the [Deployment](/deployment/vm-deployment) documentation for platform-specific guidance.
+See the [Deployment](/deployment/overview) documentation for platform-specific guidance.
 
 ## Schema-Based Environments
 

--- a/docs/deployment/cloud/gitlab-cicd.md
+++ b/docs/deployment/cloud/gitlab-cicd.md
@@ -612,7 +612,7 @@ reporting:
 
 - Explore [Bruin Cloud](/cloud/overview) for managed orchestration
 - Learn about [quality checks](/quality/overview) to add validation
-- Review other [deployment options](/deployment/vm-deployment)
+- Review other [deployment options](/deployment/overview)
 
 ## Additional Resources
 

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -1,0 +1,90 @@
+# Deployment Overview
+
+Bruin can run anywhere the CLI can run. The right deployment option depends on how much infrastructure you want to operate, where your credentials live, and whether you need a managed scheduler, CI/CD runner, serverless job, container platform, or existing orchestrator.
+
+For a managed setup with scheduling, monitoring, lineage, runs, backfills, and secure connection management, start with Bruin Cloud. If you prefer to own the runtime, use one of the self-managed options below.
+
+<script setup>
+import { withBase } from 'vitepress'
+</script>
+
+<div class="deployment-grid">
+  <a class="deployment-card deployment-card--featured" :href="withBase('/cloud/overview.html')">
+    <span class="deployment-card__eyebrow">Managed</span>
+    <strong>Bruin Cloud</strong>
+    <span>Run scheduled pipelines from your Git repo without maintaining servers. Bruin Cloud handles orchestration, logs, lineage, backfills, notifications, and encrypted connections.</span>
+    <span class="deployment-card__button">Open Bruin Cloud</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/github-actions.html')">
+    <span class="deployment-card__eyebrow">CI/CD runner</span>
+    <strong>GitHub Actions</strong>
+    <span>Use GitHub-hosted or self-hosted runners to validate, test, and run pipelines on pushes, schedules, or manual triggers.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/cloud/gitlab-cicd.html')">
+    <span class="deployment-card__eyebrow">CI/CD runner</span>
+    <strong>GitLab CI/CD</strong>
+    <span>Run Bruin from GitLab pipelines with variables for secrets, scheduled pipelines, manual jobs, and deployment environments.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/vm-deployment.html')">
+    <span class="deployment-card__eyebrow">Virtual machine</span>
+    <strong>Ubuntu VM with Cron</strong>
+    <span>Install the Bruin CLI on a VM and schedule runs with cron. This is simple, explicit, and works well when you already manage servers.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/cloud/aws-lambda.html')">
+    <span class="deployment-card__eyebrow">AWS serverless</span>
+    <strong>AWS Lambda</strong>
+    <span>Package Bruin in a Lambda container image for short scheduled or event-driven runs with EventBridge and Secrets Manager.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/cloud/aws-ecs.html')">
+    <span class="deployment-card__eyebrow">AWS containers</span>
+    <strong>AWS ECS</strong>
+    <span>Run Bruin as ECS Fargate tasks for containerized workloads that need more runtime, memory, or operational control than Lambda.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/cloud/google-cloud-run.html')">
+    <span class="deployment-card__eyebrow">GCP serverless</span>
+    <strong>Google Cloud Run Jobs</strong>
+    <span>Run Bruin in Cloud Run Jobs with Artifact Registry, Secret Manager, Cloud Scheduler, and Cloud Logging.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+
+  <a class="deployment-card" :href="withBase('/deployment/airflow.html')">
+    <span class="deployment-card__eyebrow">Orchestrator</span>
+    <strong>Apache Airflow</strong>
+    <span>Use Airflow DAGs to call Bruin from BashOperator or KubernetesPodOperator when Airflow already owns your scheduling layer.</span>
+    <span class="deployment-card__button">Open guide</span>
+  </a>
+</div>
+
+## Choosing an Option
+
+| Option | Best for | Tradeoff |
+| --- | --- | --- |
+| [Bruin Cloud](/cloud/overview) | Managed scheduling, monitoring, lineage, backfills, and secrets | Requires using the hosted Bruin Cloud control plane |
+| [GitHub Actions](/deployment/github-actions) | GitHub-native scheduled or manual production runs | Runner timeouts and concurrency depend on your GitHub plan and runner setup |
+| [GitLab CI/CD](/deployment/cloud/gitlab-cicd) | GitLab-native scheduled or manual production runs | Runtime behavior depends on GitLab runners and CI/CD variables |
+| [Ubuntu VM with Cron](/deployment/vm-deployment) | Simple self-managed deployments on EC2, Compute Engine, DigitalOcean, or another VM | You maintain the server, cron, logs, updates, and credentials |
+| [AWS Lambda](/deployment/cloud/aws-lambda) | Short event-driven or scheduled AWS workloads | Lambda timeout and package constraints limit longer pipelines |
+| [AWS ECS](/deployment/cloud/aws-ecs) | Longer AWS container tasks with more control over CPU, memory, and networking | Requires ECS, ECR, IAM, scheduling, and logging setup |
+| [Google Cloud Run Jobs](/deployment/cloud/google-cloud-run) | Serverless GCP batch jobs with Cloud Scheduler | Requires container build, Artifact Registry, IAM, and GCP job configuration |
+| [Apache Airflow](/deployment/airflow) | Teams that already operate Airflow and want Bruin inside existing DAGs | You maintain Airflow and the worker or Kubernetes runtime |
+
+## CI/CD Validation
+
+If you only want to validate and unit-test pipelines in pull requests, use the CI/CD integration guides instead of the deployment guides:
+
+- [GitHub Actions CI](/cicd/github-action)
+- [GitLab CI/CD validation](/cicd/gitlab-ci)
+- [CircleCI](/cicd/circleci)
+- [Jenkins](/cicd/jenkins)
+- [Azure Pipelines](/cicd/azure-pipelines)


### PR DESCRIPTION
## Summary

Adds a deployment overview page that helps users choose between Bruin Cloud, CI/CD runners, VM cron, AWS Lambda, AWS ECS, Google Cloud Run Jobs, and Apache Airflow.

The page includes short descriptions, direct guide links, and a comparison table. The `Deployment` sidebar group label now links to the overview page while the separate dropdown caret remains available for expanding and collapsing the section. Existing docs links that pointed to the VM guide as the generic deployment entry point now point to the overview page.

## Validation

- `npx markdownlint-cli2 --no-globs docs/deployment/overview.md docs/core-concepts/overview.md docs/core-concepts/project.md docs/deployment/cloud/gitlab-cicd.md`
- `npm run docs:build`
- Checked generated `docs/.vitepress/dist/deployment/overview.html` to confirm:
  - the `Deployment` group label links to `/deployment/overview` and the separate caret toggle remains present
  - deployment overview card links emit `/bruin/...html` targets instead of raw extensionless paths

## Notes

This is a docs-only change, so the full application `make format` / `make test` suite was not run.