### PR TITLE
Add global secrets backend flag

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2644,11 +2644,11 @@ func cloudConnectionsList() *cli.Command {
 	}
 }
 
-// connectionFromConfig loads a named connection from the local .bruin.yml and
-// returns its type and credentials as a snake_case map (the cloud wire format).
+// connectionFromConfig loads a named connection from the selected connection
+// source and returns its type and credentials as a snake_case map (the cloud wire format).
 // The struct's JSON tags already match the wire format, so a marshal round-trip
 // avoids any per-type mapping.
-func connectionFromConfig(name, environment, configFile string) (string, map[string]any, error) {
+func connectionFromConfig(ctx context.Context, name, environment, configFile string) (string, map[string]any, error) {
 	configFilePath := configFile
 	if configFilePath == "" {
 		repoRoot, err := git.FindRepoFromPath(".")
@@ -2663,28 +2663,43 @@ func connectionFromConfig(name, environment, configFile string) (string, map[str
 		return "", nil, fmt.Errorf("failed to load %s: %w", configFilePath, err)
 	}
 
-	env := cm.SelectedEnvironment
 	if environment != "" {
-		e, ok := cm.Environments[environment]
-		if !ok {
-			return "", nil, fmt.Errorf("environment '%s' not found in config", environment)
+		if err := cm.SelectEnvironment(environment); err != nil {
+			return "", nil, err
 		}
-		env = &e
 	}
+
+	if secretsBackendFromContext(ctx) != "" {
+		ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+		ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+		manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
+		if len(errs) > 0 {
+			return "", nil, fmt.Errorf("failed to create connection manager: %w", errs[0])
+		}
+
+		connType := manager.GetConnectionType(name)
+		details := manager.GetConnectionDetails(name)
+		if connType == "" || details == nil {
+			return "", nil, config.NewConnectionNotFoundError(ctx, "", name)
+		}
+
+		credentials, err := connectionCredentialsMap(details)
+		if err != nil {
+			return "", nil, err
+		}
+		return connType, credentials, nil
+	}
+
+	env := cm.SelectedEnvironment
 	if env == nil || env.Connections == nil || !env.Connections.Exists(name) {
 		return "", nil, fmt.Errorf("connection '%s' not found in config", name)
 	}
 
 	connType := env.Connections.ConnectionsSummaryList()[name]
-	data, err := json.Marshal(env.Connections.GetConnection(name))
+	credentials, err := connectionCredentialsMap(env.Connections.GetConnection(name))
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to serialize connection: %w", err)
+		return "", nil, err
 	}
-	var credentials map[string]any
-	if err := json.Unmarshal(data, &credentials); err != nil {
-		return "", nil, fmt.Errorf("failed to serialize connection: %w", err)
-	}
-	delete(credentials, "name")
 
 	// A relative service_account_file in .bruin.yml is relative to the config
 	// file, not the CWD the command runs from. Resolve it against the config dir.
@@ -2693,6 +2708,19 @@ func connectionFromConfig(name, environment, configFile string) (string, map[str
 	}
 
 	return connType, credentials, nil
+}
+
+func connectionCredentialsMap(connectionDetails any) (map[string]any, error) {
+	data, err := json.Marshal(connectionDetails)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize connection: %w", err)
+	}
+	var credentials map[string]any
+	if err := json.Unmarshal(data, &credentials); err != nil {
+		return nil, fmt.Errorf("failed to serialize connection: %w", err)
+	}
+	delete(credentials, "name")
+	return credentials, nil
 }
 
 func cloudConnectionsAdd() *cli.Command {
@@ -2747,9 +2775,9 @@ func cloudConnectionsAdd() *cli.Command {
 					return cli.Exit("", 1)
 				}
 			} else {
-				t, cr, err := connectionFromConfig(name, c.String("environment"), c.String("config-file"))
+				t, cr, err := connectionFromConfig(ctx, name, c.String("environment"), c.String("config-file"))
 				if err != nil {
-					printError(err, output, "Failed to read connection from .bruin.yml")
+					printError(err, output, "Failed to read connection")
 					return cli.Exit("", 1)
 				}
 				connType, credentials = t, cr

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -9,7 +9,6 @@ import (
 	path2 "path"
 
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -470,7 +469,9 @@ func PingConnection() *cli.Command {
 				printErrorForOutput(output, errors2.Wrap(err, "failed to select the environment"))
 				return cli.Exit("", 1)
 			}
-			manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+			ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+			ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+			manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
 			if len(errs) > 0 {
 				// Handle each error in the errs slice
 				for _, err := range errs {
@@ -481,11 +482,7 @@ func PingConnection() *cli.Command {
 
 			conn := manager.GetConnection(name)
 			if conn == nil {
-				printErrorForOutput(output, &config.MissingConnectionError{
-					Name:            name,
-					ConfigFilePath:  configFilePath,
-					EnvironmentName: cm.SelectedEnvironmentName,
-				})
+				printErrorForOutput(output, config.NewConnectionNotFoundError(ctx, "", name))
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/diff"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/query"
@@ -277,8 +276,11 @@ func DataDiffCmd() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
+			ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+			ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+
 			// Create connection manager
-			manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+			manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
 			if len(errs) > 0 {
 				// Handle multiple errors, e.g. by joining them or returning the first one
 				return fmt.Errorf("failed to create connection manager: %w", errs[0])

--- a/cmd/enhance.go
+++ b/cmd/enhance.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/diff"
 	"github.com/bruin-data/bruin/pkg/enhance"
 	"github.com/bruin-data/bruin/pkg/git"
@@ -396,7 +395,7 @@ func enhanceSingleAsset(ctx context.Context, c *cli.Command, assetPath string, f
 		if pp.Asset.Name != "" {
 			logPrefix = pp.Asset.Name
 		}
-		status, fillErr := fillColumnsFromDB(pp, fs, c.String("environment"), "", nil) //nolint:contextcheck
+		status, fillErr := fillColumnsFromDB(ctx, pp, fs, c.String("environment"), "", nil)
 		if fillErr != nil && !quiet && output != "json" {
 			warningPrinter.Printf("[%s] Warning: fill columns failed: %v\n", logPrefix, fillErr)
 		} else if status == fillStatusUpdated && !quiet && output != "json" {
@@ -470,7 +469,11 @@ func enhanceSingleAsset(ctx context.Context, c *cli.Command, assetPath string, f
 		enhancer.SetOutput(&streamBuf)
 	}
 
-	if apiKey := getAnthropicAPIKey(fs, assetPath); apiKey != "" {
+	apiKey, err := getAnthropicAPIKey(ctx, fs, assetPath, c.String("environment"))
+	if err != nil {
+		return err
+	}
+	if apiKey != "" {
 		enhancer.SetAPIKey(apiKey)
 	}
 
@@ -573,30 +576,63 @@ func printEnhanceError(output string, err error) error {
 	return cli.Exit("", 1)
 }
 
-// getAnthropicAPIKey tries to get the Anthropic API key from the config file.
-func getAnthropicAPIKey(fs afero.Fs, inputPath string) string {
+// getAnthropicAPIKey tries to get the Anthropic API key from the configured connection source.
+func getAnthropicAPIKey(ctx context.Context, fs afero.Fs, inputPath, environment string) (string, error) {
 	repoRoot, err := git.FindRepoFromPath(inputPath)
 	if err != nil {
-		return ""
+		return "", errors.Wrap(err, "failed to find repository root")
 	}
 
-	cm, err := config.LoadOrCreate(fs, filepath.Join(repoRoot.Path, ".bruin.yml"))
+	configFilePath := filepath.Join(repoRoot.Path, ".bruin.yml")
+	cm, err := config.LoadOrCreate(fs, configFilePath)
 	if err != nil {
-		return ""
+		return "", errors.Wrap(err, "failed to load config")
+	}
+	if environment != "" {
+		if err := cm.SelectEnvironment(environment); err != nil {
+			return "", errors.Wrapf(err, "failed to use the environment %q", environment)
+		}
 	}
 
 	// Get the selected environment's connections
 	env := cm.SelectedEnvironment
 	if env == nil {
-		return ""
+		return "", nil
 	}
 
 	// Return the first Anthropic connection's API key
 	if len(env.Connections.Anthropic) > 0 {
-		return env.Connections.Anthropic[0].APIKey
+		connectionName := env.Connections.Anthropic[0].Name
+		localAPIKey := env.Connections.Anthropic[0].APIKey
+		if secretsBackendFromContext(ctx) == "" {
+			return localAPIKey, nil
+		}
+
+		ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+		ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+		manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
+		if len(errs) > 0 {
+			return "", errors.Wrap(errs[0], "failed to read Anthropic connection from secrets backend")
+		}
+
+		details := manager.GetConnectionDetails(connectionName)
+		switch conn := details.(type) {
+		case *config.AnthropicConnection:
+			if conn.APIKey == "" {
+				return "", fmt.Errorf("anthropic connection %q from secrets backend does not include an API key", connectionName)
+			}
+			return conn.APIKey, nil
+		case config.AnthropicConnection:
+			if conn.APIKey == "" {
+				return "", fmt.Errorf("anthropic connection %q from secrets backend does not include an API key", connectionName)
+			}
+			return conn.APIKey, nil
+		default:
+			return "", config.NewConnectionNotFoundError(ctx, "", connectionName)
+		}
 	}
 
-	return ""
+	return "", nil
 }
 
 // showDiff displays a colored diff between the original content and the current file content.
@@ -687,7 +723,7 @@ func preFetchTableSummary(ctx context.Context, fs afero.Fs, assetPath string, as
 	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, filepath.Join(repoRoot.Path, ".bruin.yml"))
 	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
 
-	manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+	manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
 	if len(errs) > 0 {
 		return ""
 	}

--- a/cmd/environments_test.go
+++ b/cmd/environments_test.go
@@ -479,6 +479,9 @@ environments:
 
 	// Mock stdin to simulate user saying "n"
 	oldStdin := os.Stdin
+	defer func() {
+		os.Stdin = oldStdin
+	}()
 	r, w, _ := os.Pipe()
 	os.Stdin = r
 	_, _ = w.WriteString("n\n")
@@ -493,7 +496,4 @@ environments:
 	assert.True(t, cm.EnvironmentExists("dev"))
 	assert.True(t, cm.EnvironmentExists("prod"))
 	assert.Greater(t, len(cm.Environments), 1)
-
-	// Restore stdin
-	os.Stdin = oldStdin
 }

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/bigquery"
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/path"
@@ -915,18 +914,16 @@ func getConnectionAndTypeFromConfigWithContext(ctx context.Context, env string, 
 		}
 	}
 
-	manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+	manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
 	if len(errs) > 0 {
 		return nil, "", errors.Wrap(errs[0], "failed to create connection manager")
 	}
 
 	conn := manager.GetConnection(connectionName)
 	if conn == nil {
-		return nil, "", &config.MissingConnectionError{
-			Name:            connectionName,
-			ConfigFilePath:  configFilePath,
-			EnvironmentName: cm.SelectedEnvironmentName,
-		}
+		return nil, "", config.NewConnectionNotFoundError(ctx, "", connectionName)
 	}
 
 	return conn, manager.GetConnectionType(connectionName), nil
@@ -954,8 +951,11 @@ func getConnectionFromPipelineInfoWithContext(ctx context.Context, pipelineInfo 
 		}
 	}
 
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, pipelineInfo.Config.Path())
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, pipelineInfo.Config.SelectedEnvironmentName)
+
 	// Get connection info
-	manager, errs := connection.NewManagerFromConfigWithContext(ctx, pipelineInfo.Config)
+	manager, errs := connectionManagerFromConfig(ctx, pipelineInfo.Config, makeLogger(false))
 	if len(errs) > 0 {
 		return "", nil, errors.Wrap(errs[0], "failed to create connection manager")
 	}
@@ -967,11 +967,7 @@ func getConnectionFromPipelineInfoWithContext(ctx context.Context, pipelineInfo 
 
 	conn := manager.GetConnection(connName)
 	if conn == nil {
-		return "", nil, &config.MissingConnectionError{
-			Name:            connName,
-			ConfigFilePath:  pipelineInfo.Config.Path(),
-			EnvironmentName: pipelineInfo.Config.SelectedEnvironmentName,
-		}
+		return "", nil, config.NewConnectionNotFoundError(ctx, "", connName)
 	}
 
 	return connName, conn, nil
@@ -985,18 +981,16 @@ func getConnectionByNameFromPipelineInfoWithContext(ctx context.Context, pipelin
 		}
 	}
 
-	manager, errs := connection.NewManagerFromConfigWithContext(ctx, pipelineInfo.Config)
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, pipelineInfo.Config.Path())
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, pipelineInfo.Config.SelectedEnvironmentName)
+	manager, errs := connectionManagerFromConfig(ctx, pipelineInfo.Config, makeLogger(false))
 	if len(errs) > 0 {
 		return "", nil, errors.Wrap(errs[0], "failed to create connection manager")
 	}
 
 	conn := manager.GetConnection(connName)
 	if conn == nil {
-		return "", nil, &config.MissingConnectionError{
-			Name:            connName,
-			ConfigFilePath:  pipelineInfo.Config.Path(),
-			EnvironmentName: pipelineInfo.Config.SelectedEnvironmentName,
-		}
+		return "", nil, config.NewConnectionNotFoundError(ctx, "", connName)
 	}
 
 	return connName, conn, nil

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/charmbracelet/bubbles/list"
@@ -518,7 +517,7 @@ func (m *importDatabaseModel) loadDatabaseSummaryCmd() tea.Cmd {
 	cfg := m.cfg
 
 	return func() tea.Msg {
-		manager, errs := connection.NewManagerFromConfigWithContext(ctx, cfg)
+		manager, errs := connectionManagerFromConfig(ctx, cfg, makeLogger(false))
 		if len(errs) > 0 {
 			return dbSummaryLoadedMsg{err: fmt.Errorf("failed to create connection manager: %w", errs[0])}
 		}
@@ -674,6 +673,8 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 			return fmt.Errorf("failed to select environment '%s': %w", environment, envErr)
 		}
 	}
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFile)
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cfg.SelectedEnvironmentName)
 
 	if cfg.SelectedEnvironment == nil || cfg.SelectedEnvironment.Connections == nil {
 		return errors.New("no environment selected or no connections configured")

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/bigquery" //nolint:unused
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/glossary"
 	"github.com/bruin-data/bruin/pkg/ingestr"
@@ -1454,7 +1453,9 @@ func AssetMetadata() *cli.Command {
 				}
 			}
 
-			manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+			ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, cm.Path())
+			ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+			manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
 			if len(errs) > 0 {
 				printErrorJSON(errs[0])
 				return cli.Exit("", 1)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/bigquery"
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/lint"
@@ -179,7 +178,9 @@ func Lint(isDebug *bool) *cli.Command {
 
 			logger.Debugf("switched to the environment '%s'", cm.SelectedEnvironmentName)
 
-			connectionManager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+			ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+			ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+			connectionManager, errs := connectionManagerFromConfig(ctx, cm, logger)
 			if len(errs) > 0 {
 				printErrors(errs, c.String("output"), "Failed to register connections")
 				return cli.Exit("", 1)

--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/fabric"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -76,7 +75,9 @@ func buildOverrideManager(ctx context.Context, cfg *config.Config, environment s
 			return nil, errors.Wrapf(err, "failed to use the environment '%s'", environment)
 		}
 	}
-	m, errs := connection.NewManagerFromConfigWithContext(ctx, cfg)
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, cfg.Path())
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cfg.SelectedEnvironmentName)
+	m, errs := connectionManagerFromConfig(ctx, cfg, makeLogger(false))
 	if len(errs) > 0 {
 		return nil, errors.Wrap(errs[0], "failed to create connection manager")
 	}
@@ -84,7 +85,12 @@ func buildOverrideManager(ctx context.Context, cfg *config.Config, environment s
 }
 
 // Returns: status ("updated", "skipped", "failed").
-func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride string, manager config.ConnectionGetter) (string, error) {
+func fillColumnsFromDB(ctx context.Context, pp *ppInfo, fs afero.Fs, environment, connectionOverride string, manager config.ConnectionGetter) (string, error) {
+	if pp != nil && pp.Config != nil {
+		ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, pp.Config.Path())
+		ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, pp.Config.SelectedEnvironmentName)
+	}
+
 	var conn interface{}
 	var err error
 
@@ -102,15 +108,11 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride 
 			return fillStatusFailed, fmt.Errorf(
 				"failed to get connection for asset '%s': %w",
 				pp.Asset.Name,
-				&config.MissingConnectionError{
-					Name:            connName,
-					ConfigFilePath:  pp.Config.Path(),
-					EnvironmentName: pp.Config.SelectedEnvironmentName,
-				},
+				config.NewConnectionNotFoundError(ctx, "", connName),
 			)
 		}
 	} else {
-		_, conn, err = getConnectionFromPipelineInfoWithContext(context.Background(), pp, environment)
+		_, conn, err = getConnectionFromPipelineInfoWithContext(ctx, pp, environment)
 		if err != nil {
 			return fillStatusFailed, fmt.Errorf("failed to get connection for asset '%s': %w", pp.Asset.Name, err)
 		}
@@ -129,7 +131,7 @@ func fillColumnsFromDB(pp *ppInfo, fs afero.Fs, environment, connectionOverride 
 
 	queryStr := buildSchemaProbeQuery(conn, tableName)
 	q := &query.Query{Query: queryStr}
-	result, err := querier.SelectWithSchema(query.WithQueryType(context.Background(), query.QueryTypePatch), q)
+	result, err := querier.SelectWithSchema(query.WithQueryType(ctx, query.QueryTypePatch), q)
 	if err != nil {
 		return fillStatusFailed, fmt.Errorf("failed to query columns for asset '%s': %w", pp.Asset.Name, err)
 	}
@@ -424,7 +426,7 @@ func Patch() *cli.Command {
 								return cli.Exit("", 1)
 							}
 						}
-						status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, overrideManager) //nolint:contextcheck
+						status, err := fillColumnsFromDB(ctx, pp, fs, environment, connectionOverride, overrideManager)
 						if err != nil {
 							printErrorForOutput(output, fmt.Errorf("failed to fill columns from DB for asset '%s': %w", pp.Asset.Name, err))
 							return cli.Exit("", 1)
@@ -475,7 +477,7 @@ func Patch() *cli.Command {
 
 						for _, asset := range foundPipeline.Assets {
 							pp := &ppInfo{Pipeline: foundPipeline, Asset: asset, Config: cm}
-							status, err := fillColumnsFromDB(pp, fs, environment, connectionOverride, overrideManager) //nolint:contextcheck
+							status, err := fillColumnsFromDB(ctx, pp, fs, environment, connectionOverride, overrideManager)
 							processedAssets++
 							assetName := asset.Name
 							switch status {

--- a/cmd/patch_test.go
+++ b/cmd/patch_test.go
@@ -286,7 +286,7 @@ func TestFillColumnsFromDB(t *testing.T) {
 			fs := afero.NewMemMapFs()
 
 			// Execute the function with mock manager
-			status, err := fillColumnsFromDB(pp, fs, "test", "", mockManager)
+			status, err := fillColumnsFromDB(t.Context(), pp, fs, "test", "", mockManager)
 
 			// Verify results
 			if tt.expectError {
@@ -337,7 +337,7 @@ func TestFillColumnsFromDB_ConnectionOverride(t *testing.T) {
 		Config:   &config.Config{},
 	}
 
-	status, err := fillColumnsFromDB(pp, afero.NewMemMapFs(), "", "source_connection", mockManager)
+	status, err := fillColumnsFromDB(t.Context(), pp, afero.NewMemMapFs(), "", "source_connection", mockManager)
 	require.NoError(t, err)
 	assert.Equal(t, fillStatusUpdated, status)
 	assert.Equal(t, []pipeline.Column{
@@ -371,7 +371,7 @@ func TestFillColumnsFromDB_ConnectionOverrideMissing(t *testing.T) {
 		Config:   &config.Config{},
 	}
 
-	status, err := fillColumnsFromDB(pp, afero.NewMemMapFs(), "", "missing_connection", mockManager)
+	status, err := fillColumnsFromDB(t.Context(), pp, afero.NewMemMapFs(), "", "missing_connection", mockManager)
 	require.Error(t, err)
 	assert.Equal(t, fillStatusFailed, status)
 	assert.Contains(t, err.Error(), "missing_connection")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,7 +25,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/claudecode"
 	"github.com/bruin-data/bruin/pkg/clickhouse"
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/databricks"
 	dataprocserverless "github.com/bruin-data/bruin/pkg/dataproc_serverless"
 	"github.com/bruin-data/bruin/pkg/date"
@@ -55,7 +54,6 @@ import (
 	"github.com/bruin-data/bruin/pkg/s3"
 	"github.com/bruin-data/bruin/pkg/sail"
 	"github.com/bruin-data/bruin/pkg/scheduler"
-	"github.com/bruin-data/bruin/pkg/secrets"
 	"github.com/bruin-data/bruin/pkg/snowflake"
 	"github.com/bruin-data/bruin/pkg/sqlparser"
 	"github.com/bruin-data/bruin/pkg/synapse"
@@ -675,11 +673,6 @@ func Run(isDebug *bool) *cli.Command {
 				Sources: cli.EnvVars("BRUIN_CONFIG_FILE"),
 				Usage:   "the path to the .bruin.yml file",
 			},
-			&cli.StringFlag{
-				Name:    "secrets-backend",
-				Sources: cli.EnvVars("BRUIN_SECRETS_BACKEND"),
-				Usage:   "the source of secrets if different from .bruin.yml. Possible values: 'vault', 'doppler', 'aws', 'azure'",
-			},
 			&cli.BoolFlag{
 				Name:  "no-validation",
 				Usage: "skip validation for this run.",
@@ -851,7 +844,6 @@ func Run(isDebug *bool) *cli.Command {
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigRunID, runID)
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigFullRefresh, runConfig.FullRefresh)
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigQueryAnnotations, runConfig.Annotations)
-			runCtx = context.WithValue(runCtx, config.SecretsBackendContextKey, c.String("secrets-backend"))
 
 			// Preview load uses WithOnlyPipeline so we can introspect the
 			// pipeline.yml metadata (notably .Variants) before requiring the user
@@ -1163,31 +1155,7 @@ func Run(isDebug *bool) *cli.Command {
 			var connectionManager config.ConnectionAndDetailsGetter
 			var errs []error
 
-			secretsBackend := c.String("secrets-backend")
-			switch secretsBackend {
-			case "vault":
-				connectionManager, err = secrets.NewVaultClientFromEnv(logger) //nolint:contextcheck
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failed to initialize vault client"))
-				}
-			case "doppler":
-				connectionManager, err = secrets.NewDopplerClientFromEnv(logger)
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failed to initialize doppler client"))
-				}
-			case "aws":
-				connectionManager, err = secrets.NewAWSSecretsManagerClientFromEnv(ctx, logger)
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failed to initialize AWS Secrets Manager client"))
-				}
-			case "azure":
-				connectionManager, err = secrets.NewAzureKeyVaultClientFromEnv(logger)
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failed to initialize Azure Key Vault client"))
-				}
-			default:
-				connectionManager, errs = connection.NewManagerFromConfigWithContext(ctx, cm)
-			}
+			connectionManager, errs = connectionManagerFromConfig(runCtx, cm, logger)
 
 			if len(errs) > 0 {
 				printErrors(errs, runConfig.Output, "Errors occurred while initializing connection manager")

--- a/cmd/secrets_backend.go
+++ b/cmd/secrets_backend.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/connection"
+	"github.com/bruin-data/bruin/pkg/logger"
+	"github.com/bruin-data/bruin/pkg/secrets"
+	"github.com/urfave/cli/v3"
+)
+
+const secretsBackendFlagName = "secrets-backend"
+
+func SecretsBackendFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:    secretsBackendFlagName,
+		Sources: cli.EnvVars("BRUIN_SECRETS_BACKEND"),
+		Usage:   "the source of secrets if different from .bruin.yml. Possible values: 'vault', 'doppler', 'aws', 'azure'",
+	}
+}
+
+func WithSecretsBackendContext(ctx context.Context, c *cli.Command) (context.Context, error) {
+	if c == nil {
+		return ctx, nil
+	}
+
+	backend := strings.TrimSpace(c.String(secretsBackendFlagName))
+	if backend == "" {
+		return ctx, nil
+	}
+
+	return context.WithValue(ctx, config.SecretsBackendContextKey, backend), nil
+}
+
+func secretsBackendFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	backend, ok := ctx.Value(config.SecretsBackendContextKey).(string)
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimSpace(backend)
+}
+
+func connectionManagerFromConfig(ctx context.Context, cm *config.Config, log logger.Logger) (config.ConnectionAndDetailsGetter, []error) {
+	secretsBackend := secretsBackendFromContext(ctx)
+	switch secretsBackend {
+	case "":
+		return connection.NewManagerFromConfigWithContext(ctx, cm)
+	case "vault":
+		manager, err := secrets.NewVaultClientFromEnv(log) //nolint:contextcheck
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed to initialize vault client: %w", err)}
+		}
+		return manager, nil
+	case "doppler":
+		manager, err := secrets.NewDopplerClientFromEnv(log)
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed to initialize doppler client: %w", err)}
+		}
+		return manager, nil
+	case "aws":
+		manager, err := secrets.NewAWSSecretsManagerClientFromEnv(ctx, log)
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed to initialize AWS Secrets Manager client: %w", err)}
+		}
+		return manager, nil
+	case "azure":
+		manager, err := secrets.NewAzureKeyVaultClientFromEnv(log)
+		if err != nil {
+			return nil, []error{fmt.Errorf("failed to initialize Azure Key Vault client: %w", err)}
+		}
+		return manager, nil
+	default:
+		return nil, []error{fmt.Errorf("unsupported secrets backend %q; possible values: vault, doppler, aws, azure", secretsBackend)}
+	}
+}

--- a/cmd/secrets_backend_test.go
+++ b/cmd/secrets_backend_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestWithSecretsBackendContext_GlobalFlagBeforeAndAfterSubcommand(t *testing.T) { //nolint:paralleltest
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "before subcommand",
+			args: []string{"bruin", "--secrets-backend", "azure", "query"},
+		},
+		{
+			name: "after subcommand",
+			args: []string{"bruin", "query", "--secrets-backend", "azure"},
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			app := &cli.Command{
+				Name:   "bruin",
+				Flags:  []cli.Flag{SecretsBackendFlag()},
+				Before: WithSecretsBackendContext,
+				Commands: []*cli.Command{
+					{
+						Name: "query",
+						Action: func(ctx context.Context, c *cli.Command) error {
+							got = secretsBackendFromContext(ctx)
+							return nil
+						},
+					},
+				},
+			}
+
+			err := app.Run(t.Context(), tt.args)
+			require.NoError(t, err)
+			require.Equal(t, "azure", got)
+		})
+	}
+}
+
+func TestConnectionManagerFromConfigRejectsUnknownSecretsBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(t.Context(), config.SecretsBackendContextKey, "unknown")
+	manager, errs := connectionManagerFromConfig(ctx, &config.Config{}, makeLogger(false))
+
+	require.Nil(t, manager)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Error(), `unsupported secrets backend "unknown"`)
+}

--- a/cmd/unittest.go
+++ b/cmd/unittest.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/config"
-	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/date"
 	"github.com/bruin-data/bruin/pkg/git"
 	"github.com/bruin-data/bruin/pkg/jinja"
@@ -201,7 +200,8 @@ func resolveConnectionManager(ctx context.Context, pipelinePath, env string) (co
 	if err != nil {
 		return nil, fmt.Errorf("failed to find the git repository root: %w", err)
 	}
-	cm, err := config.LoadOrCreate(afero.NewOsFs(), filepath.Join(repoRoot.Path, ".bruin.yml"))
+	configFilePath := filepath.Join(repoRoot.Path, ".bruin.yml")
+	cm, err := config.LoadOrCreate(afero.NewOsFs(), configFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load the config: %w", err)
 	}
@@ -210,7 +210,9 @@ func resolveConnectionManager(ctx context.Context, pipelinePath, env string) (co
 			return nil, fmt.Errorf("failed to use the environment %q: %w", env, err)
 		}
 	}
-	manager, errs := connection.NewManagerFromConfigWithContext(ctx, cm)
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+	manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
 	if len(errs) > 0 {
 		return nil, errs[0]
 	}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,9 @@ func main() {
 				Usage:       "show debug information",
 				Destination: &isDebug,
 			},
+			cmd.SecretsBackendFlag(),
 		},
+		Before: cmd.WithSecretsBackendContext,
 		Commands: []*cli.Command{
 			cmd.Lint(&isDebug),
 			cmd.Run(&isDebug),


### PR DESCRIPTION
Adds a global --secrets-backend flag and routes CLI connection-manager creation through the same secrets backend used by run. This covers query, connections test, patch, lint, data-diff, unit-test, import/internal helpers, cloud connection upload, and AI enhance lookups. Also fixes a race in the stdin-mutating environment test. Checks: make format, make test.