### PR TITLE
Default Fabric SQLFluff dialect to TSQL

### DIFF
--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/bruin-data/bruin/pkg/python"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,4 +63,38 @@ func TestCheckLint(t *testing.T) {
 			require.Equal(t, tc.expectChange, changed, "Unexpected change detection result")
 		})
 	}
+}
+
+func TestFindSQLFilesWithDialectsUsesTSQLForFabric(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	assetsDir := filepath.Join(tempDir, "assets")
+	require.NoError(t, os.MkdirAll(assetsDir, 0o755))
+
+	fabricAssetPath := filepath.Join(assetsDir, "fabric_asset.sql")
+	require.NoError(t, os.WriteFile(fabricAssetPath, []byte(`/* @bruin
+name: test.fabric_asset
+type: fabric.sql
+@bruin */
+
+SELECT 1;
+`), 0o644))
+
+	legacyFabricAssetPath := filepath.Join(assetsDir, "legacy_fabric_asset.sql")
+	require.NoError(t, os.WriteFile(legacyFabricAssetPath, []byte(`/* @bruin
+name: test.legacy_fabric_asset
+type: fw.sql
+@bruin */
+
+SELECT 1;
+`), 0o644))
+
+	got, err := findSQLFilesWithDialects(tempDir)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []python.SQLFileInfo{
+		{FilePath: fabricAssetPath, Dialect: "tsql"},
+		{FilePath: legacyFabricAssetPath, Dialect: "tsql"},
+	}, got)
 }

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -178,6 +178,8 @@ var DatabasePrefixToSqlfluffDialect = map[string]string{
 	"rs":         "redshift",
 	"athena":     "athena",
 	"ms":         "tsql",
+	"fabric":     "tsql",
+	"fw":         "tsql",
 	"databricks": "sparksql",
 	"synapse":    "tsql",
 	"duckdb":     "duckdb",

--- a/pkg/python/uv_pyproject_test.go
+++ b/pkg/python/uv_pyproject_test.go
@@ -5,9 +5,54 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDetectDialectFromAssetType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		assetType string
+		want      string
+	}{
+		{
+			name:      "fabric uses tsql for sqlfluff",
+			assetType: string(pipeline.AssetTypeFabricQuery),
+			want:      "tsql",
+		},
+		{
+			name:      "legacy fabric warehouse uses tsql for sqlfluff",
+			assetType: string(pipeline.AssetTypeFabricQueryLegacy),
+			want:      "tsql",
+		},
+		{
+			name:      "mssql uses tsql",
+			assetType: string(pipeline.AssetTypeMsSQLQuery),
+			want:      "tsql",
+		},
+		{
+			name:      "duckdb stays duckdb",
+			assetType: string(pipeline.AssetTypeDuckDBQuery),
+			want:      "duckdb",
+		},
+		{
+			name:      "unknown falls back to ansi",
+			assetType: "unknown.sql",
+			want:      "ansi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, DetectDialectFromAssetType(tt.assetType))
+		})
+	}
+}
 
 func TestParsePyprojectToml(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fabric SQLFluff formatting now uses the TSQL dialect for both `fabric.*` and legacy `fw.*` assets instead of falling back to ANSI.

Added focused tests for asset-type detection and SQL file dialect discovery.

Validation: `make format`, `make test`.