### PR TITLE
Fix Fabric column metadata fetching

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/connection"
+	"github.com/bruin-data/bruin/pkg/fabric"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/mssql"
@@ -126,13 +127,7 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride 
 		tableName = postgres.QuoteIdentifier(tableName)
 	}
 
-	queryStr := fmt.Sprintf("SELECT * FROM %s WHERE 1=0 LIMIT 0", tableName)
-	if _, ok := conn.(*mssql.DB); ok {
-		queryStr = "SELECT TOP 0 * FROM " + tableName
-	}
-	if _, ok := conn.(*oracle.Client); ok {
-		queryStr = "SELECT * FROM " + tableName + " WHERE 1=0"
-	}
+	queryStr := buildSchemaProbeQuery(conn, tableName)
 	q := &query.Query{Query: queryStr}
 	result, err := querier.SelectWithSchema(query.WithQueryType(context.Background(), query.QueryTypePatch), q)
 	if err != nil {
@@ -212,6 +207,19 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride 
 		return fillStatusFailed, fmt.Errorf("failed to persist asset '%s': %w", pp.Asset.Name, err)
 	}
 	return fillStatusUpdated, nil
+}
+
+func buildSchemaProbeQuery(conn interface{}, tableName string) string {
+	switch conn.(type) {
+	case *mssql.DB:
+		return "SELECT TOP 0 * FROM " + tableName
+	case *fabric.DB:
+		return "SELECT TOP 0 * FROM " + fabric.QuoteIdentifier(tableName)
+	case *oracle.Client:
+		return "SELECT * FROM " + tableName + " WHERE 1=0"
+	default:
+		return fmt.Sprintf("SELECT * FROM %s WHERE 1=0 LIMIT 0", tableName)
+	}
 }
 
 func Patch() *cli.Command {

--- a/cmd/patch_test.go
+++ b/cmd/patch_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/fabric"
+	"github.com/bruin-data/bruin/pkg/mssql"
+	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/postgres"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +36,55 @@ type MockConnectionManager struct {
 func (m *MockConnectionManager) GetConnection(name string) any {
 	args := m.Called(name)
 	return args.Get(0)
+}
+
+func TestBuildSchemaProbeQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		conn      interface{}
+		tableName string
+		want      string
+	}{
+		{
+			name:      "default limit",
+			conn:      &MockConnection{},
+			tableName: "public.orders",
+			want:      "SELECT * FROM public.orders WHERE 1=0 LIMIT 0",
+		},
+		{
+			name:      "mssql uses top",
+			conn:      &mssql.DB{},
+			tableName: "dbo.orders",
+			want:      "SELECT TOP 0 * FROM dbo.orders",
+		},
+		{
+			name:      "fabric uses top and quotes identifier",
+			conn:      &fabric.DB{},
+			tableName: "sales.orders",
+			want:      "SELECT TOP 0 * FROM [sales].[orders]",
+		},
+		{
+			name:      "oracle omits limit",
+			conn:      &oracle.Client{},
+			tableName: "SALES.ORDERS",
+			want:      "SELECT * FROM SALES.ORDERS WHERE 1=0",
+		},
+		{
+			name:      "postgres receives pre-quoted identifier",
+			conn:      &postgres.Client{},
+			tableName: `"public.orders"`,
+			want:      `SELECT * FROM "public.orders" WHERE 1=0 LIMIT 0`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, buildSchemaProbeQuery(tt.conn, tt.tableName))
+		})
+	}
 }
 
 func TestFillColumnsFromDB(t *testing.T) {

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -3,10 +3,12 @@ package fabric
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/tablename"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/pkg/errors"
@@ -138,6 +140,150 @@ func (db *DB) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*que
 		Rows:        resultRows,
 		ColumnTypes: typeNames,
 	}, rows.Err()
+}
+
+func (db *DB) GetColumns(ctx context.Context, databaseName, tableName string) ([]*ansisql.DBColumn, error) {
+	if databaseName == "" {
+		return nil, errors.New("database name cannot be empty")
+	}
+	if tableName == "" {
+		return nil, errors.New("table name cannot be empty")
+	}
+
+	cb, ok := tablename.For("fabric")
+	if !ok {
+		return nil, errors.New("fabric table-name capability not found")
+	}
+	tn, err := cb.Parse(tableName, tablename.Defaults{Schema: "dbo"})
+	if err != nil {
+		return nil, err
+	}
+
+	return db.getColumns(ctx, tn.Schema, tn.Table, databaseName+"."+tableName)
+}
+
+func (db *DB) GetColumnsForTable(ctx context.Context, schemaName, tableName string) ([]*ansisql.DBColumn, error) {
+	if schemaName == "" {
+		schemaName = "dbo"
+	}
+	if tableName == "" {
+		return nil, errors.New("table name cannot be empty")
+	}
+
+	return db.getColumns(ctx, schemaName, tableName, schemaName+"."+tableName)
+}
+
+func (db *DB) getColumns(ctx context.Context, schemaName, tableName, displayName string) ([]*ansisql.DBColumn, error) {
+	const q = `
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE,
+    CHARACTER_MAXIMUM_LENGTH,
+    NUMERIC_PRECISION,
+    NUMERIC_SCALE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+ORDER BY ORDINAL_POSITION;
+`
+
+	rows, err := db.conn.QueryContext(ctx, q, schemaName, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query columns for table '%s': %w", displayName, err)
+	}
+	defer rows.Close()
+
+	columns := make([]*ansisql.DBColumn, 0)
+	for rows.Next() {
+		var columnName, dataType, isNullable string
+		var charMaxLength, numericPrecision, numericScale interface{}
+
+		err := rows.Scan(&columnName, &dataType, &isNullable, &charMaxLength, &numericPrecision, &numericScale)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan column row: %w", err)
+		}
+
+		columns = append(columns, &ansisql.DBColumn{
+			Name:       columnName,
+			Type:       formatColumnType(dataType, charMaxLength, numericPrecision, numericScale),
+			Nullable:   strings.EqualFold(isNullable, "YES"),
+			PrimaryKey: false,
+			Unique:     false,
+		})
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating column rows: %w", err)
+	}
+
+	return columns, nil
+}
+
+func formatColumnType(dataType string, charMaxLength, numericPrecision, numericScale interface{}) string {
+	switch strings.ToLower(dataType) {
+	case "char", "varchar", "nchar", "nvarchar", "binary", "varbinary":
+		if length, ok := int64Value(charMaxLength); ok {
+			if length < 0 {
+				return dataType + "(max)"
+			}
+			if length > 0 {
+				return fmt.Sprintf("%s(%d)", dataType, length)
+			}
+		}
+	case "decimal", "numeric":
+		precision, hasPrecision := int64Value(numericPrecision)
+		if !hasPrecision || precision <= 0 {
+			return dataType
+		}
+		if scale, hasScale := int64Value(numericScale); hasScale {
+			return fmt.Sprintf("%s(%d,%d)", dataType, precision, scale)
+		}
+		return fmt.Sprintf("%s(%d)", dataType, precision)
+	}
+
+	return dataType
+}
+
+func int64Value(value interface{}) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int8:
+		return int64(v), true
+	case int16:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint:
+		return unsignedToInt64(uint64(v))
+	case uint8:
+		return unsignedToInt64(uint64(v))
+	case uint16:
+		return unsignedToInt64(uint64(v))
+	case uint32:
+		return unsignedToInt64(uint64(v))
+	case uint64:
+		return unsignedToInt64(v)
+	case []byte:
+		n, err := strconv.ParseInt(string(v), 10, 64)
+		return n, err == nil
+	case string:
+		n, err := strconv.ParseInt(v, 10, 64)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func unsignedToInt64(value uint64) (int64, bool) {
+	const maxInt64 = 1<<63 - 1
+	if value > maxInt64 {
+		return 0, false
+	}
+
+	return int64(value), true
 }
 
 func fromFabricValue(value any) (string, bool) {

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -154,12 +154,12 @@ func (db *DB) GetColumns(ctx context.Context, databaseName, tableName string) ([
 	if !ok {
 		return nil, errors.New("fabric table-name capability not found")
 	}
-	tn, err := cb.Parse(tableName, tablename.Defaults{Schema: "dbo"})
+	tn, err := cb.Parse(tableName, tablename.Defaults{Catalog: databaseName, Schema: "dbo"})
 	if err != nil {
 		return nil, err
 	}
 
-	return db.getColumns(ctx, tn.Schema, tn.Table, databaseName+"."+tableName)
+	return db.getColumns(ctx, tn.Catalog, tn.Schema, tn.Table, tn.String("."))
 }
 
 func (db *DB) GetColumnsForTable(ctx context.Context, schemaName, tableName string) ([]*ansisql.DBColumn, error) {
@@ -170,11 +170,16 @@ func (db *DB) GetColumnsForTable(ctx context.Context, schemaName, tableName stri
 		return nil, errors.New("table name cannot be empty")
 	}
 
-	return db.getColumns(ctx, schemaName, tableName, schemaName+"."+tableName)
+	return db.getColumns(ctx, "", schemaName, tableName, schemaName+"."+tableName)
 }
 
-func (db *DB) getColumns(ctx context.Context, schemaName, tableName, displayName string) ([]*ansisql.DBColumn, error) {
-	const q = `
+func (db *DB) getColumns(ctx context.Context, databaseName, schemaName, tableName, displayName string) ([]*ansisql.DBColumn, error) {
+	infoSchema := "INFORMATION_SCHEMA"
+	if databaseName != "" {
+		infoSchema = QuoteIdentifier(databaseName) + ".INFORMATION_SCHEMA"
+	}
+
+	q := fmt.Sprintf(`
 SELECT
     COLUMN_NAME,
     DATA_TYPE,
@@ -182,10 +187,10 @@ SELECT
     CHARACTER_MAXIMUM_LENGTH,
     NUMERIC_PRECISION,
     NUMERIC_SCALE
-FROM INFORMATION_SCHEMA.COLUMNS
+FROM %s.COLUMNS
 WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
 ORDER BY ORDINAL_POSITION;
-`
+`, infoSchema)
 
 	rows, err := db.conn.QueryContext(ctx, q, schemaName, tableName)
 	if err != nil {

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const expectedColumnsQuery = `
+const expectedCurrentDatabaseColumnsQuery = `
 SELECT
     COLUMN_NAME,
     DATA_TYPE,
@@ -20,6 +20,32 @@ SELECT
     NUMERIC_PRECISION,
     NUMERIC_SCALE
 FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+ORDER BY ORDINAL_POSITION;
+`
+
+const expectedWarehouseColumnsQuery = `
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE,
+    CHARACTER_MAXIMUM_LENGTH,
+    NUMERIC_PRECISION,
+    NUMERIC_SCALE
+FROM [warehouse].INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+ORDER BY ORDINAL_POSITION;
+`
+
+const expectedArchiveColumnsQuery = `
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE,
+    CHARACTER_MAXIMUM_LENGTH,
+    NUMERIC_PRECISION,
+    NUMERIC_SCALE
+FROM [archive].INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
 ORDER BY ORDINAL_POSITION;
 `
@@ -40,7 +66,7 @@ func TestDB_GetColumns(t *testing.T) {
 			databaseName: "warehouse",
 			tableName:    "sales.orders",
 			mockConnection: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(expectedColumnsQuery).
+				mock.ExpectQuery(expectedWarehouseColumnsQuery).
 					WithArgs("sales", "orders").
 					WillReturnRows(sqlmock.NewRows([]string{
 						"COLUMN_NAME",
@@ -67,7 +93,7 @@ func TestDB_GetColumns(t *testing.T) {
 			databaseName: "warehouse",
 			tableName:    "orders",
 			mockConnection: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(expectedColumnsQuery).
+				mock.ExpectQuery(expectedWarehouseColumnsQuery).
 					WithArgs("dbo", "orders").
 					WillReturnRows(sqlmock.NewRows([]string{
 						"COLUMN_NAME",
@@ -83,17 +109,31 @@ func TestDB_GetColumns(t *testing.T) {
 			},
 		},
 		{
-			name:         "rejects three-part table names",
+			name:         "three-part table name scopes lookup to table database",
 			databaseName: "warehouse",
-			tableName:    "other.sales.orders",
-			wantErr:      "table name must be in format",
+			tableName:    "archive.sales.orders",
+			mockConnection: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(expectedArchiveColumnsQuery).
+					WithArgs("sales", "orders").
+					WillReturnRows(sqlmock.NewRows([]string{
+						"COLUMN_NAME",
+						"DATA_TYPE",
+						"IS_NULLABLE",
+						"CHARACTER_MAXIMUM_LENGTH",
+						"NUMERIC_PRECISION",
+						"NUMERIC_SCALE",
+					}).AddRow("id", "bigint", "NO", nil, int64(19), int64(0)))
+			},
+			want: []*ansisql.DBColumn{
+				{Name: "id", Type: "bigint", Nullable: false, PrimaryKey: false, Unique: false},
+			},
 		},
 		{
 			name:         "query error",
 			databaseName: "warehouse",
 			tableName:    "sales.orders",
 			mockConnection: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(expectedColumnsQuery).
+				mock.ExpectQuery(expectedWarehouseColumnsQuery).
 					WithArgs("sales", "orders").
 					WillReturnError(errors.New("metadata failed"))
 			},
@@ -135,7 +175,7 @@ func TestDB_GetColumnsForTable(t *testing.T) {
 	require.NoError(t, err)
 	defer mockDB.Close()
 
-	mock.ExpectQuery(expectedColumnsQuery).
+	mock.ExpectQuery(expectedCurrentDatabaseColumnsQuery).
 		WithArgs("finance", "payments").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"COLUMN_NAME",

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -1,0 +1,156 @@
+package fabric
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const expectedColumnsQuery = `
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE,
+    CHARACTER_MAXIMUM_LENGTH,
+    NUMERIC_PRECISION,
+    NUMERIC_SCALE
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+ORDER BY ORDINAL_POSITION;
+`
+
+func TestDB_GetColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		databaseName   string
+		tableName      string
+		mockConnection func(mock sqlmock.Sqlmock)
+		want           []*ansisql.DBColumn
+		wantErr        string
+	}{
+		{
+			name:         "fetches columns for schema table",
+			databaseName: "warehouse",
+			tableName:    "sales.orders",
+			mockConnection: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(expectedColumnsQuery).
+					WithArgs("sales", "orders").
+					WillReturnRows(sqlmock.NewRows([]string{
+						"COLUMN_NAME",
+						"DATA_TYPE",
+						"IS_NULLABLE",
+						"CHARACTER_MAXIMUM_LENGTH",
+						"NUMERIC_PRECISION",
+						"NUMERIC_SCALE",
+					}).
+						AddRow("id", "int", "NO", nil, int64(10), int64(0)).
+						AddRow("name", "nvarchar", "YES", int64(255), nil, nil).
+						AddRow("amount", "decimal", "YES", nil, int64(18), int64(2)).
+						AddRow("payload", "varbinary", "YES", int64(-1), nil, nil))
+			},
+			want: []*ansisql.DBColumn{
+				{Name: "id", Type: "int", Nullable: false, PrimaryKey: false, Unique: false},
+				{Name: "name", Type: "nvarchar(255)", Nullable: true, PrimaryKey: false, Unique: false},
+				{Name: "amount", Type: "decimal(18,2)", Nullable: true, PrimaryKey: false, Unique: false},
+				{Name: "payload", Type: "varbinary(max)", Nullable: true, PrimaryKey: false, Unique: false},
+			},
+		},
+		{
+			name:         "bare table defaults to dbo schema",
+			databaseName: "warehouse",
+			tableName:    "orders",
+			mockConnection: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(expectedColumnsQuery).
+					WithArgs("dbo", "orders").
+					WillReturnRows(sqlmock.NewRows([]string{
+						"COLUMN_NAME",
+						"DATA_TYPE",
+						"IS_NULLABLE",
+						"CHARACTER_MAXIMUM_LENGTH",
+						"NUMERIC_PRECISION",
+						"NUMERIC_SCALE",
+					}).AddRow("id", "bigint", "NO", nil, int64(19), int64(0)))
+			},
+			want: []*ansisql.DBColumn{
+				{Name: "id", Type: "bigint", Nullable: false, PrimaryKey: false, Unique: false},
+			},
+		},
+		{
+			name:         "rejects three-part table names",
+			databaseName: "warehouse",
+			tableName:    "other.sales.orders",
+			wantErr:      "table name must be in format",
+		},
+		{
+			name:         "query error",
+			databaseName: "warehouse",
+			tableName:    "sales.orders",
+			mockConnection: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(expectedColumnsQuery).
+					WithArgs("sales", "orders").
+					WillReturnError(errors.New("metadata failed"))
+			},
+			wantErr: "failed to query columns for table 'warehouse.sales.orders'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer mockDB.Close()
+
+			if tt.mockConnection != nil {
+				tt.mockConnection(mock)
+			}
+
+			db := &DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+			got, err := db.GetColumns(t.Context(), tt.databaseName, tt.tableName)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestDB_GetColumnsForTable(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(expectedColumnsQuery).
+		WithArgs("finance", "payments").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"COLUMN_NAME",
+			"DATA_TYPE",
+			"IS_NULLABLE",
+			"CHARACTER_MAXIMUM_LENGTH",
+			"NUMERIC_PRECISION",
+			"NUMERIC_SCALE",
+		}).AddRow("payment_id", "uniqueidentifier", "NO", nil, nil, nil))
+
+	db := &DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+	got, err := db.GetColumnsForTable(t.Context(), "finance", "payments")
+	require.NoError(t, err)
+	assert.Equal(t, []*ansisql.DBColumn{
+		{Name: "payment_id", Type: "uniqueidentifier", Nullable: false, PrimaryKey: false, Unique: false},
+	}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/tablename/capability.go
+++ b/pkg/tablename/capability.go
@@ -111,9 +111,9 @@ var registry = map[string]Capability{
 		FormatDesc: "`table` or `schema.table`",
 	},
 	"fabric": {
-		Platform: "fabric", MinComponents: 1, MaxComponents: 2,
-		Labels:     [3]string{"", "schema", "table"},
-		FormatDesc: "`table` or `schema.table`",
+		Platform: "fabric", MinComponents: 1, MaxComponents: 3,
+		Labels:     [3]string{"database", "schema", "table"},
+		FormatDesc: "`table`, `schema.table`, or `database.schema.table`",
 	},
 	"oracle": {
 		Platform: "oracle", MinComponents: 1, MaxComponents: 2,

--- a/pkg/tablename/parse_test.go
+++ b/pkg/tablename/parse_test.go
@@ -85,6 +85,12 @@ func TestCapability_Parse(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "fabric three-part is database schema table",
+			platform: "fabric",
+			raw:      "warehouse.dbo.orders",
+			want:     TableName{Catalog: "warehouse", Schema: "dbo", Table: "orders"},
+		},
+		{
 			name:     "empty component is rejected",
 			platform: "snowflake",
 			raw:      "raw..events",


### PR DESCRIPTION
Fixes `patch fill-columns-from-db` for Fabric by using T-SQL `TOP 0` instead of `LIMIT`. Adds Fabric column metadata fetchers backed by database-scoped `INFORMATION_SCHEMA.COLUMNS`, including `database.schema.table` support. Validated with `make format`, `make test`, and the PR checks.