### PR TITLE
Add `cloud dashboards update` command

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2859,6 +2859,7 @@ func CloudDashboards() *cli.Command {
 			cloudDashboardsList(),
 			cloudDashboardsGet(),
 			cloudDashboardsCreate(),
+			cloudDashboardsUpdate(),
 		},
 	}
 }
@@ -3138,6 +3139,121 @@ func cloudDashboardsCreate() *cli.Command {
 				infoPrinter.Printf("Created dashboard %d (%s) as a draft — open it to review and publish: %s\n", dashboard.ID, title, dashboard.URL)
 			} else {
 				infoPrinter.Printf("Created dashboard %d (%s) as a draft — publish it from the Bruin Cloud UI.\n", dashboard.ID, title)
+			}
+			return nil
+		},
+	}
+}
+
+func cloudDashboardsUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Update a dashboard's title, visibility or definition (definition written to draft; publish stays in the UI)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "dashboard-id",
+				Usage:    "dashboard ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "title",
+				Usage: "the new dashboard title",
+			},
+			&cli.StringFlag{
+				Name:  "visibility",
+				Usage: "team or private",
+			},
+			&cli.StringFlag{
+				Name:  "state",
+				Usage: "the dashboard definition as a JSON or YAML string",
+			},
+			&cli.StringFlag{
+				Name:  "state-file",
+				Usage: "path to a file containing the dashboard definition as JSON or YAML",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			// Build the patch from the flags actually set, so an explicit empty value
+			// is sent rather than dropped.
+			fields := map[string]any{}
+			if c.IsSet("title") {
+				fields["title"] = c.String("title")
+			}
+			if c.IsSet("visibility") {
+				visibility := c.String("visibility")
+				if visibility != "team" && visibility != "private" {
+					printError(fmt.Errorf("visibility must be 'team' or 'private', got %q", visibility), output, "Invalid --visibility")
+					return cli.Exit("", 1)
+				}
+				fields["visibility"] = visibility
+			}
+
+			// The definition can come inline (--state) or from a file (--state-file),
+			// but not both — otherwise a stale file could silently override the flag.
+			if c.IsSet("state") && c.IsSet("state-file") {
+				printError(errors.New("pass only one of --state or --state-file"), output, "Ambiguous state")
+				return cli.Exit("", 1)
+			}
+			if c.IsSet("state") || c.IsSet("state-file") {
+				raw := c.String("state")
+				if file := c.String("state-file"); file != "" {
+					data, err := os.ReadFile(file)
+					if err != nil {
+						printError(fmt.Errorf("failed to read --state-file: %w", err), output, "Invalid state file")
+						return cli.Exit("", 1)
+					}
+					raw = string(data)
+				}
+				// Accept JSON or YAML — dashboards are YAML-native and JSON is valid YAML.
+				state, err := parseDashboardState([]byte(raw))
+				if err != nil {
+					printError(fmt.Errorf("invalid dashboard definition (expected a JSON or YAML object): %w", err), output, "Invalid state")
+					return cli.Exit("", 1)
+				}
+				// A mapping is required; null/scalars/arrays are not a definition.
+				if state == nil {
+					printError(errors.New("dashboard definition must be a JSON or YAML object"), output, "Invalid state")
+					return cli.Exit("", 1)
+				}
+				fields["state"] = state
+			}
+
+			if len(fields) == 0 {
+				printError(errors.New("provide at least one of --title, --visibility, --state or --state-file"), output, "Nothing to update")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			dashboard, err := client.UpdateDashboard(ctx, c.Int("dashboard-id"), fields)
+			if err != nil {
+				printError(err, output, "Failed to update dashboard")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(dashboard, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			title := ""
+			if dashboard.Title != nil {
+				title = *dashboard.Title
+			}
+			if dashboard.URL != "" {
+				infoPrinter.Printf("Updated dashboard %d (%s) — open it to review and publish: %s\n", dashboard.ID, title, dashboard.URL)
+			} else {
+				infoPrinter.Printf("Updated dashboard %d (%s).\n", dashboard.ID, title)
 			}
 			return nil
 		},

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -228,7 +228,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	cmd := CloudDashboards()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "dashboards", cmd.Name)
-	require.Len(t, cmd.Commands, 3)
+	require.Len(t, cmd.Commands, 4)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -237,6 +237,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "list")
 	assert.Contains(t, subNames, "get")
 	assert.Contains(t, subNames, "create")
+	assert.Contains(t, subNames, "update")
 }
 
 func TestParseDashboardState(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -638,6 +638,26 @@ bruin cloud dashboards create --title "Q1 Revenue" --visibility team --state '{"
 bruin cloud dashboards create --title "Q1 Revenue" --state-file ./dashboard.json
 ```
 
+#### `update`
+
+Update an existing dashboard's title, visibility, or definition. Only the flags
+you pass are changed. Like `create`, a new definition is written to the
+dashboard's **draft** — never published automatically; publish it from the Bruin
+Cloud UI. Changing visibility requires manage-access (the dashboard creator or a
+team admin).
+
+```bash
+# Rename
+bruin cloud dashboards update --dashboard-id 42 --title "Q1 Revenue (final)"
+
+# Replace the definition, inline or from a file
+bruin cloud dashboards update --dashboard-id 42 --state '{"widgets":[]}'
+bruin cloud dashboards update --dashboard-id 42 --state-file ./dashboard.json
+
+# Change visibility
+bruin cloud dashboards update --dashboard-id 42 --visibility team
+```
+
 ---
 
 ## Common Workflows

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -600,3 +600,16 @@ func (c *APIClient) CreateDashboard(ctx context.Context, title, visibility strin
 	}
 	return &result, nil
 }
+
+// UpdateDashboard applies a partial update to a dashboard. Only the fields
+// present are changed; the definition (state) is written to the draft only
+// (never published), same as create. Changing visibility requires manage-access
+// on the server side.
+func (c *APIClient) UpdateDashboard(ctx context.Context, dashboardID int, fields map[string]any) (*Dashboard, error) {
+	var result Dashboard
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/dashboards/%d", dashboardID), fields, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -801,3 +801,27 @@ func TestCreateDashboard(t *testing.T) {
 	assert.Equal(t, 9, dashboard.ID)
 	assert.Equal(t, "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", dashboard.URL)
 }
+
+func TestUpdateDashboard(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/dashboards/9", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "Renamed", body["title"])
+		// omitted fields are left out so the server leaves them unchanged
+		_, hasVisibility := body["visibility"]
+		assert.False(t, hasVisibility)
+
+		w.WriteHeader(http.StatusOK)
+		title := "Renamed"
+		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "team", URL: "https://cloud.getbruin.com/acme/dashboards/9?mode=edit"})
+	})
+
+	dashboard, err := client.UpdateDashboard(t.Context(), 9, map[string]any{"title": "Renamed"})
+	require.NoError(t, err)
+	assert.Equal(t, 9, dashboard.ID)
+	assert.Equal(t, "Renamed", *dashboard.Title)
+}


### PR DESCRIPTION
Adds `bruin cloud dashboards update`, completing the create → get → update trio for dashboards (mirrors `cloud agents update`).

Wraps the new `PATCH /api/v1/dashboards/{id}` endpoint (cloud-side). Partial update of `--title`, `--visibility` and the definition (`--state` / `--state-file`); only the flags passed are changed. The definition is written to the **draft** only — never published; publish stays in the UI. Reuses the create command's JSON/YAML state parsing.

Server-side rules the CLI surfaces: the caller must be a user-scoped token with edit rights, and changing visibility requires manage-access (creator or team admin).

Depends on the cloud PR (bruin-data/cloud#2564) for the endpoint.