### PR TITLE
fix: rewrite cross-database developer schema references

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run integration tests
         run: make integration-test
       - name: Run MSSQL developer environment integration test
-        run: cd integration-tests/mssql && go test -v -count=1 -timeout 15m .
+        run: make integration-test-mssql
   dockerBuild:
     runs-on: depot-ubuntu-latest
     name: Docker Build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,6 +116,8 @@ jobs:
           done
       - name: Run integration tests
         run: make integration-test
+      - name: Run MSSQL developer environment integration test
+        run: cd integration-tests/mssql && go test -v -count=1 -timeout 15m .
   dockerBuild:
     runs-on: depot-ubuntu-latest
     name: Docker Build

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 
 JQ_REL_PATH = jq --arg prefix "$$(pwd)" 'walk(if type == "object" and has("path") and (.path | type == "string") then .path |= (if . == $$prefix then "integration-tests" elif startswith($$prefix + "/") then .[($$prefix | length + 1):] elif startswith($$prefix) then .[($$prefix | length):] elif startswith("integration-tests/") then .[16:] else . end) else . end)'
 
-.PHONY: all clean test build build-no-duckdb docs-app format pre-commit refresh-integration-expectations integration-test-cloud validate-links tools-update
+.PHONY: all clean test build build-no-duckdb docs-app format pre-commit refresh-integration-expectations integration-test-cloud integration-test-mssql validate-links tools-update
 all: clean deps test build
 
 deps: 
@@ -79,6 +79,10 @@ integration-test-cloud: build
 	@echo "$(OK_COLOR)==> Running cloud integration tests...$(NO_COLOR)"
 	@cd integration-tests && git init
 	@cd integration-tests/cloud-integration-tests && env SILENT=1 go test -count=1 -v .
+
+integration-test-mssql: build
+	@echo "$(OK_COLOR)==> Running MSSQL integration tests...$(NO_COLOR)"
+	@cd integration-tests/mssql && env SILENT=1 go test -count=1 -v -timeout 15m .
 
 clean:
 	@rm -rf ./bin

--- a/integration-tests/mssql/devenv_cross_database_test.go
+++ b/integration-tests/mssql/devenv_cross_database_test.go
@@ -1,0 +1,305 @@
+package mssql_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/microsoft/go-mssqldb"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mssqlImage    = "mcr.microsoft.com/mssql/server@sha256:49b45a911dc535e9345fbfd7101a1bd8a1e190a5f29b877ef75387a061e5fcf0"
+	mssqlPassword = "BruinLocal2333!Pass"
+)
+
+// TestDeveloperEnvironmentCrossDatabaseReference protects the regression from
+// https://github.com/bruin-data/bruin/issues/2333. The asset connects to Gold_WH
+// but reads a three-part Silver_WH.schema.table reference.
+//
+//nolint:paralleltest,tparallel
+func TestDeveloperEnvironmentCrossDatabaseReference(t *testing.T) {
+	host, port := startSQLServer(t)
+
+	master := openSQLServer(t, host, port, "master")
+	execSQL(t, master, "CREATE DATABASE [Silver_WH]")
+	execSQL(t, master, "CREATE DATABASE [Gold_WH]")
+
+	silver := openSQLServer(t, host, port, "Silver_WH")
+	gold := openSQLServer(t, host, port, "Gold_WH")
+	seedCrossDatabaseScenario(t, silver, gold)
+
+	configPath, assetPath := writeTestPipeline(t, host, port)
+	binary := bruinBinary(t)
+
+	t.Run("rewrites when the prefixed upstream table exists", func(t *testing.T) {
+		output := runBruin(t, binary, configPath, assetPath)
+		require.Contains(t, output, "Silver_WH.dev_myschema.upstream")
+		require.Equal(t, "silver-development", queryMarker(t, gold))
+	})
+
+	t.Run("does not trust a matching table in the current database", func(t *testing.T) {
+		execSQL(t, silver, "DROP TABLE dev_myschema.upstream")
+
+		output := runBruin(t, binary, configPath, assetPath)
+		require.Contains(t, output, "Silver_WH.myschema.upstream")
+		require.NotContains(t, output, "Silver_WH.dev_myschema.upstream")
+		require.Equal(t, "silver-production", queryMarker(t, gold))
+		require.Equal(t, "gold-decoy", queryString(t, gold, "SELECT source_marker FROM dev_myschema.upstream"))
+	})
+
+	t.Run("does not rewrite when the prefixed upstream schema is absent", func(t *testing.T) {
+		execSQL(t, silver, "DROP SCHEMA dev_myschema")
+
+		output := runBruin(t, binary, configPath, assetPath)
+		require.Contains(t, output, "Silver_WH.myschema.upstream")
+		require.NotContains(t, output, "Silver_WH.dev_myschema.upstream")
+		require.Equal(t, "silver-production", queryMarker(t, gold))
+	})
+
+	t.Run("resumes rewriting when the prefixed upstream table is restored", func(t *testing.T) {
+		execSQL(t, silver, "CREATE SCHEMA dev_myschema")
+		execSQL(t, silver, "CREATE TABLE dev_myschema.upstream (source_marker nvarchar(100) NOT NULL)")
+		execSQL(t, silver, "INSERT INTO dev_myschema.upstream VALUES (N'silver-development-restored')")
+
+		output := runBruin(t, binary, configPath, assetPath)
+		require.Contains(t, output, "Silver_WH.dev_myschema.upstream")
+		require.Equal(t, "silver-development-restored", queryMarker(t, gold))
+	})
+}
+
+func startSQLServer(t *testing.T) (string, string) {
+	t.Helper()
+
+	_, err := exec.LookPath("docker")
+	require.NoError(t, err, "Docker is required for the MSSQL integration test")
+
+	containerName := fmt.Sprintf("bruin-mssql-devenv-%d", time.Now().UnixNano())
+	image := os.Getenv("BRUIN_MSSQL_TEST_IMAGE")
+	if image == "" {
+		image = mssqlImage
+	}
+
+	args := []string{
+		"run", "-d", "--rm",
+		"--platform", "linux/amd64",
+		"--name", containerName,
+		"-e", "ACCEPT_EULA=Y",
+		"-e", "MSSQL_SA_PASSWORD=" + mssqlPassword,
+		"-p", "127.0.0.1::1433",
+		image,
+	}
+	output, err := exec.CommandContext(t.Context(), "docker", args...).CombinedOutput()
+	require.NoError(t, err, "failed to start SQL Server container: %s", output)
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cleanupOutput, cleanupErr := exec.CommandContext(cleanupCtx, "docker", "rm", "-f", containerName).CombinedOutput()
+		if cleanupErr != nil && !strings.Contains(string(cleanupOutput), "No such container") {
+			t.Logf("failed to remove SQL Server container: %v: %s", cleanupErr, cleanupOutput)
+		}
+	})
+
+	portOutput, err := exec.CommandContext(t.Context(), "docker", "port", containerName, "1433/tcp").CombinedOutput()
+	require.NoError(t, err, "failed to read SQL Server container port: %s", portOutput)
+
+	host, port, err := net.SplitHostPort(strings.TrimSpace(string(portOutput)))
+	require.NoError(t, err)
+
+	waitForSQLServer(t, host, port, containerName)
+
+	return host, port
+}
+
+func waitForSQLServer(t *testing.T, host, port, containerName string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlserver", sqlServerDSN(host, port, "master"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		err = db.PingContext(ctx)
+		cancel()
+		if err == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+
+	logs, logsErr := exec.CommandContext(t.Context(), "docker", "logs", containerName).CombinedOutput()
+	if logsErr != nil {
+		t.Logf("failed to read SQL Server logs: %v", logsErr)
+	}
+	t.Fatalf("SQL Server did not become ready: %v\n%s", err, logs)
+}
+
+func openSQLServer(t *testing.T, host, port, database string) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlserver", sqlServerDSN(host, port, database))
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return db
+}
+
+func sqlServerDSN(host, port, database string) string {
+	u := &url.URL{
+		Scheme: "sqlserver",
+		User:   url.UserPassword("sa", mssqlPassword),
+		Host:   net.JoinHostPort(host, port),
+	}
+	query := u.Query()
+	query.Set("database", database)
+	query.Set("encrypt", "disable")
+	query.Set("TrustServerCertificate", "true")
+	u.RawQuery = query.Encode()
+
+	return u.String()
+}
+
+func seedCrossDatabaseScenario(t *testing.T, silver, gold *sql.DB) {
+	t.Helper()
+
+	execSQL(t, silver, "CREATE SCHEMA myschema")
+	execSQL(t, silver, "CREATE SCHEMA dev_myschema")
+	execSQL(t, silver, "CREATE TABLE myschema.upstream (source_marker nvarchar(100) NOT NULL)")
+	execSQL(t, silver, "INSERT INTO myschema.upstream VALUES (N'silver-production')")
+	execSQL(t, silver, "CREATE TABLE dev_myschema.upstream (source_marker nvarchar(100) NOT NULL)")
+	execSQL(t, silver, "INSERT INTO dev_myschema.upstream VALUES (N'silver-development')")
+
+	execSQL(t, gold, "CREATE SCHEMA dev_gold")
+	execSQL(t, gold, "CREATE SCHEMA dev_myschema")
+	execSQL(t, gold, "CREATE TABLE dev_myschema.upstream (source_marker nvarchar(100) NOT NULL)")
+	execSQL(t, gold, "INSERT INTO dev_myschema.upstream VALUES (N'gold-decoy')")
+}
+
+func writeTestPipeline(t *testing.T, host, port string) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	assetsDir := filepath.Join(root, "assets")
+	require.NoError(t, os.MkdirAll(assetsDir, 0o755))
+
+	config := fmt.Sprintf(`default_environment: dev
+environments:
+  dev:
+    schema_prefix: dev_
+    connections:
+      mssql:
+        - name: mssql-gold
+          username: sa
+          password: %q
+          host: %s
+          port: %s
+          database: Gold_WH
+          options: "encrypt=disable&TrustServerCertificate=true"
+`, mssqlPassword, host, port)
+	pipeline := `name: issue-2333-mssql
+default_connections:
+  mssql: mssql-gold
+`
+	asset := `/* @bruin
+name: gold.reader
+type: ms.sql
+
+materialization:
+  type: table
+@bruin */
+
+SELECT source_marker
+FROM Silver_WH.myschema.upstream;
+`
+
+	configPath := filepath.Join(root, ".bruin.yml")
+	assetPath := filepath.Join(assetsDir, "reader.sql")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pipeline.yml"), []byte(pipeline), 0o600))
+	require.NoError(t, os.WriteFile(assetPath, []byte(asset), 0o600))
+
+	gitOutput, err := exec.CommandContext(t.Context(), "git", "init", root).CombinedOutput()
+	require.NoError(t, err, "failed to initialize temporary pipeline repository: %s", gitOutput)
+
+	return configPath, assetPath
+}
+
+func bruinBinary(t *testing.T) string {
+	t.Helper()
+
+	if binary := os.Getenv("BRUIN_TEST_BINARY"); binary != "" {
+		require.FileExists(t, binary)
+		return binary
+	}
+
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	repositoryRoot, err := filepath.Abs(filepath.Join(workingDirectory, "../.."))
+	require.NoError(t, err)
+
+	executable := "bruin"
+	if runtime.GOOS == "windows" {
+		executable += ".exe"
+	}
+
+	binary := filepath.Join(repositoryRoot, "bin", executable)
+	require.FileExists(t, binary)
+
+	return binary
+}
+
+func runBruin(t *testing.T, binary, configPath, assetPath string) string {
+	t.Helper()
+
+	args := []string{
+		"run",
+		"--config-file", configPath,
+		"--env", "dev",
+		"--full-refresh",
+		"--workers", "1",
+		"--verbose",
+		"--no-log-file",
+		"--no-color",
+		assetPath,
+	}
+	cmd := exec.CommandContext(t.Context(), binary, args...)
+	cmd.Env = append(os.Environ(), "DISABLE_TELEMETRY=true", "INGESTR_DISABLE_TELEMETRY=true")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Bruin run failed:\n%s", output)
+
+	return string(output)
+}
+
+func execSQL(t *testing.T, db *sql.DB, statement string) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), statement)
+	require.NoError(t, err, "SQL statement failed: %s", statement)
+}
+
+func queryMarker(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	return queryString(t, db, "SELECT source_marker FROM dev_gold.reader")
+}
+
+func queryString(t *testing.T, db *sql.DB, statement string) string {
+	t.Helper()
+	var result string
+	require.NoError(t, db.QueryRowContext(t.Context(), statement).Scan(&result))
+	return result
+}

--- a/pkg/devenv/modifier.go
+++ b/pkg/devenv/modifier.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 )
@@ -128,15 +129,18 @@ func (d *DevEnvQueryModifier) Modify(ctx context.Context, p *pipeline.Pipeline, 
 			schema := parts[1]
 			table := parts[2]
 
-			// only rewrite if the database matches the connection's database
-			if database != dbSummary.Name {
-				continue
-			}
-
 			devSchema := env.SchemaPrefix + schema
 			devTable := fmt.Sprintf("%s.%s.%s", database, devSchema, table)
 
-			if dbSummary.TableExists(devSchema, table) {
+			tableExists := dbSummary.TableExists(devSchema, table)
+			if !strings.EqualFold(database, dbSummary.Name) {
+				tableExists, err = tableExistsInDatabase(ctx, conn, devTable)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if tableExists {
 				renameMapping[tableReference] = devTable
 			}
 		default:
@@ -150,6 +154,30 @@ func (d *DevEnvQueryModifier) Modify(ctx context.Context, p *pipeline.Pipeline, 
 	}
 
 	return q, nil
+}
+
+func tableExistsInDatabase(ctx context.Context, conn any, tableName string) (bool, error) {
+	tableChecker, ok := conn.(ansisql.TableExistsChecker)
+	if !ok {
+		return false, nil
+	}
+
+	tableExistsQuery, err := tableChecker.BuildTableExistsQuery(tableName)
+	if err != nil {
+		return false, fmt.Errorf("failed to build existence check for developer environment table '%s': %w", tableName, err)
+	}
+
+	result, err := tableChecker.Select(ctx, &query.Query{Query: tableExistsQuery})
+	if err != nil {
+		return false, fmt.Errorf("failed to check developer environment table '%s': %w", tableName, err)
+	}
+
+	count, err := helpers.CastResultToInteger(result, true)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse existence check for developer environment table '%s': %w", tableName, err)
+	}
+
+	return count > 0, nil
 }
 
 func (d *DevEnvQueryModifier) RegisterAssetForSchemaCache(ctx context.Context, p *pipeline.Pipeline, a *pipeline.Asset, q *query.Query) error {

--- a/pkg/devenv/modifier_test.go
+++ b/pkg/devenv/modifier_test.go
@@ -46,6 +46,20 @@ func (m *mockConnectionInstance) GetDatabaseSummary(ctx context.Context) (*ansis
 	return args.Get(0).(*ansisql.DBDatabase), args.Error(1)
 }
 
+type mockTableCheckingConnectionInstance struct {
+	mockConnectionInstance
+}
+
+func (m *mockTableCheckingConnectionInstance) BuildTableExistsQuery(tableName string) (string, error) {
+	args := m.Called(tableName)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockTableCheckingConnectionInstance) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {
+	args := m.Called(ctx, q)
+	return args.Get(0).([][]interface{}), args.Error(1)
+}
+
 type mockConnectionWithoutDatabaseSummary struct{}
 
 func TestDevEnvQueryModifier_Modify(t *testing.T) {
@@ -342,6 +356,74 @@ func TestDevEnvQueryModifier_Modify_ThreePartNames(t *testing.T) {
 						"myschema.mytable": "dev_myschema.mytable",
 					},
 				).Return("select * from mydb.myschema.mytable", nil)
+			},
+		},
+		{
+			name:        "3-part cross-database name rewrites when dev table exists",
+			selectedEnv: &config.Environment{SchemaPrefix: "dev_"},
+			inputQuery:  "select * from upstreamdb.myschema.mytable",
+			outputQuery: "select * from upstreamdb.dev_myschema.mytable",
+			setupFields: func(f *fields) {
+				c := new(mockTableCheckingConnectionInstance)
+				c.On("GetDatabaseSummary", mock.Anything).Return(&ansisql.DBDatabase{
+					Name:    "currentdb",
+					Schemas: []*ansisql.DBSchema{},
+				}, nil)
+				c.On("BuildTableExistsQuery", "upstreamdb.dev_myschema.mytable").
+					Return("table exists query", nil)
+				c.On("Select", mock.Anything, &query.Query{Query: "table exists query"}).
+					Return([][]interface{}{{int64(1)}}, nil)
+				f.Conn.On("GetConnection", "mssql-default").Return(c)
+
+				f.Parser.On("UsedTables", "select * from upstreamdb.myschema.mytable", "tsql").
+					Return([]string{"upstreamdb.myschema.mytable"}, nil)
+
+				f.Parser.On(
+					"RenameTables",
+					"select * from upstreamdb.myschema.mytable",
+					"tsql",
+					map[string]string{
+						"myschema.mytable":            "dev_myschema.mytable",
+						"upstreamdb.myschema.mytable": "upstreamdb.dev_myschema.mytable",
+					},
+				).Return("select * from upstreamdb.dev_myschema.mytable", nil)
+			},
+		},
+		{
+			name:        "3-part cross-database name is not rewritten when dev table does not exist upstream",
+			selectedEnv: &config.Environment{SchemaPrefix: "dev_"},
+			inputQuery:  "select * from upstreamdb.myschema.mytable",
+			outputQuery: "select * from upstreamdb.myschema.mytable",
+			setupFields: func(f *fields) {
+				c := new(mockTableCheckingConnectionInstance)
+				c.On("GetDatabaseSummary", mock.Anything).Return(&ansisql.DBDatabase{
+					Name: "currentdb",
+					Schemas: []*ansisql.DBSchema{
+						{
+							Name: "dev_myschema",
+							Tables: []*ansisql.DBTable{
+								{Name: "mytable"},
+							},
+						},
+					},
+				}, nil)
+				c.On("BuildTableExistsQuery", "upstreamdb.dev_myschema.mytable").
+					Return("table exists query", nil)
+				c.On("Select", mock.Anything, &query.Query{Query: "table exists query"}).
+					Return([][]interface{}{{int64(0)}}, nil)
+				f.Conn.On("GetConnection", "mssql-default").Return(c)
+
+				f.Parser.On("UsedTables", "select * from upstreamdb.myschema.mytable", "tsql").
+					Return([]string{"upstreamdb.myschema.mytable"}, nil)
+
+				f.Parser.On(
+					"RenameTables",
+					"select * from upstreamdb.myschema.mytable",
+					"tsql",
+					map[string]string{
+						"myschema.mytable": "dev_myschema.mytable",
+					},
+				).Return("select * from upstreamdb.myschema.mytable", nil)
 			},
 		},
 		{

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -421,8 +421,8 @@ func (db *DB) BuildTableExistsQuery(tableName string) (string, error) {
 	q := fmt.Sprintf(
 		"SELECT COUNT(*) FROM %s.TABLES WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
 		infoSchema,
-		tn.Schema,
-		tn.Table,
+		strings.ReplaceAll(tn.Schema, "'", "''"),
+		strings.ReplaceAll(tn.Table, "'", "''"),
 	)
 
 	return q, nil

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -403,6 +403,31 @@ WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
 	return summary, nil
 }
 
+func (db *DB) BuildTableExistsQuery(tableName string) (string, error) {
+	cb, ok := tablename.For("fabric")
+	if !ok {
+		return "", errors.New("fabric table-name capability not found")
+	}
+	tn, err := cb.Parse(tableName, tablename.Defaults{Schema: "dbo"})
+	if err != nil {
+		return "", err
+	}
+
+	infoSchema := "INFORMATION_SCHEMA"
+	if tn.Catalog != "" {
+		infoSchema = QuoteIdentifier(tn.Catalog) + ".INFORMATION_SCHEMA"
+	}
+
+	q := fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s.TABLES WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
+		infoSchema,
+		tn.Schema,
+		tn.Table,
+	)
+
+	return q, nil
+}
+
 func (db *DB) GetIngestrURI() (string, error) {
 	return db.config.GetIngestrURI()
 }

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -243,6 +243,11 @@ func TestDB_BuildTableExistsQuery(t *testing.T) {
 			want:      "SELECT COUNT(*) FROM [upstream].INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dev_sales' AND TABLE_NAME = 'orders'",
 		},
 		{
+			name:      "schema and table with single quotes",
+			tableName: "upstream.dev_o'brien.order's",
+			want:      "SELECT COUNT(*) FROM [upstream].INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dev_o''brien' AND TABLE_NAME = 'order''s'",
+		},
+		{
 			name:      "invalid table name",
 			tableName: "database.schema.table.extra",
 			wantError: "must be in format",

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -223,6 +223,49 @@ func TestDB_GetColumns(t *testing.T) {
 	}
 }
 
+func TestDB_BuildTableExistsQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		tableName string
+		want      string
+		wantError string
+	}{
+		{
+			name:      "schema and table",
+			tableName: "sales.orders",
+			want:      "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'sales' AND TABLE_NAME = 'orders'",
+		},
+		{
+			name:      "database schema and table",
+			tableName: "upstream.dev_sales.orders",
+			want:      "SELECT COUNT(*) FROM [upstream].INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dev_sales' AND TABLE_NAME = 'orders'",
+		},
+		{
+			name:      "invalid table name",
+			tableName: "database.schema.table.extra",
+			wantError: "must be in format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := &DB{}
+			got, err := db.BuildTableExistsQuery(tt.tableName)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestDB_GetColumnsForTable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mssql/db.go
+++ b/pkg/mssql/db.go
@@ -532,8 +532,8 @@ func (db *DB) BuildTableExistsQuery(tableName string) (string, error) {
 	query := fmt.Sprintf(
 		"SELECT COUNT(*) FROM %s.tables WHERE table_schema = '%s' AND table_name = '%s'",
 		infoSchema,
-		tn.Schema,
-		tn.Table,
+		strings.ReplaceAll(tn.Schema, "'", "''"),
+		strings.ReplaceAll(tn.Table, "'", "''"),
 	)
 
 	return strings.TrimSpace(query), nil

--- a/pkg/mssql/db_test.go
+++ b/pkg/mssql/db_test.go
@@ -585,6 +585,13 @@ func TestClient_BuildTableExistsQuery(t *testing.T) {
 			wantQuery: "SELECT COUNT(*) FROM [otherdb].information_schema.tables WHERE table_schema = 'test_schema' AND table_name = 'test_table'",
 			wantErr:   false,
 		},
+		{
+			name:      "schema and table names escape single quotes",
+			c:         &DB{config: &Config{Database: "test_db"}},
+			tableName: "otherdb.dev_o'brien.order's",
+			wantQuery: "SELECT COUNT(*) FROM [otherdb].information_schema.tables WHERE table_schema = 'dev_o''brien' AND table_name = 'order''s'",
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #2333.

Developer environments now check prefixed three-part tables in the referenced database before rewriting, with Fabric support for qualified existence queries.
Adds unit coverage and a Docker-backed SQL Server regression test that runs in CI.
Validated with `make format`, `make test`, `make integration-test-light`, and `make integration-test-mssql`.
