### PR TITLE
Support ClickHouse-native types in seed column hints

### DIFF
--- a/pkg/clickhouse/ingestr_types.go
+++ b/pkg/clickhouse/ingestr_types.go
@@ -1,0 +1,117 @@
+package clickhouse
+
+// IngestrTypeHints maps ClickHouse-native column type names (and ClickHouse-specific
+// aliases) to ingestr/dlt types used for --columns hints on seed and ingest assets.
+//
+// Parameterized forms such as DateTime64(3), Decimal64(2), FixedString(16),
+// Enum8('a' = 1), and Array(UInt64) resolve via their base name. Nullable(T) and
+// LowCardinality(T) are peeled by pkg/python so the inner type is used.
+//
+// Entries that also exist in the shared defaults intentionally override them when
+// this destination is ClickHouse (e.g. int8 is Int8 here, not PostgreSQL bigint;
+// time is the Int64 alias, not a time-of-day type).
+func IngestrTypeHints() map[string]string {
+	return map[string]string{
+		// Signed integers
+		"int8":   "tinyint",
+		"int16":  "smallint",
+		"int32":  "int",
+		"int64":  "bigint",
+		"int128": "bigint",
+		"int256": "bigint",
+
+		// Unsigned integers
+		"uint8":   "tinyint",
+		"uint16":  "int",
+		"uint32":  "bigint",
+		"uint64":  "bigint",
+		"uint128": "bigint",
+		"uint256": "bigint",
+
+		// Floating point
+		"float32":  "double",
+		"float64":  "double",
+		"bfloat16": "double",
+
+		// Fixed-point decimals (Decimal(P, S) / Decimal32(S) / …)
+		"decimal":    "decimal",
+		"decimal32":  "decimal",
+		"decimal64":  "decimal",
+		"decimal128": "decimal",
+		"decimal256": "decimal",
+
+		// Boolean
+		"bool":    "bool",
+		"boolean": "bool",
+
+		// Strings
+		"string":      "text",
+		"fixedstring": "text",
+
+		// UUID
+		"uuid": "text",
+
+		// Date / time
+		"date":       "date",
+		"date32":     "date",
+		"datetime":   "timestamp",
+		"datetime64": "timestamp",
+		// ClickHouse TIME is an alias for Int64, not a time-of-day type.
+		"time": "bigint",
+
+		// Enums
+		"enum":   "text",
+		"enum8":  "text",
+		"enum16": "text",
+
+		// Nested / composite
+		"array":   "json",
+		"tuple":   "json",
+		"map":     "json",
+		"nested":  "json",
+		"variant": "json",
+		"dynamic": "json",
+		"json":    "json",
+		"object":  "json", // Object('json')
+
+		// Aggregate-state types
+		"aggregatefunction":       "json",
+		"simpleaggregatefunction": "json",
+
+		// Network
+		"ipv4":  "text",
+		"ipv6":  "text",
+		"inet4": "text", // alias of IPv4
+		"inet6": "text", // alias of IPv6
+
+		// Geo
+		"point":           "json",
+		"ring":            "json",
+		"polygon":         "json",
+		"multipolygon":    "json",
+		"linestring":      "json",
+		"multilinestring": "json",
+
+		// Intervals
+		"intervalnanosecond":  "interval",
+		"intervalmicrosecond": "interval",
+		"intervalmillisecond": "interval",
+		"intervalsecond":      "interval",
+		"intervalminute":      "interval",
+		"intervalhour":        "interval",
+		"intervalday":         "interval",
+		"intervalweek":        "interval",
+		"intervalmonth":       "interval",
+		"intervalquarter":     "interval",
+		"intervalyear":        "interval",
+
+		// Misc
+		"nothing": "text",
+	}
+}
+
+// IngestrTypeHints implements the optional connection capability used by
+// pkg/python when building ingestr --columns hints for this destination.
+func (c *Client) IngestrTypeHints() map[string]string {
+	return IngestrTypeHints()
+}

--- a/pkg/clickhouse/ingestr_types.go
+++ b/pkg/clickhouse/ingestr_types.go
@@ -110,8 +110,23 @@ func IngestrTypeHints() map[string]string {
 	}
 }
 
+// IngestrTypeWrappers are ClickHouse parameterized types whose inner type should
+// be resolved for ingestr --columns hints (e.g. Nullable(DateTime64(3))).
+func IngestrTypeWrappers() map[string]bool {
+	return map[string]bool{
+		"nullable":       true,
+		"lowcardinality": true,
+	}
+}
+
 // IngestrTypeHints implements the optional connection capability used by
 // pkg/python when building ingestr --columns hints for this destination.
 func (c *Client) IngestrTypeHints() map[string]string {
 	return IngestrTypeHints()
+}
+
+// IngestrTypeWrappers implements the optional connection capability used by
+// pkg/python when peeling destination-specific type wrappers.
+func (c *Client) IngestrTypeWrappers() map[string]bool {
+	return IngestrTypeWrappers()
 }

--- a/pkg/clickhouse/ingestr_types_test.go
+++ b/pkg/clickhouse/ingestr_types_test.go
@@ -12,19 +12,25 @@ import (
 func TestIngestrTypeHints_ClientImplementsProvider(t *testing.T) {
 	t.Parallel()
 
-	var provider python.IngestrTypeHintProvider = &Client{}
-	hints := provider.IngestrTypeHints()
+	var hintsProvider python.IngestrTypeHintProvider = &Client{}
+	hints := hintsProvider.IngestrTypeHints()
 	require.NotEmpty(t, hints)
 	assert.Equal(t, "timestamp", hints["datetime64"])
 	assert.Equal(t, "bigint", hints["uint64"])
 	assert.Equal(t, "tinyint", hints["int8"], "ClickHouse Int8 must override PostgreSQL int8→bigint")
 	assert.Equal(t, "bigint", hints["time"], "ClickHouse TIME is an Int64 alias")
+
+	var wrappersProvider python.IngestrTypeWrapperProvider = &Client{}
+	wrappers := wrappersProvider.IngestrTypeWrappers()
+	assert.True(t, wrappers["nullable"])
+	assert.True(t, wrappers["lowcardinality"])
 }
 
 func TestIngestrTypeHints_CoversClickHouseTypes(t *testing.T) {
 	t.Parallel()
 
 	hints := IngestrTypeHints()
+	wrappers := IngestrTypeWrappers()
 	cases := []struct {
 		declared string
 		want     string
@@ -103,7 +109,7 @@ func TestIngestrTypeHints_CoversClickHouseTypes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.declared, func(t *testing.T) {
 			t.Parallel()
-			got := python.ColumnHints([]pipeline.Column{{Name: "c", Type: tc.declared}}, false, hints)
+			got := python.ColumnHints([]pipeline.Column{{Name: "c", Type: tc.declared}}, false, hints, wrappers)
 			assert.Equal(t, "c:"+tc.want, got)
 		})
 	}
@@ -120,17 +126,24 @@ func TestIngestrTypeHints_UsedAsColumnHintOverlay(t *testing.T) {
 		{Name: "flag", Type: "Nullable(Bool)"},
 	}
 
-	got := python.ColumnHints(cols, false, IngestrTypeHints())
+	got := python.ColumnHints(cols, false, IngestrTypeHints(), IngestrTypeWrappers())
 	assert.Equal(t, "id:bigint,created_at:timestamp,payload:json,name:text,flag:bool", got)
 }
 
 func TestTypeHintOverlayForConnection_FromClickHouseClient(t *testing.T) {
 	t.Parallel()
 
-	overlay := python.TypeHintOverlayForConnection(&Client{})
+	client := &Client{}
+	overlay := python.TypeHintOverlayForConnection(client)
 	require.NotNil(t, overlay)
 	assert.Equal(t, IngestrTypeHints(), overlay)
 
+	wrappers := python.TypeWrappersForConnection(client)
+	require.NotNil(t, wrappers)
+	assert.Equal(t, IngestrTypeWrappers(), wrappers)
+
 	assert.Nil(t, python.TypeHintOverlayForConnection(nil))
 	assert.Nil(t, python.TypeHintOverlayForConnection(struct{}{}))
+	assert.Nil(t, python.TypeWrappersForConnection(nil))
+	assert.Nil(t, python.TypeWrappersForConnection(struct{}{}))
 }

--- a/pkg/clickhouse/ingestr_types_test.go
+++ b/pkg/clickhouse/ingestr_types_test.go
@@ -1,0 +1,136 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/python"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngestrTypeHints_ClientImplementsProvider(t *testing.T) {
+	t.Parallel()
+
+	var provider python.IngestrTypeHintProvider = &Client{}
+	hints := provider.IngestrTypeHints()
+	require.NotEmpty(t, hints)
+	assert.Equal(t, "timestamp", hints["datetime64"])
+	assert.Equal(t, "bigint", hints["uint64"])
+	assert.Equal(t, "tinyint", hints["int8"], "ClickHouse Int8 must override PostgreSQL int8→bigint")
+	assert.Equal(t, "bigint", hints["time"], "ClickHouse TIME is an Int64 alias")
+}
+
+func TestIngestrTypeHints_CoversClickHouseTypes(t *testing.T) {
+	t.Parallel()
+
+	hints := IngestrTypeHints()
+	cases := []struct {
+		declared string
+		want     string
+	}{
+		// integers
+		{"Int8", "tinyint"},
+		{"Int16", "smallint"},
+		{"Int32", "int"},
+		{"Int64", "bigint"},
+		{"Int128", "bigint"},
+		{"Int256", "bigint"},
+		{"UInt8", "tinyint"},
+		{"UInt16", "int"},
+		{"UInt32", "bigint"},
+		{"UInt64", "bigint"},
+		{"UInt128", "bigint"},
+		{"UInt256", "bigint"},
+		// floats / decimals
+		{"Float32", "double"},
+		{"Float64", "double"},
+		{"BFloat16", "double"},
+		{"Decimal", "decimal"},
+		{"Decimal32", "decimal"},
+		{"Decimal64", "decimal"},
+		{"Decimal128", "decimal"},
+		{"Decimal256", "decimal"},
+		{"Decimal64(2)", "decimal"},
+		{"Decimal(18, 4)", "decimal"},
+		// bool / string / uuid
+		{"Bool", "bool"},
+		{"String", "text"},
+		{"FixedString(16)", "text(16)"},
+		{"UUID", "text"},
+		// date / time
+		{"Date", "date"},
+		{"Date32", "date"},
+		{"DateTime", "timestamp"},
+		{"DateTime('UTC')", "timestamp"},
+		{"DateTime64", "timestamp"},
+		{"DateTime64(3)", "timestamp"},
+		{"DateTime64(3, 'UTC')", "timestamp"},
+		{"TIME", "bigint"},
+		// enums / nested
+		{"Enum8('a' = 1, 'b' = 2)", "text"},
+		{"Enum16", "text"},
+		{"Array(UInt64)", "json"},
+		{"Tuple(UInt32, String)", "json"},
+		{"Map(String, UInt64)", "json"},
+		{"Nested(x UInt32, y String)", "json"},
+		{"JSON", "json"},
+		{"Dynamic", "json"},
+		{"Variant(String, UInt64)", "json"},
+		{"Object('json')", "json"},
+		{"AggregateFunction(sum, UInt64)", "json"},
+		{"SimpleAggregateFunction(sum, UInt64)", "json"},
+		// network / geo / intervals
+		{"IPv4", "text"},
+		{"IPv6", "text"},
+		{"Point", "json"},
+		{"Ring", "json"},
+		{"Polygon", "json"},
+		{"MultiPolygon", "json"},
+		{"LineString", "json"},
+		{"MultiLineString", "json"},
+		{"IntervalDay", "interval"},
+		{"IntervalSecond", "interval"},
+		{"Nothing", "text"},
+		// wrappers peel to the inner type
+		{"Nullable(UInt64)", "bigint"},
+		{"Nullable(DateTime64(3))", "timestamp"},
+		{"LowCardinality(String)", "text"},
+		{"LowCardinality(Nullable(Int32))", "int"},
+		{"Nullable(LowCardinality(UUID))", "text"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.declared, func(t *testing.T) {
+			t.Parallel()
+			got := python.ColumnHints([]pipeline.Column{{Name: "c", Type: tc.declared}}, false, hints)
+			assert.Equal(t, "c:"+tc.want, got)
+		})
+	}
+}
+
+func TestIngestrTypeHints_UsedAsColumnHintOverlay(t *testing.T) {
+	t.Parallel()
+
+	cols := []pipeline.Column{
+		{Name: "id", Type: "UInt64"},
+		{Name: "created_at", Type: "DateTime64(3)"},
+		{Name: "payload", Type: "Tuple(String, UInt32)"},
+		{Name: "name", Type: "String"},
+		{Name: "flag", Type: "Nullable(Bool)"},
+	}
+
+	got := python.ColumnHints(cols, false, IngestrTypeHints())
+	assert.Equal(t, "id:bigint,created_at:timestamp,payload:json,name:text,flag:bool", got)
+}
+
+func TestTypeHintOverlayForConnection_FromClickHouseClient(t *testing.T) {
+	t.Parallel()
+
+	overlay := python.TypeHintOverlayForConnection(&Client{})
+	require.NotNil(t, overlay)
+	assert.Equal(t, IngestrTypeHints(), overlay)
+
+	assert.Nil(t, python.TypeHintOverlayForConnection(nil))
+	assert.Nil(t, python.TypeHintOverlayForConnection(struct{}{}))
+}

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -342,6 +342,7 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
 		NormalizeColumnNames:   false,
 		EnforceSchemaByDefault: false,
+		TypeHintOverlay:        python.TypeHintOverlayForConnection(o.conn.GetConnection(destConnectionName)),
 	})
 	if err != nil {
 		return err
@@ -664,6 +665,7 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
 		NormalizeColumnNames:   true,
 		EnforceSchemaByDefault: true,
+		TypeHintOverlay:        python.TypeHintOverlayForConnection(o.conn.GetConnection(destConnectionName)),
 	})
 	if err != nil {
 		return err

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -339,10 +339,12 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		baseArgs = append(baseArgs, "--debug")
 	}
 
+	destConn := o.conn.GetConnection(destConnectionName)
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
 		NormalizeColumnNames:   false,
 		EnforceSchemaByDefault: false,
-		TypeHintOverlay:        python.TypeHintOverlayForConnection(o.conn.GetConnection(destConnectionName)),
+		TypeHintOverlay:        python.TypeHintOverlayForConnection(destConn),
+		TypeWrappers:           python.TypeWrappersForConnection(destConn),
 	})
 	if err != nil {
 		return err
@@ -662,10 +664,12 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		baseArgs = append(baseArgs, "--debug")
 	}
 
+	destConn := o.conn.GetConnection(destConnectionName)
 	cmdArgs, err := python.ConsolidatedParameters(ctx, asset, baseArgs, &python.ColumnHintOptions{
 		NormalizeColumnNames:   true,
 		EnforceSchemaByDefault: true,
-		TypeHintOverlay:        python.TypeHintOverlayForConnection(o.conn.GetConnection(destConnectionName)),
+		TypeHintOverlay:        python.TypeHintOverlayForConnection(destConn),
+		TypeWrappers:           python.TypeWrappersForConnection(destConn),
 	})
 	if err != nil {
 		return err

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -18,6 +18,12 @@ type IngestrTypeHintProvider interface {
 	IngestrTypeHints() map[string]string
 }
 
+// IngestrTypeWrapperProvider is an optional capability for destinations that use
+// transparent type wrappers (e.g. ClickHouse Nullable(T) / LowCardinality(T)).
+type IngestrTypeWrapperProvider interface {
+	IngestrTypeWrappers() map[string]bool
+}
+
 // TypeHintMapping maps portable / cross-platform column type aliases to ingestr
 // (dlt) types. Destination-specific aliases live on the connection via
 // IngestrTypeHintProvider. 'text' is the ingestr default when no hint is emitted.
@@ -215,13 +221,6 @@ var ingestrSizedTypes = map[string]bool{
 	"text": true,
 }
 
-// typeWrappers are parameterized types whose inner type should be resolved instead
-// of the wrapper itself (ClickHouse Nullable(T) / LowCardinality(T)).
-var typeWrappers = map[string]bool{
-	"nullable":       true,
-	"lowcardinality": true,
-}
-
 // TypeHintOverlayForConnection returns DB-specific type aliases when the
 // connection implements IngestrTypeHintProvider; otherwise nil.
 func TypeHintOverlayForConnection(conn any) map[string]string {
@@ -234,12 +233,22 @@ func TypeHintOverlayForConnection(conn any) map[string]string {
 	return nil
 }
 
+// TypeWrappersForConnection returns transparent type wrappers when the
+// connection implements IngestrTypeWrapperProvider; otherwise nil.
+func TypeWrappersForConnection(conn any) map[string]bool {
+	if conn == nil {
+		return nil
+	}
+	if p, ok := conn.(IngestrTypeWrapperProvider); ok {
+		return p.IngestrTypeWrappers()
+	}
+	return nil
+}
+
 // MergeTypeHints returns a copy of base with overlay entries applied. Overlay
 // keys are normalised the same way as column types. Overlay wins on conflict.
+// The returned map is always a clone so callers cannot mutate TypeHintMapping.
 func MergeTypeHints(base, overlay map[string]string) map[string]string {
-	if len(overlay) == 0 {
-		return base
-	}
 	merged := maps.Clone(base)
 	if merged == nil {
 		merged = make(map[string]string, len(overlay))
@@ -251,8 +260,9 @@ func MergeTypeHints(base, overlay map[string]string) map[string]string {
 }
 
 // resolveColumnTypeHint maps a declared column type to an ingestr hint, peeling
-// transparent wrappers and resolving parameterized bases (e.g. DateTime64(3)).
-func resolveColumnTypeHint(typ string, mapping map[string]string) (hint string, known bool, inlineLength string) {
+// destination-specific transparent wrappers and resolving parameterized bases
+// (e.g. DateTime64(3)).
+func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[string]bool) (hint string, known bool, inlineLength string) {
 	typ = NormaliseColumnType(typ)
 	for {
 		if h, ok := mapping[typ]; ok {
@@ -263,7 +273,7 @@ func resolveColumnTypeHint(typ string, mapping map[string]string) (hint string, 
 			return "", false, ""
 		}
 		base = NormaliseColumnType(base)
-		if typeWrappers[base] {
+		if wrappers[base] {
 			typ = NormaliseColumnType(inner)
 			continue
 		}
@@ -280,11 +290,12 @@ func resolveColumnTypeHint(typ string, mapping map[string]string) (hint string, 
 // ColumnHints returns an ingestr compatible type hint string
 // that can be passed via the --column flag to the CLI.
 // overlay may be nil; when set, its aliases are merged over TypeHintMapping.
-func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string]string) string {
+// wrappers may be nil; when set, those parameterized types peel to their inner type.
+func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string]string, wrappers map[string]bool) string {
 	mapping := MergeTypeHints(TypeHintMapping, overlay)
 	hints := make([]string, 0)
 	for _, col := range cols {
-		hint, typeKnown, inlineLength := resolveColumnTypeHint(col.Type, mapping)
+		hint, typeKnown, inlineLength := resolveColumnTypeHint(col.Type, mapping, wrappers)
 
 		if !typeKnown && col.SourceColumn == "" {
 			continue
@@ -403,4 +414,7 @@ type ColumnHintOptions struct {
 	// TypeHintOverlay is an optional destination-specific alias map merged over
 	// TypeHintMapping (e.g. from IngestrTypeHintProvider on the dest connection).
 	TypeHintOverlay map[string]string
+	// TypeWrappers is an optional set of transparent parameterized type names
+	// (e.g. from IngestrTypeWrapperProvider) whose inner type should be resolved.
+	TypeWrappers map[string]bool
 }

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -10,8 +11,16 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
-// TypeHintMapping maps different destination types to dlt types.
-// 'text' mappings are omitted, since they are the default.
+// IngestrTypeHintProvider is an optional capability on destination connections.
+// Packages like clickhouse implement this so DB-native type aliases can overlay
+// the shared defaults without pkg/python needing to know about each platform.
+type IngestrTypeHintProvider interface {
+	IngestrTypeHints() map[string]string
+}
+
+// TypeHintMapping maps portable / cross-platform column type aliases to ingestr
+// (dlt) types. Destination-specific aliases live on the connection via
+// IngestrTypeHintProvider. 'text' is the ingestr default when no hint is emitted.
 var TypeHintMapping = map[string]string{
 	// Integer types — mapped to the narrowest ingestr type that preserves the
 	// declared width, so a column the source detected as Int16/Int32 is not
@@ -19,11 +28,9 @@ var TypeHintMapping = map[string]string{
 	// 8-bit (-> Int16 in ingestr; ingestr has no Int8 type)
 	"tinyint": "tinyint",
 	"byte":    "tinyint", // Spark/Databricks ByteType (-128..127)
-	"uint8":   "tinyint", // ClickHouse (0..255)
 	// 16-bit
 	"smallint":    "smallint",
 	"int2":        "smallint", // PostgreSQL alias
-	"int16":       "smallint", // ClickHouse
 	"smallserial": "smallint", // PostgreSQL auto-increment
 	"serial2":     "smallint", // PostgreSQL alias
 	"short":       "smallint", // Generic
@@ -31,22 +38,13 @@ var TypeHintMapping = map[string]string{
 	"int":       "int",
 	"integer":   "int",
 	"int4":      "int", // PostgreSQL alias
-	"int32":     "int", // ClickHouse
 	"mediumint": "int", // MySQL (24-bit, fits Int32)
 	"serial":    "int", // PostgreSQL auto-increment
 	"serial4":   "int", // PostgreSQL alias
-	"uint16":    "int", // ClickHouse (0..65535, exceeds Int16)
 	"year":      "int", // MySQL
 	// 64-bit (and wider types clamped to Int64, the widest ingestr offers)
 	"bigint":    "bigint",
 	"int8":      "bigint", // PostgreSQL alias
-	"int64":     "bigint", // ClickHouse
-	"int128":    "bigint", // ClickHouse (no wider ingestr type)
-	"int256":    "bigint", // ClickHouse (no wider ingestr type)
-	"uint32":    "bigint", // ClickHouse (0..4.3B, exceeds Int32)
-	"uint64":    "bigint", // ClickHouse (best-effort; may exceed Int64)
-	"uint128":   "bigint", // ClickHouse
-	"uint256":   "bigint", // ClickHouse
 	"bigserial": "bigint", // PostgreSQL auto-increment
 	"serial8":   "bigint", // PostgreSQL alias
 	"long":      "bigint", // Generic
@@ -57,8 +55,7 @@ var TypeHintMapping = map[string]string{
 	"float4":           "double",
 	"float8":           "double",
 	"float16":          "double", // Some systems
-	"float32":          "double", // ClickHouse
-	"float64":          "double", // ClickHouse/BigQuery
+	"float64":          "double", // BigQuery / generic
 	"double":           "double",
 	"double precision": "double",
 	"real":             "double",
@@ -115,7 +112,6 @@ var TypeHintMapping = map[string]string{
 	"datetime2":                   "timestamp_ntz", // SQL Server (no time zone)
 	"datetimeoffset":              "timestamp",     // SQL Server (has offset)
 	"smalldatetime":               "timestamp_ntz", // SQL Server (no time zone)
-	"datetime64":                  "timestamp",     // ClickHouse
 	"interval":                    "interval",      // PostgreSQL (time interval)
 
 	// String/Text types
@@ -139,8 +135,6 @@ var TypeHintMapping = map[string]string{
 	"longvarchar":       "text", // JDBC
 	"nvarchar2":         "text", // Oracle
 	"varchar2":          "text", // Oracle
-	"fixedstring":       "text", // ClickHouse
-	"lowcardinality":    "text", // ClickHouse
 
 	// UUID/GUID types
 	"uuid":             "text",
@@ -158,8 +152,6 @@ var TypeHintMapping = map[string]string{
 	"record":  "json", // BigQuery
 	"super":   "json", // Redshift
 	"hstore":  "json", // PostgreSQL key-value
-	"tuple":   "json", // ClickHouse
-	"nested":  "json", // ClickHouse
 
 	// XML type
 	"xml": "text",
@@ -223,25 +215,76 @@ var ingestrSizedTypes = map[string]bool{
 	"text": true,
 }
 
+// typeWrappers are parameterized types whose inner type should be resolved instead
+// of the wrapper itself (ClickHouse Nullable(T) / LowCardinality(T)).
+var typeWrappers = map[string]bool{
+	"nullable":       true,
+	"lowcardinality": true,
+}
+
+// TypeHintOverlayForConnection returns DB-specific type aliases when the
+// connection implements IngestrTypeHintProvider; otherwise nil.
+func TypeHintOverlayForConnection(conn any) map[string]string {
+	if conn == nil {
+		return nil
+	}
+	if p, ok := conn.(IngestrTypeHintProvider); ok {
+		return p.IngestrTypeHints()
+	}
+	return nil
+}
+
+// MergeTypeHints returns a copy of base with overlay entries applied. Overlay
+// keys are normalised the same way as column types. Overlay wins on conflict.
+func MergeTypeHints(base, overlay map[string]string) map[string]string {
+	if len(overlay) == 0 {
+		return base
+	}
+	merged := maps.Clone(base)
+	if merged == nil {
+		merged = make(map[string]string, len(overlay))
+	}
+	for k, v := range overlay {
+		merged[NormaliseColumnType(k)] = v
+	}
+	return merged
+}
+
+// resolveColumnTypeHint maps a declared column type to an ingestr hint, peeling
+// transparent wrappers and resolving parameterized bases (e.g. DateTime64(3)).
+func resolveColumnTypeHint(typ string, mapping map[string]string) (hint string, known bool, inlineLength string) {
+	typ = NormaliseColumnType(typ)
+	for {
+		if h, ok := mapping[typ]; ok {
+			return h, true, ""
+		}
+		base, inner, ok := splitParenType(typ)
+		if !ok {
+			return "", false, ""
+		}
+		base = NormaliseColumnType(base)
+		if typeWrappers[base] {
+			typ = NormaliseColumnType(inner)
+			continue
+		}
+		if h, ok := mapping[base]; ok {
+			if ingestrSizedTypes[h] {
+				return h, true, inner
+			}
+			return h, true, ""
+		}
+		return "", false, ""
+	}
+}
+
 // ColumnHints returns an ingestr compatible type hint string
 // that can be passed via the --column flag to the CLI.
-func ColumnHints(cols []pipeline.Column, normaliseNames bool) string {
+// overlay may be nil; when set, its aliases are merged over TypeHintMapping.
+func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string]string) string {
+	mapping := MergeTypeHints(TypeHintMapping, overlay)
 	hints := make([]string, 0)
 	for _, col := range cols {
-		typ := NormaliseColumnType(col.Type)
-		hint, typeKnown := TypeHintMapping[typ]
-
-		// Resolve the base type of a sized type like "varchar(100)" and re-apply the
-		// length, but only when that type accepts one.
-		inlineLength := ""
-		if !typeKnown {
-			if base, inner, ok := splitParenType(typ); ok {
-				if mapped, found := TypeHintMapping[base]; found && ingestrSizedTypes[mapped] {
-					hint, typeKnown = mapped, true
-					inlineLength = inner
-				}
-			}
-		}
+		hint, typeKnown, inlineLength := resolveColumnTypeHint(col.Type, mapping)
 
 		if !typeKnown && col.SourceColumn == "" {
 			continue
@@ -357,4 +400,7 @@ type ColumnHintOptions struct {
 	// If true, schema will be enforced by default (used for seed assets).
 	// If false, schema will only be enforced when enforce_schema="true" is explicitly set.
 	EnforceSchemaByDefault bool
+	// TypeHintOverlay is an optional destination-specific alias map merged over
+	// TypeHintMapping (e.g. from IngestrTypeHintProvider on the dest connection).
+	TypeHintOverlay map[string]string
 }

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -102,7 +102,7 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 		}
 
 		if shouldEnforce {
-			columns := ColumnHints(asset.Columns, columnOpts.NormalizeColumnNames)
+			columns := ColumnHints(asset.Columns, columnOpts.NormalizeColumnNames, columnOpts.TypeHintOverlay)
 			if columns != "" {
 				cmdArgs = append(cmdArgs, "--columns", columns)
 			}

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -102,7 +102,7 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 		}
 
 		if shouldEnforce {
-			columns := ColumnHints(asset.Columns, columnOpts.NormalizeColumnNames, columnOpts.TypeHintOverlay)
+			columns := ColumnHints(asset.Columns, columnOpts.NormalizeColumnNames, columnOpts.TypeHintOverlay, columnOpts.TypeWrappers)
 			if columns != "" {
 				cmdArgs = append(cmdArgs, "--columns", columns)
 			}

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -240,6 +240,7 @@ func TestColumnHints(t *testing.T) {
 		columns        []pipeline.Column
 		normalizeNames bool
 		overlay        map[string]string
+		wrappers       map[string]bool
 		expected       string
 	}{
 		{
@@ -442,7 +443,20 @@ func TestColumnHints(t *testing.T) {
 				{Name: "c", Type: "Nullable(LowCardinality(timestamp))"},
 			},
 			normalizeNames: false,
-			expected:       "a:int,b:text(50),c:timestamp",
+			wrappers: map[string]bool{
+				"nullable":       true,
+				"lowcardinality": true,
+			},
+			expected: "a:int,b:text(50),c:timestamp",
+		},
+		{
+			name: "wrappers are not peeled without destination wrappers",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "Nullable(integer)"},
+				{Name: "b", Type: "string"},
+			},
+			normalizeNames: false,
+			expected:       "b:text",
 		},
 		{
 			name: "destination overlay wins over defaults",
@@ -468,7 +482,7 @@ func TestColumnHints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := ColumnHints(tt.columns, tt.normalizeNames, tt.overlay)
+			result := ColumnHints(tt.columns, tt.normalizeNames, tt.overlay, tt.wrappers)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -491,10 +505,10 @@ func TestColumnHints_SizedTypes(t *testing.T) {
 		want := fmt.Sprintf("c:%s(50)", hint)
 		t.Run(typ, func(t *testing.T) {
 			t.Parallel()
-			inline := ColumnHints([]pipeline.Column{{Name: "c", Type: typ + "(50)"}}, false, nil)
+			inline := ColumnHints([]pipeline.Column{{Name: "c", Type: typ + "(50)"}}, false, nil, nil)
 			assert.Equal(t, want, inline, "inline length for %q", typ)
 
-			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Length: intPtr(50)}}, false, nil)
+			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Length: intPtr(50)}}, false, nil, nil)
 			assert.Equal(t, want, field, "length field for %q", typ)
 		})
 	}
@@ -722,11 +736,11 @@ func TestColumnHints_Normalization(t *testing.T) {
 	}
 
 	// Without normalization
-	result := ColumnHints(columns, false, nil)
+	result := ColumnHints(columns, false, nil, nil)
 	assert.Equal(t, "DateOfBirth:date", result)
 
 	// With normalization
-	result = ColumnHints(columns, true, nil)
+	result = ColumnHints(columns, true, nil, nil)
 	assert.Equal(t, "date_of_birth:date", result)
 }
 

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -239,6 +239,7 @@ func TestColumnHints(t *testing.T) {
 		name           string
 		columns        []pipeline.Column
 		normalizeNames bool
+		overlay        map[string]string
 		expected       string
 	}{
 		{
@@ -322,12 +323,11 @@ func TestColumnHints(t *testing.T) {
 				{Name: "pg_small", Type: "int2"},
 				{Name: "pg_int", Type: "int4"},
 				{Name: "pg_big", Type: "int8"},
-				{Name: "ch_unsigned", Type: "uint16"},
 				{Name: "spark_byte", Type: "byte"},
 				{Name: "mysql_year", Type: "year"},
 			},
 			normalizeNames: false,
-			expected:       "pg_small:smallint,pg_int:int,pg_big:bigint,ch_unsigned:int,spark_byte:tinyint,mysql_year:int",
+			expected:       "pg_small:smallint,pg_int:int,pg_big:bigint,spark_byte:tinyint,mysql_year:int",
 		},
 		{
 			name: "no-tz timestamps map to timestamp_ntz while tz-aware stay timestamp",
@@ -391,14 +391,14 @@ func TestColumnHints(t *testing.T) {
 			expected:       "a:text,b:text,c:text",
 		},
 		{
-			name: "non-string sized types are unaffected",
+			name: "non-string parameterized types use base mapping without length",
 			columns: []pipeline.Column{
 				{Name: "kept", Type: "int"},
-				{Name: "dropped_int", Type: "int(11)"},
-				{Name: "dropped_dec", Type: "decimal(10,2)"},
+				{Name: "sized_int", Type: "int(11)"},
+				{Name: "sized_dec", Type: "decimal(10,2)"},
 			},
 			normalizeNames: false,
-			expected:       "kept:int",
+			expected:       "kept:int,sized_int:int,sized_dec:decimal",
 		},
 		{
 			name: "sized string with source_column emits dest:text(n):source",
@@ -419,12 +419,56 @@ func TestColumnHints(t *testing.T) {
 			normalizeNames: false,
 			expected:       "bare:text,inline:text(100),field:text(50),renamed:text(255):src",
 		},
+		{
+			name: "destination overlay aliases are applied",
+			columns: []pipeline.Column{
+				{Name: "id", Type: "uint64"},
+				{Name: "ts", Type: "DateTime64"},
+				{Name: "ts_prec", Type: "DateTime64(3)"},
+				{Name: "name", Type: "string"},
+			},
+			normalizeNames: false,
+			overlay: map[string]string{
+				"uint64":     "bigint",
+				"datetime64": "timestamp",
+			},
+			expected: "id:bigint,ts:timestamp,ts_prec:timestamp,name:text",
+		},
+		{
+			name: "nullable and lowcardinality wrappers peel to inner type",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "Nullable(integer)"},
+				{Name: "b", Type: "LowCardinality(varchar(50))"},
+				{Name: "c", Type: "Nullable(LowCardinality(timestamp))"},
+			},
+			normalizeNames: false,
+			expected:       "a:int,b:text(50),c:timestamp",
+		},
+		{
+			name: "destination overlay wins over defaults",
+			columns: []pipeline.Column{
+				{Name: "x", Type: "integer"},
+			},
+			normalizeNames: false,
+			overlay:        map[string]string{"integer": "bigint"},
+			expected:       "x:bigint",
+		},
+		{
+			name: "clickhouse-only types are skipped without overlay",
+			columns: []pipeline.Column{
+				{Name: "id", Type: "uint64"},
+				{Name: "ts", Type: "datetime64"},
+				{Name: "name", Type: "string"},
+			},
+			normalizeNames: false,
+			expected:       "name:text",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := ColumnHints(tt.columns, tt.normalizeNames)
+			result := ColumnHints(tt.columns, tt.normalizeNames, tt.overlay)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -447,10 +491,10 @@ func TestColumnHints_SizedTypes(t *testing.T) {
 		want := fmt.Sprintf("c:%s(50)", hint)
 		t.Run(typ, func(t *testing.T) {
 			t.Parallel()
-			inline := ColumnHints([]pipeline.Column{{Name: "c", Type: typ + "(50)"}}, false)
+			inline := ColumnHints([]pipeline.Column{{Name: "c", Type: typ + "(50)"}}, false, nil)
 			assert.Equal(t, want, inline, "inline length for %q", typ)
 
-			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Length: intPtr(50)}}, false)
+			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Length: intPtr(50)}}, false, nil)
 			assert.Equal(t, want, field, "length field for %q", typ)
 		})
 	}
@@ -573,6 +617,25 @@ func TestConsolidatedParameters_EnforceSchema(t *testing.T) {
 			wantColumn: false,
 		},
 		{
+			name: "type hint overlay is applied when enforcing schema",
+			asset: &pipeline.Asset{
+				Parameters: pipeline.ParameterMap{},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "uint64"},
+					{Name: "ts", Type: "datetime64"},
+				},
+			},
+			columnOpts: &ColumnHintOptions{
+				NormalizeColumnNames:   false,
+				EnforceSchemaByDefault: true,
+				TypeHintOverlay: map[string]string{
+					"uint64":     "bigint",
+					"datetime64": "timestamp",
+				},
+			},
+			wantColumn: true,
+		},
+		{
 			name: "seed asset without enforce_schema uses default (true)",
 			asset: &pipeline.Asset{
 				Parameters: pipeline.ParameterMap{
@@ -659,11 +722,11 @@ func TestColumnHints_Normalization(t *testing.T) {
 	}
 
 	// Without normalization
-	result := ColumnHints(columns, false)
+	result := ColumnHints(columns, false, nil)
 	assert.Equal(t, "DateOfBirth:date", result)
 
 	// With normalization
-	result = ColumnHints(columns, true)
+	result = ColumnHints(columns, true, nil)
 	assert.Equal(t, "date_of_birth:date", result)
 }
 

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -456,6 +456,7 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		return err
 	}
 
+	destConn := u.conn.GetConnection(destConnectionName)
 	// build ingestr flags
 	cmdArgs, err := ConsolidatedParameters(ctx, asset, []string{
 		"ingest",
@@ -471,7 +472,8 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 	}, &ColumnHintOptions{
 		NormalizeColumnNames:   false,
 		EnforceSchemaByDefault: false,
-		TypeHintOverlay:        TypeHintOverlayForConnection(u.conn.GetConnection(destConnectionName)),
+		TypeHintOverlay:        TypeHintOverlayForConnection(destConn),
+		TypeWrappers:           TypeWrappersForConnection(destConn),
 	})
 	if err != nil {
 		return err

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -451,6 +451,11 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		asset.Parameters["incremental_key"] = mat.IncrementalKey
 	}
 
+	destConnectionName, err := execCtx.pipeline.GetConnectionNameForAsset(asset)
+	if err != nil {
+		return err
+	}
+
 	// build ingestr flags
 	cmdArgs, err := ConsolidatedParameters(ctx, asset, []string{
 		"ingest",
@@ -466,12 +471,8 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 	}, &ColumnHintOptions{
 		NormalizeColumnNames:   false,
 		EnforceSchemaByDefault: false,
+		TypeHintOverlay:        TypeHintOverlayForConnection(u.conn.GetConnection(destConnectionName)),
 	})
-	if err != nil {
-		return err
-	}
-
-	destConnectionName, err := execCtx.pipeline.GetConnectionNameForAsset(asset)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What
Lets ClickHouse seed/ingest assets pass native types (e.g. `DateTime64`) through to ingestr `--columns` via a per-destination type overlay on the connection.

## Changes
- Shared defaults stay in `pkg/python`; destinations can overlay aliases via `IngestrTypeHintProvider`
- ClickHouse owns its full native type map in `pkg/clickhouse`
- Peel `Nullable` / `LowCardinality` and resolve parameterized bases like `DateTime64(3)`
- Wire the overlay into seed, ingest, and Python materialization

## How to test
1. `go test ./pkg/python/ ./pkg/clickhouse/ ./pkg/ingestr/ -count=1`
2. Run a `clickhouse.seed` with `type: DateTime64(3)` and confirm `--columns` includes `timestamp`

## Risk & rollback
- **Risk:** low — additive overlay; unknown types are still skipped
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues


Made with [Cursor](https://cursor.com)