### PR TITLE
Fix T-SQL surrogate key casts

### DIFF
--- a/cmd/environments_test.go
+++ b/cmd/environments_test.go
@@ -445,9 +445,7 @@ environments:
 	}
 }
 
-func TestEnvironmentDeleteCommand_Run_UserCancellation(t *testing.T) {
-	t.Parallel()
-
+func TestEnvironmentDeleteCommand_Run_UserCancellation(t *testing.T) { //nolint:paralleltest
 	// Create a temporary config file content
 	configContent := `
 default_environment: dev

--- a/pkg/fabric/bruin_funcs.go
+++ b/pkg/fabric/bruin_funcs.go
@@ -7,7 +7,7 @@ import (
 
 func init() { //nolint:gochecknoinits
 	jinja.RegisterPlatformOverrides(jinja.PlatformFabric, jinja.MergeBuiltinOverrides(jinja.TSQLURLHelpers(), map[string]any{
-		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar", ansisql.HashBytesHashFn),
+		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar(max)", ansisql.HashBytesHashFn),
 		"deduplicate":            ansisql.DeduplicateSubquery,
 		"pivot":                  jinja.PivotWithIdentifierQuote(jinja.BracketQuoteIdentifier),
 		"width_bucket":           jinja.TSQLWidthBucket,

--- a/pkg/fabric/bruin_funcs_test.go
+++ b/pkg/fabric/bruin_funcs_test.go
@@ -1,0 +1,27 @@
+package fabric
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFabricBuiltinOverrides(t *testing.T) {
+	t.Parallel()
+
+	renderer := jinja.NewRenderer(jinja.Context{
+		"bruin": jinja.BuiltinFunctions(jinja.PlatformFabric),
+	})
+
+	t.Run("surrogate_key casts to unbounded varchar", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id', 'session_id']) }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "cast(user_id as varchar(max))")
+		assert.Contains(t, result, "cast(session_id as varchar(max))")
+		assert.NotContains(t, result, "cast(user_id as varchar)")
+		assert.Contains(t, result, "hashbytes('md5',")
+	})
+}

--- a/pkg/fabric/bruin_funcs_test.go
+++ b/pkg/fabric/bruin_funcs_test.go
@@ -21,7 +21,7 @@ func TestFabricBuiltinOverrides(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, result, "cast(user_id as varchar(max))")
 		assert.Contains(t, result, "cast(session_id as varchar(max))")
-		assert.NotContains(t, result, "cast(user_id as varchar)")
+		assert.NotRegexp(t, `cast\(user_id as varchar\s*\)`, result)
 		assert.Contains(t, result, "hashbytes('md5',")
 	})
 }

--- a/pkg/mssql/bruin_funcs.go
+++ b/pkg/mssql/bruin_funcs.go
@@ -7,7 +7,7 @@ import (
 
 func init() { //nolint:gochecknoinits
 	jinja.RegisterPlatformOverrides(jinja.PlatformMSSQL, jinja.MergeBuiltinOverrides(jinja.TSQLURLHelpers(), map[string]any{
-		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar", ansisql.HashBytesHashFn),
+		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar(max)", ansisql.HashBytesHashFn),
 		"deduplicate":            ansisql.DeduplicateSubquery,
 		"pivot":                  jinja.PivotWithIdentifierQuote(jinja.BracketQuoteIdentifier),
 		"width_bucket":           jinja.TSQLWidthBucket,

--- a/pkg/mssql/bruin_funcs_test.go
+++ b/pkg/mssql/bruin_funcs_test.go
@@ -23,7 +23,7 @@ func TestMSSQLBuiltinOverrides(t *testing.T) {
 		assert.Contains(t, result, "convert(varchar(32),")
 		assert.Contains(t, result, "cast(user_id as varchar(max))")
 		assert.Contains(t, result, "cast(session_id as varchar(max))")
-		assert.NotContains(t, result, "cast(user_id as varchar)")
+		assert.NotRegexp(t, `cast\(user_id as varchar\s*\)`, result)
 	})
 
 	t.Run("deduplicate uses TOP WITH TIES", func(t *testing.T) {

--- a/pkg/mssql/bruin_funcs_test.go
+++ b/pkg/mssql/bruin_funcs_test.go
@@ -15,12 +15,15 @@ func TestMSSQLBuiltinOverrides(t *testing.T) {
 		"bruin": jinja.BuiltinFunctions(jinja.PlatformMSSQL),
 	})
 
-	t.Run("surrogate_key uses hashbytes", func(t *testing.T) {
+	t.Run("surrogate_key uses hashbytes and casts to unbounded varchar", func(t *testing.T) {
 		t.Parallel()
-		result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id']) }}")
+		result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id', 'session_id']) }}")
 		require.NoError(t, err)
 		assert.Contains(t, result, "hashbytes('md5',")
 		assert.Contains(t, result, "convert(varchar(32),")
+		assert.Contains(t, result, "cast(user_id as varchar(max))")
+		assert.Contains(t, result, "cast(session_id as varchar(max))")
+		assert.NotContains(t, result, "cast(user_id as varchar)")
 	})
 
 	t.Run("deduplicate uses TOP WITH TIES", func(t *testing.T) {

--- a/pkg/synapse/bruin_funcs.go
+++ b/pkg/synapse/bruin_funcs.go
@@ -7,7 +7,7 @@ import (
 
 func init() { //nolint:gochecknoinits
 	jinja.RegisterPlatformOverrides(jinja.PlatformSynapse, jinja.MergeBuiltinOverrides(jinja.TSQLURLHelpers(), map[string]any{
-		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar", ansisql.HashBytesHashFn),
+		"generate_surrogate_key": jinja.SurrogateKeyWith("varchar(max)", ansisql.HashBytesHashFn),
 		"deduplicate":            ansisql.DeduplicateSubquery,
 		"pivot":                  jinja.PivotWithIdentifierQuote(jinja.BracketQuoteIdentifier),
 		"width_bucket":           jinja.TSQLWidthBucket,

--- a/pkg/synapse/bruin_funcs_test.go
+++ b/pkg/synapse/bruin_funcs_test.go
@@ -1,0 +1,27 @@
+package synapse
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSynapseBuiltinOverrides(t *testing.T) {
+	t.Parallel()
+
+	renderer := jinja.NewRenderer(jinja.Context{
+		"bruin": jinja.BuiltinFunctions(jinja.PlatformSynapse),
+	})
+
+	t.Run("surrogate_key casts to unbounded varchar", func(t *testing.T) {
+		t.Parallel()
+		result, err := renderer.Render("{{ bruin.generate_surrogate_key(['user_id', 'session_id']) }}")
+		require.NoError(t, err)
+		assert.Contains(t, result, "cast(user_id as varchar(max))")
+		assert.Contains(t, result, "cast(session_id as varchar(max))")
+		assert.NotContains(t, result, "cast(user_id as varchar)")
+		assert.Contains(t, result, "hashbytes('md5',")
+	})
+}

--- a/pkg/synapse/bruin_funcs_test.go
+++ b/pkg/synapse/bruin_funcs_test.go
@@ -21,7 +21,7 @@ func TestSynapseBuiltinOverrides(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, result, "cast(user_id as varchar(max))")
 		assert.Contains(t, result, "cast(session_id as varchar(max))")
-		assert.NotContains(t, result, "cast(user_id as varchar)")
+		assert.NotRegexp(t, `cast\(user_id as varchar\s*\)`, result)
 		assert.Contains(t, result, "hashbytes('md5',")
 	})
 }


### PR DESCRIPTION
Fixes T-SQL surrogate key macros to cast inputs as `varchar(max)` before hashing, avoiding the default 30-character truncation.

Adds renderer tests for Fabric, MSSQL, and Synapse, and keeps the stdin-mutating environment test out of parallel execution to avoid a race in CI.

Checks: `make format`; `go test -tags="no_duckdb_arrow" ./pkg/fabric ./pkg/mssql ./pkg/synapse ./pkg/jinja`; `go test -race -tags="no_duckdb_arrow" ./cmd`; GitHub Actions and Greptile passed.