### PR TITLE
Bump default ingestr version to 1.0.73

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.71"
+	IngestrVersionV1 = "1.0.73"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
Bumps `IngestrVersionV1` from `1.0.71` to `1.0.73`, the latest ingestr release on PyPI, so ingestr assets pick up the newest version by default.

The legacy `IngestrVersionV0` pin (`0.14.155`) is unchanged.