### PR TITLE
Create Fabric schemas automatically

### DIFF
--- a/integration-tests/cloud-integration-tests/fabric/fabric_test.go
+++ b/integration-tests/cloud-integration-tests/fabric/fabric_test.go
@@ -67,19 +67,6 @@ func TestFabricWorkflows(t *testing.T) {
 						},
 					},
 					{
-						Name:    "ensure schema exists",
-						Command: binary,
-						Args: append(append([]string{"query"}, configFlags...), "--connection", "fabric-default", "--query",
-							"IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'bruin_test') EXEC('CREATE SCHEMA bruin_test');"),
-						Env: []string{},
-						Expected: e2e.Output{
-							ExitCode: 0,
-						},
-						Asserts: []func(*e2e.Task) error{
-							e2e.AssertByExitCode,
-						},
-					},
-					{
 						Name:    "create the initial products table",
 						Command: binary,
 						Args:    append(append([]string{"run"}, configFlags...), "--full-refresh", "--env", "default", tempAssetPath),

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/microsoft/go-mssqldb"
@@ -13,8 +14,9 @@ import (
 )
 
 type DB struct {
-	conn   *sqlx.DB
-	config *Config
+	conn          *sqlx.DB
+	config        *Config
+	schemaCreator *SchemaCreator
 }
 
 // QuoteIdentifier quotes a Fabric identifier using square brackets.
@@ -35,7 +37,11 @@ func NewDB(c *Config) (*DB, error) {
 		return nil, errors.Wrap(err, "failed to open Fabric Warehouse connection")
 	}
 
-	return &DB{conn: conn, config: c}, nil
+	return &DB{conn: conn, config: c, schemaCreator: NewSchemaCreator()}, nil
+}
+
+func (db *DB) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error {
+	return db.schemaCreator.CreateSchemaIfNotExist(ctx, db, asset)
 }
 
 func (db *DB) Ping(ctx context.Context) error {

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -41,7 +41,33 @@ func NewDB(c *Config) (*DB, error) {
 }
 
 func (db *DB) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error {
+	schemaName, ok := schemaNameToCreate(asset.Name)
+	if ok && schemaName.catalog != "" && db.schemaCreator.currentDatabase == "" {
+		currentDatabase, err := db.GetCurrentDatabase(ctx)
+		if err != nil {
+			return err
+		}
+		db.schemaCreator.currentDatabase = currentDatabase
+	}
+
 	return db.schemaCreator.CreateSchemaIfNotExist(ctx, db, asset)
+}
+
+func (db *DB) GetCurrentDatabase(ctx context.Context) (string, error) {
+	rows, err := db.Select(ctx, &query.Query{Query: "SELECT DB_NAME()"})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get current Fabric warehouse")
+	}
+	if len(rows) == 0 || len(rows[0]) == 0 {
+		return "", errors.New("failed to get current Fabric warehouse: empty result")
+	}
+
+	currentDatabase, ok := fromFabricValue(rows[0][0])
+	if !ok || currentDatabase == "" {
+		return "", errors.New("failed to get current Fabric warehouse: empty value")
+	}
+
+	return currentDatabase, nil
 }
 
 func (db *DB) Ping(ctx context.Context) error {

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -37,7 +37,7 @@ func NewDB(c *Config) (*DB, error) {
 		return nil, errors.Wrap(err, "failed to open Fabric Warehouse connection")
 	}
 
-	return &DB{conn: conn, config: c, schemaCreator: NewSchemaCreator()}, nil
+	return &DB{conn: conn, config: c, schemaCreator: NewSchemaCreator(c.Database)}, nil
 }
 
 func (db *DB) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error {

--- a/pkg/fabric/operator.go
+++ b/pkg/fabric/operator.go
@@ -19,6 +19,7 @@ type materializer interface {
 }
 
 type fabricClient interface {
+	CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error
 	RunQueryWithoutResult(ctx context.Context, query *query.Query) error
 }
 
@@ -90,6 +91,13 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	conn, ok := rawConn.(fabricClient)
 	if !ok {
 		return errors.Errorf("connection '%s' is not a fabric warehouse connection", connName)
+	}
+
+	if t.Materialization.Type != pipeline.MaterializationTypeNone {
+		err = conn.CreateSchemaIfNotExist(ctx, t)
+		if err != nil {
+			return err
+		}
 	}
 
 	writer := ctx.Value(executor.KeyPrinter)

--- a/pkg/fabric/operator_test.go
+++ b/pkg/fabric/operator_test.go
@@ -1,0 +1,184 @@
+package fabric
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFabricExtractor struct {
+	mock.Mock
+}
+
+func (m *mockFabricExtractor) ExtractQueriesFromString(content string) ([]*query.Query, error) {
+	res := m.Called(content)
+	return res.Get(0).([]*query.Query), res.Error(1)
+}
+
+func (m *mockFabricExtractor) CloneForAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) (query.QueryExtractor, error) {
+	res := m.Called(ctx, p, asset)
+	return res.Get(0).(query.QueryExtractor), res.Error(1)
+}
+
+func (m *mockFabricExtractor) ReextractQueriesFromSlice(content []string) ([]string, error) {
+	res := m.Called(content)
+	return res.Get(0).([]string), res.Error(1)
+}
+
+type mockFabricMaterializer struct {
+	mock.Mock
+}
+
+func (m *mockFabricMaterializer) Render(asset *pipeline.Asset, query string) (string, error) {
+	res := m.Called(asset, query)
+	return res.Get(0).(string), res.Error(1)
+}
+
+type mockFabricClient struct {
+	mock.Mock
+}
+
+func (m *mockFabricClient) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error {
+	res := m.Called(ctx, asset)
+	return res.Error(0)
+}
+
+func (m *mockFabricClient) RunQueryWithoutResult(ctx context.Context, q *query.Query) error {
+	res := m.Called(ctx, q)
+	return res.Error(0)
+}
+
+type mockFabricConnectionGetter struct {
+	mock.Mock
+}
+
+func (m *mockFabricConnectionGetter) GetConnection(name string) any {
+	res := m.Called(name)
+	return res.Get(0)
+}
+
+func TestBasicOperator_RunTaskCreatesSchemaForMaterializedAsset(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "bruin_test.Products",
+		Type: pipeline.AssetTypeFabricQuery,
+		Materialization: pipeline.Materialization{
+			Type: pipeline.MaterializationTypeTable,
+		},
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "products.sql",
+			Content: "SELECT 1",
+		},
+	}
+	renderedQuery := "CREATE TABLE [bruin_test].[Products] AS\nSELECT 1"
+
+	extractor := new(mockFabricExtractor)
+	extractor.On("CloneForAsset", mock.Anything, mock.Anything, asset).Return(extractor, nil)
+	extractor.On("ExtractQueriesFromString", "SELECT 1").Return([]*query.Query{{Query: "SELECT 1"}}, nil)
+
+	materializer := new(mockFabricMaterializer)
+	materializer.On("Render", asset, "SELECT 1").Return(renderedQuery, nil)
+
+	client := new(mockFabricClient)
+	client.On("CreateSchemaIfNotExist", mock.Anything, asset).Return(nil).Once()
+	client.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: renderedQuery}).Return(nil).Once()
+
+	connections := new(mockFabricConnectionGetter)
+	connections.On("GetConnection", "fabric-default").Return(client)
+
+	operator := BasicOperator{
+		connection:   connections,
+		extractor:    extractor,
+		materializer: materializer,
+	}
+
+	err := operator.RunTask(t.Context(), &pipeline.Pipeline{}, asset)
+
+	require.NoError(t, err)
+	client.AssertExpectations(t)
+}
+
+func TestBasicOperator_RunTaskSkipsSchemaForNonMaterializedAsset(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "bruin_test.Products",
+		Type: pipeline.AssetTypeFabricQuery,
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "products.sql",
+			Content: "SELECT 1",
+		},
+	}
+
+	extractor := new(mockFabricExtractor)
+	extractor.On("CloneForAsset", mock.Anything, mock.Anything, asset).Return(extractor, nil)
+	extractor.On("ExtractQueriesFromString", "SELECT 1").Return([]*query.Query{{Query: "SELECT 1"}}, nil)
+
+	materializer := new(mockFabricMaterializer)
+	materializer.On("Render", asset, "SELECT 1").Return("SELECT 1", nil)
+
+	client := new(mockFabricClient)
+	client.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "SELECT 1"}).Return(nil).Once()
+
+	connections := new(mockFabricConnectionGetter)
+	connections.On("GetConnection", "fabric-default").Return(client)
+
+	operator := BasicOperator{
+		connection:   connections,
+		extractor:    extractor,
+		materializer: materializer,
+	}
+
+	err := operator.RunTask(t.Context(), &pipeline.Pipeline{}, asset)
+
+	require.NoError(t, err)
+	client.AssertNotCalled(t, "CreateSchemaIfNotExist", mock.Anything, asset)
+	client.AssertExpectations(t)
+}
+
+func TestBasicOperator_RunTaskReturnsSchemaCreationError(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "bruin_test.Products",
+		Type: pipeline.AssetTypeFabricQuery,
+		Materialization: pipeline.Materialization{
+			Type: pipeline.MaterializationTypeTable,
+		},
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "products.sql",
+			Content: "SELECT 1",
+		},
+	}
+
+	extractor := new(mockFabricExtractor)
+	extractor.On("CloneForAsset", mock.Anything, mock.Anything, asset).Return(extractor, nil)
+	extractor.On("ExtractQueriesFromString", "SELECT 1").Return([]*query.Query{{Query: "SELECT 1"}}, nil)
+
+	materializer := new(mockFabricMaterializer)
+	materializer.On("Render", asset, "SELECT 1").Return("CREATE TABLE [bruin_test].[Products] AS\nSELECT 1", nil)
+
+	client := new(mockFabricClient)
+	client.On("CreateSchemaIfNotExist", mock.Anything, asset).Return(errors.New("schema failed")).Once()
+
+	connections := new(mockFabricConnectionGetter)
+	connections.On("GetConnection", "fabric-default").Return(client)
+
+	operator := BasicOperator{
+		connection:   connections,
+		extractor:    extractor,
+		materializer: materializer,
+	}
+
+	err := operator.RunTask(t.Context(), &pipeline.Pipeline{}, asset)
+
+	require.ErrorContains(t, err, "schema failed")
+	client.AssertNotCalled(t, "RunQueryWithoutResult", mock.Anything, mock.Anything)
+	client.AssertExpectations(t)
+}

--- a/pkg/fabric/schema.go
+++ b/pkg/fabric/schema.go
@@ -15,6 +15,11 @@ type SchemaCreator struct {
 	schemaNameCache *sync.Map
 }
 
+type schemaIdentifier struct {
+	catalog string
+	schema  string
+}
+
 type schemaQueryRunner interface {
 	RunQueryWithoutResult(ctx context.Context, q *query.Query) error
 }
@@ -29,42 +34,61 @@ func (sc *SchemaCreator) CreateSchemaIfNotExist(ctx context.Context, qr schemaQu
 		return nil
 	}
 
-	if _, exists := sc.schemaNameCache.Load(schemaName); exists {
+	cacheKey := schemaName.cacheKey()
+	if _, exists := sc.schemaNameCache.Load(cacheKey); exists {
 		return nil
 	}
 
 	createQuery := query.Query{Query: buildCreateSchemaQuery(schemaName)}
 	if err := qr.RunQueryWithoutResult(ctx, &createQuery); err != nil {
-		return errors.Wrapf(err, "failed to create or ensure schema: %s", schemaName)
+		return errors.Wrapf(err, "failed to create or ensure schema: %s", cacheKey)
 	}
-	sc.schemaNameCache.Store(schemaName, true)
+	sc.schemaNameCache.Store(cacheKey, true)
 
 	return nil
 }
 
-func schemaNameToCreate(assetName string) (string, bool) {
+func schemaNameToCreate(assetName string) (schemaIdentifier, bool) {
 	parts := strings.Split(assetName, ".")
 	for _, part := range parts {
 		if strings.TrimSpace(part) == "" {
-			return "", false
+			return schemaIdentifier{}, false
 		}
 	}
 
 	switch len(parts) {
 	case 2:
-		return parts[0], true
+		return schemaIdentifier{schema: parts[0]}, true
 	case 3:
-		return parts[1], true
+		return schemaIdentifier{catalog: parts[0], schema: parts[1]}, true
 	default:
-		return "", false
+		return schemaIdentifier{}, false
 	}
 }
 
-func buildCreateSchemaQuery(schemaName string) string {
+func (s schemaIdentifier) cacheKey() string {
+	if s.catalog == "" {
+		return s.schema
+	}
+
+	return s.catalog + "." + s.schema
+}
+
+func buildCreateSchemaQuery(schemaName schemaIdentifier) string {
+	if schemaName.catalog != "" {
+		return fmt.Sprintf(
+			"IF NOT EXISTS (SELECT 1 FROM %s.sys.schemas WHERE name = %s)\n    EXEC(N'USE %s; CREATE SCHEMA %s')",
+			QuoteIdentifier(schemaName.catalog),
+			sqlStringLiteral(schemaName.schema),
+			strings.ReplaceAll(QuoteIdentifier(schemaName.catalog), "'", "''"),
+			strings.ReplaceAll(QuoteIdentifier(schemaName.schema), "'", "''"),
+		)
+	}
+
 	return fmt.Sprintf(
 		"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
-		sqlStringLiteral(schemaName),
-		strings.ReplaceAll(QuoteIdentifier(schemaName), "'", "''"),
+		sqlStringLiteral(schemaName.schema),
+		strings.ReplaceAll(QuoteIdentifier(schemaName.schema), "'", "''"),
 	)
 }
 

--- a/pkg/fabric/schema.go
+++ b/pkg/fabric/schema.go
@@ -41,10 +41,7 @@ func (sc *SchemaCreator) CreateSchemaIfNotExist(ctx context.Context, qr schemaQu
 	}
 
 	if schemaName.catalog != "" {
-		if sc.currentDatabase == "" {
-			return errors.Errorf("cannot create Fabric schema %s without a configured connection database", schemaName.cacheKey())
-		}
-		if !strings.EqualFold(schemaName.catalog, sc.currentDatabase) {
+		if sc.currentDatabase != "" && !strings.EqualFold(schemaName.catalog, sc.currentDatabase) {
 			return errors.Errorf(
 				"cannot create Fabric schema %s while connected to warehouse %s",
 				schemaName.cacheKey(),

--- a/pkg/fabric/schema.go
+++ b/pkg/fabric/schema.go
@@ -1,0 +1,73 @@
+package fabric
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/pkg/errors"
+)
+
+type SchemaCreator struct {
+	schemaNameCache *sync.Map
+}
+
+type schemaQueryRunner interface {
+	RunQueryWithoutResult(ctx context.Context, q *query.Query) error
+}
+
+func NewSchemaCreator() *SchemaCreator {
+	return &SchemaCreator{schemaNameCache: &sync.Map{}}
+}
+
+func (sc *SchemaCreator) CreateSchemaIfNotExist(ctx context.Context, qr schemaQueryRunner, asset *pipeline.Asset) error {
+	schemaName, ok := schemaNameToCreate(asset.Name)
+	if !ok {
+		return nil
+	}
+
+	if _, exists := sc.schemaNameCache.Load(schemaName); exists {
+		return nil
+	}
+
+	createQuery := query.Query{Query: buildCreateSchemaQuery(schemaName)}
+	if err := qr.RunQueryWithoutResult(ctx, &createQuery); err != nil {
+		return errors.Wrapf(err, "failed to create or ensure schema: %s", schemaName)
+	}
+	sc.schemaNameCache.Store(schemaName, true)
+
+	return nil
+}
+
+func schemaNameToCreate(assetName string) (string, bool) {
+	parts := strings.Split(assetName, ".")
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return "", false
+		}
+	}
+
+	switch len(parts) {
+	case 2:
+		return parts[0], true
+	case 3:
+		return parts[1], true
+	default:
+		return "", false
+	}
+}
+
+func buildCreateSchemaQuery(schemaName string) string {
+	return fmt.Sprintf(
+		"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
+		sqlStringLiteral(schemaName),
+		strings.ReplaceAll(QuoteIdentifier(schemaName), "'", "''"),
+	)
+}
+
+func sqlStringLiteral(value string) string {
+	return "N'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/pkg/fabric/schema.go
+++ b/pkg/fabric/schema.go
@@ -13,6 +13,7 @@ import (
 
 type SchemaCreator struct {
 	schemaNameCache *sync.Map
+	currentDatabase string
 }
 
 type schemaIdentifier struct {
@@ -24,14 +25,32 @@ type schemaQueryRunner interface {
 	RunQueryWithoutResult(ctx context.Context, q *query.Query) error
 }
 
-func NewSchemaCreator() *SchemaCreator {
-	return &SchemaCreator{schemaNameCache: &sync.Map{}}
+func NewSchemaCreator(currentDatabase ...string) *SchemaCreator {
+	creator := &SchemaCreator{schemaNameCache: &sync.Map{}}
+	if len(currentDatabase) > 0 {
+		creator.currentDatabase = currentDatabase[0]
+	}
+
+	return creator
 }
 
 func (sc *SchemaCreator) CreateSchemaIfNotExist(ctx context.Context, qr schemaQueryRunner, asset *pipeline.Asset) error {
 	schemaName, ok := schemaNameToCreate(asset.Name)
 	if !ok {
 		return nil
+	}
+
+	if schemaName.catalog != "" {
+		if sc.currentDatabase == "" {
+			return errors.Errorf("cannot create Fabric schema %s without a configured connection database", schemaName.cacheKey())
+		}
+		if !strings.EqualFold(schemaName.catalog, sc.currentDatabase) {
+			return errors.Errorf(
+				"cannot create Fabric schema %s while connected to warehouse %s",
+				schemaName.cacheKey(),
+				sc.currentDatabase,
+			)
+		}
 	}
 
 	cacheKey := schemaName.cacheKey()
@@ -75,16 +94,6 @@ func (s schemaIdentifier) cacheKey() string {
 }
 
 func buildCreateSchemaQuery(schemaName schemaIdentifier) string {
-	if schemaName.catalog != "" {
-		return fmt.Sprintf(
-			"IF NOT EXISTS (SELECT 1 FROM %s.sys.schemas WHERE name = %s)\n    EXEC(N'USE %s; CREATE SCHEMA %s')",
-			QuoteIdentifier(schemaName.catalog),
-			sqlStringLiteral(schemaName.schema),
-			strings.ReplaceAll(QuoteIdentifier(schemaName.catalog), "'", "''"),
-			strings.ReplaceAll(QuoteIdentifier(schemaName.schema), "'", "''"),
-		)
-	}
-
 	return fmt.Sprintf(
 		"IF SCHEMA_ID(%s) IS NULL\n    EXEC(N'CREATE SCHEMA %s')",
 		sqlStringLiteral(schemaName.schema),

--- a/pkg/fabric/schema.go
+++ b/pkg/fabric/schema.go
@@ -41,7 +41,10 @@ func (sc *SchemaCreator) CreateSchemaIfNotExist(ctx context.Context, qr schemaQu
 	}
 
 	if schemaName.catalog != "" {
-		if sc.currentDatabase != "" && !strings.EqualFold(schemaName.catalog, sc.currentDatabase) {
+		if sc.currentDatabase == "" {
+			return errors.Errorf("cannot create Fabric schema %s without a configured connection database", schemaName.cacheKey())
+		}
+		if !strings.EqualFold(schemaName.catalog, sc.currentDatabase) {
 			return errors.Errorf(
 				"cannot create Fabric schema %s while connected to warehouse %s",
 				schemaName.cacheKey(),

--- a/pkg/fabric/schema_test.go
+++ b/pkg/fabric/schema_test.go
@@ -39,7 +39,7 @@ func TestSchemaCreator_CreateSchemaIfNotExist(t *testing.T) {
 		{
 			name:      "three-part name qualifies schema with catalog",
 			assetName: "Warehouse.Sales.Orders",
-			wantQuery: "IF NOT EXISTS (SELECT 1 FROM [Warehouse].sys.schemas WHERE name = N'Sales')\n    EXEC(N'USE [Warehouse]; CREATE SCHEMA [Sales]')",
+			wantQuery: "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')",
 			wantRun:   true,
 		},
 		{
@@ -65,7 +65,7 @@ func TestSchemaCreator_CreateSchemaIfNotExist(t *testing.T) {
 			t.Parallel()
 
 			runner := &recordingSchemaRunner{}
-			creator := NewSchemaCreator()
+			creator := NewSchemaCreator("Warehouse")
 
 			err := creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: tt.assetName})
 			require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestSchemaCreator_CreateSchemaIfNotExistCachesSchemas(t *testing.T) {
 	t.Parallel()
 
 	runner := &recordingSchemaRunner{}
-	creator := NewSchemaCreator()
+	creator := NewSchemaCreator("bruin_test")
 	asset := &pipeline.Asset{Name: "bruin_test.Products"}
 
 	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, asset))
@@ -93,25 +93,24 @@ func TestSchemaCreator_CreateSchemaIfNotExistCachesSchemas(t *testing.T) {
 	assert.Len(t, runner.queries, 1)
 }
 
-func TestSchemaCreator_CreateSchemaIfNotExistCachesQualifiedSchemasSeparately(t *testing.T) {
+func TestSchemaCreator_CreateSchemaIfNotExistRejectsDifferentCatalog(t *testing.T) {
 	t.Parallel()
 
 	runner := &recordingSchemaRunner{}
-	creator := NewSchemaCreator()
+	creator := NewSchemaCreator("DB1")
 
 	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "DB1.Sales.Orders"}))
-	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "DB2.Sales.Orders"}))
+	require.ErrorContains(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "DB2.Sales.Orders"}), "cannot create Fabric schema DB2.Sales while connected to warehouse DB1")
 
-	require.Len(t, runner.queries, 2)
-	assert.Equal(t, "IF NOT EXISTS (SELECT 1 FROM [DB1].sys.schemas WHERE name = N'Sales')\n    EXEC(N'USE [DB1]; CREATE SCHEMA [Sales]')", runner.queries[0])
-	assert.Equal(t, "IF NOT EXISTS (SELECT 1 FROM [DB2].sys.schemas WHERE name = N'Sales')\n    EXEC(N'USE [DB2]; CREATE SCHEMA [Sales]')", runner.queries[1])
+	require.Len(t, runner.queries, 1)
+	assert.Equal(t, "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')", runner.queries[0])
 }
 
 func TestSchemaCreator_CreateSchemaIfNotExistReturnsQueryError(t *testing.T) {
 	t.Parallel()
 
 	runner := &recordingSchemaRunner{err: errors.New("boom")}
-	creator := NewSchemaCreator()
+	creator := NewSchemaCreator("bruin_test")
 
 	err := creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "bruin_test.Products"})
 

--- a/pkg/fabric/schema_test.go
+++ b/pkg/fabric/schema_test.go
@@ -106,6 +106,18 @@ func TestSchemaCreator_CreateSchemaIfNotExistRejectsDifferentCatalog(t *testing.
 	assert.Equal(t, "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')", runner.queries[0])
 }
 
+func TestSchemaCreator_CreateSchemaIfNotExistAllowsUnconfiguredDatabase(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingSchemaRunner{}
+	creator := NewSchemaCreator()
+
+	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "Warehouse.Sales.Orders"}))
+
+	require.Len(t, runner.queries, 1)
+	assert.Equal(t, "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')", runner.queries[0])
+}
+
 func TestSchemaCreator_CreateSchemaIfNotExistReturnsQueryError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fabric/schema_test.go
+++ b/pkg/fabric/schema_test.go
@@ -106,16 +106,16 @@ func TestSchemaCreator_CreateSchemaIfNotExistRejectsDifferentCatalog(t *testing.
 	assert.Equal(t, "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')", runner.queries[0])
 }
 
-func TestSchemaCreator_CreateSchemaIfNotExistAllowsUnconfiguredDatabase(t *testing.T) {
+func TestSchemaCreator_CreateSchemaIfNotExistRequiresDatabaseForQualifiedName(t *testing.T) {
 	t.Parallel()
 
 	runner := &recordingSchemaRunner{}
 	creator := NewSchemaCreator()
 
-	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "Warehouse.Sales.Orders"}))
+	err := creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "Warehouse.Sales.Orders"})
 
-	require.Len(t, runner.queries, 1)
-	assert.Equal(t, "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')", runner.queries[0])
+	require.ErrorContains(t, err, "cannot create Fabric schema Warehouse.Sales without a configured connection database")
+	assert.Empty(t, runner.queries)
 }
 
 func TestSchemaCreator_CreateSchemaIfNotExistReturnsQueryError(t *testing.T) {

--- a/pkg/fabric/schema_test.go
+++ b/pkg/fabric/schema_test.go
@@ -37,9 +37,9 @@ func TestSchemaCreator_CreateSchemaIfNotExist(t *testing.T) {
 			wantRun:   true,
 		},
 		{
-			name:      "three-part name uses schema component",
+			name:      "three-part name qualifies schema with catalog",
 			assetName: "Warehouse.Sales.Orders",
-			wantQuery: "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')",
+			wantQuery: "IF NOT EXISTS (SELECT 1 FROM [Warehouse].sys.schemas WHERE name = N'Sales')\n    EXEC(N'USE [Warehouse]; CREATE SCHEMA [Sales]')",
 			wantRun:   true,
 		},
 		{
@@ -91,6 +91,20 @@ func TestSchemaCreator_CreateSchemaIfNotExistCachesSchemas(t *testing.T) {
 	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, asset))
 
 	assert.Len(t, runner.queries, 1)
+}
+
+func TestSchemaCreator_CreateSchemaIfNotExistCachesQualifiedSchemasSeparately(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingSchemaRunner{}
+	creator := NewSchemaCreator()
+
+	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "DB1.Sales.Orders"}))
+	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "DB2.Sales.Orders"}))
+
+	require.Len(t, runner.queries, 2)
+	assert.Equal(t, "IF NOT EXISTS (SELECT 1 FROM [DB1].sys.schemas WHERE name = N'Sales')\n    EXEC(N'USE [DB1]; CREATE SCHEMA [Sales]')", runner.queries[0])
+	assert.Equal(t, "IF NOT EXISTS (SELECT 1 FROM [DB2].sys.schemas WHERE name = N'Sales')\n    EXEC(N'USE [DB2]; CREATE SCHEMA [Sales]')", runner.queries[1])
 }
 
 func TestSchemaCreator_CreateSchemaIfNotExistReturnsQueryError(t *testing.T) {

--- a/pkg/fabric/schema_test.go
+++ b/pkg/fabric/schema_test.go
@@ -1,0 +1,107 @@
+package fabric
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSchemaRunner struct {
+	queries []string
+	err     error
+}
+
+func (r *recordingSchemaRunner) RunQueryWithoutResult(_ context.Context, q *query.Query) error {
+	r.queries = append(r.queries, q.Query)
+	return r.err
+}
+
+func TestSchemaCreator_CreateSchemaIfNotExist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		assetName string
+		wantQuery string
+		wantRun   bool
+	}{
+		{
+			name:      "two-part name preserves schema case",
+			assetName: "bruin_Test.Products",
+			wantQuery: "IF SCHEMA_ID(N'bruin_Test') IS NULL\n    EXEC(N'CREATE SCHEMA [bruin_Test]')",
+			wantRun:   true,
+		},
+		{
+			name:      "three-part name uses schema component",
+			assetName: "Warehouse.Sales.Orders",
+			wantQuery: "IF SCHEMA_ID(N'Sales') IS NULL\n    EXEC(N'CREATE SCHEMA [Sales]')",
+			wantRun:   true,
+		},
+		{
+			name:      "schema name escapes literals and brackets",
+			assetName: "odd']schema.Orders",
+			wantQuery: "IF SCHEMA_ID(N'odd'']schema') IS NULL\n    EXEC(N'CREATE SCHEMA [odd'']]schema]')",
+			wantRun:   true,
+		},
+		{
+			name:      "single-part name has no schema",
+			assetName: "Orders",
+			wantRun:   false,
+		},
+		{
+			name:      "empty component is skipped",
+			assetName: "Warehouse..Orders",
+			wantRun:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingSchemaRunner{}
+			creator := NewSchemaCreator()
+
+			err := creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: tt.assetName})
+			require.NoError(t, err)
+
+			if !tt.wantRun {
+				assert.Empty(t, runner.queries)
+				return
+			}
+			require.Len(t, runner.queries, 1)
+			assert.Equal(t, tt.wantQuery, runner.queries[0])
+		})
+	}
+}
+
+func TestSchemaCreator_CreateSchemaIfNotExistCachesSchemas(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingSchemaRunner{}
+	creator := NewSchemaCreator()
+	asset := &pipeline.Asset{Name: "bruin_test.Products"}
+
+	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, asset))
+	require.NoError(t, creator.CreateSchemaIfNotExist(t.Context(), runner, asset))
+
+	assert.Len(t, runner.queries, 1)
+}
+
+func TestSchemaCreator_CreateSchemaIfNotExistReturnsQueryError(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingSchemaRunner{err: errors.New("boom")}
+	creator := NewSchemaCreator()
+
+	err := creator.CreateSchemaIfNotExist(t.Context(), runner, &pipeline.Asset{Name: "bruin_test.Products"})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to create or ensure schema: bruin_test")
+	require.ErrorContains(t, err, "boom")
+}


### PR DESCRIPTION
Fabric materialized assets now create their target schema before running queries. This adds case-preserving schema creation for Fabric and covers it with unit tests. The Fabric cloud workflow no longer pre-creates the test schema.