### PR TITLE
Add `cloud scheduled-runs` command

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -37,7 +37,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudAgents(),
 			CloudConnections(),
 			CloudDashboards(),
-			CloudScheduledRuns(),
+			CloudScheduledAgents(),
 		},
 	}
 }
@@ -2972,7 +2972,7 @@ func cloudDashboardsGet() *cli.Command {
 }
 
 // parseJSONOrYAMLObject decodes a JSON or YAML object (a dashboard definition, a
-// scheduled-run plan, ...) into a map. It walks the YAML node tree rather than
+// scheduled-agent plan, ...) into a map. It walks the YAML node tree rather than
 // decoding straight into a map so
 // that timestamp-like scalars (e.g. an unquoted `2024-01-01`) are preserved as
 // their original string — yaml.v3 would otherwise resolve them to time.Time,
@@ -3262,23 +3262,23 @@ func cloudDashboardsUpdate() *cli.Command {
 	}
 }
 
-func CloudScheduledRuns() *cli.Command {
+func CloudScheduledAgents() *cli.Command {
 	return &cli.Command{
-		Name:  "scheduled-runs",
-		Usage: "Manage Bruin Cloud scheduled runs",
+		Name:  "scheduled-agents",
+		Usage: "Manage Bruin Cloud scheduled agents",
 		Commands: []*cli.Command{
-			cloudScheduledRunsList(),
-			cloudScheduledRunsGet(),
-			cloudScheduledRunsCreate(),
-			cloudScheduledRunsUpdate(),
+			cloudScheduledAgentsList(),
+			cloudScheduledAgentsGet(),
+			cloudScheduledAgentsCreate(),
+			cloudScheduledAgentsUpdate(),
 		},
 	}
 }
 
-func cloudScheduledRunsList() *cli.Command {
+func cloudScheduledAgentsList() *cli.Command {
 	return &cli.Command{
 		Name:  "list",
-		Usage: "List scheduled runs",
+		Usage: "List scheduled agents",
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
@@ -3293,9 +3293,9 @@ func cloudScheduledRunsList() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			runs, err := client.ListScheduledRuns(ctx)
+			runs, err := client.ListScheduledAgents(ctx)
 			if err != nil {
-				printError(err, output, "Failed to list scheduled runs")
+				printError(err, output, "Failed to list scheduled agents")
 				return cli.Exit("", 1)
 			}
 
@@ -3317,16 +3317,16 @@ func cloudScheduledRunsList() *cli.Command {
 	}
 }
 
-func cloudScheduledRunsGet() *cli.Command {
+func cloudScheduledAgentsGet() *cli.Command {
 	return &cli.Command{
 		Name:  "get",
-		Usage: "Get a scheduled run including its plan",
+		Usage: "Get a scheduled agent including its plan",
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
 			&cli.IntFlag{
-				Name:     "scheduled-run-id",
-				Usage:    "scheduled run ID",
+				Name:     "scheduled-agent-id",
+				Usage:    "scheduled agent ID",
 				Required: true,
 			},
 		},
@@ -3340,9 +3340,9 @@ func cloudScheduledRunsGet() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			run, err := client.GetScheduledRun(ctx, c.Int("scheduled-run-id"))
+			run, err := client.GetScheduledAgent(ctx, c.Int("scheduled-agent-id"))
 			if err != nil {
-				printError(err, output, "Failed to get scheduled run")
+				printError(err, output, "Failed to get scheduled agent")
 				return cli.Exit("", 1)
 			}
 
@@ -3352,17 +3352,17 @@ func cloudScheduledRunsGet() *cli.Command {
 				return nil
 			}
 
-			printScheduledRun(run)
+			printScheduledAgent(run)
 			return nil
 		},
 	}
 }
 
-func cloudScheduledRunsCreate() *cli.Command {
+func cloudScheduledAgentsCreate() *cli.Command {
 	return &cli.Command{
 		Name:  "create",
-		Usage: "Create a scheduled run from a plan (stored as an inactive draft; activation stays in the UI)",
-		Flags: append(scheduledRunPlanFlags(),
+		Usage: "Create a scheduled agent from a plan (stored as an inactive draft; activation stays in the UI)",
+		Flags: append(scheduledAgentPlanFlags(),
 			&cli.IntFlag{
 				Name:     "agent-id",
 				Usage:    "the agent that runs the scheduled task",
@@ -3373,7 +3373,7 @@ func cloudScheduledRunsCreate() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
-			fields, err := buildScheduledRunFields(c)
+			fields, err := buildScheduledAgentFields(c)
 			if err != nil {
 				printError(err, output, "Invalid plan")
 				return cli.Exit("", 1)
@@ -3386,9 +3386,9 @@ func cloudScheduledRunsCreate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			run, err := client.CreateScheduledRun(ctx, fields)
+			run, err := client.CreateScheduledAgent(ctx, fields)
 			if err != nil {
-				printError(err, output, "Failed to create scheduled run")
+				printError(err, output, "Failed to create scheduled agent")
 				return cli.Exit("", 1)
 			}
 
@@ -3398,20 +3398,20 @@ func cloudScheduledRunsCreate() *cli.Command {
 				return nil
 			}
 
-			infoPrinter.Printf("Created scheduled run %d (%s) as a draft — review and activate it from the Bruin Cloud UI.\n", run.ID, derefString(run.Title))
+			infoPrinter.Printf("Created scheduled agent %d (%s) as a draft — review and activate it from the Bruin Cloud UI.\n", run.ID, derefString(run.Title))
 			return nil
 		},
 	}
 }
 
-func cloudScheduledRunsUpdate() *cli.Command {
+func cloudScheduledAgentsUpdate() *cli.Command {
 	return &cli.Command{
 		Name:  "update",
-		Usage: "Update a scheduled run's title or plan (activation stays in the UI)",
-		Flags: append(scheduledRunPlanFlags(),
+		Usage: "Update a scheduled agent's title or plan (activation stays in the UI)",
+		Flags: append(scheduledAgentPlanFlags(),
 			&cli.IntFlag{
-				Name:     "scheduled-run-id",
-				Usage:    "scheduled run ID",
+				Name:     "scheduled-agent-id",
+				Usage:    "scheduled agent ID",
 				Required: true,
 			},
 		),
@@ -3419,7 +3419,7 @@ func cloudScheduledRunsUpdate() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
-			fields, err := buildScheduledRunFields(c)
+			fields, err := buildScheduledAgentFields(c)
 			if err != nil {
 				printError(err, output, "Invalid plan")
 				return cli.Exit("", 1)
@@ -3435,9 +3435,9 @@ func cloudScheduledRunsUpdate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			run, err := client.UpdateScheduledRun(ctx, c.Int("scheduled-run-id"), fields)
+			run, err := client.UpdateScheduledAgent(ctx, c.Int("scheduled-agent-id"), fields)
 			if err != nil {
-				printError(err, output, "Failed to update scheduled run")
+				printError(err, output, "Failed to update scheduled agent")
 				return cli.Exit("", 1)
 			}
 
@@ -3447,14 +3447,14 @@ func cloudScheduledRunsUpdate() *cli.Command {
 				return nil
 			}
 
-			infoPrinter.Printf("Updated scheduled run %d (%s).\n", run.ID, derefString(run.Title))
+			infoPrinter.Printf("Updated scheduled agent %d (%s).\n", run.ID, derefString(run.Title))
 			return nil
 		},
 	}
 }
 
-// scheduledRunPlanFlags are the plan flags shared by create and update.
-func scheduledRunPlanFlags() []cli.Flag {
+// scheduledAgentPlanFlags are the plan flags shared by create and update.
+func scheduledAgentPlanFlags() []cli.Flag {
 	return []cli.Flag{
 		apiKeyFlag(),
 		outputFlag(),
@@ -3469,10 +3469,10 @@ func scheduledRunPlanFlags() []cli.Flag {
 	}
 }
 
-// buildScheduledRunFields assembles the request body from an optional full plan
+// buildScheduledAgentFields assembles the request body from an optional full plan
 // (--state / --state-file) overlaid with the convenience flags. Shared by create
 // and update so the two build the body identically.
-func buildScheduledRunFields(c *cli.Command) (map[string]any, error) {
+func buildScheduledAgentFields(c *cli.Command) (map[string]any, error) {
 	fields := map[string]any{}
 
 	// The plan can come inline (--state) or from a file (--state-file), not both.
@@ -3528,8 +3528,8 @@ func buildScheduledRunFields(c *cli.Command) (map[string]any, error) {
 	return fields, nil
 }
 
-func printScheduledRun(run *bruincloud.ScheduledRun) {
-	infoPrinter.Printf("Scheduled run %d: %s\n", run.ID, derefString(run.Title))
+func printScheduledAgent(run *bruincloud.ScheduledAgent) {
+	infoPrinter.Printf("Scheduled agent %d: %s\n", run.ID, derefString(run.Title))
 	fmt.Printf("  Active:    %v\n", run.IsActive)
 	fmt.Printf("  Cron:      %s\n", derefString(run.ScheduleCron))
 	fmt.Printf("  Timezone:  %s\n", derefString(run.ScheduleTimezone))

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -37,6 +37,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudAgents(),
 			CloudConnections(),
 			CloudDashboards(),
+			CloudScheduledRuns(),
 		},
 	}
 }
@@ -2970,14 +2971,15 @@ func cloudDashboardsGet() *cli.Command {
 	}
 }
 
-// parseDashboardState decodes a dashboard definition from JSON or YAML into a
-// map. It walks the YAML node tree rather than decoding straight into a map so
+// parseJSONOrYAMLObject decodes a JSON or YAML object (a dashboard definition, a
+// scheduled-run plan, ...) into a map. It walks the YAML node tree rather than
+// decoding straight into a map so
 // that timestamp-like scalars (e.g. an unquoted `2024-01-01`) are preserved as
 // their original string — yaml.v3 would otherwise resolve them to time.Time,
 // which JSON-encodes as an RFC3339 timestamp and changes the value. Returns a
 // nil map (no error) when the document is empty or not a mapping; the caller
 // rejects that as "must be an object".
-func parseDashboardState(raw []byte) (map[string]any, error) {
+func parseJSONOrYAMLObject(raw []byte) (map[string]any, error) {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
 		return nil, err
@@ -3100,7 +3102,7 @@ func cloudDashboardsCreate() *cli.Command {
 			// Accept JSON or YAML — dashboards are YAML-native and JSON is valid YAML.
 			var state map[string]any
 			if c.IsSet("state") || c.IsSet("state-file") {
-				parsed, err := parseDashboardState([]byte(raw))
+				parsed, err := parseJSONOrYAMLObject([]byte(raw))
 				if err != nil {
 					printError(fmt.Errorf("invalid dashboard definition (expected a JSON or YAML object): %w", err), output, "Invalid state")
 					return cli.Exit("", 1)
@@ -3210,7 +3212,7 @@ func cloudDashboardsUpdate() *cli.Command {
 					raw = string(data)
 				}
 				// Accept JSON or YAML — dashboards are YAML-native and JSON is valid YAML.
-				state, err := parseDashboardState([]byte(raw))
+				state, err := parseJSONOrYAMLObject([]byte(raw))
 				if err != nil {
 					printError(fmt.Errorf("invalid dashboard definition (expected a JSON or YAML object): %w", err), output, "Invalid state")
 					return cli.Exit("", 1)
@@ -3258,4 +3260,289 @@ func cloudDashboardsUpdate() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func CloudScheduledRuns() *cli.Command {
+	return &cli.Command{
+		Name:  "scheduled-runs",
+		Usage: "Manage Bruin Cloud scheduled runs",
+		Commands: []*cli.Command{
+			cloudScheduledRunsList(),
+			cloudScheduledRunsGet(),
+			cloudScheduledRunsCreate(),
+			cloudScheduledRunsUpdate(),
+		},
+	}
+}
+
+func cloudScheduledRunsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List scheduled runs",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			runs, err := client.ListScheduledRuns(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list scheduled runs")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(runs, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Title", "Active", "Cron", "Next Run"})
+			for _, r := range runs {
+				t.AppendRow(table.Row{r.ID, derefString(r.Title), r.IsActive, derefString(r.ScheduleCron), derefString(r.NextRunAt)})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudScheduledRunsGet() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "Get a scheduled run including its plan",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "scheduled-run-id",
+				Usage:    "scheduled run ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			run, err := client.GetScheduledRun(ctx, c.Int("scheduled-run-id"))
+			if err != nil {
+				printError(err, output, "Failed to get scheduled run")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(run, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			printScheduledRun(run)
+			return nil
+		},
+	}
+}
+
+func cloudScheduledRunsCreate() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a scheduled run from a plan (stored as an inactive draft; activation stays in the UI)",
+		Flags: append(scheduledRunPlanFlags(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "the agent that runs the scheduled task",
+				Required: true,
+			},
+		),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			fields, err := buildScheduledRunFields(c)
+			if err != nil {
+				printError(err, output, "Invalid plan")
+				return cli.Exit("", 1)
+			}
+			fields["agent_id"] = c.Int("agent-id")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			run, err := client.CreateScheduledRun(ctx, fields)
+			if err != nil {
+				printError(err, output, "Failed to create scheduled run")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(run, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Created scheduled run %d (%s) as a draft — review and activate it from the Bruin Cloud UI.\n", run.ID, derefString(run.Title))
+			return nil
+		},
+	}
+}
+
+func cloudScheduledRunsUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Update a scheduled run's title or plan (activation stays in the UI)",
+		Flags: append(scheduledRunPlanFlags(),
+			&cli.IntFlag{
+				Name:     "scheduled-run-id",
+				Usage:    "scheduled run ID",
+				Required: true,
+			},
+		),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			fields, err := buildScheduledRunFields(c)
+			if err != nil {
+				printError(err, output, "Invalid plan")
+				return cli.Exit("", 1)
+			}
+			if len(fields) == 0 {
+				printError(errors.New("provide at least one field to update (e.g. --title, --cron, --instructions or --state-file)"), output, "Nothing to update")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			run, err := client.UpdateScheduledRun(ctx, c.Int("scheduled-run-id"), fields)
+			if err != nil {
+				printError(err, output, "Failed to update scheduled run")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(run, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Updated scheduled run %d (%s).\n", run.ID, derefString(run.Title))
+			return nil
+		},
+	}
+}
+
+// scheduledRunPlanFlags are the plan flags shared by create and update.
+func scheduledRunPlanFlags() []cli.Flag {
+	return []cli.Flag{
+		apiKeyFlag(),
+		outputFlag(),
+		&cli.StringFlag{Name: "title", Usage: "the run title"},
+		&cli.StringFlag{Name: "cron", Usage: "cron schedule, e.g. '0 9 * * *'"},
+		&cli.StringFlag{Name: "timezone", Usage: "schedule timezone, e.g. 'UTC'"},
+		&cli.StringFlag{Name: "instructions", Usage: "what the run should do"},
+		&cli.StringFlag{Name: "output-formatting", Usage: "how the result should be formatted"},
+		&cli.StringFlag{Name: "connection", Usage: "the data connection to query"},
+		&cli.StringFlag{Name: "state", Usage: "the full plan as a JSON or YAML object string"},
+		&cli.StringFlag{Name: "state-file", Usage: "path to a file with the full plan as JSON or YAML"},
+	}
+}
+
+// buildScheduledRunFields assembles the request body from an optional full plan
+// (--state / --state-file) overlaid with the convenience flags. Shared by create
+// and update so the two build the body identically.
+func buildScheduledRunFields(c *cli.Command) (map[string]any, error) {
+	fields := map[string]any{}
+
+	// The plan can come inline (--state) or from a file (--state-file), not both.
+	if c.IsSet("state") && c.IsSet("state-file") {
+		return nil, errors.New("pass only one of --state or --state-file")
+	}
+	if c.IsSet("state") || c.IsSet("state-file") {
+		raw := c.String("state")
+		if file := c.String("state-file"); file != "" {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read --state-file: %w", err)
+			}
+			raw = string(data)
+		}
+		parsed, err := parseJSONOrYAMLObject([]byte(raw))
+		if err != nil {
+			return nil, fmt.Errorf("invalid plan (expected a JSON or YAML object): %w", err)
+		}
+		if parsed == nil {
+			return nil, errors.New("plan must be a JSON or YAML object")
+		}
+		fields = parsed
+	}
+
+	if c.IsSet("title") {
+		fields["title"] = c.String("title")
+	}
+	if c.IsSet("instructions") {
+		fields["instructions"] = c.String("instructions")
+	}
+	if c.IsSet("output-formatting") {
+		fields["output_formatting"] = c.String("output-formatting")
+	}
+	if c.IsSet("connection") {
+		fields["connection"] = c.String("connection")
+	}
+	// --cron / --timezone are shorthand for the nested schedule object.
+	if c.IsSet("cron") || c.IsSet("timezone") {
+		schedule, _ := fields["schedule"].(map[string]any)
+		if schedule == nil {
+			schedule = map[string]any{}
+		}
+		if c.IsSet("cron") {
+			schedule["cron"] = c.String("cron")
+		}
+		if c.IsSet("timezone") {
+			schedule["timezone"] = c.String("timezone")
+		}
+		fields["schedule"] = schedule
+	}
+
+	return fields, nil
+}
+
+func printScheduledRun(run *bruincloud.ScheduledRun) {
+	infoPrinter.Printf("Scheduled run %d: %s\n", run.ID, derefString(run.Title))
+	fmt.Printf("  Active:    %v\n", run.IsActive)
+	fmt.Printf("  Cron:      %s\n", derefString(run.ScheduleCron))
+	fmt.Printf("  Timezone:  %s\n", derefString(run.ScheduleTimezone))
+	fmt.Printf("  Next run:  %s\n", derefString(run.NextRunAt))
+	fmt.Printf("  Last run:  %s\n", derefString(run.LastRunAt))
+	if run.Instructions != nil && *run.Instructions != "" {
+		fmt.Printf("  Instructions:\n%s\n", *run.Instructions)
+	}
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -158,7 +158,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "agents")
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "dashboards")
-	assert.Contains(t, subNames, "scheduled-runs")
+	assert.Contains(t, subNames, "scheduled-agents")
 }
 
 func TestCloudProjectsCommand_Help(t *testing.T) {
@@ -241,11 +241,11 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "update")
 }
 
-func TestCloudScheduledRunsCommand_Help(t *testing.T) {
+func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	t.Parallel()
-	cmd := CloudScheduledRuns()
+	cmd := CloudScheduledAgents()
 	require.NotNil(t, cmd)
-	assert.Equal(t, "scheduled-runs", cmd.Name)
+	assert.Equal(t, "scheduled-agents", cmd.Name)
 	require.Len(t, cmd.Commands, 4)
 
 	subNames := make([]string, len(cmd.Commands))

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -143,7 +143,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 9)
+	assert.Len(t, cmd.Commands, 10)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -158,6 +158,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "agents")
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "dashboards")
+	assert.Contains(t, subNames, "scheduled-runs")
 }
 
 func TestCloudProjectsCommand_Help(t *testing.T) {
@@ -240,26 +241,43 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "update")
 }
 
+func TestCloudScheduledRunsCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := CloudScheduledRuns()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "scheduled-runs", cmd.Name)
+	require.Len(t, cmd.Commands, 4)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "list")
+	assert.Contains(t, subNames, "get")
+	assert.Contains(t, subNames, "create")
+	assert.Contains(t, subNames, "update")
+}
+
 func TestParseDashboardState(t *testing.T) {
 	t.Parallel()
 
 	t.Run("parses a JSON object", func(t *testing.T) {
 		t.Parallel()
-		got, err := parseDashboardState([]byte(`{"name":"d","rows":[]}`))
+		got, err := parseJSONOrYAMLObject([]byte(`{"name":"d","rows":[]}`))
 		require.NoError(t, err)
 		assert.Equal(t, "d", got["name"])
 	})
 
 	t.Run("parses a YAML object", func(t *testing.T) {
 		t.Parallel()
-		got, err := parseDashboardState([]byte("name: d\nrows: []\n"))
+		got, err := parseJSONOrYAMLObject([]byte("name: d\nrows: []\n"))
 		require.NoError(t, err)
 		assert.Equal(t, "d", got["name"])
 	})
 
 	t.Run("preserves an unquoted date-like scalar as a string", func(t *testing.T) {
 		t.Parallel()
-		got, err := parseDashboardState([]byte("default: 2024-01-01\n"))
+		got, err := parseJSONOrYAMLObject([]byte("default: 2024-01-01\n"))
 		require.NoError(t, err)
 		assert.Equal(t, "2024-01-01", got["default"])
 	})
@@ -267,7 +285,7 @@ func TestParseDashboardState(t *testing.T) {
 	t.Run("returns nil for non-object documents", func(t *testing.T) {
 		t.Parallel()
 		for _, in := range []string{"", "null", `"scalar"`, "[1, 2]"} {
-			got, err := parseDashboardState([]byte(in))
+			got, err := parseJSONOrYAMLObject([]byte(in))
 			require.NoError(t, err, "input %q", in)
 			assert.Nil(t, got, "input %q", in)
 		}
@@ -275,7 +293,7 @@ func TestParseDashboardState(t *testing.T) {
 
 	t.Run("errors on malformed YAML", func(t *testing.T) {
 		t.Parallel()
-		_, err := parseDashboardState([]byte("name: [unclosed"))
+		_, err := parseJSONOrYAMLObject([]byte("name: [unclosed"))
 		require.Error(t, err)
 	})
 }

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -660,6 +660,44 @@ bruin cloud dashboards update --dashboard-id 42 --visibility team
 
 ---
 
+### `scheduled-runs`
+
+Manage scheduled runs — cron-based recurring agent tasks.
+
+#### `list` / `get`
+
+```bash
+bruin cloud scheduled-runs list
+bruin cloud scheduled-runs get --scheduled-run-id 42
+bruin cloud scheduled-runs get --scheduled-run-id 42 --output json
+```
+
+#### `create`
+
+Create a scheduled run from a plan. It is stored as an inactive **draft** — a
+human reviews and activates it from the Bruin Cloud UI; the CLI never activates a
+run. Pass the plan with convenience flags, or the full plan via `--state-file`
+(JSON or YAML with `schedule`, `instructions`, `verified_sqls`, `memory`, ...).
+
+```bash
+bruin cloud scheduled-runs create --agent-id 7 --title "Daily revenue" \
+  --cron "0 9 * * *" --timezone UTC --instructions "Summarise yesterday's revenue."
+
+bruin cloud scheduled-runs create --agent-id 7 --state-file ./plan.yaml
+```
+
+#### `update`
+
+Update a run's title or plan. Only the flags you pass change. Activation stays in
+the UI.
+
+```bash
+bruin cloud scheduled-runs update --scheduled-run-id 42 --cron "0 8 * * 1"
+bruin cloud scheduled-runs update --scheduled-run-id 42 --state-file ./plan.yaml
+```
+
+---
+
 ## Common Workflows
 
 ### "My pipeline failed, what happened?"

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -660,30 +660,30 @@ bruin cloud dashboards update --dashboard-id 42 --visibility team
 
 ---
 
-### `scheduled-runs`
+### `scheduled-agents`
 
-Manage scheduled runs — cron-based recurring agent tasks.
+Manage scheduled agents — cron-based recurring agent tasks.
 
 #### `list` / `get`
 
 ```bash
-bruin cloud scheduled-runs list
-bruin cloud scheduled-runs get --scheduled-run-id 42
-bruin cloud scheduled-runs get --scheduled-run-id 42 --output json
+bruin cloud scheduled-agents list
+bruin cloud scheduled-agents get --scheduled-agent-id 42
+bruin cloud scheduled-agents get --scheduled-agent-id 42 --output json
 ```
 
 #### `create`
 
-Create a scheduled run from a plan. It is stored as an inactive **draft** — a
+Create a scheduled agent from a plan. It is stored as an inactive **draft** — a
 human reviews and activates it from the Bruin Cloud UI; the CLI never activates a
 run. Pass the plan with convenience flags, or the full plan via `--state-file`
 (JSON or YAML with `schedule`, `instructions`, `verified_sqls`, `memory`, ...).
 
 ```bash
-bruin cloud scheduled-runs create --agent-id 7 --title "Daily revenue" \
+bruin cloud scheduled-agents create --agent-id 7 --title "Daily revenue" \
   --cron "0 9 * * *" --timezone UTC --instructions "Summarise yesterday's revenue."
 
-bruin cloud scheduled-runs create --agent-id 7 --state-file ./plan.yaml
+bruin cloud scheduled-agents create --agent-id 7 --state-file ./plan.yaml
 ```
 
 #### `update`
@@ -692,8 +692,8 @@ Update a run's title or plan. Only the flags you pass change. Activation stays i
 the UI.
 
 ```bash
-bruin cloud scheduled-runs update --scheduled-run-id 42 --cron "0 8 * * 1"
-bruin cloud scheduled-runs update --scheduled-run-id 42 --state-file ./plan.yaml
+bruin cloud scheduled-agents update --scheduled-agent-id 42 --cron "0 8 * * 1"
+bruin cloud scheduled-agents update --scheduled-agent-id 42 --state-file ./plan.yaml
 ```
 
 ---

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -614,40 +614,40 @@ func (c *APIClient) UpdateDashboard(ctx context.Context, dashboardID int, fields
 	return &result, nil
 }
 
-func (c *APIClient) ListScheduledRuns(ctx context.Context) ([]ScheduledRun, error) {
+func (c *APIClient) ListScheduledAgents(ctx context.Context) ([]ScheduledAgent, error) {
 	var resp struct {
-		ScheduledRuns []ScheduledRun `json:"scheduled_runs"`
+		ScheduledAgents []ScheduledAgent `json:"scheduled_agents"`
 	}
-	err := c.doRequest(ctx, http.MethodGet, "/scheduled-runs", nil, &resp)
-	return resp.ScheduledRuns, err
+	err := c.doRequest(ctx, http.MethodGet, "/scheduled-agents", nil, &resp)
+	return resp.ScheduledAgents, err
 }
 
-func (c *APIClient) GetScheduledRun(ctx context.Context, scheduledRunID int) (*ScheduledRun, error) {
-	var result ScheduledRun
-	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/scheduled-runs/%d", scheduledRunID), nil, &result)
+func (c *APIClient) GetScheduledAgent(ctx context.Context, scheduledAgentID int) (*ScheduledAgent, error) {
+	var result ScheduledAgent
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/scheduled-agents/%d", scheduledAgentID), nil, &result)
 	if err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-// CreateScheduledRun creates a scheduled run from a plan. The server stores it as
+// CreateScheduledAgent creates a scheduled agent from a plan. The server stores it as
 // an inactive draft (a human activates it from the UI); fields is the request
 // body and must include agent_id.
-func (c *APIClient) CreateScheduledRun(ctx context.Context, fields map[string]any) (*ScheduledRun, error) {
-	var result ScheduledRun
-	err := c.doRequest(ctx, http.MethodPost, "/scheduled-runs", fields, &result)
+func (c *APIClient) CreateScheduledAgent(ctx context.Context, fields map[string]any) (*ScheduledAgent, error) {
+	var result ScheduledAgent
+	err := c.doRequest(ctx, http.MethodPost, "/scheduled-agents", fields, &result)
 	if err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-// UpdateScheduledRun applies a partial update to a scheduled run's plan. Only the
+// UpdateScheduledAgent applies a partial update to a scheduled agent's plan. Only the
 // fields present are changed; activation is not updatable via the API.
-func (c *APIClient) UpdateScheduledRun(ctx context.Context, scheduledRunID int, fields map[string]any) (*ScheduledRun, error) {
-	var result ScheduledRun
-	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/scheduled-runs/%d", scheduledRunID), fields, &result)
+func (c *APIClient) UpdateScheduledAgent(ctx context.Context, scheduledAgentID int, fields map[string]any) (*ScheduledAgent, error) {
+	var result ScheduledAgent
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/scheduled-agents/%d", scheduledAgentID), fields, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -613,3 +613,43 @@ func (c *APIClient) UpdateDashboard(ctx context.Context, dashboardID int, fields
 	}
 	return &result, nil
 }
+
+func (c *APIClient) ListScheduledRuns(ctx context.Context) ([]ScheduledRun, error) {
+	var resp struct {
+		ScheduledRuns []ScheduledRun `json:"scheduled_runs"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/scheduled-runs", nil, &resp)
+	return resp.ScheduledRuns, err
+}
+
+func (c *APIClient) GetScheduledRun(ctx context.Context, scheduledRunID int) (*ScheduledRun, error) {
+	var result ScheduledRun
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/scheduled-runs/%d", scheduledRunID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateScheduledRun creates a scheduled run from a plan. The server stores it as
+// an inactive draft (a human activates it from the UI); fields is the request
+// body and must include agent_id.
+func (c *APIClient) CreateScheduledRun(ctx context.Context, fields map[string]any) (*ScheduledRun, error) {
+	var result ScheduledRun
+	err := c.doRequest(ctx, http.MethodPost, "/scheduled-runs", fields, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateScheduledRun applies a partial update to a scheduled run's plan. Only the
+// fields present are changed; activation is not updatable via the API.
+func (c *APIClient) UpdateScheduledRun(ctx context.Context, scheduledRunID int, fields map[string]any) (*ScheduledRun, error) {
+	var result ScheduledRun
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/scheduled-runs/%d", scheduledRunID), fields, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -825,3 +825,67 @@ func TestUpdateDashboard(t *testing.T) {
 	assert.Equal(t, 9, dashboard.ID)
 	assert.Equal(t, "Renamed", *dashboard.Title)
 }
+
+func TestListScheduledRuns(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/scheduled-runs", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		title := "Nightly"
+		cron := "0 0 * * *"
+		writeJSON(t, w, map[string]any{
+			"scheduled_runs": []ScheduledRun{{ID: 3, Title: &title, IsActive: true, ScheduleCron: &cron}},
+		})
+	})
+
+	runs, err := client.ListScheduledRuns(t.Context())
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, 3, runs[0].ID)
+	assert.True(t, runs[0].IsActive)
+}
+
+func TestCreateScheduledRun(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/scheduled-runs", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.EqualValues(t, 7, body["agent_id"])
+		assert.Equal(t, "Daily", body["title"])
+
+		w.WriteHeader(http.StatusCreated)
+		title := "Daily"
+		writeJSON(t, w, ScheduledRun{ID: 11, Title: &title, IsActive: false})
+	})
+
+	run, err := client.CreateScheduledRun(t.Context(), map[string]any{"agent_id": 7, "title": "Daily"})
+	require.NoError(t, err)
+	assert.Equal(t, 11, run.ID)
+	// Created as a draft — never active from the API.
+	assert.False(t, run.IsActive)
+}
+
+func TestUpdateScheduledRun(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/scheduled-runs/11", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "Renamed", body["title"])
+
+		w.WriteHeader(http.StatusOK)
+		title := "Renamed"
+		writeJSON(t, w, ScheduledRun{ID: 11, Title: &title})
+	})
+
+	run, err := client.UpdateScheduledRun(t.Context(), 11, map[string]any{"title": "Renamed"})
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed", *run.Title)
+}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -847,6 +847,37 @@ func TestListScheduledRuns(t *testing.T) {
 	assert.True(t, runs[0].IsActive)
 }
 
+func TestGetScheduledRun(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/scheduled-runs/5", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		title := "Nightly"
+		cron := "0 0 * * *"
+		writeJSON(t, w, ScheduledRun{ID: 5, Title: &title, IsActive: true, ScheduleCron: &cron})
+	})
+
+	run, err := client.GetScheduledRun(t.Context(), 5)
+	require.NoError(t, err)
+	assert.Equal(t, 5, run.ID)
+	assert.Equal(t, "Nightly", *run.Title)
+	assert.Equal(t, "0 0 * * *", *run.ScheduleCron)
+}
+
+func TestGetScheduledRun_NotFound(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(t, w, map[string]any{"message": "Scheduled run not found", "error": "not_found"})
+	})
+
+	// A 404 surfaces as an error, not a zero-value run.
+	_, err := client.GetScheduledRun(t.Context(), 999)
+	require.Error(t, err)
+}
+
 func TestCreateScheduledRun(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -826,63 +826,63 @@ func TestUpdateDashboard(t *testing.T) {
 	assert.Equal(t, "Renamed", *dashboard.Title)
 }
 
-func TestListScheduledRuns(t *testing.T) {
+func TestListScheduledAgents(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/scheduled-runs", r.URL.Path)
+		assert.Equal(t, "/scheduled-agents", r.URL.Path)
 
 		w.WriteHeader(http.StatusOK)
 		title := "Nightly"
 		cron := "0 0 * * *"
 		writeJSON(t, w, map[string]any{
-			"scheduled_runs": []ScheduledRun{{ID: 3, Title: &title, IsActive: true, ScheduleCron: &cron}},
+			"scheduled_agents": []ScheduledAgent{{ID: 3, Title: &title, IsActive: true, ScheduleCron: &cron}},
 		})
 	})
 
-	runs, err := client.ListScheduledRuns(t.Context())
+	runs, err := client.ListScheduledAgents(t.Context())
 	require.NoError(t, err)
 	require.Len(t, runs, 1)
 	assert.Equal(t, 3, runs[0].ID)
 	assert.True(t, runs[0].IsActive)
 }
 
-func TestGetScheduledRun(t *testing.T) {
+func TestGetScheduledAgent(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/scheduled-runs/5", r.URL.Path)
+		assert.Equal(t, "/scheduled-agents/5", r.URL.Path)
 
 		w.WriteHeader(http.StatusOK)
 		title := "Nightly"
 		cron := "0 0 * * *"
-		writeJSON(t, w, ScheduledRun{ID: 5, Title: &title, IsActive: true, ScheduleCron: &cron})
+		writeJSON(t, w, ScheduledAgent{ID: 5, Title: &title, IsActive: true, ScheduleCron: &cron})
 	})
 
-	run, err := client.GetScheduledRun(t.Context(), 5)
+	run, err := client.GetScheduledAgent(t.Context(), 5)
 	require.NoError(t, err)
 	assert.Equal(t, 5, run.ID)
 	assert.Equal(t, "Nightly", *run.Title)
 	assert.Equal(t, "0 0 * * *", *run.ScheduleCron)
 }
 
-func TestGetScheduledRun_NotFound(t *testing.T) {
+func TestGetScheduledAgent_NotFound(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		writeJSON(t, w, map[string]any{"message": "Scheduled run not found", "error": "not_found"})
+		writeJSON(t, w, map[string]any{"message": "Scheduled agent not found", "error": "not_found"})
 	})
 
 	// A 404 surfaces as an error, not a zero-value run.
-	_, err := client.GetScheduledRun(t.Context(), 999)
+	_, err := client.GetScheduledAgent(t.Context(), 999)
 	require.Error(t, err)
 }
 
-func TestCreateScheduledRun(t *testing.T) {
+func TestCreateScheduledAgent(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/scheduled-runs", r.URL.Path)
+		assert.Equal(t, "/scheduled-agents", r.URL.Path)
 
 		var body map[string]any
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -891,21 +891,21 @@ func TestCreateScheduledRun(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		title := "Daily"
-		writeJSON(t, w, ScheduledRun{ID: 11, Title: &title, IsActive: false})
+		writeJSON(t, w, ScheduledAgent{ID: 11, Title: &title, IsActive: false})
 	})
 
-	run, err := client.CreateScheduledRun(t.Context(), map[string]any{"agent_id": 7, "title": "Daily"})
+	run, err := client.CreateScheduledAgent(t.Context(), map[string]any{"agent_id": 7, "title": "Daily"})
 	require.NoError(t, err)
 	assert.Equal(t, 11, run.ID)
 	// Created as a draft — never active from the API.
 	assert.False(t, run.IsActive)
 }
 
-func TestUpdateScheduledRun(t *testing.T) {
+func TestUpdateScheduledAgent(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
-		assert.Equal(t, "/scheduled-runs/11", r.URL.Path)
+		assert.Equal(t, "/scheduled-agents/11", r.URL.Path)
 
 		var body map[string]any
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -913,10 +913,10 @@ func TestUpdateScheduledRun(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		title := "Renamed"
-		writeJSON(t, w, ScheduledRun{ID: 11, Title: &title})
+		writeJSON(t, w, ScheduledAgent{ID: 11, Title: &title})
 	})
 
-	run, err := client.UpdateScheduledRun(t.Context(), 11, map[string]any{"title": "Renamed"})
+	run, err := client.UpdateScheduledAgent(t.Context(), 11, map[string]any{"title": "Renamed"})
 	require.NoError(t, err)
 	assert.Equal(t, "Renamed", *run.Title)
 }

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -256,10 +256,10 @@ type Dashboard struct {
 	State      json.RawMessage `json:"state,omitempty"`
 }
 
-// ScheduledRun represents a Bruin Cloud scheduled run — a cron-based recurring
+// ScheduledAgent represents a Bruin Cloud scheduled agent — a cron-based recurring
 // agent task. The nested plan fields (verified SQLs, memory, ...) are kept as raw
 // JSON so `--output json` round-trips the full server response faithfully.
-type ScheduledRun struct {
+type ScheduledAgent struct {
 	ID                int             `json:"id"`
 	Title             *string         `json:"title"`
 	IsActive          bool            `json:"is_active"`

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -255,3 +255,22 @@ type Dashboard struct {
 	URL        string          `json:"url"`
 	State      json.RawMessage `json:"state,omitempty"`
 }
+
+// ScheduledRun represents a Bruin Cloud scheduled run — a cron-based recurring
+// agent task. The nested plan fields (verified SQLs, memory, ...) are kept as raw
+// JSON so `--output json` round-trips the full server response faithfully.
+type ScheduledRun struct {
+	ID                int             `json:"id"`
+	Title             *string         `json:"title"`
+	IsActive          bool            `json:"is_active"`
+	ScheduleCron      *string         `json:"schedule_cron"`
+	ScheduleTimezone  *string         `json:"schedule_timezone"`
+	NextRunAt         *string         `json:"next_run_at"`
+	LastRunAt         *string         `json:"last_run_at"`
+	Instructions      *string         `json:"instructions"`
+	OutputFormatting  *string         `json:"output_formatting"`
+	VerifiedSqls      json.RawMessage `json:"verified_sqls,omitempty"`
+	Memory            json.RawMessage `json:"memory,omitempty"`
+	MonitorsDashboard json.RawMessage `json:"monitors_dashboard,omitempty"`
+	RecentExecutions  json.RawMessage `json:"recent_executions,omitempty"`
+}


### PR DESCRIPTION
Adds `bruin cloud scheduled-runs list/get/create/update`, completing the token-API + CLI pattern for scheduled runs (mirrors `cloud dashboards`).

Wraps the new cloud endpoints (`/api/v1/scheduled-runs`, bruin-data/cloud#2585). The plan can be supplied via convenience flags (`--cron`, `--timezone`, `--instructions`, `--title`, `--output-formatting`, `--connection`) or the full plan via `--state`/`--state-file` (JSON or YAML with `schedule`, `verified_sqls`, `memory`, ...).

`create` stores an **inactive draft** — a human activates it from the UI; the CLI never activates a run. `--cron` is validated server-side.

De-dup: the generic JSON/YAML object parser (was `parseDashboardState`) is renamed `parseJSONOrYAMLObject` and reused for the plan; create/update share one field-builder and flag set.

Depends on the cloud PR for the endpoints.