### PR TITLE
test(bigquery): fix dry-run expectations for bigquery SDK v1.74.0

### DIFF
--- a/integration-tests/cloud-integration-tests/bigquery/test-pipelines/dry-run-pipeline/expectations/results.json
+++ b/integration-tests/cloud-integration-tests/bigquery/test-pipelines/dry-run-pipeline/expectations/results.json
@@ -32,7 +32,8 @@
         "DefaultValueExpression": "",
         "Collation": "",
         "RangeElementType": null,
-        "RoundingMode": ""
+        "RoundingMode": "",
+        "TimestampPrecision": 0
       },
       {
         "Name": "name",
@@ -48,7 +49,8 @@
         "DefaultValueExpression": "",
         "Collation": "",
         "RangeElementType": null,
-        "RoundingMode": ""
+        "RoundingMode": "",
+        "TimestampPrecision": 0
       },
       {
         "Name": "value",
@@ -64,7 +66,8 @@
         "DefaultValueExpression": "",
         "Collation": "",
         "RangeElementType": null,
-        "RoundingMode": ""
+        "RoundingMode": "",
+        "TimestampPrecision": 0
       },
       {
         "Name": "category",
@@ -80,10 +83,12 @@
         "DefaultValueExpression": "",
         "Collation": "",
         "RangeElementType": null,
-        "RoundingMode": ""
+        "RoundingMode": "",
+        "TimestampPrecision": 0
       }
     ],
       "SlotMillis": 0,
+      "TotalServicesSkuSlotMillis": 0,
       "UndeclaredQueryParameterNames": null,
       "DDLTargetTable": null,
       "DDLOperationPerformed": "",


### PR DESCRIPTION
## What

The `Release` run for `177dc5647` failed on the cloud integration test `TestBigQueryWorkflows/bigquery-dry-run-pipeline`:

```
mismatch at path [bigquery Schema 3 TimestampPrecision].
Expected json: [], but found: [0]
```

## Why it broke

PR #2374 bumped `cloud.google.com/go/bigquery` **v1.72.0 → v1.74.0**. Bruin's `internal asset-metadata` marshals the SDK's statistics/schema structs directly to JSON, so new SDK fields appear automatically. v1.74.0 added:

- `TimestampPrecision` on `bigquery.FieldSchema` (emitted per column)
- `TotalServicesSkuSlotMillis` on the query statistics

The dry-run test compares that JSON against a golden snapshot (`results.json`) recorded under v1.72.0, so the strict comparator failed on the first new field. This is deterministic — re-running the release would fail identically. No Bruin logic changed; the snapshot just went stale relative to the upgraded dependency.

## Fix

Add the two new fields (all `0` for this query) to `dry-run-pipeline/expectations/results.json`.

## Testing

- JSON validated well-formed; new fields match the actual output captured in the failed CI log.
- Cloud integration test not run locally (requires BigQuery credentials) — validated against the exact actual output from the failed Release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)