### PR TITLE
docs: mysql: correct cdc_mode to batch-only

### DIFF
--- a/docs/platforms/mysql.md
+++ b/docs/platforms/mysql.md
@@ -160,7 +160,7 @@ CDC is enabled by setting `cdc: "true"` on an ingestr asset with a MySQL source 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `cdc` | Yes | Set to `"true"` to enable CDC mode |
-| `cdc_mode` | No | `"stream"` for real-time streaming or `"batch"` for batch replication |
+| `cdc_mode` | No | Only `"batch"` (the default) is supported. MySQL binary-log CDC reads up to the current binlog position and exits; `"stream"` is rejected by ingestr |
 | `cdc_server_id` | No | Replication server identifier for MySQL binary-log CDC |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
 | `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |


### PR DESCRIPTION
## What

The MySQL CDC parameter table in `docs/platforms/mysql.md` documents `cdc_mode` as accepting `"stream"` for real-time streaming. It doesn't. This corrects the row to describe the only supported value, `"batch"`.

## Why

Bruin maps the `cdc_mode` asset parameter onto `?mode=` on the ingestr source URI (`pkg/ingestr/operator.go:297`). ingestr's MySQL CDC source rejects `mode=stream` outright:

```
MySQL CDC stream mode is not supported; use mode=batch
```

So an asset written against the current docs fails at run time instead of streaming. Of the CDC sources Bruin can target, only Postgres and MongoDB honour `mode=stream`; MySQL binary-log CDC reads up to the current binlog position and exits.

Postgres' table (`docs/platforms/postgres.md:201`) is accurate and is left alone.