### PR TITLE
fix: disable ANSI colors in run output

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -568,6 +568,12 @@ func setApplyIntervalModifiers(c *cli.Command) bool {
 	return applyIntervalModifiers
 }
 
+func disableColorIfRequested(noColor bool) {
+	if noColor {
+		color.NoColor = true
+	}
+}
+
 func Run(isDebug *bool) *cli.Command {
 	return &cli.Command{
 		Name:      "run",
@@ -735,6 +741,8 @@ func Run(isDebug *bool) *cli.Command {
 		DisableSliceFlagSeparator: true,
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
+			noColor := c.Bool("no-color")
+			disableColorIfRequested(noColor)
 
 			logger := makeLogger(*isDebug)
 			if c.IsSet("use-pip") {
@@ -1169,7 +1177,6 @@ func Run(isDebug *bool) *cli.Command {
 				pipelineInfo.RunDownstreamTasks = true
 			}
 
-			noColor := c.Bool("no-color")
 			minimalLogs := c.Bool("minimal-logs")
 
 			// Detect the real terminal here, before logOutput swaps os.Stdout for

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -13,12 +13,30 @@ import (
 	"github.com/bruin-data/bruin/pkg/logger"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/scheduler"
+	"github.com/fatih/color"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
+
+func TestDisableColorIfRequested(t *testing.T) { //nolint:paralleltest // mutates global color.NoColor
+	previousNoColor := color.NoColor
+	t.Cleanup(func() {
+		color.NoColor = previousNoColor
+	})
+
+	color.NoColor = true
+	disableColorIfRequested(false)
+	assert.True(t, color.NoColor)
+
+	color.NoColor = false
+	printer := color.New(color.FgBlue)
+	disableColorIfRequested(true)
+	assert.True(t, color.NoColor)
+	assert.NotContains(t, printer.Sprint("asset output"), "\x1b[")
+}
 
 func TestClean(t *testing.T) {
 	t.Parallel()

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -14,6 +14,8 @@ This command is used to execute a Bruin pipeline or a specific asset within a pi
 bruin run [FLAGS] [optional path to the pipeline/asset]
 ```
 
+Bruin omits ANSI color codes when `--no-color` is passed, when the `NO_COLOR` environment variable is set, or when standard output is not a terminal.
+
 <img alt="Bruin - init" src="/chesspipeline.gif" style="margin: 10px;" />
 
 <style>

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	_ "github.com/bruin-data/bruin/internal/bootstrap"
 	"github.com/bruin-data/bruin/pkg/telemetry"
 	v "github.com/bruin-data/bruin/pkg/version"
-	"github.com/fatih/color"
 	"github.com/urfave/cli/v3"
 )
 
@@ -21,7 +20,6 @@ var (
 
 func main() {
 	isDebug := false
-	color.NoColor = false
 	var optOut bool
 	if os.Getenv("TELEMETRY_OPTOUT") != "" {
 		optOut = true


### PR DESCRIPTION
Closes #2265.

Disables colors globally for `--no-color` and stops overriding `NO_COLOR` and non-TTY detection. Adds regression coverage and documents the behavior.

Tests: `make format`, `make test`, and built-binary pseudo-TTY checks.