### PR TITLE
Add incremental predicates to merge materialization

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -83,6 +83,23 @@ This is the column of the table that will be used for incremental updates of the
 - **Type:** `String`
 - **Default:** `""`
 
+### `materialization > incremental_predicate`
+
+Additional plain SQL added to the match condition of a `merge` materialization. This is useful for limiting the destination partitions scanned by warehouses such as BigQuery. The generated merge exposes the new data and the destination table as the `source` and `target` aliases.
+
+```yaml
+materialization:
+  type: table
+  strategy: merge
+  incremental_predicate: target.event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+```
+
+- **Type:** `String`
+- **Default:** `""`
+- **Supported platforms:** BigQuery, Athena, Databricks, Doris, DuckDB, MSSQL, MySQL, Oracle, PostgreSQL, Snowflake, Synapse, and Vertica. It is not supported for Redshift (whose `MERGE` only accepts equality predicates in its match condition), Ingestr assets, or Python assets.
+
+The predicate is database-specific SQL and is inserted without validation. It must cover every existing destination row that could match the source data. If a matching primary key exists outside the predicate, the merge treats the source row as new and may insert a duplicate.
+
 ## Strategies
 
 Bruin supports various materialization strategies that take your code and convert it to another structure behind the scenes to materialize the execution results of your assets.

--- a/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
+++ b/integration-tests/test-pipelines/parse-asset-extends/expectations/pipeline.json
@@ -30,6 +30,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [],

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage-asset.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage-asset.json
@@ -16,6 +16,7 @@
       "partition_by": "",
       "cluster_by": null,
       "incremental_key": "",
+      "incremental_predicate": "",
       "time_granularity": ""
     },
     "upstreams": [

--- a/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-asset-lineage-pipeline/expectations/lineage.json
@@ -23,6 +23,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "interval_modifiers": null,
@@ -123,6 +124,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "interval_modifiers": null,
@@ -288,6 +290,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "interval_modifiers": null,
@@ -442,6 +445,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "interval_modifiers": null,

--- a/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-default-option/expectations/pipeline.yml.json
@@ -184,6 +184,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/pipeline.yml.json
@@ -186,6 +186,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [

--- a/integration-tests/test-pipelines/parse-happy-path/expectations/player_summary.sql.json
+++ b/integration-tests/test-pipelines/parse-happy-path/expectations/player_summary.sql.json
@@ -16,6 +16,7 @@
       "partition_by": "",
       "cluster_by": null,
       "incremental_key": "",
+      "incremental_predicate": "",
       "time_granularity": ""
     },
     "upstreams": [

--- a/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
+++ b/integration-tests/test-pipelines/parse-lineage-pipeline/expectations/lineage.json
@@ -30,6 +30,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [
@@ -148,6 +149,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [
@@ -345,6 +347,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [
@@ -531,6 +534,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [],

--- a/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
+++ b/integration-tests/test-pipelines/parse-whole-pipeline/expectations/pipeline.yml.json
@@ -164,6 +164,7 @@
         "partition_by": "",
         "cluster_by": null,
         "incremental_key": "",
+        "incremental_predicate": "",
         "time_granularity": ""
       },
       "upstreams": [

--- a/pkg/ansisql/materialization.go
+++ b/pkg/ansisql/materialization.go
@@ -20,6 +20,19 @@ func GetColumnsWithMergeLogic(asset *pipeline.Asset) []pipeline.Column {
 	return columns
 }
 
+// AddIncrementalPredicate appends the user-provided SQL predicate to a merge
+// match condition. The predicate is intentionally treated as plain SQL so it
+// can use database-specific syntax and the target/source aliases exposed by
+// materializers.
+func AddIncrementalPredicate(conditions []string, predicate string) []string {
+	predicate = strings.TrimSpace(predicate)
+	if predicate == "" {
+		return conditions
+	}
+
+	return append(conditions, "("+predicate+")")
+}
+
 // BuildTruncateInsertQuery creates a truncate+insert query that works for standard ANSI SQL databases.
 // This can be used by platforms that support standard TRUNCATE TABLE syntax with transactions.
 func BuildTruncateInsertQuery(task *pipeline.Asset, query string) (string, error) {

--- a/pkg/ansisql/materialization_test.go
+++ b/pkg/ansisql/materialization_test.go
@@ -60,3 +60,17 @@ COMMIT;`,
 		})
 	}
 }
+
+func TestAddIncrementalPredicate(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"target.id = source.id"}
+
+	assert.Equal(t, base, AddIncrementalPredicate(base, ""))
+	assert.Equal(t, base, AddIncrementalPredicate(base, "   "))
+	assert.Equal(
+		t,
+		[]string{"target.id = source.id", "(target.event_date >= DATE '2026-07-01')"},
+		AddIncrementalPredicate(base, "  target.event_date >= DATE '2026-07-01'  "),
+	)
+}

--- a/pkg/athena/materialization.go
+++ b/pkg/athena/materialization.go
@@ -94,6 +94,7 @@ func buildMergeQuery(asset *pipeline.Asset, query, location string) ([]string, e
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	columnNamesWithSource := make([]string, len(columnNames))

--- a/pkg/bigquery/materialization.go
+++ b/pkg/bigquery/materialization.go
@@ -72,6 +72,7 @@ func mergeMaterializer(asset *pipeline.Asset, query string) (string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("(source.%s = target.%s OR (source.%s IS NULL and target.%s IS NULL))", key, key, key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	allColumnValues := strings.Join(columnNames, ", ")

--- a/pkg/bigquery/materialization_test.go
+++ b/pkg/bigquery/materialization_test.go
@@ -323,6 +323,29 @@ INSERT INTO my.asset SELECT 1 as id, 'test' as name`,
 				"WHEN NOT MATCHED THEN INSERT\\(dt, event_type, value, value2\\) VALUES\\(dt, event_type, value, value2\\);",
 		},
 		{
+			name: "merge with incremental predicate",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true},
+					{Name: "event_date"},
+					{Name: "value", UpdateOnMerge: true},
+				},
+				Materialization: pipeline.Materialization{
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyMerge,
+					IncrementalPredicate: "target.event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)",
+				},
+			},
+			query: "SELECT id, event_date, value FROM source_table",
+			want: "MERGE my.asset target\n" +
+				"USING (SELECT id, event_date, value FROM source_table) source\n" +
+				"ON ((source.id = target.id OR (source.id IS NULL and target.id IS NULL)) AND (target.event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)))\n" +
+				"WHEN MATCHED THEN UPDATE SET target.value = source.value\n" +
+				"WHEN NOT MATCHED THEN INSERT(id, event_date, value) VALUES(id, event_date, value);",
+			exactMatch: true,
+		},
+		{
 			name: "merge with merge_sql custom expressions",
 			task: &pipeline.Asset{
 				Name: "my.asset",

--- a/pkg/databricks/materialization.go
+++ b/pkg/databricks/materialization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/tablename"
@@ -96,6 +97,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) ([]string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	allColumnValues := strings.Join(columnNames, ", ")

--- a/pkg/doris/materialization.go
+++ b/pkg/doris/materialization.go
@@ -200,6 +200,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", quoteColumnName(key), quoteColumnName(key)))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 
 	mergeLines := []string{
 		fmt.Sprintf("MERGE INTO %s target", quoteIdentifier(asset.Name)),

--- a/pkg/duckdb/materialization.go
+++ b/pkg/duckdb/materialization.go
@@ -126,6 +126,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	for _, pk := range primaryKeys {
 		onConditions = append(onConditions, fmt.Sprintf("target.%s = source.%s", pk, pk))
 	}
+	onConditions = ansisql.AddIncrementalPredicate(onConditions, asset.Materialization.IncrementalPredicate)
 	onCondition := strings.Join(onConditions, " AND ")
 
 	allColumnNames := strings.Join(columnNames, ", ")

--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -101,6 +101,11 @@ func buildDeleteInsertQuery(asset *pipeline.Asset, query string) (string, error)
 
 // buildMergeQuery falls back to delete+insert because Fabric MERGE is limited.
 func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
+	// The delete+insert fallback has no merge match condition to attach the predicate to.
+	if strings.TrimSpace(asset.Materialization.IncrementalPredicate) != "" {
+		return "", errors.New("incremental_predicate is not supported for Fabric merge materialization")
+	}
+
 	return buildDeleteInsertQuery(asset, query)
 }
 

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -99,6 +99,21 @@ func TestBuildDeleteInsertQuery(t *testing.T) {
 	})
 }
 
+func TestBuildMergeQueryRejectsIncrementalPredicate(t *testing.T) {
+	t.Parallel()
+	asset := &pipeline.Asset{
+		Name: "dbo.Table",
+		Materialization: pipeline.Materialization{
+			Type:                 pipeline.MaterializationTypeTable,
+			Strategy:             pipeline.MaterializationStrategyMerge,
+			IncrementalPredicate: "target.event_date >= '2026-07-01'",
+		},
+		Columns: []pipeline.Column{{Name: "id", PrimaryKey: true}},
+	}
+	_, err := buildMergeQuery(asset, "SELECT 1")
+	require.ErrorContains(t, err, "incremental_predicate is not supported for Fabric merge materialization")
+}
+
 func TestBuildDDLQuery(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -447,6 +447,10 @@ func applyMaterializationParameters(asset *pipeline.Asset) error {
 	}
 
 	mat := asset.Materialization
+	if hasIngestrIncrementalPredicate(asset, mat) {
+		return errors.New("incremental_predicate is not supported for ingestr assets")
+	}
+
 	if mat.Type == pipeline.MaterializationTypeNone {
 		return nil
 	}
@@ -482,7 +486,6 @@ func applyMaterializationParameters(asset *pipeline.Asset) error {
 	if hasIngestrIncrementalKey(asset, mat) && !python.IsIngestrIncrementalKeyStrategy(effectiveStrategy) {
 		return errors.New("materialization.incremental_key is only supported for append, merge, and delete+insert strategies on ingestr assets")
 	}
-
 	if err := setMaterializationParameter(asset.Parameters, "incremental_key", mat.IncrementalKey, "materialization.incremental_key"); err != nil {
 		return err
 	}
@@ -507,6 +510,14 @@ func hasIngestrIncrementalKey(asset *pipeline.Asset, mat pipeline.Materializatio
 	}
 	key, _ := asset.Parameters.GetString("incremental_key")
 	return strings.TrimSpace(key) != ""
+}
+
+func hasIngestrIncrementalPredicate(asset *pipeline.Asset, mat pipeline.Materialization) bool {
+	if strings.TrimSpace(mat.IncrementalPredicate) != "" {
+		return true
+	}
+	predicate, _ := asset.Parameters.GetString("incremental_predicate")
+	return strings.TrimSpace(predicate) != ""
 }
 
 func setMaterializationParameter(params pipeline.ParameterMap, key, value, source string) error {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -205,6 +205,39 @@ func TestApplyMaterializationParameters(t *testing.T) {
 			},
 		},
 		{
+			name: "incremental predicate from materialization is rejected",
+			asset: &pipeline.Asset{
+				Materialization: pipeline.Materialization{
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyMerge,
+					IncrementalPredicate: "target.event_date >= DATE '2026-07-01'",
+				},
+			},
+			wantErr: "incremental_predicate is not supported for ingestr assets",
+		},
+		{
+			name: "incremental predicate from parameters is rejected",
+			asset: &pipeline.Asset{
+				Parameters: pipeline.ParameterMap{
+					"incremental_predicate": "target.event_date >= DATE '2026-06-01'",
+				},
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+			},
+			wantErr: "incremental_predicate is not supported for ingestr assets",
+		},
+		{
+			name: "incremental predicate is rejected even without materialization",
+			asset: &pipeline.Asset{
+				Parameters: pipeline.ParameterMap{
+					"incremental_predicate": "target.event_date >= DATE '2026-06-01'",
+				},
+			},
+			wantErr: "incremental_predicate is not supported for ingestr assets",
+		},
+		{
 			name: "matching parameters are allowed",
 			asset: &pipeline.Asset{
 				Parameters: pipeline.ParameterMap{

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -346,6 +346,13 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 func validateIngestrMaterialization(asset *pipeline.Asset, effectiveStrategy string) ([]*Issue, string) {
 	issues := make([]*Issue, 0)
 	mat := asset.Materialization
+	if hasIngestrMaterializationIncrementalPredicate(asset, mat) {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Incremental predicate is not supported for ingestr assets",
+		})
+	}
+
 	if mat.Type == pipeline.MaterializationTypeNone {
 		return issues, ""
 	}
@@ -378,7 +385,6 @@ func validateIngestrMaterialization(asset *pipeline.Asset, effectiveStrategy str
 			Description: "Materialization incremental key is only supported for append, merge, and delete+insert strategies on ingestr assets",
 		})
 	}
-
 	issues = append(issues, validateIngestrMaterializationConflict(asset, "incremental_key", mat.IncrementalKey, "materialization.incremental_key")...)
 	issues = append(issues, validateIngestrMaterializationConflict(asset, "partition_by", mat.PartitionBy, "materialization.partition_by")...)
 	issues = append(issues, validateIngestrMaterializationConflict(asset, "cluster_by", strings.Join(mat.ClusterBy, ","), "materialization.cluster_by")...)
@@ -392,6 +398,14 @@ func hasIngestrMaterializationIncrementalKey(asset *pipeline.Asset, mat pipeline
 	}
 	key, _ := asset.Parameters.GetString("incremental_key")
 	return strings.TrimSpace(key) != ""
+}
+
+func hasIngestrMaterializationIncrementalPredicate(asset *pipeline.Asset, mat pipeline.Materialization) bool {
+	if strings.TrimSpace(mat.IncrementalPredicate) != "" {
+		return true
+	}
+	predicate, _ := asset.Parameters.GetString("incremental_predicate")
+	return strings.TrimSpace(predicate) != ""
 }
 
 func validateIngestrMaterializationConflict(asset *pipeline.Asset, key, value, source string) []*Issue {
@@ -618,6 +632,13 @@ func ValidatePythonAssetMaterialization(ctx context.Context, p *pipeline.Pipelin
 		issues = append(issues, &Issue{
 			Task:        asset,
 			Description: "A task with materialization must have a connection defined",
+		})
+	}
+
+	if asset.Materialization.IncrementalPredicate != "" {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Incremental predicate is not supported for Python assets",
 		})
 	}
 
@@ -1304,6 +1325,13 @@ func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *p
 			})
 		}
 
+		if asset.Materialization.IncrementalPredicate != "" {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "Materialization incremental predicate is not supported for views",
+			})
+		}
+
 		if asset.Materialization.ClusterBy != nil {
 			issues = append(issues, &Issue{
 				Task:        asset,
@@ -1319,6 +1347,13 @@ func EnsureMaterializationValuesAreValidForSingleAsset(ctx context.Context, p *p
 		}
 
 	case pipeline.MaterializationTypeTable:
+		if asset.Materialization.IncrementalPredicate != "" && asset.Materialization.Strategy != pipeline.MaterializationStrategyMerge {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "Incremental predicate is only supported with the 'merge' strategy.",
+			})
+		}
+
 		if asset.Materialization.Strategy == pipeline.MaterializationStrategyNone {
 			return issues, nil
 		}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1264,11 +1264,12 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 				{
 					Name: "task1",
 					Materialization: pipeline.Materialization{
-						Type:           pipeline.MaterializationTypeView,
-						Strategy:       "whatever",
-						IncrementalKey: "whatever",
-						ClusterBy:      []string{"whatever"},
-						PartitionBy:    "whatever",
+						Type:                 pipeline.MaterializationTypeView,
+						Strategy:             "whatever",
+						IncrementalKey:       "whatever",
+						IncrementalPredicate: "whatever",
+						ClusterBy:            []string{"whatever"},
+						PartitionBy:          "whatever",
 					},
 				},
 			},
@@ -1276,6 +1277,7 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			want: []string{
 				materializationStrategyIsNotSupportedForViews,
 				materializationIncrementalKeyNotSupportedForViews,
+				"Materialization incremental predicate is not supported for views",
 				materializationClusterByNotSupportedForViews,
 				materializationPartitionByNotSupportedForViews,
 			},
@@ -1321,6 +1323,23 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			wantErr: assert.NoError,
 			want: []string{
 				"Incremental key is only supported with 'delete+insert', 'time_interval', 'scd2_by_time' and 'scd2_by_column' strategies.",
+			},
+		},
+		{
+			name: "table materialization has incremental predicate but wrong strategy",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:                 pipeline.MaterializationTypeTable,
+						Strategy:             pipeline.MaterializationStrategyAppend,
+						IncrementalPredicate: "target.dt >= DATE '2026-07-01'",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: []string{
+				"Incremental predicate is only supported with the 'merge' strategy.",
 			},
 		},
 		{
@@ -2056,6 +2075,41 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 				},
 			},
 			wantErrMessage: "Materialization strategy 'ddl' is not supported for ingestr assets. Supported strategies are: create+replace, append, merge, delete+insert, truncate+insert",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "ingestr asset with incremental predicate",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "conn1",
+					"source_table":      "table1",
+					"destination":       "dest1",
+				},
+				Materialization: pipeline.Materialization{
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyMerge,
+					IncrementalPredicate: "target.updated_at >= DATE '2026-07-01'",
+				},
+				Columns: []pipeline.Column{
+					{Name: "col1", PrimaryKey: true},
+				},
+			},
+			wantErrMessage: "Incremental predicate is not supported for ingestr assets",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "ingestr asset with incremental predicate parameter and no materialization",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{
+					"source_connection":     "conn1",
+					"source_table":          "table1",
+					"destination":           "dest1",
+					"incremental_predicate": "target.updated_at >= DATE '2026-07-01'",
+				},
+			},
+			wantErrMessage: "Incremental predicate is not supported for ingestr assets",
 			wantErr:        assert.NoError,
 		},
 		{
@@ -3281,6 +3335,39 @@ func TestEnsureValidPythonAssetMaterialization(t *testing.T) {
 				},
 			},
 			want:    []*Issue{},
+			wantErr: false,
+		},
+		{
+			name: "python asset with incremental predicate",
+			p: &pipeline.Pipeline{
+				Assets: []*pipeline.Asset{
+					{
+						Name: "asset1",
+						Type: pipeline.AssetTypePython,
+						Materialization: pipeline.Materialization{
+							Type:                 pipeline.MaterializationTypeTable,
+							Strategy:             pipeline.MaterializationStrategyMerge,
+							IncrementalPredicate: "target.updated_at >= DATE '2026-07-01'",
+						},
+						Connection: "conn1",
+					},
+				},
+			},
+			want: []*Issue{
+				{
+					Task: &pipeline.Asset{
+						Name: "asset1",
+						Type: pipeline.AssetTypePython,
+						Materialization: pipeline.Materialization{
+							Type:                 pipeline.MaterializationTypeTable,
+							Strategy:             pipeline.MaterializationStrategyMerge,
+							IncrementalPredicate: "target.updated_at >= DATE '2026-07-01'",
+						},
+						Connection: "conn1",
+					},
+					Description: "Incremental predicate is not supported for Python assets",
+				},
+			},
 			wantErr: false,
 		},
 		{

--- a/pkg/mssql/materialization.go
+++ b/pkg/mssql/materialization.go
@@ -144,6 +144,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	allColumnValues := strings.Join(columnNames, ", ")

--- a/pkg/mysql/materialization.go
+++ b/pkg/mysql/materialization.go
@@ -213,6 +213,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 
 	tempTableName := "__bruin_merge_tmp_" + helpers.PrefixGenerator()
 	onClause := buildJoinConditions(primaryKeys, "target", "source")
+	onClause = strings.Join(ansisql.AddIncrementalPredicate([]string{onClause}, asset.Materialization.IncrementalPredicate), " AND ")
 
 	queries := []string{
 		"START TRANSACTION",

--- a/pkg/oracle/materialization.go
+++ b/pkg/oracle/materialization.go
@@ -305,7 +305,8 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	}
 	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
 
-	onQuery := strings.Join(buildPKConditions(primaryKeys, "target", "source"), " AND ")
+	on := ansisql.AddIncrementalPredicate(buildPKConditions(primaryKeys, "target", "source"), asset.Materialization.IncrementalPredicate)
+	onQuery := strings.Join(on, " AND ")
 
 	insertCols := strings.Join(columnNames, ", ")
 

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -358,6 +358,9 @@ func commentRowsToTask(commentRows []string) (*Asset, error) {
 			case "incremental_key":
 				task.Materialization.IncrementalKey = value
 				continue
+			case "incremental_predicate":
+				task.Materialization.IncrementalPredicate = value
+				continue
 			case "cluster_by":
 				values := strings.Split(value, ",")
 				for _, v := range values {

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -87,11 +87,12 @@ func Test_createTaskFromFile(t *testing.T) {
 				},
 
 				Materialization: pipeline.Materialization{
-					Type:           pipeline.MaterializationTypeTable,
-					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
-					PartitionBy:    "dt",
-					IncrementalKey: "dt",
-					ClusterBy:      []string{"event_name"},
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyDeleteInsert,
+					PartitionBy:          "dt",
+					IncrementalKey:       "dt",
+					IncrementalPredicate: "target.dt >= DATE '2026-07-01'",
+					ClusterBy:            []string{"event_name"},
 				},
 				Columns: []pipeline.Column{
 					{Name: "some_column", PrimaryKey: true, Type: "numeric", Precision: ptrInt(10), Scale: ptrInt(2), Checks: make([]pipeline.ColumnCheck, 0)},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -604,16 +604,17 @@ var AllAvailableMaterializationStrategies = []MaterializationStrategy{
 }
 
 type Materialization struct {
-	Type            MaterializationType            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
-	Strategy        MaterializationStrategy        `json:"strategy" yaml:"strategy,omitempty" mapstructure:"strategy"`
-	PartitionBy     string                         `json:"partition_by" yaml:"partition_by,omitempty" mapstructure:"partition_by"`
-	ClusterBy       []string                       `json:"cluster_by" yaml:"cluster_by,omitempty" mapstructure:"cluster_by"`
-	IncrementalKey  string                         `json:"incremental_key" yaml:"incremental_key,omitempty" mapstructure:"incremental_key"`
-	TimeGranularity MaterializationTimeGranularity `json:"time_granularity" yaml:"time_granularity,omitempty" mapstructure:"time_granularity"`
+	Type                 MaterializationType            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
+	Strategy             MaterializationStrategy        `json:"strategy" yaml:"strategy,omitempty" mapstructure:"strategy"`
+	PartitionBy          string                         `json:"partition_by" yaml:"partition_by,omitempty" mapstructure:"partition_by"`
+	ClusterBy            []string                       `json:"cluster_by" yaml:"cluster_by,omitempty" mapstructure:"cluster_by"`
+	IncrementalKey       string                         `json:"incremental_key" yaml:"incremental_key,omitempty" mapstructure:"incremental_key"`
+	IncrementalPredicate string                         `json:"incremental_predicate" yaml:"incremental_predicate,omitempty" mapstructure:"incremental_predicate"`
+	TimeGranularity      MaterializationTimeGranularity `json:"time_granularity" yaml:"time_granularity,omitempty" mapstructure:"time_granularity"`
 }
 
 func (m Materialization) MarshalJSON() ([]byte, error) {
-	if m.Type == "" && m.Strategy == "" && m.PartitionBy == "" && len(m.ClusterBy) == 0 && m.IncrementalKey == "" && m.TimeGranularity == "" {
+	if m.Type == "" && m.Strategy == "" && m.PartitionBy == "" && len(m.ClusterBy) == 0 && m.IncrementalKey == "" && m.IncrementalPredicate == "" && m.TimeGranularity == "" {
 		return []byte("null"), nil
 	}
 
@@ -3251,6 +3252,9 @@ func mergeMaterializationDefaults(target *Materialization, defaults Materializat
 	}
 	if target.IncrementalKey == "" {
 		target.IncrementalKey = defaults.IncrementalKey
+	}
+	if target.IncrementalPredicate == "" {
+		target.IncrementalPredicate = defaults.IncrementalPredicate
 	}
 	if target.TimeGranularity == "" {
 		target.TimeGranularity = defaults.TimeGranularity

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -989,7 +989,14 @@ func TestMaterialization_MarshalJSON(t *testing.T) {
 			materialization: pipeline.Materialization{
 				TimeGranularity: pipeline.MaterializationTimeGranularityDate,
 			},
-			want: `{"type":"","strategy":"","partition_by":"","cluster_by":null,"incremental_key":"","time_granularity":"date"}`,
+			want: `{"type":"","strategy":"","partition_by":"","cluster_by":null,"incremental_key":"","incremental_predicate":"","time_granularity":"date"}`,
+		},
+		{
+			name: "incremental predicate only materialization is preserved",
+			materialization: pipeline.Materialization{
+				IncrementalPredicate: "target.dt >= DATE '2026-07-01'",
+			},
+			want: `{"type":"","strategy":"","partition_by":"","cluster_by":null,"incremental_key":"","incremental_predicate":"target.dt >= DATE '2026-07-01'","time_granularity":""}`,
 		},
 	}
 
@@ -2731,11 +2738,12 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 		Domains:     []string{"default-domain", "asset-domain"},
 		Meta:        pipeline.EmptyStringMap{"shared": "default", "default": "yes"},
 		Materialization: pipeline.Materialization{
-			Type:           pipeline.MaterializationTypeTable,
-			Strategy:       pipeline.MaterializationStrategyCreateReplace,
-			PartitionBy:    "dt",
-			ClusterBy:      []string{"tenant"},
-			IncrementalKey: "updated_at",
+			Type:                 pipeline.MaterializationTypeTable,
+			Strategy:             pipeline.MaterializationStrategyCreateReplace,
+			PartitionBy:          "dt",
+			ClusterBy:            []string{"tenant"},
+			IncrementalKey:       "updated_at",
+			IncrementalPredicate: "target.dt >= DATE '2026-07-01'",
 		},
 		Upstreams: []pipeline.Upstream{
 			{Type: "asset", Value: "default-upstream"},
@@ -2814,6 +2822,8 @@ func TestBuilder_SetupDefaultsFromPipelineAppliesAssetFieldDefaults(t *testing.T
 	assert.Equal(t, pipeline.MaterializationStrategyAppend, got.Materialization.Strategy)
 	assert.Equal(t, "dt", got.Materialization.PartitionBy)
 	assert.Equal(t, []string{"tenant"}, got.Materialization.ClusterBy)
+	assert.Equal(t, "updated_at", got.Materialization.IncrementalKey)
+	assert.Equal(t, "target.dt >= DATE '2026-07-01'", got.Materialization.IncrementalPredicate)
 	assert.Equal(t, []pipeline.Upstream{
 		{Type: "asset", Value: "asset-upstream"},
 		{Type: "asset", Value: "default-upstream"},

--- a/pkg/pipeline/testdata/comments/test.sql
+++ b/pkg/pipeline/testdata/comments/test.sql
@@ -14,6 +14,7 @@
 -- @bruin.materialization.cluster_by: event_name
 -- @bruin.materialization.strategy: delete+insert
 -- @bruin.materialization.incremental_key: dt
+-- @bruin.materialization.incremental_predicate: target.dt >= DATE '2026-07-01'
 -- @bruin.columns.some_column.primary_key: true
 -- @bruin.columns.some_column.type: numeric
 -- @bruin.columns.some_column.precision: 10

--- a/pkg/pipeline/testdata/yaml/task1/task.yml
+++ b/pkg/pipeline/testdata/yaml/task1/task.yml
@@ -13,6 +13,7 @@ materialization:
   strategy: "create+replace"
   partition_by: dt
   incremental_key: dt
+  incremental_predicate: target.dt >= DATE '2026-07-01'
   cluster_by:
     - key1
     - key2
@@ -44,4 +45,3 @@ columns:
           - 3
   - name: col2
     description: "column two"
-

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -425,6 +425,9 @@ func renderAssetStrings(render RenderFunc, a *Asset) error {
 	if a.Materialization.IncrementalKey, err = maybeRender(render, fmt.Sprintf("asset[%s].materialization.incremental_key", originalName), a.Materialization.IncrementalKey); err != nil {
 		return err
 	}
+	if a.Materialization.IncrementalPredicate, err = maybeRender(render, fmt.Sprintf("asset[%s].materialization.incremental_predicate", originalName), a.Materialization.IncrementalPredicate); err != nil {
+		return err
+	}
 	for i, c := range a.Materialization.ClusterBy {
 		if a.Materialization.ClusterBy[i], err = maybeRender(render, fmt.Sprintf("asset[%s].materialization.cluster_by[%d]", originalName, i), c); err != nil {
 			return err

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -210,12 +210,13 @@ func (a *clusterBy) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type materialization struct {
-	Type            string    `yaml:"type"`
-	Strategy        string    `yaml:"strategy"`
-	PartitionBy     string    `yaml:"partition_by"`
-	ClusterBy       clusterBy `yaml:"cluster_by"`
-	IncrementalKey  string    `yaml:"incremental_key"`
-	TimeGranularity string    `yaml:"time_granularity,omitempty"`
+	Type                 string    `yaml:"type"`
+	Strategy             string    `yaml:"strategy"`
+	PartitionBy          string    `yaml:"partition_by"`
+	ClusterBy            clusterBy `yaml:"cluster_by"`
+	IncrementalKey       string    `yaml:"incremental_key"`
+	IncrementalPredicate string    `yaml:"incremental_predicate"`
+	TimeGranularity      string    `yaml:"time_granularity,omitempty"`
 }
 
 type columnCheckValue struct {
@@ -505,12 +506,13 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 
 func taskDefinitionToAsset(definition taskDefinition) (*Asset, error) {
 	mat := Materialization{
-		Type:            MaterializationType(strings.ToLower(definition.Materialization.Type)),
-		Strategy:        MaterializationStrategy(strings.ToLower(definition.Materialization.Strategy)),
-		ClusterBy:       definition.Materialization.ClusterBy,
-		PartitionBy:     definition.Materialization.PartitionBy,
-		IncrementalKey:  definition.Materialization.IncrementalKey,
-		TimeGranularity: MaterializationTimeGranularity(strings.ToLower(definition.Materialization.TimeGranularity)),
+		Type:                 MaterializationType(strings.ToLower(definition.Materialization.Type)),
+		Strategy:             MaterializationStrategy(strings.ToLower(definition.Materialization.Strategy)),
+		ClusterBy:            definition.Materialization.ClusterBy,
+		PartitionBy:          definition.Materialization.PartitionBy,
+		IncrementalKey:       definition.Materialization.IncrementalKey,
+		IncrementalPredicate: definition.Materialization.IncrementalPredicate,
+		TimeGranularity:      MaterializationTimeGranularity(strings.ToLower(definition.Materialization.TimeGranularity)),
 	}
 
 	columns := make([]Column, len(definition.Columns))

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -69,11 +69,12 @@ func TestCreateTaskFromYamlDefinition(t *testing.T) {
 					},
 				},
 				Materialization: pipeline.Materialization{
-					Type:           pipeline.MaterializationTypeTable,
-					Strategy:       pipeline.MaterializationStrategyCreateReplace,
-					ClusterBy:      []string{"key1", "key2"},
-					PartitionBy:    "dt",
-					IncrementalKey: "dt",
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyCreateReplace,
+					ClusterBy:            []string{"key1", "key2"},
+					PartitionBy:          "dt",
+					IncrementalKey:       "dt",
+					IncrementalPredicate: "target.dt >= DATE '2026-07-01'",
 				},
 				Hooks: pipeline.Hooks{
 					Pre:  []pipeline.Hook{{Query: "select 1"}},

--- a/pkg/postgres/materialization.go
+++ b/pkg/postgres/materialization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
@@ -132,6 +133,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", QuoteIdentifier(key), QuoteIdentifier(key)))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	// Quote all column names for INSERT clause
@@ -171,6 +173,12 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 }
 
 func buildRedshiftMergeQuery(asset *pipeline.Asset, query string) (string, error) {
+	// Redshift MERGE only accepts equality predicates between source and target columns
+	// in its match condition, so arbitrary incremental predicates cannot be supported.
+	if strings.TrimSpace(asset.Materialization.IncrementalPredicate) != "" {
+		return "", errors.New("incremental_predicate is not supported for Redshift merge materialization")
+	}
+
 	if len(asset.Columns) == 0 {
 		return "", fmt.Errorf("materialization strategy %s requires the `columns` field to be set", asset.Materialization.Strategy)
 	}

--- a/pkg/postgres/materialization_test.go
+++ b/pkg/postgres/materialization_test.go
@@ -222,6 +222,44 @@ WHEN MATCHED THEN UPDATE SET "name" = source\."name"
 WHEN NOT MATCHED THEN INSERT\("id", "name"\) VALUES\(source."id", source."name"\);$`,
 		},
 		{
+			name: "merge with incremental predicate",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyMerge,
+					IncrementalPredicate: "target.event_date >= DATE '2026-07-01'",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "name", Type: "varchar", PrimaryKey: false, UpdateOnMerge: true},
+				},
+			},
+			query: "SELECT 1 as id, 'abc' as name",
+			want: `^MERGE INTO "my"\."asset" target
+USING \(SELECT 1 as id, 'abc' as name\) source ON target\."id" = source\."id" AND \(target\.event_date >= DATE '2026-07-01'\)
+WHEN MATCHED THEN UPDATE SET "name" = source\."name"
+WHEN NOT MATCHED THEN INSERT\("id", "name"\) VALUES\("id", "name"\);$`,
+		},
+		{
+			name: "redshift merge with incremental predicate is rejected",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Type: "rs.sql",
+				Materialization: pipeline.Materialization{
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyMerge,
+					IncrementalPredicate: "event_date >= DATE '2026-07-01'",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "name", Type: "varchar", PrimaryKey: false, UpdateOnMerge: true},
+				},
+			},
+			query:   "SELECT 1 as id, 'abc' as name",
+			wantErr: true,
+		},
+		{
 			name: "merge with case-sensitive fields",
 			task: &pipeline.Asset{
 				Name: "my.asset",

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -350,6 +350,10 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		return errors.New("only table materialization is supported for Python assets")
 	}
 
+	if mat.IncrementalPredicate != "" {
+		return errors.New("incremental_predicate is not supported for Python assets")
+	}
+
 	arrowFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("asset_data_%d.arrow", time.Now().UnixNano()))
 	defer func(name string) {
 		_ = os.Remove(name)

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -152,6 +152,27 @@ func Test_uvPythonRunner_RunWithMaterialization_DisablesTelemetryForIngestrUploa
 	cmd.AssertExpectations(t)
 }
 
+func Test_uvPythonRunner_RunWithMaterialization_RejectsIncrementalPredicate(t *testing.T) {
+	t.Parallel()
+
+	runner := &UvPythonRunner{}
+
+	err := runner.runWithMaterialization(t.Context(), &executionContext{
+		asset: &pipeline.Asset{
+			Name:       "public.asset_data",
+			Type:       pipeline.AssetTypePython,
+			Connection: "dest",
+			Materialization: pipeline.Materialization{
+				Type:                 "table",
+				Strategy:             pipeline.MaterializationStrategyMerge,
+				IncrementalPredicate: "target.event_date >= DATE '2026-07-01'",
+			},
+		},
+	}, "")
+
+	require.ErrorContains(t, err, "incremental_predicate is not supported for Python assets")
+}
+
 func extractArrowPathFromScript(t *testing.T, script string) string {
 	t.Helper()
 

--- a/pkg/snowflake/materialization.go
+++ b/pkg/snowflake/materialization.go
@@ -107,6 +107,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	allColumnValues := strings.Join(columnNames, ", ")

--- a/pkg/synapse/materialization.go
+++ b/pkg/synapse/materialization.go
@@ -127,6 +127,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) ([]string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	allColumnValues := strings.Join(columnNames, ", ")

--- a/pkg/vertica/materialization.go
+++ b/pkg/vertica/materialization.go
@@ -106,6 +106,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	for _, key := range primaryKeys {
 		on = append(on, fmt.Sprintf("target.%s = source.%s", key, key))
 	}
+	on = ansisql.AddIncrementalPredicate(on, asset.Materialization.IncrementalPredicate)
 	onQuery := strings.Join(on, " AND ")
 
 	allColumnValues := strings.Join(columnNames, ", ")


### PR DESCRIPTION
Adds `materialization.incremental_predicate` and applies its raw SQL to merge match conditions for supported SQL assets. Unsupported Redshift, Fabric, Ingestr, and Python paths now return clear validation errors, with parsing snapshots and documentation updated. Validated with `make format` and `make test`.
