### PR TITLE
Render ingestr URIs through the secrets backends

### DIFF
--- a/cmd/ingestr_uri.go
+++ b/cmd/ingestr_uri.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	path2 "path"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/git"
+	"github.com/bruin-data/bruin/pkg/ingestruri"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/urfave/cli/v3"
+)
+
+func IngestrURI() *cli.Command {
+	return &cli.Command{
+		Name:      "ingestr-uri",
+		Usage:     "resolve a connection name to an ingestr URI and write it to a file",
+		ArgsUsage: "[output file] [connection name]",
+		Description: "Resolves the connection name against the active secrets backend, or " +
+			"against .bruin.yml when no backend is selected, and writes the resulting ingestr " +
+			"URI to the output file as plaintext, with no trailing newline.\n\n" +
+			"The URI contains credentials in plaintext. The file is created with 0600 " +
+			"permissions and the command refuses to write to a path that already exists. " +
+			"Deleting the file once it has been read is the caller's responsibility.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "config-file",
+				Usage: "the path to the .bruin.yml file, ignored when a secrets backend is selected",
+			},
+			&cli.StringFlag{
+				Name:  "environment",
+				Usage: "the environment to use, ignored when a secrets backend is selected",
+			},
+			&cli.BoolFlag{
+				Name:  "cdc",
+				Usage: "rewrite the URI onto its change data capture scheme, e.g. 'postgres+cdc'",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			args := c.Args().Slice()
+			if len(args) != 2 {
+				printErrorJSON(errors.New("exactly one output file and one connection name are required"))
+				return cli.Exit("", 1)
+			}
+			outputPath, connectionName := args[0], args[1]
+
+			ctx, cm, err := ingestrURIConfig(ctx, c)
+			if err != nil {
+				printErrorJSON(err)
+				return cli.Exit("", 1)
+			}
+
+			manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
+			if len(errs) > 0 {
+				printErrorJSON(errors.Wrap(errs[0], "failed to create connection manager"))
+				return cli.Exit("", 1)
+			}
+
+			uri, err := ingestruri.ForConnection(ctx, manager, "", connectionName)
+			if err != nil {
+				printErrorJSON(err)
+				return cli.Exit("", 1)
+			}
+
+			uri = ingestruri.Normalize(uri)
+			if c.Bool("cdc") {
+				uri, err = ingestruri.CDC(uri)
+				if err != nil {
+					printErrorJSON(errors.Wrapf(err, "connection '%s'", connectionName))
+					return cli.Exit("", 1)
+				}
+			}
+
+			if err := writeSecretFile(outputPath, uri); err != nil {
+				printErrorJSON(err)
+				return cli.Exit("", 1)
+			}
+
+			return nil
+		},
+	}
+}
+
+// ingestrURIConfig loads .bruin.yml, which is only needed when connections are
+// read from it. A secrets backend supplies its own connections, so requiring a
+// config file there would break deployments that ship without one.
+func ingestrURIConfig(ctx context.Context, c *cli.Command) (context.Context, *config.Config, error) {
+	if secretsBackendFromContext(ctx) != "" {
+		return ctx, &config.Config{}, nil
+	}
+
+	configFilePath := c.String("config-file")
+	if configFilePath == "" {
+		repoRoot, err := git.FindRepoFromPath(".")
+		if err != nil {
+			return ctx, nil, errors.Wrap(err, "failed to find the git repository root")
+		}
+		configFilePath = path2.Join(repoRoot.Path, ".bruin.yml")
+	}
+
+	cm, err := config.LoadOrCreate(afero.NewOsFs(), configFilePath)
+	if err != nil {
+		return ctx, nil, errors.Wrap(err, "failed to load or create config")
+	}
+
+	environment := c.String("environment")
+	if environment == "" {
+		environment = cm.DefaultEnvironmentName
+	}
+	if err := cm.SelectEnvironment(environment); err != nil {
+		return ctx, nil, errors.Wrap(err, "failed to select the environment")
+	}
+
+	ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, configFilePath)
+	ctx = context.WithValue(ctx, config.EnvironmentNameContextKey, cm.SelectedEnvironmentName)
+
+	return ctx, cm, nil
+}
+
+// writeSecretFile writes uri to path, owner-readable only.
+//
+// O_EXCL rejects an existing path so that a pre-planted symlink cannot redirect
+// the credentials somewhere world-readable, and the mode is set at creation so
+// the file is never briefly readable by others.
+//
+// On Windows the mode only maps to the read-only bit; the file inherits the
+// directory ACL instead.
+func writeSecretFile(path string, uri string) error {
+	contents := []byte(uri)
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create the output file '%s'", path)
+	}
+
+	if _, err := file.Write(contents); err != nil {
+		file.Close()
+		os.Remove(path)
+		return errors.Wrapf(err, "failed to write the output file '%s'", path)
+	}
+
+	if err := file.Close(); err != nil {
+		os.Remove(path)
+		return errors.Wrapf(err, "failed to close the output file '%s'", path)
+	}
+
+	return nil
+}

--- a/cmd/ingestr_uri_test.go
+++ b/cmd/ingestr_uri_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteSecretFile(t *testing.T) {
+	t.Parallel()
+
+	const uri = "postgresql://u:p@h:5432/db"
+
+	t.Run("writes the bare uri with no trailing newline", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "uri.txt")
+		require.NoError(t, writeSecretFile(path, uri))
+
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, uri, string(contents))
+	})
+
+	t.Run("creates the file owner readable only", func(t *testing.T) {
+		t.Parallel()
+
+		if runtime.GOOS == "windows" {
+			t.Skip("unix permission bits do not map onto windows ACLs")
+		}
+
+		path := filepath.Join(t.TempDir(), "uri.txt")
+		require.NoError(t, writeSecretFile(path, uri))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+
+	t.Run("refuses to overwrite an existing path", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "uri.txt")
+		require.NoError(t, os.WriteFile(path, []byte("pre-existing"), 0o600))
+
+		err := writeSecretFile(path, uri)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create the output file")
+
+		// The original contents must survive, so nothing leaks into a file the
+		// caller did not create.
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "pre-existing", string(contents))
+	})
+
+	t.Run("does not leave a file behind when the directory is missing", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "missing", "uri.txt")
+
+		err := writeSecretFile(path, uri)
+		require.Error(t, err)
+		assert.NoFileExists(t, path)
+	})
+}

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -54,6 +54,7 @@ func Internal() *cli.Command {
 			ListVariants(),
 			AssetMetadata(),
 			IngestrSources(),
+			IngestrURI(),
 			LockAssetDependencies(),
 		},
 	}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -181,6 +181,16 @@ type ConnectionAndDetailsGetter interface {
 	ConnectionDetailsGetter
 }
 
+// ConnectionResolver is an optional counterpart to ConnectionGetter for
+// implementations that can explain why a lookup failed. GetConnection returns a
+// bare nil, which cannot distinguish "no such connection" from "the secrets
+// backend rejected our credentials".
+//
+// A nil connection with a nil error means the connection does not exist.
+type ConnectionResolver interface {
+	ResolveConnection(name string) (any, error)
+}
+
 func (c *Connections) ConnectionsSummaryList() map[string]string {
 	if c.typeNameMap == nil {
 		c.buildConnectionKeyMap()

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -13,6 +13,7 @@ import (
 	duck "github.com/bruin-data/bruin/pkg/duckdb"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/git"
+	"github.com/bruin-data/bruin/pkg/ingestruri"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/python"
@@ -167,10 +168,6 @@ type SeedOperator struct {
 	jinjaRenderer jinja.RendererInterface
 }
 
-type pipelineConnection interface {
-	GetIngestrURI() (string, error)
-}
-
 func NewBasicOperator(conn config.ConnectionGetter, j jinja.RendererInterface) (*BasicOperator, error) {
 	uvRunner := &python.UvPythonRunner{
 		UvInstaller: &python.UvChecker{},
@@ -212,26 +209,12 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		return errors.New("source connection not configured")
 	}
 
-	sourceConnection := o.conn.GetConnection(sourceConnectionName)
-	if sourceConnection == nil {
-		return config.NewConnectionNotFoundError(ctx, "source", sourceConnectionName)
-	}
-
-	sourceURI, err := sourceConnection.(pipelineConnection).GetIngestrURI()
+	sourceURI, err := ingestruri.ForConnection(ctx, o.conn, "source", sourceConnectionName)
 	if err != nil {
-		return fmt.Errorf("could not get the source uri: %w", err)
+		return err
 	}
 
-	if sourceURI == "" {
-		return errors.New("source uri is empty, which means the source connection is not configured correctly")
-	}
-
-	// Ensure the URI has the authority separator "//" after the scheme.
-	// Some source configs build URIs without a Host, causing Go's url.URL.String()
-	// to produce "scheme:?params" instead of "scheme://?params".
-	if parts := strings.SplitN(sourceURI, ":", 2); len(parts) == 2 && !strings.HasPrefix(parts[1], "//") {
-		sourceURI = parts[0] + "://" + parts[1]
-	}
+	sourceURI = ingestruri.Normalize(sourceURI)
 
 	// some connection types can be shared among sources, therefore inferring source URI from the connection type is not
 	// always feasible. In the case of GSheets, we have to reuse the same GCP credentials, but change the prefix with gsheets://
@@ -240,32 +223,14 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 	}
 
 	// Handle CDC mode - transform the source URI into ingestr's CDC scheme and auto-set merge strategy.
-	// Supported today: PostgreSQL (postgres+cdc), the MySQL family (mysql+cdc / mariadb+cdc),
-	// Vitess (vitess+cdc, VStream) and PlanetScale (ps_mysql+cdc, psdbconnect).
 	if cdcVal, _ := asset.Parameters.GetString("cdc"); cdcVal == "true" {
-		// url.Parse rejects schemes containing an underscore (PlanetScale's ps_mysql), so split
-		// the scheme off manually, parse the remainder under a placeholder, and restore the real
-		// scheme. This mirrors how ingestr parses its own MySQL-family URIs.
-		scheme, rest, found := strings.Cut(sourceURI, "://")
-		if !found {
-			return fmt.Errorf("source URI %q has no scheme, cannot enable CDC", sourceURI)
-		}
-		parsedURI, err := url.Parse("placeholder://" + rest)
+		parsedURI, err := ingestruri.Parse(sourceURI)
 		if err != nil {
-			return fmt.Errorf("failed to parse source URI for CDC: %w", err)
+			return fmt.Errorf("cannot enable CDC: %w", err)
 		}
-		parsedURI.Scheme = scheme
 
-		switch {
-		case strings.Contains(parsedURI.Scheme, "postgresql"):
-			parsedURI.Scheme = strings.ReplaceAll(parsedURI.Scheme, "postgresql", "postgres+cdc")
-		case strings.HasPrefix(parsedURI.Scheme, "mysql"), strings.HasPrefix(parsedURI.Scheme, "mariadb"),
-			strings.HasPrefix(parsedURI.Scheme, "vitess"), strings.HasPrefix(parsedURI.Scheme, "ps_mysql"):
-			// mysql+cdc / mariadb+cdc / vitess+cdc / ps_mysql+cdc are all valid CDC schemes.
-			if !strings.HasSuffix(parsedURI.Scheme, "+cdc") {
-				parsedURI.Scheme += "+cdc"
-			}
-		}
+		// An unsupported scheme is left alone here, and ingestr rejects it downstream.
+		parsedURI.Scheme, _ = ingestruri.CDCScheme(parsedURI.Scheme)
 
 		q := parsedURI.Query()
 		// PostgreSQL logical-replication parameters.
@@ -325,18 +290,9 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		return err
 	}
 
-	destConnection := o.conn.GetConnection(destConnectionName)
-	if destConnection == nil {
-		return config.NewConnectionNotFoundError(ctx, "destination", destConnectionName)
-	}
-
-	destURI, err := destConnection.(pipelineConnection).GetIngestrURI()
+	destURI, err := ingestruri.ForConnection(ctx, o.conn, "destination", destConnectionName)
 	if err != nil {
-		return errors.Wrap(err, "could not get the destination uri")
-	}
-
-	if destURI == "" {
-		return errors.New("destination uri is empty, which means the connection is not configured correctly")
+		return err
 	}
 
 	if strings.HasPrefix(destURI, "clickhouse://") {
@@ -651,17 +607,9 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		return err
 	}
 
-	destConnection := o.conn.GetConnection(destConnectionName)
-	if destConnection == nil {
-		return config.NewConnectionNotFoundError(ctx, "destination", destConnectionName)
-	}
-
-	destURI, err := destConnection.(pipelineConnection).GetIngestrURI()
+	destURI, err := ingestruri.ForConnection(ctx, o.conn, "destination", destConnectionName)
 	if err != nil {
-		return errors.Wrap(err, "could not get the destination uri")
-	}
-	if destURI == "" {
-		return errors.New("destination uri is empty, which means the destination connection is not configured correctly")
+		return err
 	}
 
 	destTable := o.resolveSeedDestinationTableName(destConnectionName, destURI, asset.Name)

--- a/pkg/ingestruri/uri.go
+++ b/pkg/ingestruri/uri.go
@@ -1,0 +1,141 @@
+// Package ingestruri resolves connection names into ingestr URIs.
+//
+// It lives outside pkg/ingestr because pkg/ingestr imports pkg/python, and
+// pkg/python needs this resolution too.
+package ingestruri
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/pkg/errors"
+)
+
+// Connection is implemented by every connection type that ingestr can talk to.
+type Connection interface {
+	GetIngestrURI() (string, error)
+}
+
+// ForConnection resolves name through conn and returns its ingestr URI.
+//
+// role describes the connection's part in the transfer ("source",
+// "destination") and is only used to build error messages. It may be empty.
+//
+// The returned URI is not normalized; call Normalize when the URI is handed to
+// ingestr as a source.
+func ForConnection(ctx context.Context, conn config.ConnectionGetter, role, name string) (string, error) {
+	prefix := ""
+	if role = strings.TrimSpace(role); role != "" {
+		prefix = role + " "
+	}
+
+	resolved, err := resolve(conn, name)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve %sconnection '%s'", prefix, name)
+	}
+
+	if resolved == nil {
+		return "", config.NewConnectionNotFoundError(ctx, role, name)
+	}
+
+	ingestrConn, ok := resolved.(Connection)
+	if !ok {
+		return "", errors.Errorf("%sconnection '%s' is not supported by ingestr", prefix, name)
+	}
+
+	uri, err := ingestrConn.GetIngestrURI()
+	if err != nil {
+		return "", errors.Wrapf(err, "could not get the %suri", prefix)
+	}
+
+	if uri == "" {
+		return "", errors.Errorf("%suri is empty, which means the %sconnection '%s' is not configured correctly", prefix, prefix, name)
+	}
+
+	return uri, nil
+}
+
+// resolve prefers ConnectionResolver so that a secrets backend can report why a
+// lookup failed. Plain ConnectionGetter implementations collapse every failure
+// into a nil connection.
+func resolve(conn config.ConnectionGetter, name string) (any, error) {
+	if resolver, ok := conn.(config.ConnectionResolver); ok {
+		return resolver.ResolveConnection(name)
+	}
+
+	return conn.GetConnection(name), nil
+}
+
+// Normalize ensures the URI carries the "//" authority separator after its
+// scheme. Some source configs build URIs without a Host, which makes Go's
+// url.URL.String() emit "scheme:?params" rather than "scheme://?params".
+func Normalize(uri string) string {
+	parts := strings.SplitN(uri, ":", 2)
+	if len(parts) != 2 || strings.HasPrefix(parts[1], "//") {
+		return uri
+	}
+
+	return parts[0] + "://" + parts[1]
+}
+
+// Parse parses an ingestr URI.
+//
+// url.Parse rejects schemes containing an underscore (PlanetScale's ps_mysql),
+// so the scheme is split off by hand, the remainder parsed under a placeholder,
+// and the real scheme restored. This mirrors how ingestr parses its own
+// MySQL-family URIs.
+func Parse(uri string) (*url.URL, error) {
+	scheme, rest, found := strings.Cut(uri, "://")
+	if !found {
+		return nil, errors.Errorf("uri %q has no scheme", uri)
+	}
+
+	parsed, err := url.Parse("placeholder://" + rest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse uri %q", uri)
+	}
+	parsed.Scheme = scheme
+
+	return parsed, nil
+}
+
+// CDCScheme maps scheme onto ingestr's change-data-capture scheme and reports
+// whether the scheme supports CDC at all.
+//
+// This is not a plain "+cdc" suffix: PostgreSQL's ingestr URI uses the
+// "postgresql" scheme but its CDC scheme is "postgres+cdc".
+//
+// Supported today: PostgreSQL, the MySQL family (mysql, mariadb), Vitess, and
+// PlanetScale (ps_mysql).
+func CDCScheme(scheme string) (string, bool) {
+	switch {
+	case strings.HasSuffix(scheme, "+cdc"):
+		return scheme, true
+	case strings.Contains(scheme, "postgresql"):
+		return strings.ReplaceAll(scheme, "postgresql", "postgres+cdc"), true
+	case strings.HasPrefix(scheme, "mysql"), strings.HasPrefix(scheme, "mariadb"),
+		strings.HasPrefix(scheme, "vitess"), strings.HasPrefix(scheme, "ps_mysql"):
+		return scheme + "+cdc", true
+	}
+
+	return scheme, false
+}
+
+// CDC rewrites uri onto its change-data-capture scheme, and fails when the
+// scheme has no CDC counterpart.
+func CDC(uri string) (string, error) {
+	parsed, err := Parse(uri)
+	if err != nil {
+		return "", errors.Wrap(err, "cannot enable cdc")
+	}
+
+	scheme, ok := CDCScheme(parsed.Scheme)
+	if !ok {
+		return "", errors.Errorf("scheme '%s' does not support change data capture", parsed.Scheme)
+	}
+	parsed.Scheme = scheme
+
+	return parsed.String(), nil
+}

--- a/pkg/ingestruri/uri_test.go
+++ b/pkg/ingestruri/uri_test.go
@@ -1,0 +1,287 @@
+package ingestruri
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConn implements Connection.
+type fakeConn struct {
+	uri string
+	err error
+}
+
+func (f fakeConn) GetIngestrURI() (string, error) { return f.uri, f.err }
+
+// unsupportedConn deliberately does not implement Connection, mirroring
+// config.GenericConnection.
+type unsupportedConn struct{}
+
+// getter implements config.ConnectionGetter only.
+type getter struct {
+	conns map[string]any
+}
+
+func (g getter) GetConnection(name string) any { return g.conns[name] }
+
+// resolver implements config.ConnectionResolver as the secrets backends do.
+type resolver struct {
+	getter
+	err error
+}
+
+func (r resolver) ResolveConnection(name string) (any, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.conns[name], nil
+}
+
+func TestForConnection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		conn     config.ConnectionGetter
+		role     string
+		connName string
+		want     string
+		wantErr  string
+	}{
+		{
+			name:     "returns the uri",
+			conn:     getter{conns: map[string]any{"pg": fakeConn{uri: "postgresql://u:p@h:5432/db"}}},
+			role:     "source",
+			connName: "pg",
+			want:     "postgresql://u:p@h:5432/db",
+		},
+		{
+			name:     "missing connection reports the role",
+			conn:     getter{conns: map[string]any{}},
+			role:     "destination",
+			connName: "nope",
+			wantErr:  "destination connection 'nope' not found",
+		},
+		{
+			name:     "missing connection without a role",
+			conn:     getter{conns: map[string]any{}},
+			connName: "nope",
+			wantErr:  "connection 'nope' not found",
+		},
+		{
+			name:     "connection that cannot speak ingestr errors rather than panicking",
+			conn:     getter{conns: map[string]any{"gen": unsupportedConn{}}},
+			role:     "source",
+			connName: "gen",
+			wantErr:  "source connection 'gen' is not supported by ingestr",
+		},
+		{
+			name:     "empty uri is rejected",
+			conn:     getter{conns: map[string]any{"pg": fakeConn{uri: ""}}},
+			role:     "source",
+			connName: "pg",
+			wantErr:  "source uri is empty",
+		},
+		{
+			name:     "GetIngestrURI failure is wrapped",
+			conn:     getter{conns: map[string]any{"pg": fakeConn{err: errors.New("boom")}}},
+			role:     "source",
+			connName: "pg",
+			wantErr:  "could not get the source uri: boom",
+		},
+		{
+			name: "resolver surfaces the backend error instead of not-found",
+			conn: resolver{
+				getter: getter{conns: map[string]any{}},
+				err:    errors.New("vault: permission denied"),
+			},
+			role:     "source",
+			connName: "pg",
+			wantErr:  "failed to resolve source connection 'pg': vault: permission denied",
+		},
+		{
+			name: "resolver returns the uri when it succeeds",
+			conn: resolver{
+				getter: getter{conns: map[string]any{"pg": fakeConn{uri: "postgresql://x"}}},
+			},
+			role:     "source",
+			connName: "pg",
+			want:     "postgresql://x",
+		},
+		{
+			name:     "resolver with no error and no connection is a not-found",
+			conn:     resolver{getter: getter{conns: map[string]any{}}},
+			role:     "source",
+			connName: "pg",
+			wantErr:  "source connection 'pg' not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ForConnection(context.Background(), tt.conn, tt.role, tt.connName)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestForConnection_NotFoundMentionsSecretsBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), config.SecretsBackendContextKey, "vault")
+
+	_, err := ForConnection(ctx, getter{conns: map[string]any{}}, "source", "pg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in secrets backend 'vault'")
+}
+
+func TestCDCScheme(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		scheme string
+		want   string
+		wantOK bool
+	}{
+		// postgres is a rename, not a suffix: the ingestr URI scheme is
+		// "postgresql" but its CDC scheme is "postgres+cdc".
+		{scheme: "postgresql", want: "postgres+cdc", wantOK: true},
+		{scheme: "mysql", want: "mysql+cdc", wantOK: true},
+		{scheme: "mysql+pymysql", want: "mysql+pymysql+cdc", wantOK: true},
+		{scheme: "mariadb", want: "mariadb+cdc", wantOK: true},
+		{scheme: "vitess", want: "vitess+cdc", wantOK: true},
+		{scheme: "ps_mysql", want: "ps_mysql+cdc", wantOK: true},
+
+		// already a cdc scheme
+		{scheme: "postgres+cdc", want: "postgres+cdc", wantOK: true},
+		{scheme: "mysql+cdc", want: "mysql+cdc", wantOK: true},
+
+		// no cdc counterpart
+		{scheme: "bigquery", want: "bigquery", wantOK: false},
+		{scheme: "duckdb", want: "duckdb", wantOK: false},
+		{scheme: "snowflake", want: "snowflake", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scheme, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := CDCScheme(tt.scheme)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+func TestCDCScheme_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	for _, scheme := range []string{"postgresql", "mysql", "mariadb", "vitess", "ps_mysql"} {
+		once, ok := CDCScheme(scheme)
+		require.True(t, ok)
+
+		twice, ok := CDCScheme(once)
+		require.True(t, ok)
+		assert.Equal(t, once, twice, "applying the cdc scheme twice must not double the suffix")
+	}
+}
+
+func TestCDC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "postgres",
+			uri:  "postgresql://u:p@h:5432/db",
+			want: "postgres+cdc://u:p@h:5432/db",
+		},
+		{
+			name: "preserves the query string",
+			uri:  "mysql://u:p@h:3306/db?ssl=true",
+			want: "mysql+cdc://u:p@h:3306/db?ssl=true",
+		},
+		{
+			// url.Parse rejects an underscore in the scheme, hence the manual split.
+			name: "planetscale scheme with an underscore",
+			uri:  "ps_mysql://u:p@aws.connect.psdb.cloud:3306/db",
+			want: "ps_mysql+cdc://u:p@aws.connect.psdb.cloud:3306/db",
+		},
+		{
+			name: "vitess keeps its grpc_port",
+			uri:  "vitess://u:p@vtgate.internal:15306/commerce?grpc_port=15991",
+			want: "vitess+cdc://u:p@vtgate.internal:15306/commerce?grpc_port=15991",
+		},
+		{
+			name:    "unsupported scheme is an error rather than a silent passthrough",
+			uri:     "bigquery://project/dataset",
+			wantErr: "scheme 'bigquery' does not support change data capture",
+		},
+		{
+			name:    "missing scheme",
+			uri:     "not-a-uri",
+			wantErr: "has no scheme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CDC(tt.uri)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{name: "adds the authority separator", uri: "gsheets:?key=value", want: "gsheets://?key=value"},
+		{name: "leaves a well formed uri alone", uri: "postgresql://u:p@h:5432/db", want: "postgresql://u:p@h:5432/db"},
+		{name: "leaves extra slashes alone", uri: "duckdb:////some/path", want: "duckdb:////some/path"},
+		{name: "leaves a schemeless string alone", uri: "not-a-uri", want: "not-a-uri"},
+		{name: "leaves an empty string alone", uri: "", want: ""},
+		{name: "is idempotent", uri: "gsheets://?key=value", want: "gsheets://?key=value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, Normalize(tt.uri))
+			assert.Equal(t, tt.want, Normalize(Normalize(tt.uri)))
+		})
+	}
+}

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -17,6 +17,7 @@ import (
 	duck "github.com/bruin-data/bruin/pkg/duckdb"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/git"
+	"github.com/bruin-data/bruin/pkg/ingestruri"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/uv"
 	"github.com/pkg/errors"
@@ -196,10 +197,6 @@ type UvChecker struct {
 
 type uvInstaller interface {
 	EnsureUvInstalled(ctx context.Context) (string, error)
-}
-
-type pipelineConnection interface {
-	GetIngestrURI() (string, error)
 }
 
 type UvPythonRunner struct {
@@ -479,23 +476,9 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		return err
 	}
 
-	destConnection := u.conn.GetConnection(destConnectionName)
-	if destConnection == nil {
-		return config.NewConnectionNotFoundError(ctx, "destination", destConnectionName)
-	}
-
-	destConnectionInst, ok := destConnection.(pipelineConnection)
-	if !ok {
-		return errors.Errorf("destination connection '%s' is not supported by ingestr", destConnectionName)
-	}
-
-	destURI, err := destConnectionInst.GetIngestrURI()
+	destURI, err := ingestruri.ForConnection(ctx, u.conn, "destination", destConnectionName)
 	if err != nil {
-		return errors.Wrap(err, "could not get the destination uri")
-	}
-
-	if destURI == "" {
-		return errors.New("destination uri is empty, which means the destination connection is not configured correctly")
+		return err
 	}
 
 	cmdArgs = append(cmdArgs, "--dest-uri", destURI)
@@ -505,7 +488,7 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 	extraPackages = AddExtraPackages(destURI, "", extraPackages)
 
 	if strings.HasPrefix(destURI, "duckdb://") {
-		if dbURIGetter, ok := destConnectionInst.(interface{ GetDBConnectionURI() string }); ok {
+		if dbURIGetter, ok := u.conn.GetConnection(destConnectionName).(interface{ GetDBConnectionURI() string }); ok {
 			duck.LockDatabase(dbURIGetter.GetDBConnectionURI())
 			defer duck.UnlockDatabase(dbURIGetter.GetDBConnectionURI())
 		}

--- a/pkg/secrets/aws_secretsmanager.go
+++ b/pkg/secrets/aws_secretsmanager.go
@@ -99,17 +99,27 @@ func newAWSSecretsManagerClientFromConfig(logger logger.Logger, cfg aws.Config) 
 
 // GetConnection retrieves a connection by name from AWS Secrets Manager.
 func (c *AWSSecretsManagerClient) GetConnection(name string) any {
+	conn, err := c.ResolveConnection(name)
+	if err != nil {
+		c.logger.Errorf("%v", err)
+		return nil
+	}
+
+	return conn
+}
+
+// ResolveConnection implements config.ConnectionResolver.
+func (c *AWSSecretsManagerClient) ResolveConnection(name string) (any, error) {
 	c.cacheMu.RLock()
 	if conn, ok := c.cacheConnections[name]; ok {
 		c.cacheMu.RUnlock()
-		return conn
+		return conn, nil
 	}
 	c.cacheMu.RUnlock()
 
 	manager, err := c.getAWSSecretsManager(name)
 	if err != nil {
-		c.logger.Errorf("%v", err)
-		return nil
+		return nil, err
 	}
 
 	conn := manager.GetConnection(name)
@@ -118,7 +128,7 @@ func (c *AWSSecretsManagerClient) GetConnection(name string) any {
 	c.cacheConnections[name] = conn
 	c.cacheMu.Unlock()
 
-	return conn
+	return conn, nil
 }
 
 // GetConnectionDetails retrieves connection details by name from AWS Secrets Manager.

--- a/pkg/secrets/azure_keyvault.go
+++ b/pkg/secrets/azure_keyvault.go
@@ -174,17 +174,27 @@ func newAzureKeyVaultClientWithCredential(logger logger.Logger, vaultURL string,
 
 // GetConnection retrieves a connection by name from Azure Key Vault.
 func (c *AzureKeyVaultClient) GetConnection(name string) any {
+	conn, err := c.ResolveConnection(name)
+	if err != nil {
+		c.logger.Errorf("%v", err)
+		return nil
+	}
+
+	return conn
+}
+
+// ResolveConnection implements config.ConnectionResolver.
+func (c *AzureKeyVaultClient) ResolveConnection(name string) (any, error) {
 	c.cacheMu.RLock()
 	if conn, ok := c.cacheConnections[name]; ok {
 		c.cacheMu.RUnlock()
-		return conn
+		return conn, nil
 	}
 	c.cacheMu.RUnlock()
 
 	manager, err := c.getAzureKeyVaultManager(name)
 	if err != nil {
-		c.logger.Errorf("%v", err)
-		return nil
+		return nil, err
 	}
 
 	conn := manager.GetConnection(name)
@@ -193,7 +203,7 @@ func (c *AzureKeyVaultClient) GetConnection(name string) any {
 	c.cacheConnections[name] = conn
 	c.cacheMu.Unlock()
 
-	return conn
+	return conn, nil
 }
 
 // GetConnectionDetails retrieves connection details by name from Azure Key Vault.

--- a/pkg/secrets/doppler.go
+++ b/pkg/secrets/doppler.go
@@ -130,20 +130,30 @@ func NewDopplerClient(logger logger.Logger, token, project, config string) (*Dop
 
 // GetConnection retrieves a connection by name from Doppler.
 func (c *DopplerClient) GetConnection(name string) any {
-	if conn, ok := c.cacheConnections[name]; ok {
-		return conn
-	}
-
-	manager, err := c.getDopplerManager(name)
+	conn, err := c.ResolveConnection(name)
 	if err != nil {
 		c.logger.Errorf("%v", err)
 		return nil
 	}
 
+	return conn
+}
+
+// ResolveConnection implements config.ConnectionResolver.
+func (c *DopplerClient) ResolveConnection(name string) (any, error) {
+	if conn, ok := c.cacheConnections[name]; ok {
+		return conn, nil
+	}
+
+	manager, err := c.getDopplerManager(name)
+	if err != nil {
+		return nil, err
+	}
+
 	conn := manager.GetConnection(name)
 	c.cacheConnections[name] = conn
 
-	return conn
+	return conn, nil
 }
 
 // GetConnectionDetails retrieves connection details by name from Doppler.

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,18 @@
+package secrets
+
+import "github.com/bruin-data/bruin/pkg/config"
+
+// Every backend resolves a connection by name and can say why a lookup failed.
+// GetConnection collapses that failure into a nil, so callers that need the
+// reason reach for ResolveConnection instead.
+var (
+	_ config.ConnectionAndDetailsGetter = (*Client)(nil)
+	_ config.ConnectionAndDetailsGetter = (*DopplerClient)(nil)
+	_ config.ConnectionAndDetailsGetter = (*AWSSecretsManagerClient)(nil)
+	_ config.ConnectionAndDetailsGetter = (*AzureKeyVaultClient)(nil)
+
+	_ config.ConnectionResolver = (*Client)(nil)
+	_ config.ConnectionResolver = (*DopplerClient)(nil)
+	_ config.ConnectionResolver = (*AWSSecretsManagerClient)(nil)
+	_ config.ConnectionResolver = (*AzureKeyVaultClient)(nil)
+)

--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -133,20 +133,30 @@ func newVaultClientWithKubernetesAuth(host, role, mountPath, kubernetesAuthMount
 }
 
 func (c *Client) GetConnection(name string) any {
-	if conn, ok := c.cacheConnections[name]; ok {
-		return conn
-	}
-
-	manager, err := c.getVaultManager(name)
+	conn, err := c.ResolveConnection(name)
 	if err != nil {
 		c.logger.Errorf("%v", err)
 		return nil
 	}
 
+	return conn
+}
+
+// ResolveConnection implements config.ConnectionResolver.
+func (c *Client) ResolveConnection(name string) (any, error) {
+	if conn, ok := c.cacheConnections[name]; ok {
+		return conn, nil
+	}
+
+	manager, err := c.getVaultManager(name)
+	if err != nil {
+		return nil, err
+	}
+
 	conn := manager.GetConnection(name)
 	c.cacheConnections[name] = conn
 
-	return conn
+	return conn, nil
 }
 
 func (c *Client) GetConnectionDetails(name string) any {


### PR DESCRIPTION
Callers that spawn a standalone ingestr process only have a connection name, but need a URI. This adds a hidden `bruin internal ingestr-uri` command that resolves one against whichever connection source the global `--secrets-backend` flag selects.

```
BRUIN_SECRETS_BACKEND=vault bruin internal ingestr-uri /tmp/src.uri my-pg-source --cdc
```

writes `postgres+cdc://u:p@h:5432/db` to `/tmp/src.uri`.

No backend-specific code was needed. `connectionManagerFromConfig` already returns a `config.ConnectionAndDetailsGetter` for `.bruin.yml`, Vault, Doppler, AWS Secrets Manager, and Azure Key Vault alike, and every backend hands back the same concrete typed connection struct. The command composes that with the existing `GetIngestrURI()`.

### Output goes to a file, not stdout

The logger writes to stdout, so a backend failure would interleave its log line with the URI. The URI also embeds credentials, so the file is opened `O_EXCL` with mode `0600`: `O_EXCL` stops a pre-planted symlink from redirecting the credentials somewhere readable, and setting the mode at creation means the file is never briefly world-readable. On Windows the mode only maps to the read-only bit. Removing the file after reading it is the caller's job.

`.bruin.yml` is only loaded when no secrets backend is selected — a backend supplies its own connections, and requiring a config file would break deployments that ship without one.

### Supporting changes

**`pkg/ingestruri` (new).** Resolving a name into a URI was open-coded in four places, three of which type-asserted without checking — a connection type lacking `GetIngestrURI`, such as `config.GenericConnection`, panicked rather than erroring. The package cannot live in `pkg/ingestr`, which imports `pkg/python`, because `pkg/python` needs it too; it depends only on `pkg/config`.

The CDC scheme rewrite moves there as well, so the pipeline path and the new command cannot drift. It is not a plain `+cdc` suffix: postgres uses the `postgresql` scheme but its CDC scheme is `postgres+cdc`, and only the postgres, mysql, mariadb, vitess and ps_mysql families have a CDC counterpart. `--cdc` on a scheme without one is an error, unlike the operator, which leaves it alone and lets ingestr reject it downstream.

**`config.ConnectionResolver` (new, optional).** `GetConnection` returns a bare `any`, so a backend that cannot reach Vault logs the error and returns nil. Callers then report "connection not found" for what was really an auth failure. Backends now also implement `ResolveConnection(name) (any, error)`; `GetConnection` delegates to it and preserves the old behaviour, so no existing caller changes.

Behaviour is otherwise unchanged. The unchecked type assertions become errors.