### PR TITLE
Support data-diff for Fabric

### DIFF
--- a/cmd/datadiff.go
+++ b/cmd/datadiff.go
@@ -211,7 +211,7 @@ func DataDiffCmd() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "target-dialect",
-				Usage:       "Target SQL dialect for ALTER TABLE statements (postgresql, snowflake, bigquery, duckdb, generic). Auto-detected if not specified.",
+				Usage:       "Target SQL dialect for ALTER TABLE statements (postgresql, snowflake, bigquery, duckdb, tsql, generic). Auto-detected if not specified.",
 				Destination: &targetDialect,
 			},
 			&cli.BoolFlag{

--- a/docs/commands/data-diff.md
+++ b/docs/commands/data-diff.md
@@ -44,7 +44,7 @@ table td:first-child {
 | `--config-file` | str | - | Optional path to the `.bruin.yml` configuration file. Other [secret backends](../secrets/overview.md) can be used.|
 | `--full` | bool | `false` | Include detailed row counts and column statistics analysis in addition to schema comparison |
 | `--fail-if-diff` | bool | `false` | Return a non-zero exit code if differences are found |
-| `--target-dialect` | str | auto-detect | Target SQL dialect for ALTER TABLE statements (postgresql, snowflake, bigquery, duckdb, generic). Auto-detected from connection types if not specified |
+| `--target-dialect` | str | auto-detect | Target SQL dialect for ALTER TABLE statements (postgresql, snowflake, bigquery, duckdb, tsql, generic). Auto-detected from connection types if not specified |
 | `--reverse` | bool | `false` | Reverse the direction of ALTER statements (transform Table1 to match Table2 instead of Table2 to match Table1) |
 | `--sample` | int | `0` | For MongoDB sources, sample at most N documents per collection instead of scanning the whole collection (statistics become approximate). `0` scans everything. Ignored by other connection types |
 
@@ -156,6 +156,7 @@ The generated statements can:
 - Snowflake (`snowflake`)
 - BigQuery (`bigquery`)
 - DuckDB (`duckdb`)
+- SQL Server / Microsoft Fabric (`tsql`)
 - Generic SQL (`generic`)
 
 ## Examples

--- a/pkg/diff/alter.go
+++ b/pkg/diff/alter.go
@@ -13,6 +13,7 @@ const (
 	DialectSnowflake  DatabaseDialect = "snowflake"
 	DialectBigQuery   DatabaseDialect = "bigquery"
 	DialectDuckDB     DatabaseDialect = "duckdb"
+	DialectTSQL       DatabaseDialect = "tsql"
 	DialectGeneric    DatabaseDialect = "generic"
 )
 
@@ -25,7 +26,7 @@ type AlterStatementGenerator struct {
 // NewAlterStatementGenerator creates a new ALTER statement generator with the specified dialect.
 func NewAlterStatementGenerator(dialect DatabaseDialect, reverse bool) *AlterStatementGenerator {
 	return &AlterStatementGenerator{
-		dialect: dialect,
+		dialect: normalizeDialect(dialect),
 		reverse: reverse,
 	}
 }
@@ -109,6 +110,22 @@ func (g *AlterStatementGenerator) generateMissingColumnClause(missingCol Missing
 
 // generateAddColumnClause generates an ADD COLUMN clause.
 func (g *AlterStatementGenerator) generateAddColumnClause(columnName, dataType string, nullable, primaryKey, unique bool) string {
+	if g.dialect == DialectTSQL {
+		clause := fmt.Sprintf("ADD %s %s", g.quoteIdentifier(columnName), dataType)
+		if nullable {
+			clause += " NULL"
+		} else {
+			clause += " NOT NULL"
+		}
+		if unique {
+			clause += " UNIQUE"
+		}
+		if primaryKey {
+			clause += " /* PRIMARY KEY - may need to be added separately */"
+		}
+		return clause
+	}
+
 	clause := fmt.Sprintf("ADD COLUMN %s %s", g.quoteIdentifier(columnName), dataType)
 
 	// DuckDB doesn't support adding columns with constraints directly
@@ -185,6 +202,8 @@ func (g *AlterStatementGenerator) generateAlterTypeClause(columnName string, typ
 		return fmt.Sprintf("ALTER COLUMN %s TYPE %s", g.quoteIdentifier(columnName), newType)
 	case DialectSnowflake, DialectBigQuery:
 		return fmt.Sprintf("ALTER COLUMN %s SET DATA TYPE %s", g.quoteIdentifier(columnName), newType)
+	case DialectTSQL:
+		return fmt.Sprintf("ALTER COLUMN %s %s", g.quoteIdentifier(columnName), newType)
 	case DialectGeneric:
 		return fmt.Sprintf("ALTER COLUMN %s TYPE %s", g.quoteIdentifier(columnName), newType)
 	default:
@@ -217,6 +236,8 @@ func (g *AlterStatementGenerator) generateAlterNullabilityClause(columnName stri
 		// BigQuery doesn't support ALTER COLUMN for nullability changes on existing columns
 		// This requires recreating the table
 		return fmt.Sprintf("/* BigQuery does not support changing nullability - column %s would need table recreation */", g.quoteIdentifier(columnName))
+	case DialectTSQL:
+		return fmt.Sprintf("/* SQL Server/Fabric requires ALTER COLUMN with the full data type to change nullability for column %s */", g.quoteIdentifier(columnName))
 	case DialectGeneric:
 		fallthrough
 	default:
@@ -240,6 +261,8 @@ func (g *AlterStatementGenerator) canCombineAlterClauses() bool {
 	case DialectBigQuery:
 		// BigQuery supports multiple ADD COLUMN but not mixing with ALTER COLUMN
 		return false
+	case DialectTSQL:
+		return false
 	case DialectGeneric:
 		return true
 	default:
@@ -254,6 +277,9 @@ func (g *AlterStatementGenerator) quoteIdentifier(identifier string) string {
 		return identifier
 	}
 	if strings.HasPrefix(identifier, "`") && strings.HasSuffix(identifier, "`") {
+		return identifier
+	}
+	if strings.HasPrefix(identifier, "[") && strings.HasSuffix(identifier, "]") {
 		return identifier
 	}
 
@@ -272,6 +298,16 @@ func (g *AlterStatementGenerator) quoteIdentifier(identifier string) string {
 		return fmt.Sprintf("\"%s\"", identifier)
 	case DialectSnowflake, DialectDuckDB:
 		return fmt.Sprintf("\"%s\"", identifier)
+	case DialectTSQL:
+		if strings.Contains(identifier, ".") {
+			parts := strings.Split(identifier, ".")
+			quotedParts := make([]string, len(parts))
+			for i, part := range parts {
+				quotedParts[i] = fmt.Sprintf("[%s]", strings.ReplaceAll(part, "]", "]]"))
+			}
+			return strings.Join(quotedParts, ".")
+		}
+		return fmt.Sprintf("[%s]", strings.ReplaceAll(identifier, "]", "]]"))
 	case DialectGeneric:
 		return fmt.Sprintf("\"%s\"", identifier)
 	default:
@@ -307,7 +343,28 @@ func dialectFromConnectionType(connType string) DatabaseDialect {
 		return DialectBigQuery
 	case strings.Contains(connType, "duckdb"), strings.Contains(connType, "duck"):
 		return DialectDuckDB
+	case strings.Contains(connType, "fabric"), strings.Contains(connType, "mssql"), strings.Contains(connType, "sqlserver"):
+		return DialectTSQL
 	default:
 		return DialectGeneric
+	}
+}
+
+func normalizeDialect(dialect DatabaseDialect) DatabaseDialect {
+	switch strings.ToLower(string(dialect)) {
+	case "postgres", "postgresql":
+		return DialectPostgreSQL
+	case "snowflake":
+		return DialectSnowflake
+	case "bigquery", "bq":
+		return DialectBigQuery
+	case "duckdb", "duck":
+		return DialectDuckDB
+	case "tsql", "t-sql", "mssql", "sqlserver", "sql-server", "fabric":
+		return DialectTSQL
+	case "generic":
+		return DialectGeneric
+	default:
+		return dialect
 	}
 }

--- a/pkg/diff/alter_test.go
+++ b/pkg/diff/alter_test.go
@@ -26,6 +26,41 @@ func TestNewAlterStatementGenerator(t *testing.T) {
 	})
 }
 
+func TestGenerateAlterStatements_TSQL(t *testing.T) {
+	t.Parallel()
+
+	gen := NewAlterStatementGenerator(DialectTSQL, false)
+	result := &SchemaComparisonResult{
+		HasSchemaDifferences: true,
+		Table1: &TableSummaryResult{
+			Table: &Table{Name: "dbo.users"},
+		},
+		Table2: &TableSummaryResult{
+			Table: &Table{Name: "dbo.users_copy"},
+		},
+		MissingColumns: []MissingColumn{
+			{
+				ColumnName:  "email",
+				Type:        "nvarchar(255)",
+				Nullable:    false,
+				MissingFrom: "dbo.users_copy",
+				TableName:   "dbo.users",
+			},
+		},
+	}
+
+	statements := gen.GenerateAlterStatements(result)
+	require.Len(t, statements, 1)
+	assert.Equal(t, "ALTER TABLE [dbo].[users_copy] ADD [email] nvarchar(255) NOT NULL;", statements[0])
+}
+
+func TestDetectDialectFromConnectionFabric(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, DialectTSQL, DetectDialectFromConnection("fabric_gold", "fabric_gold"))
+	assert.Equal(t, DialectTSQL, NewAlterStatementGenerator(DatabaseDialect("fabric"), false).dialect)
+}
+
 func TestGenerateAlterStatements_NoChanges(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/diff/datetime_test.go
+++ b/pkg/diff/datetime_test.go
@@ -47,6 +47,12 @@ func TestParseDateTime(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "datetime2 without timezone",
+			input:    "2023-01-15T10:30:00.1234567",
+			wantTime: timePtr(time.Date(2023, 1, 15, 10, 30, 0, 123456700, time.UTC)),
+			wantErr:  false,
+		},
+		{
 			name:     "standard datetime string",
 			input:    "2023-01-15 10:30:00",
 			wantTime: timePtr(time.Date(2023, 1, 15, 10, 30, 0, 0, time.UTC)),
@@ -68,6 +74,12 @@ func TestParseDateTime(t *testing.T) {
 			name:     "time only string",
 			input:    "10:30:00",
 			wantTime: timePtr(time.Date(0, 1, 1, 10, 30, 0, 0, time.UTC)),
+			wantErr:  false,
+		},
+		{
+			name:     "time only with fractional seconds",
+			input:    "10:30:00.1234567",
+			wantTime: timePtr(time.Date(0, 1, 1, 10, 30, 0, 123456700, time.UTC)),
 			wantErr:  false,
 		},
 		{

--- a/pkg/diff/types.go
+++ b/pkg/diff/types.go
@@ -352,6 +352,47 @@ func NewSnowflakeTypeMapper() *DatabaseTypeMapper {
 	return mapper
 }
 
+// NewSQLServerTypeMapper provides SQL Server-compatible type mapping, including
+// Microsoft Fabric Warehouse types exposed through the TDS endpoint.
+func NewSQLServerTypeMapper() *DatabaseTypeMapper {
+	mapper := NewDatabaseTypeMapper()
+
+	mapper.AddNumericTypes(
+		"bigint", "int", "smallint", "tinyint",
+		"decimal", "numeric",
+		"float", "real",
+		"money", "smallmoney",
+	)
+
+	mapper.AddStringTypes(
+		"char", "varchar",
+		"nchar", "nvarchar",
+		"text", "ntext",
+		"uniqueidentifier",
+		"xml",
+	)
+
+	mapper.AddBooleanTypes(
+		"bit",
+	)
+
+	mapper.AddDateTimeTypes(
+		"date",
+		"time",
+		"datetime",
+		"datetime2",
+		"smalldatetime",
+		"datetimeoffset",
+	)
+
+	mapper.AddBinaryTypes(
+		"binary", "varbinary",
+		"image",
+	)
+
+	return mapper
+}
+
 // NewMongoTypeMapper provides MongoDB type mapping. The keys are the BSON type
 // aliases reported by the aggregation `$type` operator (e.g. "double", "string",
 // "objectId"), since MongoDB has no static catalog and types are inferred from
@@ -511,10 +552,13 @@ func ParseDateTime(value interface{}) (*time.Time, error) {
 			time.RFC3339,                    // 2006-01-02T15:04:05Z07:00
 			time.RFC3339Nano,                // 2006-01-02T15:04:05.999999999Z07:00
 			"2006-01-02T15:04:05",           // RFC3339 without timezone
+			"2006-01-02T15:04:05.999999999", // RFC3339Nano without timezone
 			"2006-01-02 15:04:05 -0700 MST", // BigQuery format with timezone
 			"2006-01-02 15:04:05",           // Standard datetime
+			"2006-01-02 15:04:05.999999999", // Standard datetime with fractional seconds
 			"2006-01-02 15:04:05.999999",    // With microseconds
 			"2006-01-02",                    // Date only
+			"15:04:05.999999999",            // Time only with fractional seconds
 			"15:04:05",                      // Time only
 		}
 

--- a/pkg/diff/types_test.go
+++ b/pkg/diff/types_test.go
@@ -256,6 +256,40 @@ func TestBigQueryTypeMapper(t *testing.T) {
 	}
 }
 
+func TestSQLServerTypeMapper(t *testing.T) {
+	t.Parallel()
+	mapper := NewSQLServerTypeMapper()
+
+	tests := []struct {
+		inputType      string
+		expectedResult CommonDataType
+	}{
+		{"int", CommonTypeNumeric},
+		{"bigint", CommonTypeNumeric},
+		{"decimal(18,2)", CommonTypeNumeric},
+		{"float", CommonTypeNumeric},
+		{"nvarchar", CommonTypeString},
+		{"varchar(255)", CommonTypeString},
+		{"uniqueidentifier", CommonTypeString},
+		{"bit", CommonTypeBoolean},
+		{"date", CommonTypeDateTime},
+		{"datetime2", CommonTypeDateTime},
+		{"datetimeoffset", CommonTypeDateTime},
+		{"varbinary(max)", CommonTypeBinary},
+		{"geography", CommonTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run("SQLServer_"+tt.inputType, func(t *testing.T) {
+			t.Parallel()
+			result := mapper.MapType(tt.inputType)
+			if result != tt.expectedResult {
+				t.Errorf("SQL Server mapper: MapType(%q) = %v, want %v", tt.inputType, result, tt.expectedResult)
+			}
+		})
+	}
+}
+
 func TestDatabaseTypeMapper_IsNumeric(t *testing.T) {
 	t.Parallel()
 	mapper := createTestMapper()

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/diff"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/tablename"
@@ -19,6 +20,7 @@ type DB struct {
 	conn          *sqlx.DB
 	config        *Config
 	schemaCreator *SchemaCreator
+	typeMapper    *diff.DatabaseTypeMapper
 }
 
 // QuoteIdentifier quotes a Fabric identifier using square brackets.
@@ -39,7 +41,7 @@ func NewDB(c *Config) (*DB, error) {
 		return nil, errors.Wrap(err, "failed to open Fabric Warehouse connection")
 	}
 
-	return &DB{conn: conn, config: c, schemaCreator: NewSchemaCreator(c.Database)}, nil
+	return &DB{conn: conn, config: c, schemaCreator: NewSchemaCreator(c.Database), typeMapper: diff.NewSQLServerTypeMapper()}, nil
 }
 
 func (db *DB) CreateSchemaIfNotExist(ctx context.Context, asset *pipeline.Asset) error {

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -3,6 +3,7 @@ package fabric
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -76,12 +77,32 @@ SELECT
     STDEV(CAST([id] AS FLOAT)) as stddev_val
 FROM [warehouse].[dbo].[orders]`
 
+const expectedStringStatsQuery = `
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG([name]) as null_count,
+    COUNT_BIG(DISTINCT CONVERT(NVARCHAR(4000), [name])) as distinct_count,
+    COUNT_BIG(CASE WHEN CONVERT(NVARCHAR(4000), [name]) = N'' THEN 1 END) as empty_count,
+    MIN(LEN(CONVERT(NVARCHAR(4000), [name]))) as min_length,
+    MAX(LEN(CONVERT(NVARCHAR(4000), [name]))) as max_length,
+    AVG(CAST(LEN(CONVERT(NVARCHAR(4000), [name])) AS FLOAT)) as avg_length
+FROM [warehouse].[dbo].[orders]`
+
 const expectedBooleanStatsQuery = `
 SELECT
     COUNT_BIG(*) as count,
     COUNT_BIG(*) - COUNT_BIG([is_active]) as null_count,
     COUNT_BIG(CASE WHEN [is_active] = 1 THEN 1 END) as true_count,
     COUNT_BIG(CASE WHEN [is_active] = 0 THEN 1 END) as false_count
+FROM [warehouse].[dbo].[orders]`
+
+const expectedDateTimeStatsQuery = `
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG([created_at]) as null_count,
+    COUNT_BIG(DISTINCT [created_at]) as unique_count,
+    CONVERT(VARCHAR(33), MIN([created_at]), 126) as earliest_date,
+    CONVERT(VARCHAR(33), MAX([created_at]), 126) as latest_date
 FROM [warehouse].[dbo].[orders]`
 
 func TestDB_GetColumns(t *testing.T) {
@@ -332,6 +353,37 @@ func TestDB_GetTableSummaryFullNumericalStats(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestDB_FetchStringStats(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(expectedStringStatsQuery).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"count",
+			"null_count",
+			"distinct_count",
+			"empty_count",
+			"min_length",
+			"max_length",
+			"avg_length",
+		}).AddRow(int64(5), int64(1), int64(3), int64(1), int64(0), int64(12), float64(4.5)))
+
+	db := &DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+	got, err := db.fetchStringStats(t.Context(), "[warehouse].[dbo].[orders]", "[name]")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), got.Count)
+	assert.Equal(t, int64(1), got.NullCount)
+	assert.Equal(t, int64(3), got.DistinctCount)
+	assert.Equal(t, int64(1), got.EmptyCount)
+	assert.Equal(t, 0, got.MinLength)
+	assert.Equal(t, 12, got.MaxLength)
+	assert.InDelta(t, float64(4.5), got.AvgLength, 0)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDB_FetchBooleanStats(t *testing.T) {
 	t.Parallel()
 
@@ -354,5 +406,34 @@ func TestDB_FetchBooleanStats(t *testing.T) {
 	assert.Equal(t, int64(1), got.NullCount)
 	assert.Equal(t, int64(3), got.TrueCount)
 	assert.Equal(t, int64(1), got.FalseCount)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_FetchDateTimeStats(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(expectedDateTimeStatsQuery).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"count",
+			"null_count",
+			"unique_count",
+			"earliest_date",
+			"latest_date",
+		}).AddRow(int64(5), int64(1), int64(4), "2024-01-01T10:30:00.1234567", "2024-01-02T11:30:00.1234567"))
+
+	db := &DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+	got, err := db.fetchDateTimeStats(t.Context(), "[warehouse].[dbo].[orders]", "[created_at]")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), got.Count)
+	assert.Equal(t, int64(1), got.NullCount)
+	assert.Equal(t, int64(4), got.UniqueCount)
+	require.NotNil(t, got.EarliestDate)
+	require.NotNil(t, got.LatestDate)
+	assert.Equal(t, time.Date(2024, 1, 1, 10, 30, 0, 123456700, time.UTC), *got.EarliestDate)
+	assert.Equal(t, time.Date(2024, 1, 2, 11, 30, 0, 123456700, time.UTC), *got.LatestDate)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bruin-data/bruin/pkg/ansisql"
+	"github.com/bruin-data/bruin/pkg/diff"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,6 +50,39 @@ FROM [archive].INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
 ORDER BY ORDINAL_POSITION;
 `
+
+const expectedWarehouseDiffColumnsQuery = `
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE,
+    COLUMN_DEFAULT,
+    CHARACTER_MAXIMUM_LENGTH,
+    NUMERIC_PRECISION,
+    NUMERIC_SCALE
+FROM [warehouse].INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+ORDER BY ORDINAL_POSITION;
+`
+
+const expectedNumericalStatsQuery = `
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG([id]) as null_count,
+    MIN(CAST([id] AS FLOAT)) as min_val,
+    MAX(CAST([id] AS FLOAT)) as max_val,
+    AVG(CAST([id] AS FLOAT)) as avg_val,
+    SUM(CAST([id] AS FLOAT)) as sum_val,
+    STDEV(CAST([id] AS FLOAT)) as stddev_val
+FROM [warehouse].[dbo].[orders]`
+
+const expectedBooleanStatsQuery = `
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG([is_active]) as null_count,
+    COUNT_BIG(CASE WHEN [is_active] = 1 THEN 1 END) as true_count,
+    COUNT_BIG(CASE WHEN [is_active] = 0 THEN 1 END) as false_count
+FROM [warehouse].[dbo].[orders]`
 
 func TestDB_GetColumns(t *testing.T) {
 	t.Parallel()
@@ -192,5 +226,133 @@ func TestDB_GetColumnsForTable(t *testing.T) {
 	assert.Equal(t, []*ansisql.DBColumn{
 		{Name: "payment_id", Type: "uniqueidentifier", Nullable: false, PrimaryKey: false, Unique: false},
 	}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_GetTableSummarySchemaOnly(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(expectedWarehouseDiffColumnsQuery).
+		WithArgs("dbo", "DimDateFirstLead").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"COLUMN_NAME",
+			"DATA_TYPE",
+			"IS_NULLABLE",
+			"COLUMN_DEFAULT",
+			"CHARACTER_MAXIMUM_LENGTH",
+			"NUMERIC_PRECISION",
+			"NUMERIC_SCALE",
+		}).
+			AddRow("id", "bigint", "NO", nil, nil, int64(19), int64(0)).
+			AddRow("name", "nvarchar", "YES", nil, int64(255), nil, nil).
+			AddRow("is_active", "bit", "NO", nil, nil, nil, nil).
+			AddRow("created_at", "datetime2", "YES", nil, nil, nil, nil).
+			AddRow("payload", "varbinary", "YES", nil, int64(-1), nil, nil))
+
+	db := &DB{
+		conn:       sqlx.NewDb(mockDB, "sqlmock"),
+		config:     &Config{Database: "warehouse"},
+		typeMapper: diff.NewSQLServerTypeMapper(),
+	}
+
+	got, err := db.GetTableSummary(t.Context(), "dbo.DimDateFirstLead", true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got.RowCount)
+	require.NotNil(t, got.Table)
+	assert.Equal(t, "dbo.DimDateFirstLead", got.Table.Name)
+	assert.Equal(t, []*diff.Column{
+		{Name: "id", Type: "bigint", NormalizedType: diff.CommonTypeNumeric, Nullable: false, PrimaryKey: false, Unique: false},
+		{Name: "name", Type: "nvarchar(255)", NormalizedType: diff.CommonTypeString, Nullable: true, PrimaryKey: false, Unique: false},
+		{Name: "is_active", Type: "bit", NormalizedType: diff.CommonTypeBoolean, Nullable: false, PrimaryKey: false, Unique: false},
+		{Name: "created_at", Type: "datetime2", NormalizedType: diff.CommonTypeDateTime, Nullable: true, PrimaryKey: false, Unique: false},
+		{Name: "payload", Type: "varbinary(max)", NormalizedType: diff.CommonTypeBinary, Nullable: true, PrimaryKey: false, Unique: false},
+	}, got.Table.Columns)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_GetTableSummaryFullNumericalStats(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery("SELECT COUNT_BIG(*) as row_count FROM [warehouse].[dbo].[orders]").
+		WillReturnRows(sqlmock.NewRows([]string{"row_count"}).AddRow(int64(3)))
+	mock.ExpectQuery(expectedWarehouseDiffColumnsQuery).
+		WithArgs("dbo", "orders").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"COLUMN_NAME",
+			"DATA_TYPE",
+			"IS_NULLABLE",
+			"COLUMN_DEFAULT",
+			"CHARACTER_MAXIMUM_LENGTH",
+			"NUMERIC_PRECISION",
+			"NUMERIC_SCALE",
+		}).AddRow("id", "int", "NO", nil, nil, int64(10), int64(0)))
+	mock.ExpectQuery(expectedNumericalStatsQuery).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"count",
+			"null_count",
+			"min_val",
+			"max_val",
+			"avg_val",
+			"sum_val",
+			"stddev_val",
+		}).AddRow(int64(3), int64(0), float64(1), float64(3), float64(2), float64(6), float64(1)))
+
+	db := &DB{
+		conn:       sqlx.NewDb(mockDB, "sqlmock"),
+		config:     &Config{Database: "warehouse"},
+		typeMapper: diff.NewSQLServerTypeMapper(),
+	}
+
+	got, err := db.GetTableSummary(t.Context(), "orders", false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), got.RowCount)
+	require.Len(t, got.Table.Columns, 1)
+	stats, ok := got.Table.Columns[0].Stats.(*diff.NumericalStatistics)
+	require.True(t, ok)
+	assert.Equal(t, int64(3), stats.Count)
+	assert.Equal(t, int64(0), stats.NullCount)
+	require.NotNil(t, stats.Min)
+	require.NotNil(t, stats.Max)
+	require.NotNil(t, stats.Avg)
+	require.NotNil(t, stats.Sum)
+	require.NotNil(t, stats.StdDev)
+	assert.InDelta(t, float64(1), *stats.Min, 0)
+	assert.InDelta(t, float64(3), *stats.Max, 0)
+	assert.InDelta(t, float64(2), *stats.Avg, 0)
+	assert.InDelta(t, float64(6), *stats.Sum, 0)
+	assert.InDelta(t, float64(1), *stats.StdDev, 0)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_FetchBooleanStats(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(expectedBooleanStatsQuery).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"count",
+			"null_count",
+			"true_count",
+			"false_count",
+		}).AddRow(int64(5), int64(1), int64(3), int64(1)))
+
+	db := &DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+	got, err := db.fetchBooleanStats(t.Context(), "[warehouse].[dbo].[orders]", "[is_active]")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), got.Count)
+	assert.Equal(t, int64(1), got.NullCount)
+	assert.Equal(t, int64(3), got.TrueCount)
+	assert.Equal(t, int64(1), got.FalseCount)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/fabric/diff.go
+++ b/pkg/fabric/diff.go
@@ -1,0 +1,412 @@
+package fabric
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/bruin/pkg/diff"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/tablename"
+)
+
+var _ diff.TableSummarizer = (*DB)(nil)
+
+func (db *DB) GetTableSummary(ctx context.Context, tableName string, schemaOnly bool) (*diff.TableSummaryResult, error) {
+	table, err := db.parseDiffTableName(tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	quotedTableName := quoteTableName(table)
+	var rowCount int64
+	if !schemaOnly {
+		countResult, err := db.Select(ctx, &query.Query{Query: "SELECT COUNT_BIG(*) as row_count FROM " + quotedTableName})
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute count query for table '%s': %w", tableName, err)
+		}
+		if len(countResult) > 0 && len(countResult[0]) > 0 {
+			rowCount, err = parseFabricInt64(countResult[0][0], "row count")
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse row count for table '%s': %w", tableName, err)
+			}
+		}
+	}
+
+	infoSchema := "INFORMATION_SCHEMA"
+	if table.Catalog != "" {
+		infoSchema = QuoteIdentifier(table.Catalog) + ".INFORMATION_SCHEMA"
+	}
+
+	schemaQuery := fmt.Sprintf(`
+SELECT
+    COLUMN_NAME,
+    DATA_TYPE,
+    IS_NULLABLE,
+    COLUMN_DEFAULT,
+    CHARACTER_MAXIMUM_LENGTH,
+    NUMERIC_PRECISION,
+    NUMERIC_SCALE
+FROM %s.COLUMNS
+WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+ORDER BY ORDINAL_POSITION;
+`, infoSchema)
+
+	rows, err := db.conn.QueryContext(ctx, schemaQuery, table.Schema, table.Table)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute schema query for table '%s': %w", tableName, err)
+	}
+	defer rows.Close()
+
+	columns := make([]*diff.Column, 0)
+	for rows.Next() {
+		var columnName, dataType, isNullable string
+		var columnDefault, charMaxLength, numericPrecision, numericScale interface{}
+
+		if err := rows.Scan(&columnName, &dataType, &isNullable, &columnDefault, &charMaxLength, &numericPrecision, &numericScale); err != nil {
+			return nil, fmt.Errorf("failed to scan schema info for table '%s': %w", tableName, err)
+		}
+
+		fullType := formatColumnType(dataType, charMaxLength, numericPrecision, numericScale)
+		normalizedType := db.diffTypeMapper().MapType(dataType)
+		nullable := strings.EqualFold(isNullable, "YES")
+
+		var stats diff.ColumnStatistics
+		if !schemaOnly {
+			quotedColumnName := QuoteIdentifier(columnName)
+			switch normalizedType {
+			case diff.CommonTypeNumeric:
+				stats, err = db.fetchNumericalStats(ctx, quotedTableName, quotedColumnName)
+			case diff.CommonTypeString:
+				stats, err = db.fetchStringStats(ctx, quotedTableName, quotedColumnName)
+			case diff.CommonTypeBoolean:
+				stats, err = db.fetchBooleanStats(ctx, quotedTableName, quotedColumnName)
+			case diff.CommonTypeDateTime:
+				stats, err = db.fetchDateTimeStats(ctx, quotedTableName, quotedColumnName)
+			case diff.CommonTypeBinary, diff.CommonTypeJSON, diff.CommonTypeUnknown:
+				stats = &diff.UnknownStatistics{}
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch %s stats for column '%s': %w", normalizedType, columnName, err)
+			}
+		}
+
+		columns = append(columns, &diff.Column{
+			Name:           columnName,
+			Type:           fullType,
+			NormalizedType: normalizedType,
+			Nullable:       nullable,
+			PrimaryKey:     false,
+			Unique:         false,
+			Stats:          stats,
+		})
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error after iterating schema rows for table '%s': %w", tableName, err)
+	}
+
+	return &diff.TableSummaryResult{
+		RowCount: rowCount,
+		Table: &diff.Table{
+			Name:    tableName,
+			Columns: columns,
+		},
+	}, nil
+}
+
+func (db *DB) parseDiffTableName(tableName string) (tablename.TableName, error) {
+	cb, ok := tablename.For("fabric")
+	if !ok {
+		return tablename.TableName{}, errors.New("fabric table-name capability not found")
+	}
+
+	databaseName := ""
+	if db.config != nil {
+		databaseName = db.config.Database
+	}
+
+	return cb.Parse(tableName, tablename.Defaults{Catalog: databaseName, Schema: "dbo"})
+}
+
+func (db *DB) diffTypeMapper() *diff.DatabaseTypeMapper {
+	if db.typeMapper != nil {
+		return db.typeMapper
+	}
+	return diff.NewSQLServerTypeMapper()
+}
+
+func quoteTableName(table tablename.TableName) string {
+	return QuoteIdentifier(table.String("."))
+}
+
+func (db *DB) fetchNumericalStats(ctx context.Context, tableName, columnName string) (*diff.NumericalStatistics, error) {
+	queryString := fmt.Sprintf(`
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG(%s) as null_count,
+    MIN(CAST(%s AS FLOAT)) as min_val,
+    MAX(CAST(%s AS FLOAT)) as max_val,
+    AVG(CAST(%s AS FLOAT)) as avg_val,
+    SUM(CAST(%s AS FLOAT)) as sum_val,
+    STDEV(CAST(%s AS FLOAT)) as stddev_val
+FROM %s`,
+		columnName, columnName, columnName, columnName, columnName, columnName, tableName)
+
+	result, err := db.Select(ctx, &query.Query{Query: queryString})
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &diff.NumericalStatistics{}
+	if len(result) == 0 || len(result[0]) < 7 {
+		return stats, nil
+	}
+
+	row := result[0]
+	if stats.Count, err = parseFabricInt64(row[0], "count"); err != nil {
+		return nil, err
+	}
+	if stats.NullCount, err = parseFabricInt64(row[1], "null count"); err != nil {
+		return nil, err
+	}
+	if stats.Min, err = parseFabricOptionalFloat64(row[2], "min"); err != nil {
+		return nil, err
+	}
+	if stats.Max, err = parseFabricOptionalFloat64(row[3], "max"); err != nil {
+		return nil, err
+	}
+	if stats.Avg, err = parseFabricOptionalFloat64(row[4], "avg"); err != nil {
+		return nil, err
+	}
+	if stats.Sum, err = parseFabricOptionalFloat64(row[5], "sum"); err != nil {
+		return nil, err
+	}
+	if stats.StdDev, err = parseFabricOptionalFloat64(row[6], "stddev"); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func (db *DB) fetchStringStats(ctx context.Context, tableName, columnName string) (*diff.StringStatistics, error) {
+	valueExpr := fmt.Sprintf("CONVERT(NVARCHAR(4000), %s)", columnName)
+	queryString := fmt.Sprintf(`
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG(%s) as null_count,
+    COUNT(DISTINCT %s) as distinct_count,
+    COUNT_BIG(CASE WHEN %s = N'' THEN 1 END) as empty_count,
+    MIN(LEN(%s)) as min_length,
+    MAX(LEN(%s)) as max_length,
+    AVG(CAST(LEN(%s) AS FLOAT)) as avg_length
+FROM %s`,
+		columnName, valueExpr, valueExpr, valueExpr, valueExpr, valueExpr, tableName)
+
+	result, err := db.Select(ctx, &query.Query{Query: queryString})
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &diff.StringStatistics{}
+	if len(result) == 0 || len(result[0]) < 7 {
+		return stats, nil
+	}
+
+	row := result[0]
+	if stats.Count, err = parseFabricInt64(row[0], "count"); err != nil {
+		return nil, err
+	}
+	if stats.NullCount, err = parseFabricInt64(row[1], "null count"); err != nil {
+		return nil, err
+	}
+	if stats.DistinctCount, err = parseFabricInt64(row[2], "distinct count"); err != nil {
+		return nil, err
+	}
+	if stats.EmptyCount, err = parseFabricInt64(row[3], "empty count"); err != nil {
+		return nil, err
+	}
+	if row[4] != nil {
+		minLength, err := parseFabricInt64(row[4], "min length")
+		if err != nil {
+			return nil, err
+		}
+		stats.MinLength = int(minLength)
+	}
+	if row[5] != nil {
+		maxLength, err := parseFabricInt64(row[5], "max length")
+		if err != nil {
+			return nil, err
+		}
+		stats.MaxLength = int(maxLength)
+	}
+	avgLength, err := parseFabricOptionalFloat64(row[6], "avg length")
+	if err != nil {
+		return nil, err
+	}
+	if avgLength != nil {
+		stats.AvgLength = *avgLength
+	}
+
+	return stats, nil
+}
+
+func (db *DB) fetchBooleanStats(ctx context.Context, tableName, columnName string) (*diff.BooleanStatistics, error) {
+	queryString := fmt.Sprintf(`
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG(%s) as null_count,
+    COUNT_BIG(CASE WHEN %s = 1 THEN 1 END) as true_count,
+    COUNT_BIG(CASE WHEN %s = 0 THEN 1 END) as false_count
+FROM %s`,
+		columnName, columnName, columnName, tableName)
+
+	result, err := db.Select(ctx, &query.Query{Query: queryString})
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &diff.BooleanStatistics{}
+	if len(result) == 0 || len(result[0]) < 4 {
+		return stats, nil
+	}
+
+	row := result[0]
+	if stats.Count, err = parseFabricInt64(row[0], "count"); err != nil {
+		return nil, err
+	}
+	if stats.NullCount, err = parseFabricInt64(row[1], "null count"); err != nil {
+		return nil, err
+	}
+	if stats.TrueCount, err = parseFabricInt64(row[2], "true count"); err != nil {
+		return nil, err
+	}
+	if stats.FalseCount, err = parseFabricInt64(row[3], "false count"); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func (db *DB) fetchDateTimeStats(ctx context.Context, tableName, columnName string) (*diff.DateTimeStatistics, error) {
+	queryString := fmt.Sprintf(`
+SELECT
+    COUNT_BIG(*) as count,
+    COUNT_BIG(*) - COUNT_BIG(%s) as null_count,
+    COUNT(DISTINCT %s) as unique_count,
+    CONVERT(VARCHAR(33), MIN(%s), 126) as earliest_date,
+    CONVERT(VARCHAR(33), MAX(%s), 126) as latest_date
+FROM %s`,
+		columnName, columnName, columnName, columnName, tableName)
+
+	result, err := db.Select(ctx, &query.Query{Query: queryString})
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &diff.DateTimeStatistics{}
+	if len(result) == 0 || len(result[0]) < 5 {
+		return stats, nil
+	}
+
+	row := result[0]
+	if stats.Count, err = parseFabricInt64(row[0], "count"); err != nil {
+		return nil, err
+	}
+	if stats.NullCount, err = parseFabricInt64(row[1], "null count"); err != nil {
+		return nil, err
+	}
+	if stats.UniqueCount, err = parseFabricInt64(row[2], "unique count"); err != nil {
+		return nil, err
+	}
+	if stats.EarliestDate, err = parseFabricOptionalTime(row[3], "earliest date"); err != nil {
+		return nil, err
+	}
+	if stats.LatestDate, err = parseFabricOptionalTime(row[4], "latest date"); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func parseFabricInt64(value interface{}, fieldName string) (int64, error) {
+	if n, ok := int64Value(value); ok {
+		return n, nil
+	}
+
+	switch v := value.(type) {
+	case float32:
+		return int64(v), nil
+	case float64:
+		return int64(v), nil
+	case nil:
+		return 0, fmt.Errorf("%s is NULL", fieldName)
+	default:
+		return 0, fmt.Errorf("unexpected %s type: got %T with value %v", fieldName, value, value)
+	}
+}
+
+func parseFabricOptionalFloat64(value interface{}, fieldName string) (*float64, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	var parsed float64
+	switch v := value.(type) {
+	case float32:
+		parsed = float64(v)
+	case float64:
+		parsed = v
+	case int:
+		parsed = float64(v)
+	case int8:
+		parsed = float64(v)
+	case int16:
+		parsed = float64(v)
+	case int32:
+		parsed = float64(v)
+	case int64:
+		parsed = float64(v)
+	case uint:
+		parsed = float64(v)
+	case uint8:
+		parsed = float64(v)
+	case uint16:
+		parsed = float64(v)
+	case uint32:
+		parsed = float64(v)
+	case uint64:
+		parsed = float64(v)
+	case []byte:
+		n, err := strconv.ParseFloat(string(v), 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s %q: %w", fieldName, string(v), err)
+		}
+		parsed = n
+	case string:
+		n, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s %q: %w", fieldName, v, err)
+		}
+		parsed = n
+	default:
+		return nil, fmt.Errorf("unexpected %s type: got %T with value %v", fieldName, value, value)
+	}
+
+	return &parsed, nil
+}
+
+func parseFabricOptionalTime(value interface{}, fieldName string) (*time.Time, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	parsed, err := diff.ParseDateTime(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", fieldName, err)
+	}
+
+	return parsed, nil
+}

--- a/pkg/fabric/diff.go
+++ b/pkg/fabric/diff.go
@@ -197,7 +197,7 @@ func (db *DB) fetchStringStats(ctx context.Context, tableName, columnName string
 SELECT
     COUNT_BIG(*) as count,
     COUNT_BIG(*) - COUNT_BIG(%s) as null_count,
-    COUNT(DISTINCT %s) as distinct_count,
+    COUNT_BIG(DISTINCT %s) as distinct_count,
     COUNT_BIG(CASE WHEN %s = N'' THEN 1 END) as empty_count,
     MIN(LEN(%s)) as min_length,
     MAX(LEN(%s)) as max_length,
@@ -295,7 +295,7 @@ func (db *DB) fetchDateTimeStats(ctx context.Context, tableName, columnName stri
 SELECT
     COUNT_BIG(*) as count,
     COUNT_BIG(*) - COUNT_BIG(%s) as null_count,
-    COUNT(DISTINCT %s) as unique_count,
+    COUNT_BIG(DISTINCT %s) as unique_count,
     CONVERT(VARCHAR(33), MIN(%s), 126) as earliest_date,
     CONVERT(VARCHAR(33), MAX(%s), 126) as latest_date
 FROM %s`,


### PR DESCRIPTION
Adds Fabric table summarization so data-diff can compare Fabric Warehouse tables. Includes T-SQL type and dialect handling, Fabric-compatible stats queries, datetime parsing coverage, and docs/help updates. Validated with make format and make test.