### PR TITLE
[codex] audit ingestr documentation

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -55,15 +55,15 @@ parameters:
   source: string # optional, used when inferring the source from connection is not enough, e.g. GCP connection + GSheets source
   source_connection: string
   source_table: string
-  destination: string # logical destination type, e.g. bigquery, snowflake, duckdb, postgres
+  destination: string # logical destination type; required unless connection or destination_connection is set
   destination_connection: string # optional, used instead of destination default connection when connection is not set
   
   # optional
-  version: v0 | v1 | v1.x.y
+  version: v0 | v1 | vMAJOR.MINOR.PATCH
   incremental_strategy: replace | append | merge | delete+insert | truncate+insert # legacy alternative to materialization.strategy
   incremental_key: string # legacy alternative to materialization.incremental_key
   schema_contract: evolve | freeze | discard_row | discard_value
-  schema_naming: default | direct | snake_case
+  schema_naming: auto | default | direct | snake_case
   sql_backend: pyarrow | sqlalchemy
   page_size: integer
   loader_file_format: jsonl | csv | parquet
@@ -102,9 +102,9 @@ parameters:
 | `source` | No | _n/a_ | Overrides the inferred source type. For example, set `gsheets` when reusing a BigQuery connection for Google Sheets. |
 | `source_table` | Yes | `--source-table` | Table, sheet, or resource identifier to pull from the source. |
 | `file_type` | No | `--source-table` suffix | Appended to the `source_table` as `table#type` for connectors that need a file format hint (`csv`, `jsonl`, `parquet`). |
-| `version` | No | _n/a_ | Selects the version of ingestr to install and use. Valid options are `v1` (latest), `v0` (legacy), or `v1.x.y` (full version specifier). |
+| `version` | No | _n/a_ | Selects the version of ingestr to install and use. Valid options are bare family markers such as `v1` or `v0`, or a full version pin such as `v1.0.71`. |
 | `materialization` | No | `--incremental-*`, `--partition-by`, `--cluster-by` | Preferred way to define destination write behavior. Supports `type: table` with `create+replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`. |
-| `destination` | Yes | _n/a_ | Logical destination type. When `connection` and `destination_connection` are omitted, Bruin uses this value to choose the pipeline default destination connection. |
+| `destination` | Unless `connection` or `destination_connection` is set | _n/a_ | Logical destination type used for default connection inference. When `connection` and `destination_connection` are omitted, Bruin uses this value to choose the pipeline default destination connection. |
 | `destination_connection` | No | _n/a_ | Named destination connection to use when `connection` is omitted. This overrides default connection inference from `destination`. |
 | `incremental_strategy` | No | `--incremental-strategy` | Passes the incremental loading strategy (`replace`, `append`, `merge`, `delete+insert`, or `truncate+insert`) to Ingestr. Prefer `materialization.strategy` for new assets. |
 | `incremental_key` | No | `--incremental-key` | Column that determines incremental progress. When the column is defined with type `date`, Bruin also forwards it through the `--columns` option so Ingestr treats it as a date field. |
@@ -162,7 +162,7 @@ Bruin forwards these write strategies to ingestr:
 | `materialization.strategy: truncate+insert` | `truncate+insert` |
 | `parameters.incremental_strategy` | Passed through as-is |
 
-Use `materialization.incremental_key` or `parameters.incremental_key` only with `append`, `merge`, and `delete+insert`. `merge` requires at least one `primary_key: true` column unless the asset is a CDC asset, where ingestr determines the keys from the source. `truncate+insert` is accepted by Bruin, but ingestr will fail the run if the selected destination cannot truncate tables. Ingestr's `scd2` strategy is not a supported Bruin ingestr asset materialization strategy.
+Use `materialization.incremental_key` or `parameters.incremental_key` only with `append`, `merge`, and `delete+insert`. `merge` requires primary keys, supplied either by ingestr source metadata/schema or by asset columns marked `primary_key: true`; CDC assets determine keys from the source. `truncate+insert` is accepted by Bruin, but ingestr will fail the run if the selected destination cannot truncate tables. Ingestr's `scd2` strategy is not a supported Bruin ingestr asset materialization strategy.
 
 Destination support depends on ingestr's destination implementation:
 
@@ -245,7 +245,7 @@ The examples below show how to use the `ingestr` asset type in your pipeline. Fe
 name: raw.transactions
 type: ingestr
 parameters:
-  source_connection: mssql_prod
+  source_connection: mysql_prod
   source_table: public.transactions
   destination: bigquery
 ```
@@ -258,7 +258,7 @@ This example shows how to use `updated_at` column to incrementally load the data
 name: raw.transactions
 type: ingestr
 parameters:
-  source_connection: mysql_prod
+  source_connection: mssql_prod
   source_table: dbo.transactions
   destination: snowflake
 materialization:

--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -1,6 +1,6 @@
 # Ingestr Assets
 
-[Ingestr](https://github.com/bruin-data/ingestr) is a CLI tool that allows you to easily move data between platforms. Bruin supports `ingestr` natively as an asset type.
+[Ingestr](https://github.com/bruin-data/ingestr) is a CLI tool that allows you to move data between platforms. Bruin supports `ingestr` natively as an asset type.
 
 Using Ingestr, you can move data from:
 
@@ -21,14 +21,22 @@ Using Ingestr, you can move data from:
 
 to your data warehouses:
 
+* AWS Athena
 * Google BigQuery
+* ClickHouse
+* Databricks
+* DuckDB
+* Microsoft SQL Server
+* Oracle
+* Postgres
+* StarRocks
 * Snowflake
 * AWS Redshift
 * Azure Synapse
-* Postgres
+* other ingestr destinations when the asset points at an explicit Bruin connection
 
 > [!INFO]
-> You can read more about the capabilities of ingestr [in its documentation](https://getbruin.com/docs/ingestr/).
+> See the ingestr [platform catalog](https://getbruin.com/docs/ingestr/supported-sources/platforms.html), [ingest command reference](https://getbruin.com/docs/ingestr/commands/ingest.html), and [incremental loading guide](https://getbruin.com/docs/ingestr/getting-started/incremental-loading.html) for the upstream source, destination, and strategy behavior.
 
 ## Asset Structure
 
@@ -47,14 +55,15 @@ parameters:
   source: string # optional, used when inferring the source from connection is not enough, e.g. GCP connection + GSheets source
   source_connection: string
   source_table: string
-  destination: bigquery | snowflake | redshift | synapse
+  destination: string # logical destination type, e.g. bigquery, snowflake, duckdb, postgres
+  destination_connection: string # optional, used instead of destination default connection when connection is not set
   
   # optional
   version: v0 | v1 | v1.x.y
-  incremental_strategy: replace | append | merge | delete+insert # legacy alternative to materialization.strategy
+  incremental_strategy: replace | append | merge | delete+insert | truncate+insert # legacy alternative to materialization.strategy
   incremental_key: string # legacy alternative to materialization.incremental_key
   schema_contract: evolve | freeze | discard_row | discard_value
-  schema_naming: auto | direct | snake_case
+  schema_naming: default | direct | snake_case
   sql_backend: pyarrow | sqlalchemy
   page_size: integer
   loader_file_format: jsonl | csv | parquet
@@ -72,6 +81,16 @@ parameters:
   flush_interval: string
   flush_records: integer
   enforce_schema: true|false # Will ensure that the columns defined in the asset are present in the destination and with the desired types (see https://getbruin.com/docs/bruin/assets/columns.html)
+  cdc: "true"|"false"
+  cdc_mode: stream | batch
+  cdc_publication: string
+  cdc_slot: string
+  cdc_server_id: string
+  cdc_tls: string
+  cdc_grpc_port: string
+  cdc_grpc_host: string
+  cdc_grpc_tls: string
+  cdc_dest_schema: string
 ```
 
 ## Parameter reference
@@ -83,10 +102,11 @@ parameters:
 | `source` | No | _n/a_ | Overrides the inferred source type. For example, set `gsheets` when reusing a BigQuery connection for Google Sheets. |
 | `source_table` | Yes | `--source-table` | Table, sheet, or resource identifier to pull from the source. |
 | `file_type` | No | `--source-table` suffix | Appended to the `source_table` as `table#type` for connectors that need a file format hint (`csv`, `jsonl`, `parquet`). |
-| `version` | No | _n/a_  | Selects the version of ingestr to install and use.. Valid options are `v1` (latest), `v0` (legacy) or `v1.x.y` (full version specifer) | 
+| `version` | No | _n/a_ | Selects the version of ingestr to install and use. Valid options are `v1` (latest), `v0` (legacy), or `v1.x.y` (full version specifier). |
 | `materialization` | No | `--incremental-*`, `--partition-by`, `--cluster-by` | Preferred way to define destination write behavior. Supports `type: table` with `create+replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`. |
-| `destination` | Yes | `--dest-uri` | Logical destination used to select the target connection; Bruin converts it into the URI supplied to Ingestr. |
-| `incremental_strategy` | No | `--incremental-strategy` | Passes the incremental loading strategy (`replace`, `append`, `merge`, `delete+insert`) to Ingestr. |
+| `destination` | Yes | _n/a_ | Logical destination type. When `connection` and `destination_connection` are omitted, Bruin uses this value to choose the pipeline default destination connection. |
+| `destination_connection` | No | _n/a_ | Named destination connection to use when `connection` is omitted. This overrides default connection inference from `destination`. |
+| `incremental_strategy` | No | `--incremental-strategy` | Passes the incremental loading strategy (`replace`, `append`, `merge`, `delete+insert`, or `truncate+insert`) to Ingestr. Prefer `materialization.strategy` for new assets. |
 | `incremental_key` | No | `--incremental-key` | Column that determines incremental progress. When the column is defined with type `date`, Bruin also forwards it through the `--columns` option so Ingestr treats it as a date field. |
 | `partition_by` | No | `--partition-by` | Comma-separated list of destination columns to partition by. |
 | `cluster_by` | No | `--cluster-by` | Comma-separated list of destination clustering keys. |
@@ -110,6 +130,75 @@ parameters:
 | `flush_interval` | No | `--flush-interval` | Flush interval for streaming mode, such as `30s`. |
 | `flush_records` | No | `--flush-records` | Number of buffered records that triggers a flush in streaming mode. |
 | `enforce_schema` | No | `--columns` | When set to `true`, enforces the column types defined in the asset's `columns` section. Ingestr will create or update the destination table with the specified schema. |
+| `cdc` | No | source URI scheme | Enables Bruin's CDC URI handling for PostgreSQL, MySQL/MariaDB, Vitess, and PlanetScale sources when set to `"true"`. CDC assets must use `merge`; Bruin sets it automatically when omitted and rejects other strategies. |
+| `cdc_mode` | No | source URI query | CDC mode, either `stream` or `batch`. |
+| `cdc_publication` | No | source URI query | PostgreSQL publication name. |
+| `cdc_slot` | No | source URI query | PostgreSQL replication slot name. |
+| `cdc_server_id` | No | source URI query | MySQL-family binlog replication server ID. |
+| `cdc_tls` | No | source URI query | MySQL-family CDC TLS setting. |
+| `cdc_grpc_port` | No | source URI query | Vitess VStream gRPC port override. |
+| `cdc_grpc_host` | No | source URI query | Vitess VStream gRPC host override. |
+| `cdc_grpc_tls` | No | source URI query | Vitess VStream TLS setting. |
+| `cdc_dest_schema` | No | source URI query | Destination schema used for multi-table CDC runs. |
+
+## Destination connections and strategies
+
+Bruin resolves the destination connection in this order:
+
+1. `connection` on the asset, when set.
+2. `parameters.destination_connection`, when set.
+3. The pipeline default connection for `parameters.destination`.
+
+When Bruin infers a destination connection from `parameters.destination`, the built-in destination values are `athena`, `bigquery`, `clickhouse`, `databricks`, `doris`, `duckdb`, `dynamodb`, `elasticsearch`, `gsheets`, `motherduck`, `mssql`, `oracle`, `postgres`, `redshift`, `snowflake`, `starrocks`, `synapse`, and `vertica`. Other ingestr destinations can still be used when you set `connection` or `destination_connection` to a compatible Bruin connection.
+
+Bruin forwards these write strategies to ingestr:
+
+| Bruin configuration | Ingestr strategy |
+| --- | --- |
+| `materialization.strategy: create+replace` | `replace` |
+| `materialization.strategy: append` | `append` |
+| `materialization.strategy: merge` | `merge` |
+| `materialization.strategy: delete+insert` | `delete+insert` |
+| `materialization.strategy: truncate+insert` | `truncate+insert` |
+| `parameters.incremental_strategy` | Passed through as-is |
+
+Use `materialization.incremental_key` or `parameters.incremental_key` only with `append`, `merge`, and `delete+insert`. `merge` requires at least one `primary_key: true` column unless the asset is a CDC asset, where ingestr determines the keys from the source. `truncate+insert` is accepted by Bruin, but ingestr will fail the run if the selected destination cannot truncate tables. Ingestr's `scd2` strategy is not a supported Bruin ingestr asset materialization strategy.
+
+Destination support depends on ingestr's destination implementation:
+
+| Destination / scheme | Bruin can infer default connection from `destination` | Supported strategies in Bruin ingestr assets |
+| --- | --- | --- |
+| Athena / `athena` | Yes | `replace`, `append` |
+| BigQuery / `bigquery` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Blob storage / `s3`, `gcs`, `adls`, `abfs`, etc. | No, set `connection` | `replace`, `append` |
+| Cassandra / `cassandra` | No, set `connection` | `replace`, `append`, `merge`, `truncate+insert` |
+| ClickHouse / `clickhouse` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| CrateDB / `cratedb` | No, set `connection` | `replace`, `append`, `merge`, `truncate+insert` |
+| CSV, JSONL, Parquet / `csv`, `jsonl`, `parquet` | No, set `connection` | `replace`, `append` |
+| Databricks / `databricks` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| DuckDB, MotherDuck / `duckdb`, `motherduck`, `md` | Yes for `duckdb` and `motherduck` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| DynamoDB / `dynamodb` | Yes | `replace`, `append`, `merge` |
+| Elasticsearch / `elasticsearch` | Yes | `replace`, `append` |
+| Fabric / `fabric` | No, set `connection` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Google Sheets / `gsheets` | Yes | `replace`, `append` |
+| Iceberg / `iceberg`, `iceberg+rest`, etc. | No, set `connection` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| MaxCompute / `maxcompute`, `odps` | No, set `connection` | `replace`, `append`, `truncate+insert` without primary keys |
+| MongoDB / `mongodb`, `mongodb+srv` | No, set `connection` | `replace`, `append`, `merge` |
+| MS SQL Server / `mssql` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| MySQL, Vitess, PlanetScale / `mysql`, `vitess`, `ps_mysql` | No, set `connection` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| OneLake / `onelake` | No, set `connection` | `replace`, `append`, `merge`, `delete+insert` |
+| Oracle / `oracle` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| PostgreSQL / `postgres` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Redshift / `redshift` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Snowflake / `snowflake` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| SQLite / `sqlite` | No, set `connection` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| StarRocks / `starrocks` | Yes | `replace`, `append`, `merge` |
+| Synapse / `synapse` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Trino / `trino` | No, set `connection` | `replace`, `append`, `merge` |
+
+For `truncate+insert`, ingestr truncates the target table before loading new rows. If primary keys are configured, ingestr also needs destination merge support to deduplicate rows from staging. The Bruin CLI can infer default connections for `doris` and `vertica`, but the current ingestr source does not register `doris://` or `vertica://` destinations; use native Bruin assets for those platforms unless your ingestr version adds destination support.
+
+Each source-specific ingestion page in this documentation lists that source's supported tables with primary keys, incremental keys, and default incremental strategies. The upstream ingestr docs remain the source of truth for destination-specific strategy limits.
 
 ### Column metadata
 
@@ -156,7 +245,7 @@ The examples below show how to use the `ingestr` asset type in your pipeline. Fe
 name: raw.transactions
 type: ingestr
 parameters:
-  source_connection: mysql_prod
+  source_connection: mssql_prod
   source_table: public.transactions
   destination: bigquery
 ```

--- a/docs/ingestion/applovin.md
+++ b/docs/ingestion/applovin.md
@@ -41,7 +41,7 @@ parameters:
 - `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For AppLovin, it will be always `ingestr`.
 - `source_connection`: The name of the AppLovin connection defined in `.bruin.yml`.
 - `source_table`: The name of the table in AppLovin to ingest.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/applovin_max.md
+++ b/docs/ingestion/applovin_max.md
@@ -42,7 +42,7 @@ parameters:
 - `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For AppLovin Max, it will be always `ingestr`.
 - `source_connection`: The name of the AppLovin Max connection defined in `.bruin.yml`.
 - `source_table`: The name of the table in AppLovin Max to ingest. The format is `<table_name>:<application_ids>` where `application_ids` is a comma-separated list of application IDs.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/balldontlie.md
+++ b/docs/ingestion/balldontlie.md
@@ -43,7 +43,7 @@ parameters:
 - `type`: Always `ingestr` for BallDontLie FIFA.
 - `source_connection`: Name of the BallDontLie connection defined in `.bruin.yml`.
 - `source_table`: One of the tables listed below.
-- `destination`: Destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/clickup.md
+++ b/docs/ingestion/clickup.md
@@ -38,7 +38,7 @@ parameters:
 - `type`: Always `ingestr` for ClickUp.
 - `source_connection`: The ClickUp connection name defined in `.bruin.yml`.
 - `source_table`: Name of the ClickUp table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/google_analytics.md
+++ b/docs/ingestion/google_analytics.md
@@ -71,7 +71,7 @@ parameters:
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
 - `source_connection`: The name of the Google Analytics connection defined in .bruin.yml.
 - `source_table`: The name of the data table in Google Analytics to ingest data from.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/granola.md
+++ b/docs/ingestion/granola.md
@@ -45,7 +45,7 @@ parameters:
 - `type`: Always `ingestr` for Granola.
 - `source_connection`: The Granola connection name defined in `.bruin.yml`.
 - `source_table`: Name of the Granola table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/influxdb.md
+++ b/docs/ingestion/influxdb.md
@@ -49,7 +49,7 @@ parameters:
 - `type`: Always `ingestr` for InfluxDB.
 - `source_connection`: The InfluxDB connection name defined in `.bruin.yml`.
 - `source_table`: Name of the InfluxDB table to ingest. The measurement name should be provided as the value for --source-table.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/jobtread.md
+++ b/docs/ingestion/jobtread.md
@@ -43,7 +43,7 @@ parameters:
 - `type`: Always `ingestr` for JobTread.
 - `source_connection`: The JobTread connection name defined in `.bruin.yml`.
 - `source_table`: Name of the JobTread table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/linear.md
+++ b/docs/ingestion/linear.md
@@ -38,7 +38,7 @@ parameters:
 - `type`: Always `ingestr` for Linear.
 - `source_connection`: The Linear connection name defined in `.bruin.yml`.
 - `source_table`: Name of the Linear table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/mixpanel.md
+++ b/docs/ingestion/mixpanel.md
@@ -59,7 +59,7 @@ parameters:
 - `type`: Always `ingestr` for Mixpanel.
 - `source_connection`: The Mixpanel connection name defined in `.bruin.yml`.
 - `source_table`: Name of the Mixpanel table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/overview.md
+++ b/docs/ingestion/overview.md
@@ -11,6 +11,8 @@ Bruin has built-in data ingestion capabilities thanks to [ingestr](https://githu
 
 Using Bruin, you can load data from any source into your data platforms as a regular asset.
 
+For the complete Bruin asset schema, destination resolution behavior, and write-strategy configuration, see [Ingestr assets](/assets/ingestr). For the upstream connector catalog, see the ingestr [platform catalog](https://getbruin.com/docs/ingestr/supported-sources/platforms.html).
+
 ## Definition Schema
 
 Ingestr assets are defined in a simple YAML file:
@@ -31,6 +33,8 @@ The interesting part is in the `parameters` list:
 - `destination`: the destination you'd like to load the data on
 
 Effectively, this asset will run `ingestr` in the background and load the data to your data warehouse.
+
+Source-specific pages in this section list the available source tables and their primary keys, incremental keys, and default incremental strategies. You can override the destination write strategy on an asset with `materialization.strategy` (`create+replace`, `append`, `merge`, `delete+insert`, or `truncate+insert`) when the selected ingestr destination supports it.
 
 ## Examples
 

--- a/docs/ingestion/personio.md
+++ b/docs/ingestion/personio.md
@@ -60,7 +60,7 @@ parameters:
 | `custom_reports_list` | id | – | replace | Retrieves metadata about existing custom reports in your Personio account, such as report name, report type, report date / timeframe. |
 | `employees_absences_balance` | [employee_id,id] | – | merge | Retrieves the absence balance for a specific employee |
 
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/pinterest.md
+++ b/docs/ingestion/pinterest.md
@@ -40,7 +40,7 @@ parameters:
 
 - `source_connection`: name of the Pinterest connection defined in `.bruin.yml`.
 - `source_table`: Pinterest table to ingest.
-- `destination`: name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/pipedrive.md
+++ b/docs/ingestion/pipedrive.md
@@ -42,7 +42,7 @@ parameters:
 - `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For Pipedrive, it will be always `ingestr`
 - `source_connection`: The name of the Pipedrive connection defined in `.bruin.yml`
 - `source_table`: The name of the table in Pipedrive to ingest.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/planetscale.md
+++ b/docs/ingestion/planetscale.md
@@ -89,7 +89,7 @@ CDC is enabled by setting `cdc: "true"` on an ingestr asset with a PlanetScale s
 |-----------|----------|-------------|
 | `cdc` | Yes | Set to `"true"` to enable CDC mode |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
-| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
+| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
 
 Requirements:
 

--- a/docs/ingestion/polymarket.md
+++ b/docs/ingestion/polymarket.md
@@ -56,7 +56,7 @@ parameters:
 - `type`: Always `ingestr` for Polymarket.
 - `source_connection`: The Polymarket connection name defined in `.bruin.yml`.
 - `source_table`: The Polymarket table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 - `schema_naming`: `direct` is recommended for Polymarket tables because provider columns and keys can use camelCase.
 
 ### Step 3: Run the asset

--- a/docs/ingestion/polymarket.md
+++ b/docs/ingestion/polymarket.md
@@ -56,7 +56,7 @@ parameters:
 - `type`: Always `ingestr` for Polymarket.
 - `source_connection`: The Polymarket connection name defined in `.bruin.yml`.
 - `source_table`: The Polymarket table to ingest.
-- `destination`: The destination platform/type, for example `postgres`.
+- `destination`: The destination platform/type, for example `duckdb`.
 - `schema_naming`: `direct` is recommended for Polymarket tables because provider columns and keys can use camelCase.
 
 ### Step 3: Run the asset

--- a/docs/ingestion/posthog.md
+++ b/docs/ingestion/posthog.md
@@ -42,7 +42,7 @@ parameters:
 - `type`: Always `ingestr` for PostHog.
 - `source_connection`: The PostHog connection name defined in `.bruin.yml`.
 - `source_table`: Name of the PostHog table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/primer.md
+++ b/docs/ingestion/primer.md
@@ -42,7 +42,7 @@ parameters:
 - `type`: Specifies the asset's type. Set this to `ingestr` to use the ingestr data pipeline. For Primer, it will be always `ingestr`
 - `source_connection`: The name of the Primer connection defined in `.bruin.yml`
 - `source_table`: The name of the table in Primer to ingest.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/quickbooks.md
+++ b/docs/ingestion/quickbooks.md
@@ -48,7 +48,7 @@ parameters:
 
 - `source_connection`: name of the QuickBooks connection defined in `.bruin.yml`.
 - `source_table`: QuickBooks table to ingest.
-- `destination`: name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/reddit_ads.md
+++ b/docs/ingestion/reddit_ads.md
@@ -53,7 +53,7 @@ parameters:
 - `connection`: The destination connection, which defines where the data should be stored.
 - `source_connection`: The name of the Reddit Ads connection defined in `.bruin.yml`.
 - `source_table`: The Reddit Ads table to ingest. See [Available Source Tables](#available-source-tables) for options.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 
@@ -61,14 +61,13 @@ Reddit Ads source allows ingesting the following tables:
 
 | Table | PK | Inc Key | Inc Strategy | Details |
 |-------|----|---------|--------------|---------|
-| `accounts` | id | - | replace | Retrieves all ad accounts accessible by the authenticated user. |
-| `campaigns` | id | - | replace | Retrieves campaigns for each ad account. |
-| `ad_groups` | id | - | replace | Retrieves ad groups for each ad account. |
-| `ads` | id | - | replace | Retrieves ads for each ad account. |
-| `posts` | id | - | replace | Retrieves ad posts (creatives) for each ad account. |
-| `custom_audiences` | id | - | replace | Retrieves custom audiences for targeting. |
-| `saved_audiences` | id | - | replace | Retrieves saved audience configurations. |
-| `pixels` | id | - | replace | Retrieves conversion tracking pixels. |
+| `accounts` | id | modified_at | merge | Retrieves the ad accounts accessible by the authenticated user, or the accounts scoped in the table name. |
+| `campaigns` | id | modified_at | merge | Retrieves campaigns for each ad account. |
+| `ad_groups` | id | modified_at | merge | Retrieves ad groups for each ad account. |
+| `ads` | id | modified_at | merge | Retrieves ads for each ad account. |
+| `custom_audiences` | id | modified_at | merge | Retrieves custom audiences for targeting. |
+| `saved_audiences` | id | updated_at | merge | Retrieves saved audience configurations. |
+| `pixels` | id | modified_at | merge | Retrieves conversion tracking pixels. |
 | `funding_instruments` | id | - | replace | Retrieves funding instruments (payment methods) for each ad account. |
 | `custom` | [level_id, breakdowns] | date | merge | Custom reports allow you to retrieve performance data based on specific levels, breakdowns, and metrics. |
 

--- a/docs/ingestion/revenuecat.md
+++ b/docs/ingestion/revenuecat.md
@@ -39,7 +39,7 @@ parameters:
 - `type`: Always `ingestr` for RevenueCat.
 - `source_connection`: The RevenueCat connection name defined in `.bruin.yml`.
 - `source_table`: Name of the RevenueCat table to ingest.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -157,7 +157,7 @@ parameters:
 - `type`: Specifies the asset's type. Set this to `ingestr` to use the ingestr data pipeline. For Salesforce, it will be always `ingestr`.
 - `source_connection`: The name of the Salesforce connection defined in `.bruin.yml` or Bruin Cloud.
 - `source_table`: The name of the table in Salesforce to ingest.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 Before running a full pipeline, test with one Salesforce ingestion asset.
 

--- a/docs/ingestion/sharepoint.md
+++ b/docs/ingestion/sharepoint.md
@@ -51,7 +51,7 @@ parameters:
 
 ### Example assets
 
-These examples use DuckDB as the destination. Replace `connection` and `destination` with the destination connection you want to load into.
+These examples use DuckDB as the destination. Replace `connection` with the destination connection name and `destination` with the destination platform/type you want to load into.
 
 Single Excel sheet:
 

--- a/docs/ingestion/spanner.md
+++ b/docs/ingestion/spanner.md
@@ -53,7 +53,7 @@ parameters:
 - `connection`: The name of the destination connection. For example, "neon" is a connection name.
 - `source_connection`: The name of the GCP Spanner connection defined in .bruin.yml.
 - `source_table`: The name of the data table in GCP Spanner that you want to ingest.
-- `destination`: The name or type of the destination connection, which is Postgres.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/sqlite.md
+++ b/docs/ingestion/sqlite.md
@@ -45,7 +45,7 @@ parameters:
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
 - `source_connection`: The name of the SQLite connection defined in .bruin.yml.
 - `source_table`: The name of the data table in SQLite that you want to ingest.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/square.md
+++ b/docs/ingestion/square.md
@@ -61,7 +61,7 @@ parameters:
 | `team_member_wages` | id | - | replace | Hourly wage settings per team member. |
 | `shifts` | id | - | replace | Worked shifts (Labor API). |
 | `bank_accounts` | id | - | replace | Linked bank accounts. |
-| `cash_drawers` | id | - | replace | Cash drawer shifts across all locations. |
+| `cash_drawers` | id, location_id | - | replace | Cash drawer shifts across all locations. |
 | `loyalty` | id | - | replace | Loyalty accounts (requires a paid Square Loyalty subscription). |
 
 ### Step 3: [Run](/commands/run) asset to ingest data

--- a/docs/ingestion/square.md
+++ b/docs/ingestion/square.md
@@ -61,7 +61,7 @@ parameters:
 | `team_member_wages` | id | - | replace | Hourly wage settings per team member. |
 | `shifts` | id | - | replace | Worked shifts (Labor API). |
 | `bank_accounts` | id | - | replace | Linked bank accounts. |
-| `cash_drawers` | id, location_id | - | replace | Cash drawer shifts across all locations. |
+| `cash_drawers` | id | - | replace | Cash drawer shifts across all locations. |
 | `loyalty` | id | - | replace | Loyalty accounts (requires a paid Square Loyalty subscription). |
 
 ### Step 3: [Run](/commands/run) asset to ingest data

--- a/docs/ingestion/surveymonkey.md
+++ b/docs/ingestion/surveymonkey.md
@@ -47,7 +47,7 @@ parameters:
 
 - `source_connection`: The name of the SurveyMonkey connection defined in `.bruin.yml`.
 - `source_table`: The table to ingest from SurveyMonkey (see available tables below).
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/trustpilot.md
+++ b/docs/ingestion/trustpilot.md
@@ -40,7 +40,7 @@ parameters:
 
 - `source_connection`: The Trustpilot connection name defined in `.bruin.yml`.
 - `source_table`: Table to ingest. See the available tables below.
-- `destination`: Destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/twilio.md
+++ b/docs/ingestion/twilio.md
@@ -58,7 +58,20 @@ parameters:
 | `calls` | sid | date_updated | merge | Voice calls. Lifecycle changes (status/duration/end_time) bump `date_updated`. |
 | `recordings` | sid | date_updated | merge | Call recordings, including deleted ones (soft-deletes surface as `status=deleted`). |
 | `incoming_phone_numbers` | sid | - | replace | Phone numbers owned by the account. |
-| `usage_records` | - | - | replace | Usage totals per category over the account lifetime. Accepts an optional `:daily`, `:monthly`, or `:yearly` granularity suffix (e.g. `usage_records:daily`) that loads incrementally by period. |
+| `usage_records` | - | - | replace | Usage totals per category over the account lifetime. Accepts optional granularity suffixes listed below. |
+
+### Usage record granularity
+
+`usage_records` accepts an optional granularity suffix that switches to Twilio's `Daily`, `Monthly`, or `Yearly` sub-resources:
+
+| Source table | Grain | Inc Key | Inc Strategy |
+| ------------ | ----- | ------- | ------------ |
+| `usage_records` | lifetime total per category | - | replace |
+| `usage_records:daily` | one row per category per day | start_date | merge |
+| `usage_records:monthly` | one row per category per month | start_date | merge |
+| `usage_records:yearly` | one row per category per year | start_date | merge |
+
+The granular variants load incrementally by period: past periods are loaded once and the current period is refreshed on each run.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/vitess.md
+++ b/docs/ingestion/vitess.md
@@ -98,7 +98,7 @@ Vitess CDC streams inserts, updates, and deletes through vtgate's VStream gRPC A
 | `cdc_grpc_host` | No | Overrides the connection's `grpc_host` for this asset |
 | `cdc_grpc_tls` | No | Overrides the connection's `grpc_tls` for this asset |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
-| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
+| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
 
 Requirements:
 

--- a/docs/ingestion/wise.md
+++ b/docs/ingestion/wise.md
@@ -42,7 +42,7 @@ parameters:
 - `type`: Specifies the asset’s type. Set this to `ingestr` to use the ingestr data pipeline. For Wise, it will be always `ingestr`
 - `source_connection`: The name of the Wise connection defined in `.bruin.yml`
 - `source_table`: The name of the table in Wise to ingest.
-- `destination`: The name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/wistia.md
+++ b/docs/ingestion/wistia.md
@@ -38,7 +38,7 @@ parameters:
 
 - `source_connection`: The name of the Wistia connection defined in `.bruin.yml`.
 - `source_table`: The Wistia table to ingest. See available tables below.
-- `destination`: The destination connection name.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/zoom.md
+++ b/docs/ingestion/zoom.md
@@ -49,7 +49,7 @@ parameters:
 
 - `source_connection`: name of the Zoom connection defined in `.bruin.yml`.
 - `source_table`: Zoom table to ingest.
-- `destination`: name of the destination connection.
+- `destination`: The destination platform/type, for example `postgres`.
 
 ## Available Source Tables
 

--- a/docs/ingestion/zoom.md
+++ b/docs/ingestion/zoom.md
@@ -49,7 +49,7 @@ parameters:
 
 - `source_connection`: name of the Zoom connection defined in `.bruin.yml`.
 - `source_table`: Zoom table to ingest.
-- `destination`: The destination platform/type, for example `postgres`.
+- `destination`: The destination platform/type, for example `duckdb`.
 
 ## Available Source Tables
 

--- a/docs/platforms/elasticsearch.md
+++ b/docs/platforms/elasticsearch.md
@@ -81,12 +81,12 @@ connections:
 
 Elasticsearch can be used as a destination for [Ingestr Assets](../assets/ingestr.md). This allows you to load data from various sources into your Elasticsearch cluster.
 
-### Example: Load data from Snapchat Ads to Elasticsearch
+### Example: Load Snapchat Ads transactions to Elasticsearch
 
 ```yaml
-name: snapchat_ads
+name: snapchat_transactions
 type: ingestr
-description: Snapchat Ads individual ads data with merge strategy for incremental updates
+description: Snapchat Ads transactions data
 
 tags:
   - snapchat
@@ -96,13 +96,13 @@ tags:
 parameters:
   destination: elasticsearch
   source_connection: my-snapchatads
-  source_table: ads
+  source_table: transactions
 ```
 
 This configuration will:
 
-1. Extract ads data from Snapchat Ads using the `my-snapchatads` connection
-2. Load the data into the `snapchat_ads` index in your Elasticsearch cluster
+1. Extract transactions data from Snapchat Ads using the `my-snapchatads` connection
+2. Load the data into the `snapchat_transactions` index in your Elasticsearch cluster
 3. Use the default Elasticsearch connection (`elasticsearch-default`) from your pipeline configuration
 
 > [!NOTE]

--- a/docs/platforms/elasticsearch.md
+++ b/docs/platforms/elasticsearch.md
@@ -84,7 +84,7 @@ Elasticsearch can be used as a destination for [Ingestr Assets](../assets/ingest
 ### Example: Load data from Snapchat Ads to Elasticsearch
 
 ```yaml
-name: snapchat.ads
+name: snapchat_ads
 type: ingestr
 description: Snapchat Ads individual ads data with merge strategy for incremental updates
 
@@ -102,7 +102,7 @@ parameters:
 This configuration will:
 
 1. Extract ads data from Snapchat Ads using the `my-snapchatads` connection
-2. Load the data into the `ads` index in your Elasticsearch cluster
+2. Load the data into the `snapchat_ads` index in your Elasticsearch cluster
 3. Use the default Elasticsearch connection (`elasticsearch-default`) from your pipeline configuration
 
 > [!NOTE]
@@ -110,7 +110,7 @@ This configuration will:
 
 ## Index Naming
 
-The `destination_table` parameter specifies the Elasticsearch index name where data will be loaded. Index names in Elasticsearch:
+For ingestr assets, Bruin passes the asset `name` as ingestr's `--dest-table`. For Elasticsearch destinations, that destination table is the target index name. Index names in Elasticsearch:
 
 - Must be lowercase
 - Cannot contain spaces or special characters like `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`

--- a/docs/platforms/mongoatlas.md
+++ b/docs/platforms/mongoatlas.md
@@ -26,7 +26,7 @@ To set up a MongoDB Atlas connection, you need to add a configuration item to `c
 - `username`: MongoDB Atlas database username
 - `password`: MongoDB Atlas database password
 - `host`: MongoDB Atlas cluster hostname, without the `mongodb+srv://` protocol (e.g., `cluster0.example.mongodb.net`)
-- `database`: Optional. If set, Bruin appends it to the connection URI path. For ingestr assets, the target database is usually provided in `source_table` or `destination_table` as `database.collection`.
+- `database`: Optional. If set, Bruin appends it to the connection URI path. For ingestr assets, the target database is usually provided in `source_table` for source assets or in the asset `name` for destination assets, using `database.collection` format.
 
 > [!NOTE]
 > The connection uses the `mongodb+srv://` protocol, which is the standard for MongoDB Atlas connections. You don't need to specify the protocol or a port in the configuration.
@@ -57,17 +57,15 @@ MongoDB Atlas can be used as a destination for [Ingestr Assets](../assets/ingest
 ### Example: Load data from PostgreSQL to MongoDB Atlas
 
 ```yaml
-name: ingest.users
+name: mydb.users
 type: ingestr
-connection: postgres
+connection: connection_name
 
 parameters:
   source_connection: postgres
   source_table: 'public.users'
 
   destination: mongo_atlas
-  destination_connection: connection_name
-  destination_table: 'mydb.users'
 ```
 
 This configuration will:
@@ -75,7 +73,7 @@ This configuration will:
 1. Extract data from the `public.users` table in PostgreSQL
 2. Load the data into the `users` collection in the `mydb` MongoDB Atlas database
 
-`destination_connection` must match the `name` of a `mongo_atlas` connection in `.bruin.yml`. `destination_table` uses `database.collection` format.
+`connection` must match the `name` of a `mongo_atlas` connection in `.bruin.yml`. Bruin passes the asset `name` as ingestr's destination table, so use `database.collection` format in `name`.
 
 ## Using MongoDB Atlas as a Source
 

--- a/docs/platforms/mongoatlas.md
+++ b/docs/platforms/mongoatlas.md
@@ -64,8 +64,6 @@ connection: connection_name
 parameters:
   source_connection: postgres
   source_table: 'public.users'
-
-  destination: mongo_atlas
 ```
 
 This configuration will:
@@ -73,7 +71,7 @@ This configuration will:
 1. Extract data from the `public.users` table in PostgreSQL
 2. Load the data into the `users` collection in the `mydb` MongoDB Atlas database
 
-`connection` must match the `name` of a `mongo_atlas` connection in `.bruin.yml`. Bruin passes the asset `name` as ingestr's destination table, so use `database.collection` format in `name`.
+`connection` must match the `name` of a `mongo_atlas` connection in `.bruin.yml`; no `destination` parameter is needed when the destination connection is explicit. Bruin passes the asset `name` as ingestr's destination table, so use `database.collection` format in `name`.
 
 ## Using MongoDB Atlas as a Source
 

--- a/docs/platforms/mysql.md
+++ b/docs/platforms/mysql.md
@@ -163,7 +163,7 @@ CDC is enabled by setting `cdc: "true"` on an ingestr asset with a MySQL source 
 | `cdc_mode` | No | `"stream"` for real-time streaming or `"batch"` for batch replication |
 | `cdc_server_id` | No | Replication server identifier for MySQL binary-log CDC |
 | `cdc_dest_schema` | No | Destination schema to use for multi-table CDC runs |
-| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
+| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
 
 Requirements:
 

--- a/docs/platforms/postgres.md
+++ b/docs/platforms/postgres.md
@@ -203,7 +203,7 @@ CDC is enabled by setting `cdc: "true"` on an `ingestr` asset with a PostgreSQL 
 | `cdc_slot` | No | Name of the PostgreSQL replication slot to use |
 | `cdc_dest_schema` | No | Schema to use when running multi-table CDC |
 | `source_table` | Yes | Source table in `schema.table` format, or `"*"` to replicate all tables in the publication |
-| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled; can be overridden to `"append"` |
+| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
 
 > [!NOTE]
 > When CDC is enabled, primary key columns do not need to be specified in the asset definition — they are determined automatically from the source table.


### PR DESCRIPTION
## Summary

- Update the central ingestr asset docs with current Bruin configuration, destination resolution, CDC parameters, materialization mapping, and destination strategy support.
- Correct stale source/platform details for Reddit Ads, Twilio, Square, Elasticsearch, MongoDB Atlas, and CDC strategy guidance.
- Clarify `connection` vs `parameters.destination` wording across ingestion pages and verify upstream ingestr doc links against the local ingestr docs tree.

## Validation

- `git diff --check`
- checked 42 `getbruin.com/docs/ingestr` links against `/Users/bear/Github/ingestr/docs` with 0 missing
- `npm ci`
- `npm run docs:build`

`make format` and `make test` were not run because this change is documentation-only.