### PR TITLE
Speed up local lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ format: lint-python
 	go tool gofumpt -w cmd pkg semantic-engine &
 
 	@echo "$(OK_COLOR)>> [golangci-lint] running$(NO_COLOR)" & \
-	golangci-lint run --timeout 10m60s --build-tags="no_duckdb_arrow" ./...  & \
-	cd semantic-engine && golangci-lint run --timeout 10m60s & \
+	golangci-lint run --timeout 10m60s --new-from-merge-base=origin/main --build-tags="no_duckdb_arrow" ./...  & \
+	cd semantic-engine && golangci-lint run --timeout 10m60s --new-from-merge-base=origin/main & \
 	wait
 
 tools-update:


### PR DESCRIPTION
Updates the local format lint step to report only issues on changed lines against origin/main. CI still runs the full golangci-lint workflow.