### PR TITLE
Respect full refresh restrictions across asset types

### DIFF
--- a/pkg/executor/sequential.go
+++ b/pkg/executor/sequential.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"fmt"
+	"io"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/scheduler"
@@ -22,6 +24,15 @@ type Sequential struct {
 
 func (s Sequential) RunSingleTask(ctx context.Context, instance scheduler.TaskInstance) error {
 	task := instance.GetAsset()
+	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	if fullRefresh && task.RefreshRestricted != nil && *task.RefreshRestricted {
+		ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, false)
+		if instance.GetType() == scheduler.TaskInstanceTypeMain {
+			if printer, ok := ctx.Value(KeyPrinter).(io.Writer); ok {
+				_, _ = fmt.Fprintf(printer, "Warning: full refresh is restricted for asset %q; running incrementally.\n", task.Name)
+			}
+		}
+	}
 
 	// check if task type exists in map
 	executors, ok := s.TaskTypeMap[task.Type]

--- a/pkg/executor/sequential_test.go
+++ b/pkg/executor/sequential_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -49,6 +50,39 @@ func TestLocal_RunSingleTask(t *testing.T) {
 		err := l.RunSingleTask(t.Context(), instance)
 
 		require.NoError(t, err)
+		mockOperator.AssertExpectations(t)
+	})
+
+	t.Run("full refresh restriction is applied before dispatch", func(t *testing.T) {
+		t.Parallel()
+
+		restricted := true
+		restrictedAsset := &pipeline.Asset{
+			Name:              "restricted-task",
+			Type:              "test",
+			RefreshRestricted: &restricted,
+		}
+		restrictedInstance := &scheduler.AssetInstance{Asset: restrictedAsset}
+		mockOperator := new(mockOperator)
+		mockOperator.On("Run", mock.MatchedBy(func(ctx context.Context) bool {
+			fullRefresh, ok := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+			return ok && !fullRefresh
+		}), restrictedInstance).Return(nil)
+		l := Sequential{
+			TaskTypeMap: map[pipeline.AssetType]Config{
+				"test": {
+					scheduler.TaskInstanceTypeMain: mockOperator,
+				},
+			},
+		}
+		var output bytes.Buffer
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, true)
+		ctx = context.WithValue(ctx, KeyPrinter, &output)
+
+		err := l.RunSingleTask(ctx, restrictedInstance)
+
+		require.NoError(t, err)
+		require.Equal(t, "Warning: full refresh is restricted for asset \"restricted-task\"; running incrementally.\n", output.String())
 		mockOperator.AssertExpectations(t)
 	})
 

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -37,6 +37,7 @@ var ingestrBoolParameterFlags = []string{
 }
 
 func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs []string, columnOpts *ColumnHintOptions) ([]string, error) {
+	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
 	cmdArgs = appendIngestrParameterFlags(asset.Parameters, cmdArgs)
 	cmdArgs = appendIngestrMaskFlags(asset.Parameters, asset.Columns, cmdArgs, columnOpts != nil && columnOpts.NormalizeColumnNames)
 
@@ -60,8 +61,6 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 	if ctx.Value(pipeline.RunConfigStartDate) != nil {
 		startTimeInstance, okParse := ctx.Value(pipeline.RunConfigStartDate).(time.Time)
 		if okParse {
-			fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
-
 			// If full-refresh and asset has a start_date, use that instead
 			if fullRefresh && asset.StartDate != "" {
 				parsedStartDate, err := time.Parse("2006-01-02", asset.StartDate)
@@ -91,8 +90,7 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 		}
 	}
 
-	fullRefresh := ctx.Value(pipeline.RunConfigFullRefresh)
-	if fullRefresh != nil && fullRefresh.(bool) {
+	if fullRefresh {
 		cmdArgs = append(cmdArgs, "--full-refresh")
 	}
 


### PR DESCRIPTION
Apply full-refresh restrictions at the shared executor boundary so every asset type receives an incremental execution context. This prevents ingestr assets from forwarding `--full-refresh` while preserving their configured incremental strategy and logs a warning when the restriction applies. Tested with `make format`, `make test`, and a disposable DuckDB-to-DuckDB ingestr run with a destructive control.
