### PR TITLE
feat(ingestr): add Amplitude source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -276,6 +276,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                 items: [
                                     {text: "Adjust", link: "/ingestion/adjust"},
                                     {text: "Airtable", link: "/ingestion/airtable"},
+                                    {text: "Amplitude", link: "/ingestion/amplitude"},
                                     {text: "Anthropic", link: "/ingestion/anthropic"},
                                     {text: "Allium", link: "/ingestion/allium"},
                                     {text: "API-Football", link: "/ingestion/api-football"},

--- a/docs/ingestion/amplitude.md
+++ b/docs/ingestion/amplitude.md
@@ -1,0 +1,69 @@
+# Amplitude
+
+[Amplitude](https://amplitude.com/) is a product analytics platform used to track and analyze user behavior across web and mobile applications.
+
+Bruin supports Amplitude as a source for [Ingestr assets](/assets/ingestr). You can ingest data from Amplitude into your data platform.
+
+To set up an Amplitude connection, add a configuration item in the `.bruin.yml` file and in your asset file. You authenticate with your project's `api_key` and `secret_key`. Optionally you can set `region` (defaults to `us`).
+
+Follow these steps to set up Amplitude and run ingestion.
+
+## Configuration
+
+### Step 1: Add a connection to the .bruin.yml file
+
+```yaml
+connections:
+  amplitude:
+    - name: "amplitude"
+      api_key: "your-api-key"
+      secret_key: "your-secret-key"
+      region: "us"
+```
+
+- `api_key`: (Required) Amplitude project API key.
+- `secret_key`: (Required) Amplitude project secret key.
+- `region`: (Optional) Data residency region (`us` or `eu`). Defaults to `us`.
+
+### Step 2: Create an asset file for data ingestion
+
+Create an [asset configuration](/assets/ingestr#asset-structure) file (e.g., `amplitude_ingestion.yml`) inside the assets folder with the following content:
+
+```yaml
+name: public.amplitude
+type: ingestr
+
+parameters:
+  source_connection: amplitude
+  source_table: 'events'
+
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Always `ingestr` for Amplitude.
+- `source_connection`: The Amplitude connection name defined in `.bruin.yml`.
+- `source_table`: Name of the Amplitude table to ingest.
+- `destination`: The destination connection name.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| events | uuid | event_time | merge | Raw event data, ingested incrementally. |
+| cohorts | id | | replace | Behavioral cohorts. |
+| annotations | id | | replace | Chart annotations. |
+| event_types | event_type | | replace | Event type definitions. |
+| event_categories | id | | replace | Event categories. |
+| event_properties | event_property | | replace | Event property definitions. |
+| user_properties | user_property | | replace | User property definitions. |
+
+The `events` table is loaded incrementally (merge on `uuid` using `event_time`). All other tables are fully refreshed on each run (replace).
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/amplitude_ingestion.yml
+```
+
+Running this command ingests data from Amplitude into your Postgres database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -132,6 +132,30 @@
         "api_key"
       ]
     },
+    "AmplitudeConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "api_key": {
+          "type": "string"
+        },
+        "secret_key": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
     "AnthropicConnection": {
       "properties": {
         "name": {
@@ -1203,6 +1227,12 @@
         "mixpanel": {
           "items": {
             "$ref": "#/$defs/MixpanelConnection"
+          },
+          "type": "array"
+        },
+        "amplitude": {
+          "items": {
+            "$ref": "#/$defs/AmplitudeConnection"
           },
           "type": "array"
         },

--- a/pkg/amplitude/client.go
+++ b/pkg/amplitude/client.go
@@ -1,0 +1,13 @@
+package amplitude
+
+type Client struct {
+	config Config
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{c}, nil
+}

--- a/pkg/amplitude/config.go
+++ b/pkg/amplitude/config.go
@@ -1,0 +1,45 @@
+package amplitude
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Config describes credentials for Amplitude connection.
+type Config struct {
+	APIKey    string `yaml:"api_key" json:"api_key" mapstructure:"api_key"`
+	SecretKey string `yaml:"secret_key" json:"secret_key" mapstructure:"secret_key"`
+	Region    string `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
+}
+
+type requiredField struct {
+	key   string
+	value string
+}
+
+// GetIngestrURI builds the Amplitude ingestr URI.
+func (c *Config) GetIngestrURI() (string, error) {
+	params := url.Values{}
+
+	requiredFields := []requiredField{
+		{"api_key", c.APIKey},
+		{"secret_key", c.SecretKey},
+	}
+
+	for _, field := range requiredFields {
+		field.value = strings.TrimSpace(field.value)
+		if field.value == "" {
+			return "", fmt.Errorf("amplitude: %s must be provided", field.key)
+		}
+		params.Set(field.key, field.value)
+	}
+
+	region := strings.TrimSpace(c.Region)
+	if region == "" {
+		region = "us"
+	}
+	params.Set("region", region)
+
+	return "amplitude://?" + params.Encode(), nil
+}

--- a/pkg/amplitude/config_test.go
+++ b/pkg/amplitude/config_test.go
@@ -1,0 +1,64 @@
+package amplitude
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "all fields set",
+			config: Config{APIKey: "key", SecretKey: "secret", Region: "eu"},
+			want:   "amplitude://?api_key=key&region=eu&secret_key=secret",
+		},
+		{
+			name:   "region defaults to us",
+			config: Config{APIKey: "key", SecretKey: "secret"},
+			want:   "amplitude://?api_key=key&region=us&secret_key=secret",
+		},
+		{
+			name:    "missing api_key",
+			config:  Config{SecretKey: "secret"},
+			wantErr: true,
+		},
+		{
+			name:    "missing secret_key",
+			config:  Config{APIKey: "key"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.config.GetIngestrURI()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{APIKey: "key", SecretKey: "secret"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "amplitude://?api_key=key&region=us&secret_key=secret", uri)
+}

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1331,6 +1331,17 @@ func (c MixpanelConnection) GetName() string {
 	return c.Name
 }
 
+type AmplitudeConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	APIKey             string `yaml:"api_key,omitempty" json:"api_key,omitempty" mapstructure:"api_key" sensitive:"true"`
+	SecretKey          string `yaml:"secret_key,omitempty" json:"secret_key,omitempty" mapstructure:"secret_key" sensitive:"true"`
+	Region             string `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
+}
+
+func (c AmplitudeConnection) GetName() string {
+	return c.Name
+}
+
 type ClickupConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	APIToken           string `yaml:"api_token,omitempty" json:"api_token" mapstructure:"api_token" sensitive:"true"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -106,6 +106,7 @@ type Connections struct {
 	Pipedrive           []PipedriveConnection           `yaml:"pipedrive,omitempty" json:"pipedrive,omitempty" mapstructure:"pipedrive"`
 	Polymarket          []PolymarketConnection          `yaml:"polymarket,omitempty" json:"polymarket,omitempty" mapstructure:"polymarket"`
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
+	Amplitude           []AmplitudeConnection           `yaml:"amplitude,omitempty" json:"amplitude,omitempty" mapstructure:"amplitude"`
 	Clickup             []ClickupConnection             `yaml:"clickup,omitempty" json:"clickup,omitempty" mapstructure:"clickup"`
 	Jobtread            []JobtreadConnection            `yaml:"jobtread,omitempty" json:"jobtread,omitempty" mapstructure:"jobtread"`
 	Posthog             []PosthogConnection             `yaml:"posthog,omitempty" json:"posthog,omitempty" mapstructure:"posthog"`
@@ -1359,6 +1360,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Mixpanel = append(env.Connections.Mixpanel, conn)
+	case "amplitude":
+		var conn AmplitudeConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Amplitude = append(env.Connections.Amplitude, conn)
 	case "wise":
 		var conn WiseConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1973,6 +1981,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Manifold = removeConnection(env.Connections.Manifold, connectionName)
 	case "mixpanel":
 		env.Connections.Mixpanel = removeConnection(env.Connections.Mixpanel, connectionName)
+	case "amplitude":
+		env.Connections.Amplitude = removeConnection(env.Connections.Amplitude, connectionName)
 	case "pinterest":
 		env.Connections.Pinterest = removeConnection(env.Connections.Pinterest, connectionName)
 	case "trino":
@@ -2260,6 +2270,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Pipedrive, source.Pipedrive)
 	mergeConnectionList(&c.Polymarket, source.Polymarket)
 	mergeConnectionList(&c.Mixpanel, source.Mixpanel)
+	mergeConnectionList(&c.Amplitude, source.Amplitude)
 	mergeConnectionList(&c.Clickup, source.Clickup)
 	mergeConnectionList(&c.Jobtread, source.Jobtread)
 	mergeConnectionList(&c.Posthog, source.Posthog)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -621,6 +621,14 @@ func TestLoadFromFile(t *testing.T) {
 					Server:             "eu",
 				},
 			},
+			Amplitude: []AmplitudeConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "amplitude-1"},
+					APIKey:             "api-key-123",
+					SecretKey:          "secret-key-123",
+					Region:             "us",
+				},
+			},
 			Wise: []WiseConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "wise-1"},
@@ -2666,6 +2674,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Pipedrive:           []PipedriveConnection{{ConnectionMetadata: ConnectionMetadata{Name: "pipedrive1"}}},
 				Polymarket:          []PolymarketConnection{{ConnectionMetadata: ConnectionMetadata{Name: "polymarket1"}}},
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
+				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
 				Posthog:             []PosthogConnection{{ConnectionMetadata: ConnectionMetadata{Name: "posthog1"}}},
@@ -2800,6 +2809,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Pipedrive:           []PipedriveConnection{{ConnectionMetadata: ConnectionMetadata{Name: "pipedrive1"}}},
 				Polymarket:          []PolymarketConnection{{ConnectionMetadata: ConnectionMetadata{Name: "polymarket1"}}},
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
+				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
 				Posthog:             []PosthogConnection{{ConnectionMetadata: ConnectionMetadata{Name: "posthog1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -379,6 +379,11 @@ environments:
           password: "secret-123"
           project_id: "12345"
           server: "eu"
+      amplitude:
+        - name: "amplitude-1"
+          api_key: "api-key-123"
+          secret_key: "secret-key-123"
+          region: "us"
       wise:
         - name: "wise-1"
           api_key: "token-123"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -381,6 +381,11 @@ environments:
           password: "secret-123"
           project_id: "12345"
           server: "eu"
+      amplitude:
+        - name: "amplitude-1"
+          api_key: "api-key-123"
+          secret_key: "secret-key-123"
+          region: "us"
       wise:
         - name: "wise-1"
           api_key: "token-123"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/adls"
 	"github.com/bruin-data/bruin/pkg/airtable"
 	"github.com/bruin-data/bruin/pkg/allium"
+	"github.com/bruin-data/bruin/pkg/amplitude"
 	"github.com/bruin-data/bruin/pkg/anthropic"
 	"github.com/bruin-data/bruin/pkg/apifootball"
 	"github.com/bruin-data/bruin/pkg/appleads"
@@ -229,6 +230,7 @@ type Manager struct {
 	Pipedrive            map[string]*pipedrive.Client
 	Polymarket           map[string]*polymarket.Client
 	Mixpanel             map[string]*mixpanel.Client
+	Amplitude            map[string]*amplitude.Client
 	Clickup              map[string]*clickup.Client
 	Jobtread             map[string]*jobtread.Client
 	Posthog              map[string]*posthog.Client
@@ -2876,6 +2878,29 @@ func (m *Manager) AddMixpanelConnectionFromConfig(connection *config.MixpanelCon
 	return nil
 }
 
+func (m *Manager) AddAmplitudeConnectionFromConfig(connection *config.AmplitudeConnection) error {
+	m.mutex.Lock()
+	if m.Amplitude == nil {
+		m.Amplitude = make(map[string]*amplitude.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := amplitude.NewClient(amplitude.Config{
+		APIKey:    connection.APIKey,
+		SecretKey: connection.SecretKey,
+		Region:    connection.Region,
+	})
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Amplitude[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddGoogleAnalyticsConnectionFromConfig(connection *config.GoogleAnalyticsConnection) error {
 	m.mutex.Lock()
 	if m.GoogleAnalytics == nil {
@@ -3988,6 +4013,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Jobtread, connectionManager.AddJobtreadConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Posthog, connectionManager.AddPosthogConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Mixpanel, connectionManager.AddMixpanelConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Amplitude, connectionManager.AddAmplitudeConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Pinterest, connectionManager.AddPinterestConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Trustpilot, connectionManager.AddTrustpilotConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.QuickBooks, connectionManager.AddQuickBooksConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -663,6 +663,17 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "boost_history", PrimaryKey: "id", IncKey: "createdTime", IncStrategy: "merge"},
 	},
 
+	// Amplitude - Analytics
+	"amplitude": {
+		{Name: "events", PrimaryKey: "uuid", IncKey: "event_time", IncStrategy: "merge"},
+		{Name: "cohorts", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "annotations", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "event_types", PrimaryKey: "event_type", IncKey: "", IncStrategy: "replace"},
+		{Name: "event_categories", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "event_properties", PrimaryKey: "event_property", IncKey: "", IncStrategy: "replace"},
+		{Name: "user_properties", PrimaryKey: "user_property", IncKey: "", IncStrategy: "replace"},
+	},
+
 	// Mixpanel - Analytics
 	"mixpanel": {
 		{Name: "events", PrimaryKey: "distinct_id", IncKey: "time", IncStrategy: "merge"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -261,6 +261,7 @@ var defaultMapping = map[string]string{
 	"kinesis":               "kinesis-default",
 	"linear":                "linear-default",
 	"linkedinads":           "linkedinads-default",
+	"amplitude":             "amplitude-default",
 	"mailchimp":             "mailchimp-default",
 	"manifold":              "manifold-default",
 	"mixpanel":              "mixpanel-default",


### PR DESCRIPTION
Wire the Amplitude ingestr source (amplitude://) with api_key, secret_key, and optional region params across config, connection manager, source-table registry, docs, testdata, and regenerated connection schema expectations.