### PR TITLE
Fix asset discovery on Windows in bruin format

### DIFF
--- a/pkg/path/walk.go
+++ b/pkg/path/walk.go
@@ -189,8 +189,11 @@ func GetAllPossibleAssetPaths(pipelinePath string, assetsDirectoryNames []string
 	}
 
 	for _, file := range files {
+		// Normalize separators to forward slashes so the directory match works
+		// regardless of the OS path separator (e.g. backslashes on Windows).
+		normalized := filepath.ToSlash(file)
 		for _, dir := range assetsDirectoryNames {
-			if strings.Contains(file, "/"+dir+"/") {
+			if strings.Contains(normalized, "/"+dir+"/") {
 				taskFiles = append(taskFiles, file)
 				break
 			}

--- a/pkg/path/walk_test.go
+++ b/pkg/path/walk_test.go
@@ -54,6 +54,32 @@ func TestGetPipelinePaths(t *testing.T) {
 	}
 }
 
+func TestGetAllPossibleAssetPaths(t *testing.T) {
+	t.Parallel()
+
+	mp := func(path string) string {
+		abs, err := filepath.Abs(testPipelinePath)
+		if err != nil {
+			t.Fatal()
+		}
+		return filepath.Join(abs, path)
+	}
+
+	got := GetAllPossibleAssetPaths(testPipelinePath, []string{"tasks", "assets"}, []string{".yml"})
+
+	// Only files that live under a "tasks"/"assets" directory should be returned,
+	// the top-level pipeline.yml files must be excluded.
+	want := []string{
+		mp("first-pipeline/tasks/helloworld/task.yml"),
+		mp("first-pipeline/tasks/test1/task.yml"),
+		mp("first-pipeline/tasks/test2/task.yml"),
+		mp("second-pipeline/tasks/test1/task.yml"),
+		mp("second-pipeline/tasks/test2/task.yml"),
+	}
+
+	require.Equal(t, want, got)
+}
+
 func TestGetPipelineRootFromTask(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
On Windows, `bruin format <project-dir>` aborted with "No assets were found" because `GetAllPossibleAssetPaths` matched a hardcoded `/dir/` against paths built with the OS-native separator, so backslash paths never matched. Paths are now normalized with `filepath.ToSlash` before matching. Formatting a single asset already worked since it takes a different code path.