### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+
+
+## Risk
+
+- [ ] Security-relevant (auth, secrets, credentials, access control)
+- [ ] Data impact (customer/user data)
+- [ ] Breaking change
+- [ ] None of the above
+
+## Tests
+
+- [ ] `make build-no-duckdb`
+- [ ] `make format`
+- [ ] `make test`
+
+## Rollback
+
+Revert the merge commit.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,29 @@
-## Summary
+## What
+<!-- What does this PR change and why? Keep it concise. -->
 
+## Changes
+<!-- List the files/areas affected and what was done in each. -->
+-
 
+## How to test
+<!-- Steps a reviewer can follow to verify the change. -->
+1.
 
-## Risk
+## Risk & rollback
+- **Risk:** <!-- low / medium / high — and why -->
+- **Rollback:** Revert the merge commit. <!-- Note any extra steps if applicable. -->
 
-- [ ] Security-relevant (auth, secrets, credentials, access control)
-- [ ] Data impact (customer/user data)
-- [ ] Breaking change
-- [ ] None of the above
+## Checklist
+- [ ] Unit tests added or updated (`make test`)
+- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
+- [ ] Integration tests pass if affected (`make integration-test`)
+- [ ] No unrelated changes included
+- [ ] Tested locally
 
-## Tests
+## Security
+- [ ] No secrets, credentials, or PII in this change
+- [ ] No new dependencies with known vulnerabilities
+- [ ] Security implications considered (if applicable)
 
-- [ ] `make build-no-duckdb`
-- [ ] `make format`
-- [ ] `make test`
-
-## Rollback
-
-Revert the merge commit.
+## Related issues
+<!-- Link the issue(s) this PR closes, e.g. Closes #1234 -->


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md` to standardize PRs for SOC 2 change-management.

Sections: what/changes/how-to-test, a two-line risk & rollback note, a repo-specific test/lint checklist (`make test`, `make build-no-duckdb`, `make format`, `make integration-test`), a security review checklist, and related issues.