### PR TITLE
Bump default ingestr version to 1.0.74

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.73"
+	IngestrVersionV1 = "1.0.74"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
Bumps the default ingestr version (`IngestrVersionV1`) from `1.0.73` to `1.0.74` in `pkg/python/uv.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)