### PR TITLE
feat(import): add --ingestr database import flag

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -17,6 +17,7 @@ import (
 	"cloud.google.com/go/bigquery/datatransfer/apiv1/datatransferpb"
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/bigquery"
+	"github.com/bruin-data/bruin/pkg/ingestruri"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/logger"
 	"github.com/bruin-data/bruin/pkg/mongo"
@@ -81,12 +82,13 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 				Usage:   "skip filling column metadata from database schema",
 			},
 			&cli.BoolFlag{
-				Name:  "as-ingestr",
-				Usage: "generate runnable ingestr assets that replicate the source instead of source placeholders (MongoDB only)",
+				Name:    "ingestr",
+				Aliases: []string{"as-ingestr"},
+				Usage:   "generate runnable ingestr assets that replicate the source instead of source placeholders",
 			},
 			&cli.StringFlag{
 				Name:  "destination",
-				Usage: "destination platform for --as-ingestr assets (e.g. duckdb, postgres, bigquery)",
+				Usage: "destination platform for --ingestr assets (e.g. duckdb, postgres, bigquery)",
 			},
 			&cli.StringFlag{
 				Name:    "environment",
@@ -108,18 +110,18 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 
 			connectionName := c.String("connection")
 			noColumns := c.Bool("no-columns")
-			asIngestr := c.Bool("as-ingestr")
+			ingestrImport := c.Bool("ingestr")
 			destination := c.String("destination")
 			environment := c.String("environment")
 			configFile := c.String("config-file")
 			var err error
 
-			if validationErr := validateIngestrImportFlags(asIngestr, destination); validationErr != nil {
+			if validationErr := validateIngestrImportFlags(ingestrImport, destination); validationErr != nil {
 				return cli.Exit(validationErr.Error(), 1)
 			}
 
 			if connectionName == "" {
-				err = runImportDatabaseTUI(ctx, pipelinePath, environment, configFile, !noColumns, asIngestr, destination)
+				err = runImportDatabaseTUI(ctx, pipelinePath, environment, configFile, !noColumns, ingestrImport, destination)
 			} else {
 				schema := c.String("schema")
 				schemas := c.StringSlice("schemas")
@@ -128,7 +130,7 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 				}
 
 				log := makeLogger(*isDebug)
-				err = runImport(ctx, log, pipelinePath, connectionName, schema, schemas, !noColumns, environment, configFile, asIngestr, destination)
+				err = runImport(ctx, log, pipelinePath, connectionName, schema, schemas, !noColumns, environment, configFile, ingestrImport, destination)
 			}
 
 			if err != nil {
@@ -140,21 +142,21 @@ func ImportDatabase(isDebug *bool) *cli.Command {
 	}
 }
 
-// validateIngestrImportFlags validates the --as-ingestr / --destination flag
+// validateIngestrImportFlags validates the --ingestr / --destination flag
 // combination. The destination is required (and must be a known ingestr
 // destination platform) so the generated ingestr assets are runnable, and it
-// is rejected without --as-ingestr so a forgotten --as-ingestr does not
+// is rejected without --ingestr so a forgotten --ingestr does not
 // silently fall back to plain source placeholders.
-func validateIngestrImportFlags(asIngestr bool, destination string) error {
-	if !asIngestr {
+func validateIngestrImportFlags(ingestrImport bool, destination string) error {
+	if !ingestrImport {
 		if destination != "" {
-			return errors.New("--destination has no effect without --as-ingestr")
+			return errors.New("--destination has no effect without --ingestr")
 		}
 		return nil
 	}
 
 	if destination == "" {
-		return errors.New("--destination is required when using --as-ingestr")
+		return errors.New("--destination is required when using --ingestr")
 	}
 
 	if _, ok := pipeline.IngestrTypeConnectionMapping[destination]; !ok {
@@ -312,11 +314,11 @@ type importWarning struct {
 	message   string
 }
 
-func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionName, schema string, schemas []string, fillColumns bool, environment, configFile string, asIngestr bool, destination string) error {
+func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionName, schema string, schemas []string, fillColumns bool, environment, configFile string, ingestrImport bool, destination string) error {
 	fs := afero.NewOsFs()
 
-	log.Debugf("starting database import: connection=%s, schema=%q, schemas=%v, fillColumns=%v, environment=%q, asIngestr=%v, destination=%q",
-		connectionName, schema, schemas, fillColumns, environment, asIngestr, destination)
+	log.Debugf("starting database import: connection=%s, schema=%q, schemas=%v, fillColumns=%v, environment=%q, ingestr=%v, destination=%q",
+		connectionName, schema, schemas, fillColumns, environment, ingestrImport, destination)
 
 	conn, err := getConnectionFromConfigWithContext(ctx, environment, connectionName, fs, configFile)
 	if err != nil {
@@ -325,8 +327,8 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 
 	log.Debugf("resolved connection type: %T", conn)
 
-	if asIngestr && !isMongoConnection(conn) {
-		return fmt.Errorf("--as-ingestr is currently only supported for MongoDB connections, but '%s' is not a MongoDB connection", connectionName)
+	if ingestrImport && !supportsIngestrSource(conn) {
+		return fmt.Errorf("connection '%s' cannot be used as an ingestr source", connectionName)
 	}
 
 	var summary *ansisql.DBDatabase
@@ -405,7 +407,7 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 			fullName := fmt.Sprintf("%s.%s", schemaObj.Name, table.Name)
 			var createdAsset *pipeline.Asset
 			var warning string
-			if asIngestr {
+			if ingestrImport {
 				createdAsset = createIngestrAsset(assetsPath, schemaObj.Name, table.Name, connectionName, destination, table)
 			} else {
 				createdAsset, warning = createAsset(ctx, assetsPath, schemaObj.Name, table.Name, assetType, conn, fillColumns, table)
@@ -432,7 +434,7 @@ func runImport(ctx context.Context, log logger.Logger, pipelinePath, connectionN
 				}
 				existingAssets[assetName] = createdAsset
 				totalTables++
-			case asIngestr:
+			case ingestrImport:
 				// ingestr assets carry no columns, so there is nothing to merge
 				// into an existing asset; skip it without re-persisting to avoid
 				// a misleading "Merged" count on re-runs.
@@ -796,22 +798,16 @@ func createAsset(ctx context.Context, assetsPath, schemaName, tableName string, 
 	return asset, ""
 }
 
-// isMongoConnection reports whether the given connection is a MongoDB
-// connection (regular or Atlas), used to gate --as-ingestr support.
-func isMongoConnection(conn interface{}) bool {
-	switch conn.(type) {
-	case *mongo.DB, *mongoatlas.DB:
-		return true
-	default:
-		return false
-	}
+func supportsIngestrSource(conn any) bool {
+	_, ok := conn.(ingestruri.Connection)
+	return ok
 }
 
-// createIngestrAsset builds a runnable ingestr asset for a single MongoDB
-// collection. Running the generated asset replicates the collection into the
+// createIngestrAsset builds a runnable ingestr asset for a single database
+// table. Running the generated asset replicates the table into the
 // chosen destination. The asset name and file path follow the same lowercased
 // convention as createAsset, but source_table preserves the original database
-// and collection names because MongoDB identifiers are case-sensitive.
+// identifiers because some sources use case-sensitive names.
 func createIngestrAsset(assetsPath, schemaName, tableName, sourceConnection, destination string, table *ansisql.DBTable) *pipeline.Asset {
 	schemaFolder := filepath.Join(assetsPath, strings.ToLower(schemaName))
 	fileName := strings.ToLower(tableName) + ".asset.yml"

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -174,13 +174,13 @@ func (d schemaCheckboxDelegate) Render(w io.Writer, m list.Model, index int, ite
 }
 
 type importDatabaseModel struct {
-	ctx          context.Context //nolint:containedctx // bubbletea pattern for async commands
-	pipelinePath string
-	environment  string
-	configFile   string
-	fillColumns  bool
-	asIngestr    bool
-	destination  string
+	ctx           context.Context //nolint:containedctx // bubbletea pattern for async commands
+	pipelinePath  string
+	environment   string
+	configFile    string
+	fillColumns   bool
+	ingestrImport bool
+	destination   string
 
 	step int
 
@@ -526,6 +526,9 @@ func (m *importDatabaseModel) loadDatabaseSummaryCmd() tea.Cmd {
 		if conn == nil {
 			return dbSummaryLoadedMsg{err: fmt.Errorf("connection '%s' not found", connName)}
 		}
+		if m.ingestrImport && !supportsIngestrSource(conn) {
+			return dbSummaryLoadedMsg{err: fmt.Errorf("connection '%s' cannot be used as an ingestr source", connName)}
+		}
 
 		summarizer, ok := conn.(interface {
 			GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error)
@@ -549,7 +552,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 	connName := m.selectedConnName
 	conn := m.conn
 	fillColumns := m.fillColumns
-	asIngestr := m.asIngestr
+	ingestrImport := m.ingestrImport
 	destination := m.destination
 	summary := m.dbSummary
 
@@ -594,7 +597,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 
 				var createdAsset *pipeline.Asset
 				var warning string
-				if asIngestr {
+				if ingestrImport {
 					createdAsset = createIngestrAsset(assetsPath, schema.Name, table.Name, connName, destination, table)
 				} else {
 					createdAsset, warning = createAsset(ctx, assetsPath, schema.Name, table.Name, assetType, conn, fillColumns, table)
@@ -618,7 +621,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 					}
 					existingAssets[assetName] = createdAsset
 					totalTables++
-				case asIngestr:
+				case ingestrImport:
 					// ingestr assets carry no columns, so there is nothing to
 					// merge into an existing asset; skip it without re-persisting
 					// to avoid a misleading "merged" count on re-runs.
@@ -651,7 +654,7 @@ func (m *importDatabaseModel) executeImportCmd() tea.Cmd {
 	}
 }
 
-func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, configFile string, fillColumns, asIngestr bool, destination string) error {
+func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, configFile string, fillColumns, ingestrImport bool, destination string) error {
 	fs := afero.NewOsFs()
 
 	repoRoot, err := git.FindRepoFromPath(".")
@@ -687,18 +690,10 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 		if !supportedImportConnectionTypes[connType] {
 			continue
 		}
-		// --as-ingestr is only supported for MongoDB connections, so restrict
-		// the selectable connections to mongo / mongo_atlas in that mode.
-		if asIngestr && connType != "mongo" && connType != "mongo_atlas" {
-			continue
-		}
 		connItems = append(connItems, importConnectionItem{name: name, connType: connType})
 	}
 
 	if len(connItems) == 0 {
-		if asIngestr {
-			return errors.New("--as-ingestr requires a MongoDB connection, but none were found")
-		}
 		return errors.New("no database connections found that support import")
 	}
 
@@ -719,17 +714,17 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 	connList.Styles.Title = dbtuiHeaderStyle
 
 	model := &importDatabaseModel{
-		ctx:          ctx,
-		pipelinePath: pipelinePath,
-		environment:  environment,
-		configFile:   configFile,
-		fillColumns:  fillColumns,
-		asIngestr:    asIngestr,
-		destination:  destination,
-		step:         dbtuiStepConnection,
-		cfg:          cfg,
-		connList:     connList,
-		connItems:    connItems,
+		ctx:           ctx,
+		pipelinePath:  pipelinePath,
+		environment:   environment,
+		configFile:    configFile,
+		fillColumns:   fillColumns,
+		ingestrImport: ingestrImport,
+		destination:   destination,
+		step:          dbtuiStepConnection,
+		cfg:           cfg,
+		connList:      connList,
+		connItems:     connItems,
 	}
 
 	p := tea.NewProgram(model, tea.WithAltScreen())

--- a/cmd/import_database_tui.go
+++ b/cmd/import_database_tui.go
@@ -39,6 +39,28 @@ var supportedImportConnectionTypes = map[string]bool{
 	"mongo_atlas":           true,
 }
 
+// supportedIngestrImportConnectionTypes is intentionally explicit so a future
+// database connection added to supportedImportConnectionTypes is not offered
+// in ingestr mode until its connection implements ingestruri.Connection.
+var supportedIngestrImportConnectionTypes = map[string]bool{
+	"google_cloud_platform": true,
+	"snowflake":             true,
+	"postgres":              true,
+	"mssql":                 true,
+	"mysql":                 true,
+	"databricks":            true,
+	"duckdb":                true,
+	"motherduck":            true,
+	"clickhouse":            true,
+	"oracle":                true,
+	"athena":                true,
+	"synapse":               true,
+	"redshift":              true,
+	"sqlite":                true,
+	"mongo":                 true,
+	"mongo_atlas":           true,
+}
+
 const (
 	dbtuiStepConnection = iota
 	dbtuiStepLoading
@@ -688,6 +710,9 @@ func runImportDatabaseTUI(ctx context.Context, pipelinePath, environment, config
 	var connItems []importConnectionItem
 	for name, connType := range connSummary {
 		if !supportedImportConnectionTypes[connType] {
+			continue
+		}
+		if ingestrImport && !supportedIngestrImportConnectionTypes[connType] {
 			continue
 		}
 		connItems = append(connItems, importConnectionItem{name: name, connType: connType})

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -968,9 +968,9 @@ func TestCreateIngestrAsset(t *testing.T) {
 
 	testAssetsPath := filepath.Join("test", "assets")
 
-	// Mixed-case database/collection names verify that the asset name and file
+	// Mixed-case schema/table names verify that the asset name and file
 	// path are lowercased while source_table preserves the original case
-	// (MongoDB identifiers are case-sensitive).
+	// for databases with case-sensitive identifiers.
 	table := &ansisql.DBTable{
 		Name: "Users",
 		Type: ansisql.DBTableTypeTable,
@@ -1003,37 +1003,37 @@ func TestValidateIngestrImportFlags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		asIngestr   bool
-		destination string
-		wantErr     string
+		name          string
+		ingestrImport bool
+		destination   string
+		wantErr       string
 	}{
 		{
-			name:        "not as-ingestr with no destination is fine",
-			asIngestr:   false,
-			destination: "",
+			name:          "regular import with no destination is fine",
+			ingestrImport: false,
+			destination:   "",
 		},
 		{
-			name:        "destination without as-ingestr is rejected",
-			asIngestr:   false,
-			destination: "duckdb",
-			wantErr:     "--destination has no effect without --as-ingestr",
+			name:          "destination without ingestr is rejected",
+			ingestrImport: false,
+			destination:   "duckdb",
+			wantErr:       "--destination has no effect without --ingestr",
 		},
 		{
-			name:      "as-ingestr requires destination",
-			asIngestr: true,
-			wantErr:   "--destination is required",
+			name:          "ingestr requires destination",
+			ingestrImport: true,
+			wantErr:       "--destination is required",
 		},
 		{
-			name:        "as-ingestr rejects unknown destination",
-			asIngestr:   true,
-			destination: "bogus",
-			wantErr:     "invalid --destination",
+			name:          "ingestr rejects unknown destination",
+			ingestrImport: true,
+			destination:   "bogus",
+			wantErr:       "invalid --destination",
 		},
 		{
-			name:        "as-ingestr accepts valid destination",
-			asIngestr:   true,
-			destination: "duckdb",
+			name:          "ingestr accepts valid destination",
+			ingestrImport: true,
+			destination:   "duckdb",
 		},
 	}
 
@@ -1041,7 +1041,7 @@ func TestValidateIngestrImportFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateIngestrImportFlags(tt.asIngestr, tt.destination)
+			err := validateIngestrImportFlags(tt.ingestrImport, tt.destination)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -1052,24 +1052,25 @@ func TestValidateIngestrImportFlags(t *testing.T) {
 	}
 }
 
-func TestIsMongoConnection(t *testing.T) {
+func TestImportDatabaseIngestrFlag(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		conn interface{}
-		want bool
-	}{
-		{name: "mongo connection", conn: &mongo.DB{}, want: true},
-		{name: "mongo atlas connection", conn: &mongoatlas.DB{}, want: true},
-		{name: "mssql connection", conn: &mssql.DB{}, want: false},
-		{name: "nil connection", conn: nil, want: false},
+	command := ImportDatabase(new(bool))
+	for _, flag := range command.Flags {
+		if flag.Names()[0] == "ingestr" {
+			assert.Equal(t, []string{"ingestr", "as-ingestr"}, flag.Names())
+			return
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, isMongoConnection(tt.conn))
-		})
-	}
+	t.Fatal("ingestr flag not found")
+}
+
+func TestSupportsIngestrSource(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, supportsIngestrSource(&mssql.DB{}))
+	assert.True(t, supportsIngestrSource(&mongo.DB{}))
+	assert.False(t, supportsIngestrSource(&mockConnection{}))
+	assert.False(t, supportsIngestrSource(nil))
 }

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -53,8 +53,8 @@ table td:first-child {
 | `--connection`, `-c` | string | - | **Required.** Name of the connection to use as defined in `.bruin.yml` (or other [secrets backend](../secrets/overview.md)) |
 | `--schema`, `-s` | string | - | Filter by specific schema name |
 | `--no-columns`, `-n` | bool | `false` | Skip filling column metadata from database schema |
-| `--as-ingestr` | bool | `false` | Generate runnable [ingestr](../assets/ingestr.md) assets that replicate the source instead of source placeholders. Currently MongoDB only; requires `--destination` |
-| `--destination` | string | - | Destination platform for `--as-ingestr` assets (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`) |
+| `--ingestr` | bool | `false` | Generate runnable [ingestr](../assets/ingestr.md) assets that replicate the source instead of source placeholders. `--as-ingestr` is retained as an alias; requires `--destination` |
+| `--destination` | string | - | Destination platform for `--ingestr` assets (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`) |
 | `--environment`, `--env` | string | - | Target environment name as defined in `.bruin.yml` |
 | `--config-file` | string | - | Path to the `.bruin.yml` file. Can also be set via `BRUIN_CONFIG_FILE` environment variable |
 
@@ -72,18 +72,43 @@ table td:first-child {
 - **MS SQL Server** → `mssql`
 - **MongoDB** → `mongo`, `mongo_atlas`
 
+### Importing as ingestr assets
+
+Use `--ingestr` with `--destination` to generate executable ingestr assets for the discovered tables instead of metadata-only source assets. This works with every database connection supported by `import database` that can be used as an ingestr source.
+
+For example, the following command scans `postgres-source` and creates assets that copy its tables directly into the pipeline's default DuckDB connection:
+
+```bash
+bruin import database --connection postgres-source --ingestr --destination duckdb ./my-pipeline
+```
+
+For a source table named `public.Users`, it writes `assets/public/users.asset.yml`:
+
+```yaml
+name: public.users
+type: ingestr
+parameters:
+  source_connection: postgres-source
+  source_table: public.Users
+  destination: duckdb
+```
+
+The destination connection is resolved from the pipeline's default connection for the selected destination platform. Running the pipeline then transfers each source table directly to the identically named destination table. The source schema and table spelling is preserved in `source_table`, while the Bruin asset name and destination table name use the import command's existing lowercase convention.
+
+`--destination` is required and must be a supported ingestr destination. Passing it without `--ingestr` is rejected. Re-running an ingestr import skips assets that already exist instead of overwriting them. The older `--as-ingestr` spelling remains available as an alias for compatibility.
+
 #### MongoDB
 
 MongoDB is schemaless and has no `database → schema → table` hierarchy, so it maps as **database → schema** and **collection → table**. The import scans every database on the server (excluding the internal `admin`, `local`, and `config` databases) and creates one `mongo.source` asset per collection under `assets/<database>/`. Use `--schema <database>` to import a single database.
 
-Because collections have no fixed schema, imported MongoDB assets are created **without columns** — they are name + metadata stubs (the `--no-columns` flag has no additional effect). You can add column definitions yourself afterwards, for example when turning a collection into an `ingestr` asset, where columns drive schema enforcement, masking, and primary keys.
+Because collections have no fixed schema, regular imported MongoDB assets are created **without columns** — they are name + metadata stubs (the `--no-columns` flag has no additional effect). You can add column definitions yourself afterwards, where columns drive schema enforcement, masking, and primary keys.
 
-##### Replicating MongoDB with `--as-ingestr`
+##### Replicating MongoDB with `--ingestr`
 
-A `mongo.source` asset is a metadata placeholder and is **not runnable** on its own (MongoDB is not SQL). To generate assets that actually replicate the data, add `--as-ingestr` together with a `--destination` platform. Instead of `mongo.source` placeholders, each collection becomes a runnable [ingestr](../assets/ingestr.md) asset:
+A `mongo.source` asset is a metadata placeholder and is **not runnable** on its own (MongoDB is not SQL). Use the general [ingestr import mode](#importing-as-ingestr-assets) to make each collection a runnable asset instead:
 
 ```bash
-bruin import database --connection localMongo --as-ingestr --destination duckdb ./my-pipeline
+bruin import database --connection localMongo --ingestr --destination duckdb ./my-pipeline
 ```
 
 For a database `myDB` with a `Users` collection this writes `assets/mydb/users.asset.yml`:
@@ -97,12 +122,7 @@ parameters:
   destination: duckdb
 ```
 
-Running the pipeline (`bruin run ./my-pipeline`) then replicates every collection into the destination via ingestr. The destination *connection* is resolved from the pipeline's default connection for that platform. Notes:
-
-- `--destination` is **required** with `--as-ingestr` and must be a supported ingestr destination (e.g. `duckdb`, `postgres`, `bigquery`, `snowflake`, `redshift`, `clickhouse`). Passing `--destination` without `--as-ingestr` is rejected so a forgotten `--as-ingestr` does not silently produce `mongo.source` placeholders.
-- Re-running the import skips collections whose assets already exist (it never overwrites them); the summary reports how many were skipped.
-- `--as-ingestr` is currently **MongoDB only**; using it with a non-MongoDB connection is rejected. In the interactive TUI (when `--connection` is omitted) only MongoDB connections are offered.
-- The asset name and file path are lowercased, but `source_table` preserves the original database/collection casing because MongoDB identifiers are case-sensitive.
+The asset name and file path are lowercased, but `source_table` preserves the original database/collection casing because MongoDB identifiers are case-sensitive.
 
 ### How It Works
 
@@ -155,15 +175,15 @@ Import using a specific environment configuration:
 bruin import database --connection snowflake-prod --environment production ./my-pipeline
 ```
 
-#### Replicate MongoDB as ingestr assets
+#### Replicate a database as ingestr assets
 
-Generate runnable ingestr assets for every collection so the database can be replicated into a destination (MongoDB only):
+Generate runnable ingestr assets for every discovered table so the database can be replicated into a destination:
 
 ```bash
-bruin import database --connection localMongo --as-ingestr --destination duckdb ./my-pipeline
+bruin import database --connection postgres-source --ingestr --destination duckdb ./my-pipeline
 ```
 
-See [MongoDB](#mongodb) above for the generated asset structure.
+See [Importing as ingestr assets](#importing-as-ingestr-assets) above for the generated asset structure.
 
 ### Generated Asset Structure
 

--- a/docs/ingestion/mongo.md
+++ b/docs/ingestion/mongo.md
@@ -75,11 +75,11 @@ As a result of this command, Bruin will ingest data from the given MongoDB table
 
 > [!TIP]
 > Instead of writing one asset per collection by hand, you can scaffold them automatically with
-> [`bruin import database --as-ingestr`](/commands/import#mongodb). It scans the MongoDB connection
+> [`bruin import database --ingestr`](/commands/import#mongodb). It scans the MongoDB connection
 > and generates a runnable ingestr asset for every collection, so you can replicate the whole
 > database by running the generated pipeline:
 > ```bash
-> bruin import database --connection localMongo --as-ingestr --destination duckdb ./my-pipeline
+> bruin import database --connection localMongo --ingestr --destination duckdb ./my-pipeline
 > ```
 
 <img width="1017" alt="image" src="https://github.com/user-attachments/assets/2bad9131-baa1-4f20-8e3d-eed4329e7f90">


### PR DESCRIPTION
## What
Add `--ingestr` to `bruin import database` so discovered tables can be generated as runnable ingestr assets targeting a destination platform.

## Changes
- Generalize the existing MongoDB ingestr path to ingestr-capable database sources, retaining `--as-ingestr` as an alias.
- Update TUI behavior, tests, and import documentation.

## How to test
1. `make format`
2. `make test`
3. `make build`
4. Verified a local DuckDB source-to-DuckDB destination transfer of two rows through a generated asset.

## Risk & rollback
- **Risk:** Low; regular imports remain unchanged.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (not applicable)

## Related issues
None.