### PR TITLE
Support sized string types for ingestr column overrides

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -227,3 +227,21 @@ columns:
 ```
 
 When `enforce_schema: true` is set, Bruin passes the column type hints to Ingestr via the `--columns` flag, ensuring the destination table schema matches your definition.
+
+#### Sized string types
+
+You can give a string column an optional length to create a bounded column instead of an unbounded one. Set the length inline in the `type` or with the `length` field (requires `enforce_schema: true`):
+
+```yaml
+parameters:
+  enforce_schema: "true"
+
+columns:
+  - name: name
+    type: varchar(100)
+  - name: email
+    type: string
+    length: 255
+```
+
+If you set both, the inline length wins. A string type without a length creates an unbounded column.

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -3,6 +3,7 @@ package python
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -216,6 +217,12 @@ var TypeHintMapping = map[string]string{
 
 var multipleSpacePattern = regexp.MustCompile(`\s+`)
 
+// ingestrSizedTypes are the ingestr types that accept a single length parameter, e.g.
+// text(50). Add an entry if a source type starts mapping to another sized type.
+var ingestrSizedTypes = map[string]bool{
+	"text": true,
+}
+
 // ColumnHints returns an ingestr compatible type hint string
 // that can be passed via the --column flag to the CLI.
 func ColumnHints(cols []pipeline.Column, normaliseNames bool) string {
@@ -224,8 +231,28 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool) string {
 		typ := NormaliseColumnType(col.Type)
 		hint, typeKnown := TypeHintMapping[typ]
 
+		// Resolve the base type of a sized type like "varchar(100)" and re-apply the
+		// length, but only when that type accepts one.
+		inlineLength := ""
+		if !typeKnown {
+			if base, inner, ok := splitParenType(typ); ok {
+				if mapped, found := TypeHintMapping[base]; found && ingestrSizedTypes[mapped] {
+					hint, typeKnown = mapped, true
+					inlineLength = inner
+				}
+			}
+		}
+
 		if !typeKnown && col.SourceColumn == "" {
 			continue
+		}
+
+		// Append a length to sized types; an inline length takes precedence over the
+		// length field, and a non-numeric size is treated as unbounded.
+		if typeKnown && ingestrSizedTypes[hint] {
+			if length := sizedStringLength(inlineLength, col.Length); length != "" {
+				hint = fmt.Sprintf("%s(%s)", hint, length)
+			}
 		}
 
 		name := col.Name
@@ -243,6 +270,33 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool) string {
 		}
 	}
 	return strings.Join(hints, ",")
+}
+
+// splitParenType splits a type such as "varchar(100)" into base ("varchar") and inner
+// ("100"), returning ok=false when there is no trailing parenthesised section.
+func splitParenType(typ string) (base, inner string, ok bool) {
+	open := strings.IndexByte(typ, '(')
+	if open <= 0 || !strings.HasSuffix(typ, ")") {
+		return "", "", false
+	}
+	base = strings.TrimSpace(typ[:open])
+	inner = strings.TrimSpace(typ[open+1 : len(typ)-1])
+	return base, inner, true
+}
+
+// sizedStringLength resolves the length for a sized string type, preferring an inline
+// length over the length field; only positive integers yield a bounded column.
+func sizedStringLength(inlineLength string, lengthField *int) string {
+	if inlineLength != "" {
+		if n, err := strconv.Atoi(inlineLength); err == nil && n > 0 {
+			return strconv.Itoa(n)
+		}
+		return ""
+	}
+	if lengthField != nil && *lengthField > 0 {
+		return strconv.Itoa(*lengthField)
+	}
+	return ""
 }
 
 func NormaliseColumnType(typ string) string {

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -1,6 +1,7 @@
 package python
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -229,6 +230,8 @@ func TestConsolidatedParameters_ColumnMasks(t *testing.T) {
 	}
 }
 
+func intPtr(i int) *int { return &i }
+
 func TestColumnHints(t *testing.T) {
 	t.Parallel()
 
@@ -347,6 +350,75 @@ func TestColumnHints(t *testing.T) {
 			normalizeNames: false,
 			expected:       "span:interval,huge:decimal",
 		},
+		{
+			name: "inline sized string aliases become text(n)",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "string(50)"},
+				{Name: "b", Type: "varchar(100)"},
+				{Name: "c", Type: "nvarchar(50)"},
+				{Name: "d", Type: "text(255)"},
+				{Name: "e", Type: "longtext(20)"},
+			},
+			normalizeNames: false,
+			expected:       "a:text(50),b:text(100),c:text(50),d:text(255),e:text(20)",
+		},
+		{
+			name: "length field sizes string types",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "varchar", Length: intPtr(100)},
+				{Name: "b", Type: "nvarchar", Length: intPtr(50)},
+				{Name: "c", Type: "text", Length: intPtr(255)},
+			},
+			normalizeNames: false,
+			expected:       "a:text(100),b:text(50),c:text(255)",
+		},
+		{
+			name: "inline length takes precedence over length field",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "varchar(100)", Length: intPtr(50)},
+			},
+			normalizeNames: false,
+			expected:       "a:text(100)",
+		},
+		{
+			name: "unbounded and non-positive lengths stay unbounded text",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "varchar"},
+				{Name: "b", Type: "varchar(max)"},
+				{Name: "c", Type: "varchar", Length: intPtr(0)},
+			},
+			normalizeNames: false,
+			expected:       "a:text,b:text,c:text",
+		},
+		{
+			name: "non-string sized types are unaffected",
+			columns: []pipeline.Column{
+				{Name: "kept", Type: "int"},
+				{Name: "dropped_int", Type: "int(11)"},
+				{Name: "dropped_dec", Type: "decimal(10,2)"},
+			},
+			normalizeNames: false,
+			expected:       "kept:int",
+		},
+		{
+			name: "sized string with source_column emits dest:text(n):source",
+			columns: []pipeline.Column{
+				{Name: "email", SourceColumn: "eml", Type: "varchar(255)"},
+			},
+			normalizeNames: false,
+			expected:       "email:text(255):eml",
+		},
+		{
+			name: "nvarchar maps to text and honors length",
+			columns: []pipeline.Column{
+				{Name: "bare", Type: "nvarchar"},
+				{Name: "inline", Type: "nvarchar(100)"},
+				{Name: "field", Type: "nvarchar", Length: intPtr(50)},
+				{Name: "renamed", SourceColumn: "src", Type: "nvarchar(255)"},
+			},
+			normalizeNames: false,
+			expected:       "bare:text,inline:text(100),field:text(50),renamed:text(255):src",
+		},
 	}
 
 	for _, tt := range tests {
@@ -354,6 +426,32 @@ func TestColumnHints(t *testing.T) {
 			t.Parallel()
 			result := ColumnHints(tt.columns, tt.normalizeNames)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestColumnHints_SizedTypes guards that every alias mapping to a sized ingestr type
+// accepts a length, both via an inline length and via the length field.
+func TestColumnHints_SizedTypes(t *testing.T) {
+	t.Parallel()
+
+	sized := make(map[string]string) // source alias -> expected hint
+	for typ, hint := range TypeHintMapping {
+		if ingestrSizedTypes[hint] {
+			sized[typ] = hint
+		}
+	}
+	require.NotEmpty(t, sized)
+
+	for typ, hint := range sized {
+		want := fmt.Sprintf("c:%s(50)", hint)
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
+			inline := ColumnHints([]pipeline.Column{{Name: "c", Type: typ + "(50)"}}, false)
+			assert.Equal(t, want, inline, "inline length for %q", typ)
+
+			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Length: intPtr(50)}}, false)
+			assert.Equal(t, want, field, "length field for %q", typ)
 		})
 	}
 }


### PR DESCRIPTION
## What

Ingestr column overrides now forward an optional **length** on string types, so users can create bounded columns (e.g. `varchar(50)`) instead of unbounded `text`.

## How to use

The length can be given inline in the `type` or via the `length` field (requires `enforce_schema: true`):

```yaml
parameters:
  enforce_schema: "true"
columns:
  - name: name
    type: varchar(100)   # inline
  - name: email
    type: string
    length: 255          # length field
```

- If both are set, the inline length wins.
- A string type without a length creates an unbounded column.
- Applies to every string alias that normalises to ingestr's `text` type; non-string types are unaffected.