### PR TITLE
Fix Windows credential path normalization

### DIFF
--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -348,13 +348,14 @@ func (c *Config) SelectEnvironment(name string) error {
 }
 
 func isAnchoredLocalPath(path string) bool {
-	if filepath.IsAbs(path) {
-		return true
-	}
+	return hasAnchoredLocalPathPrefix(path) || filepath.IsAbs(path)
+}
+
+func hasAnchoredLocalPathPrefix(path string) bool {
 	if path == "" {
 		return false
 	}
-	if path[0] == '\\' {
+	if path[0] == '/' || path[0] == '\\' {
 		return true
 	}
 	if len(path) < 3 {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -347,6 +347,26 @@ func (c *Config) SelectEnvironment(name string) error {
 	return nil
 }
 
+func isAnchoredLocalPath(path string) bool {
+	if filepath.IsAbs(path) {
+		return true
+	}
+	if path == "" {
+		return false
+	}
+	if path[0] == '\\' || path[0] == '/' {
+		return true
+	}
+	if len(path) < 3 {
+		return false
+	}
+
+	drive := path[0]
+	return ((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) &&
+		path[1] == ':' &&
+		(path[2] == '\\' || path[2] == '/')
+}
+
 func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 	var config Config
 	envConfig := os.Getenv("BRUIN_CONFIG_FILE_CONTENT")
@@ -396,7 +416,7 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 				continue
 			}
 
-			if filepath.IsAbs(conn.ServiceAccountFile) {
+			if isAnchoredLocalPath(conn.ServiceAccountFile) {
 				continue
 			}
 			env.Connections.GoogleCloudPlatform[i].ServiceAccountFile = filepath.Join(configLocation, conn.ServiceAccountFile)
@@ -404,7 +424,7 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 		// Make GoogleSheets service account file paths absolute (bruin reads and
 		// embeds these into the ingestr URI, so masking must find the same file).
 		for i, conn := range env.Connections.GoogleSheets {
-			if conn.ServiceAccountFile == "" || filepath.IsAbs(conn.ServiceAccountFile) {
+			if conn.ServiceAccountFile == "" || isAnchoredLocalPath(conn.ServiceAccountFile) {
 				continue
 			}
 			env.Connections.GoogleSheets[i].ServiceAccountFile = filepath.Join(configLocation, conn.ServiceAccountFile)

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -354,7 +354,7 @@ func isAnchoredLocalPath(path string) bool {
 	if path == "" {
 		return false
 	}
-	if path[0] == '\\' || path[0] == '/' {
+	if path[0] == '\\' {
 		return true
 	}
 	if len(path) < 3 {
@@ -431,45 +431,45 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 		}
 		// Make MySQL SSL file paths absolute
 		for i, conn := range env.Connections.MySQL {
-			if conn.SslCaPath != "" && !filepath.IsAbs(conn.SslCaPath) {
+			if conn.SslCaPath != "" && !isAnchoredLocalPath(conn.SslCaPath) {
 				env.Connections.MySQL[i].SslCaPath = filepath.Join(configLocation, conn.SslCaPath)
 			}
 
-			if conn.SslCertPath != "" && !filepath.IsAbs(conn.SslCertPath) {
+			if conn.SslCertPath != "" && !isAnchoredLocalPath(conn.SslCertPath) {
 				env.Connections.MySQL[i].SslCertPath = filepath.Join(configLocation, conn.SslCertPath)
 			}
 
-			if conn.SslKeyPath != "" && !filepath.IsAbs(conn.SslKeyPath) {
+			if conn.SslKeyPath != "" && !isAnchoredLocalPath(conn.SslKeyPath) {
 				env.Connections.MySQL[i].SslKeyPath = filepath.Join(configLocation, conn.SslKeyPath)
 			}
 		}
 
 		// Make Doris SSL file paths absolute
 		for i, conn := range env.Connections.Doris {
-			if conn.SslCaPath != "" && !filepath.IsAbs(conn.SslCaPath) {
+			if conn.SslCaPath != "" && !isAnchoredLocalPath(conn.SslCaPath) {
 				env.Connections.Doris[i].SslCaPath = filepath.Join(configLocation, conn.SslCaPath)
 			}
 
-			if conn.SslCertPath != "" && !filepath.IsAbs(conn.SslCertPath) {
+			if conn.SslCertPath != "" && !isAnchoredLocalPath(conn.SslCertPath) {
 				env.Connections.Doris[i].SslCertPath = filepath.Join(configLocation, conn.SslCertPath)
 			}
 
-			if conn.SslKeyPath != "" && !filepath.IsAbs(conn.SslKeyPath) {
+			if conn.SslKeyPath != "" && !isAnchoredLocalPath(conn.SslKeyPath) {
 				env.Connections.Doris[i].SslKeyPath = filepath.Join(configLocation, conn.SslKeyPath)
 			}
 		}
 
 		// Make Vitess SSL file paths absolute
 		for i, conn := range env.Connections.Vitess {
-			if conn.SslCaPath != "" && !filepath.IsAbs(conn.SslCaPath) {
+			if conn.SslCaPath != "" && !isAnchoredLocalPath(conn.SslCaPath) {
 				env.Connections.Vitess[i].SslCaPath = filepath.Join(configLocation, conn.SslCaPath)
 			}
 
-			if conn.SslCertPath != "" && !filepath.IsAbs(conn.SslCertPath) {
+			if conn.SslCertPath != "" && !isAnchoredLocalPath(conn.SslCertPath) {
 				env.Connections.Vitess[i].SslCertPath = filepath.Join(configLocation, conn.SslCertPath)
 			}
 
-			if conn.SslKeyPath != "" && !filepath.IsAbs(conn.SslKeyPath) {
+			if conn.SslKeyPath != "" && !isAnchoredLocalPath(conn.SslKeyPath) {
 				env.Connections.Vitess[i].SslKeyPath = filepath.Join(configLocation, conn.SslKeyPath)
 			}
 		}
@@ -480,7 +480,7 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 				continue
 			}
 
-			if filepath.IsAbs(conn.PrivateKeyPath) {
+			if isAnchoredLocalPath(conn.PrivateKeyPath) {
 				continue
 			}
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -1194,10 +1194,31 @@ func TestLoadDoesNotPrefixAnchoredCredentialPaths(t *testing.T) {
 	configPath := "/repo/.bruin.yml"
 	drivePath := `C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`
 	rootedPath := `\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`
+	caPath := `C:\certs\ca.pem`
+	certPath := `C:\certs\client.pem`
+	keyPath := `C:\certs\client-key.pem`
 	yml := `default_environment: default
 environments:
   default:
     connections:
+      snowflake:
+        - name: sf-drive
+          private_key_path: 'C:\certs\client-key.pem'
+      mysql:
+        - name: mysql-drive
+          ssl_ca_path: 'C:\certs\ca.pem'
+          ssl_cert_path: 'C:\certs\client.pem'
+          ssl_key_path: 'C:\certs\client-key.pem'
+      doris:
+        - name: doris-drive
+          ssl_ca_path: 'C:\certs\ca.pem'
+          ssl_cert_path: 'C:\certs\client.pem'
+          ssl_key_path: 'C:\certs\client-key.pem'
+      vitess:
+        - name: vitess-drive
+          ssl_ca_path: 'C:\certs\ca.pem'
+          ssl_cert_path: 'C:\certs\client.pem'
+          ssl_key_path: 'C:\certs\client-key.pem'
       google_cloud_platform:
         - name: gcp-drive
           project_id: proj
@@ -1212,6 +1233,24 @@ environments:
 
 	cfg, err := LoadOrCreate(fs, configPath)
 	require.NoError(t, err)
+
+	require.Len(t, cfg.SelectedEnvironment.Connections.Snowflake, 1)
+	assert.Equal(t, keyPath, cfg.SelectedEnvironment.Connections.Snowflake[0].PrivateKeyPath)
+
+	require.Len(t, cfg.SelectedEnvironment.Connections.MySQL, 1)
+	assert.Equal(t, caPath, cfg.SelectedEnvironment.Connections.MySQL[0].SslCaPath)
+	assert.Equal(t, certPath, cfg.SelectedEnvironment.Connections.MySQL[0].SslCertPath)
+	assert.Equal(t, keyPath, cfg.SelectedEnvironment.Connections.MySQL[0].SslKeyPath)
+
+	require.Len(t, cfg.SelectedEnvironment.Connections.Doris, 1)
+	assert.Equal(t, caPath, cfg.SelectedEnvironment.Connections.Doris[0].SslCaPath)
+	assert.Equal(t, certPath, cfg.SelectedEnvironment.Connections.Doris[0].SslCertPath)
+	assert.Equal(t, keyPath, cfg.SelectedEnvironment.Connections.Doris[0].SslKeyPath)
+
+	require.Len(t, cfg.SelectedEnvironment.Connections.Vitess, 1)
+	assert.Equal(t, caPath, cfg.SelectedEnvironment.Connections.Vitess[0].SslCaPath)
+	assert.Equal(t, certPath, cfg.SelectedEnvironment.Connections.Vitess[0].SslCertPath)
+	assert.Equal(t, keyPath, cfg.SelectedEnvironment.Connections.Vitess[0].SslKeyPath)
 
 	require.Len(t, cfg.SelectedEnvironment.Connections.GoogleCloudPlatform, 1)
 	assert.Equal(t, drivePath, cfg.SelectedEnvironment.Connections.GoogleCloudPlatform[0].ServiceAccountFile)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -1188,6 +1188,92 @@ environments:
 	assert.True(t, filepath.IsAbs(sheets), "sheets path should be absolute: %s", sheets)
 }
 
+func TestLoadDoesNotPrefixAnchoredCredentialPaths(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	configPath := "/repo/.bruin.yml"
+	drivePath := `C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`
+	rootedPath := `\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`
+	yml := `default_environment: default
+environments:
+  default:
+    connections:
+      google_cloud_platform:
+        - name: gcp-drive
+          project_id: proj
+          service_account_file: 'C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json'
+      google_sheets:
+        - name: sheets-drive
+          service_account_file: 'C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json'
+        - name: sheets-rooted
+          service_account_file: '\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json'
+`
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(yml), 0o644))
+
+	cfg, err := LoadOrCreate(fs, configPath)
+	require.NoError(t, err)
+
+	require.Len(t, cfg.SelectedEnvironment.Connections.GoogleCloudPlatform, 1)
+	assert.Equal(t, drivePath, cfg.SelectedEnvironment.Connections.GoogleCloudPlatform[0].ServiceAccountFile)
+
+	require.Len(t, cfg.SelectedEnvironment.Connections.GoogleSheets, 2)
+	assert.Equal(t, drivePath, cfg.SelectedEnvironment.Connections.GoogleSheets[0].ServiceAccountFile)
+	assert.Equal(t, rootedPath, cfg.SelectedEnvironment.Connections.GoogleSheets[1].ServiceAccountFile)
+}
+
+func TestIsAnchoredLocalPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "relative unix",
+			path: "creds/service-account.json",
+			want: false,
+		},
+		{
+			name: "relative windows",
+			path: `creds\service-account.json`,
+			want: false,
+		},
+		{
+			name: "windows drive absolute with backslashes",
+			path: `C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`,
+			want: true,
+		},
+		{
+			name: "windows drive absolute with slashes",
+			path: "C:/Users/ColtonChilders/Documents/GCS Keys/plated-mesh.json",
+			want: true,
+		},
+		{
+			name: "windows drive relative",
+			path: `C:Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`,
+			want: false,
+		},
+		{
+			name: "windows rooted current drive",
+			path: `\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`,
+			want: true,
+		},
+		{
+			name: "unix absolute",
+			path: "/Users/ColtonChilders/Documents/GCS Keys/plated-mesh.json",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isAnchoredLocalPath(tt.path))
+		})
+	}
+}
+
 func TestLoadOrCreateWithoutPathAbsolutization(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -1194,6 +1194,7 @@ func TestLoadDoesNotPrefixAnchoredCredentialPaths(t *testing.T) {
 	configPath := "/repo/.bruin.yml"
 	drivePath := `C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`
 	rootedPath := `\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json`
+	slashRootedPath := "/Users/ColtonChilders/Documents/GCS Keys/plated-mesh.json"
 	caPath := `C:\certs\ca.pem`
 	certPath := `C:\certs\client.pem`
 	keyPath := `C:\certs\client-key.pem`
@@ -1228,6 +1229,8 @@ environments:
           service_account_file: 'C:\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json'
         - name: sheets-rooted
           service_account_file: '\Users\ColtonChilders\Documents\GCS Keys\plated-mesh.json'
+        - name: sheets-slash-rooted
+          service_account_file: '/Users/ColtonChilders/Documents/GCS Keys/plated-mesh.json'
 `
 	require.NoError(t, afero.WriteFile(fs, configPath, []byte(yml), 0o644))
 
@@ -1255,9 +1258,10 @@ environments:
 	require.Len(t, cfg.SelectedEnvironment.Connections.GoogleCloudPlatform, 1)
 	assert.Equal(t, drivePath, cfg.SelectedEnvironment.Connections.GoogleCloudPlatform[0].ServiceAccountFile)
 
-	require.Len(t, cfg.SelectedEnvironment.Connections.GoogleSheets, 2)
+	require.Len(t, cfg.SelectedEnvironment.Connections.GoogleSheets, 3)
 	assert.Equal(t, drivePath, cfg.SelectedEnvironment.Connections.GoogleSheets[0].ServiceAccountFile)
 	assert.Equal(t, rootedPath, cfg.SelectedEnvironment.Connections.GoogleSheets[1].ServiceAccountFile)
+	assert.Equal(t, slashRootedPath, cfg.SelectedEnvironment.Connections.GoogleSheets[2].ServiceAccountFile)
 }
 
 func TestIsAnchoredLocalPath(t *testing.T) {
@@ -1299,7 +1303,7 @@ func TestIsAnchoredLocalPath(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "unix absolute",
+			name: "slash rooted",
 			path: "/Users/ColtonChilders/Documents/GCS Keys/plated-mesh.json",
 			want: true,
 		},
@@ -1309,6 +1313,54 @@ func TestIsAnchoredLocalPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, isAnchoredLocalPath(tt.path))
+		})
+	}
+}
+
+func TestHasAnchoredLocalPathPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "slash rooted",
+			path: "/Users/x/key.json",
+			want: true,
+		},
+		{
+			name: "backslash rooted",
+			path: `\Users\x\key.json`,
+			want: true,
+		},
+		{
+			name: "windows drive absolute with backslashes",
+			path: `C:\Users\x\key.json`,
+			want: true,
+		},
+		{
+			name: "windows drive absolute with slashes",
+			path: "C:/Users/x/key.json",
+			want: true,
+		},
+		{
+			name: "drive relative",
+			path: `C:Users\x\key.json`,
+			want: false,
+		},
+		{
+			name: "relative",
+			path: "Users/x/key.json",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hasAnchoredLocalPathPrefix(tt.path))
 		})
 	}
 }


### PR DESCRIPTION
Fixes Windows credential file paths being prefixed with the config directory when they are already anchored.

Adds coverage for drive-qualified and rooted Windows paths.