### PR TITLE
starrocks: take partition and distribution from materialization

### DIFF
--- a/docs/platforms/starrocks.md
+++ b/docs/platforms/starrocks.md
@@ -61,6 +61,8 @@ so they work the same way as on the other platforms:
 - `materialization.cluster_by` → `DISTRIBUTED BY HASH(...)` (defaults to the key columns)
 - `materialization.partition_by` → `PARTITION BY (...)` (a column or expression such as `date_trunc('day', event_date)`)
 
+`partition_by` is emitted verbatim so that expressions work, so it is **not** automatically backtick-quoted. If you partition on a single column whose name is a StarRocks reserved word (e.g. `date`, `value`, `key`), quote it yourself: `partition_by: "`date`"`.
+
 StarRocks-specific layout that has no materialization equivalent is declared under `starrocks`:
 
 ```yaml

--- a/docs/platforms/starrocks.md
+++ b/docs/platforms/starrocks.md
@@ -55,14 +55,24 @@ View materialization is also supported. For local and single-node StarRocks clus
 
 #### Table layout
 
-Optional StarRocks table layout settings can be declared under `starrocks`:
+Distribution and partitioning are taken from the standard materialization fields,
+so they work the same way as on the other platforms:
+
+- `materialization.cluster_by` → `DISTRIBUTED BY HASH(...)` (defaults to the key columns)
+- `materialization.partition_by` → `PARTITION BY (...)` (a column or expression such as `date_trunc('day', event_date)`)
+
+StarRocks-specific layout that has no materialization equivalent is declared under `starrocks`:
 
 ```yaml
+materialization:
+  type: table
+  strategy: create+replace
+  cluster_by: [account_id]          # DISTRIBUTED BY HASH(account_id)
+  partition_by: event_date          # PARTITION BY (event_date)
+
 starrocks:
-  table_model: primary_key         # duplicate_key | unique_key | primary_key
-  distributed_by: [account_id]      # defaults to the key columns
-  partition_by: [event_date]        # optional expression partitioning
-  buckets: 8                        # defaults to 1
+  table_model: primary_key          # duplicate_key | unique_key | primary_key
+  buckets: 8                         # defaults to 1
   properties:
     replication_num: "1"
 ```

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1191,12 +1191,14 @@ func (d DorisConfig) IsZero() bool {
 	return d.TableModel == "" && len(d.DistributedBy) == 0 && d.Buckets == 0 && len(d.Properties) == 0
 }
 
+// StarRocksConfig carries StarRocks-specific table layout that has no
+// materialization-level equivalent. Distribution and partitioning are taken from
+// the materialization's `cluster_by` and `partition_by` fields respectively, so
+// they are intentionally absent here.
 type StarRocksConfig struct {
-	TableModel    string            `json:"table_model,omitempty" yaml:"table_model,omitempty" mapstructure:"table_model"`
-	DistributedBy []string          `json:"distributed_by,omitempty" yaml:"distributed_by,omitempty" mapstructure:"distributed_by"`
-	PartitionBy   []string          `json:"partition_by,omitempty" yaml:"partition_by,omitempty" mapstructure:"partition_by"`
-	Buckets       int               `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets"`
-	Properties    map[string]string `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties"`
+	TableModel string            `json:"table_model,omitempty" yaml:"table_model,omitempty" mapstructure:"table_model"`
+	Buckets    int               `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets"`
+	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties"`
 }
 
 func (s StarRocksConfig) MarshalJSON() ([]byte, error) {
@@ -1209,7 +1211,7 @@ func (s StarRocksConfig) MarshalJSON() ([]byte, error) {
 }
 
 func (s StarRocksConfig) IsZero() bool {
-	return s.TableModel == "" && len(s.DistributedBy) == 0 && len(s.PartitionBy) == 0 && s.Buckets == 0 && len(s.Properties) == 0
+	return s.TableModel == "" && s.Buckets == 0 && len(s.Properties) == 0
 }
 
 type RoutingConfig struct {
@@ -3277,12 +3279,6 @@ func mergeDorisDefaults(target *DorisConfig, defaults DorisConfig) {
 func mergeStarRocksDefaults(target *StarRocksConfig, defaults StarRocksConfig) {
 	if target.TableModel == "" {
 		target.TableModel = defaults.TableModel
-	}
-	if len(target.DistributedBy) == 0 && len(defaults.DistributedBy) > 0 {
-		target.DistributedBy = append([]string(nil), defaults.DistributedBy...)
-	}
-	if len(target.PartitionBy) == 0 && len(defaults.PartitionBy) > 0 {
-		target.PartitionBy = append([]string(nil), defaults.PartitionBy...)
 	}
 	if target.Buckets == 0 {
 		target.Buckets = defaults.Buckets

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -455,16 +455,6 @@ func renderAssetStrings(render RenderFunc, a *Asset) error {
 	if a.StarRocks.TableModel, err = maybeRender(render, fmt.Sprintf("asset[%s].starrocks.table_model", originalName), a.StarRocks.TableModel); err != nil {
 		return err
 	}
-	for i, column := range a.StarRocks.DistributedBy {
-		if a.StarRocks.DistributedBy[i], err = maybeRender(render, fmt.Sprintf("asset[%s].starrocks.distributed_by[%d]", originalName, i), column); err != nil {
-			return err
-		}
-	}
-	for i, column := range a.StarRocks.PartitionBy {
-		if a.StarRocks.PartitionBy[i], err = maybeRender(render, fmt.Sprintf("asset[%s].starrocks.partition_by[%d]", originalName, i), column); err != nil {
-			return err
-		}
-	}
 	for key, value := range a.StarRocks.Properties {
 		if a.StarRocks.Properties[key], err = maybeRender(render, fmt.Sprintf("asset[%s].starrocks.properties[%s]", originalName, key), value); err != nil {
 			return err

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -569,10 +569,8 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 			Properties:    map[string]string{"replication_num": "1"},
 		},
 		StarRocks: pipeline.StarRocksConfig{
-			TableModel:    "primary_key",
-			DistributedBy: []string{"id"},
-			PartitionBy:   []string{"dt"},
-			Properties:    map[string]string{"replication_num": "1"},
+			TableModel: "primary_key",
+			Properties: map[string]string{"replication_num": "1"},
 		},
 		Routing: &pipeline.RoutingConfig{EgressGateway: "gw"},
 	}
@@ -626,10 +624,8 @@ func buildFullyPopulatedPipelineForVisitorTest() *pipeline.Pipeline {
 				Properties:    map[string]string{"replication_num": "1"},
 			},
 			StarRocks: pipeline.StarRocksConfig{
-				TableModel:    "primary_key",
-				DistributedBy: []string{"id"},
-				PartitionBy:   []string{"dt"},
-				Properties:    map[string]string{"replication_num": "1"},
+				TableModel: "primary_key",
+				Properties: map[string]string{"replication_num": "1"},
 			},
 			Routing: &pipeline.RoutingConfig{EgressGateway: "gw"},
 			Notifications: &pipeline.Notifications{

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -387,11 +387,9 @@ type doris struct {
 }
 
 type starrocks struct {
-	TableModel    string            `yaml:"table_model"`
-	DistributedBy []string          `yaml:"distributed_by"`
-	PartitionBy   []string          `yaml:"partition_by"`
-	Buckets       int               `yaml:"buckets"`
-	Properties    map[string]string `yaml:"properties"`
+	TableModel string            `yaml:"table_model"`
+	Buckets    int               `yaml:"buckets"`
+	Properties map[string]string `yaml:"properties"`
 }
 
 func notificationsOrNil(n Notifications) *Notifications {
@@ -652,11 +650,9 @@ func taskDefinitionToAsset(definition taskDefinition) (*Asset, error) {
 			Properties:    definition.Doris.Properties,
 		},
 		StarRocks: StarRocksConfig{
-			TableModel:    definition.StarRocks.TableModel,
-			DistributedBy: definition.StarRocks.DistributedBy,
-			PartitionBy:   definition.StarRocks.PartitionBy,
-			Buckets:       definition.StarRocks.Buckets,
-			Properties:    definition.StarRocks.Properties,
+			TableModel: definition.StarRocks.TableModel,
+			Buckets:    definition.StarRocks.Buckets,
+			Properties: definition.StarRocks.Properties,
 		},
 		Routing:           definition.Routing,
 		IntervalModifiers: definition.IntervalModifiers,

--- a/pkg/starrocks/materialization.go
+++ b/pkg/starrocks/materialization.go
@@ -269,8 +269,8 @@ func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
 func requiresTypedCreateTable(asset *pipeline.Asset) bool {
 	return asset.Materialization.Strategy == pipeline.MaterializationStrategyMerge ||
 		strings.TrimSpace(asset.StarRocks.TableModel) != "" ||
-		len(asset.StarRocks.DistributedBy) > 0 ||
-		len(asset.StarRocks.PartitionBy) > 0 ||
+		len(asset.Materialization.ClusterBy) > 0 ||
+		strings.TrimSpace(asset.Materialization.PartitionBy) != "" ||
 		asset.StarRocks.Buckets != 0
 }
 
@@ -312,10 +312,6 @@ func buildCreateTableStatement(asset *pipeline.Asset, ifNotExists bool) (string,
 	if err != nil {
 		return "", err
 	}
-	partitionBy, err := starRocksPartitionByColumns(asset)
-	if err != nil {
-		return "", err
-	}
 
 	columnDefs := make([]string, 0, len(orderedColumns))
 	keyColumnSet := columnSet(keyColumns)
@@ -328,9 +324,12 @@ func buildCreateTableStatement(asset *pipeline.Asset, ifNotExists bool) (string,
 		createPrefix += "IF NOT EXISTS "
 	}
 
+	// StarRocks partitioning comes from the materialization's `partition_by`,
+	// which is a free-form expression (a column or an expression such as
+	// date_trunc('day', ts)) mirroring how the other platforms treat it.
 	partitionClause := ""
-	if len(partitionBy) > 0 {
-		partitionClause = fmt.Sprintf("PARTITION BY (%s)\n", strings.Join(quoteColumnNames(partitionBy), ", "))
+	if partitionBy := strings.TrimSpace(asset.Materialization.PartitionBy); partitionBy != "" {
+		partitionClause = fmt.Sprintf("PARTITION BY (%s)\n", partitionBy)
 	}
 
 	return fmt.Sprintf(
@@ -459,32 +458,23 @@ func starRocksKeyColumns(asset *pipeline.Asset, model string) ([]string, error) 
 	return []string{asset.Columns[0].Name}, nil
 }
 
+// starRocksDistributedByColumns resolves the hash distribution columns for
+// `DISTRIBUTED BY HASH(...)`. StarRocks' data distribution is expressed through
+// the materialization's `cluster_by` field, which is the same notion of "the
+// columns that decide how rows are laid out" used across the other platforms.
+// It falls back to the table's key columns when `cluster_by` is unset.
 func starRocksDistributedByColumns(asset *pipeline.Asset, keyColumns []string) ([]string, error) {
-	if len(asset.StarRocks.DistributedBy) == 0 {
+	if len(asset.Materialization.ClusterBy) == 0 {
 		return keyColumns, nil
 	}
 
-	for _, column := range asset.StarRocks.DistributedBy {
+	for _, column := range asset.Materialization.ClusterBy {
 		if strings.TrimSpace(column) == "" {
-			return nil, errors.New("starrocks distributed_by columns cannot be empty")
+			return nil, errors.New("starrocks cluster_by columns cannot be empty")
 		}
 	}
 
-	return asset.StarRocks.DistributedBy, nil
-}
-
-func starRocksPartitionByColumns(asset *pipeline.Asset) ([]string, error) {
-	if len(asset.StarRocks.PartitionBy) == 0 {
-		return nil, nil
-	}
-
-	for _, column := range asset.StarRocks.PartitionBy {
-		if strings.TrimSpace(column) == "" {
-			return nil, errors.New("starrocks partition_by columns cannot be empty")
-		}
-	}
-
-	return asset.StarRocks.PartitionBy, nil
+	return asset.Materialization.ClusterBy, nil
 }
 
 func starRocksBuckets(asset *pipeline.Asset) (int, error) {

--- a/pkg/starrocks/materialization_test.go
+++ b/pkg/starrocks/materialization_test.go
@@ -194,6 +194,29 @@ func TestMaterializer_Render(t *testing.T) {
 				"PROPERTIES (\"replication_num\" = \"1\");",
 		},
 		{
+			name: "ddl emits expression partition by clause",
+			asset: &pipeline.Asset{
+				Name: "analytics.events",
+				Materialization: pipeline.Materialization{
+					Type:        pipeline.MaterializationTypeTable,
+					Strategy:    pipeline.MaterializationStrategyDDL,
+					PartitionBy: "date_trunc('day', event_ts)",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "INT"},
+					{Name: "event_ts", Type: "DATETIME"},
+				},
+			},
+			want: "CREATE TABLE IF NOT EXISTS `analytics`.`events` (\n" +
+				"`id` INT,\n" +
+				"`event_ts` DATETIME\n" +
+				")\n" +
+				"DUPLICATE KEY(`id`)\n" +
+				"PARTITION BY (date_trunc('day', event_ts))\n" +
+				"DISTRIBUTED BY HASH(`id`) BUCKETS 1\n" +
+				"PROPERTIES (\"replication_num\" = \"1\");",
+		},
+		{
 			name: "merge creates primary key table and upserts",
 			asset: &pipeline.Asset{
 				Name: "analytics.accounts",

--- a/pkg/starrocks/materialization_test.go
+++ b/pkg/starrocks/materialization_test.go
@@ -171,13 +171,13 @@ func TestMaterializer_Render(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "analytics.events",
 				Materialization: pipeline.Materialization{
-					Type:     pipeline.MaterializationTypeTable,
-					Strategy: pipeline.MaterializationStrategyDDL,
+					Type:        pipeline.MaterializationTypeTable,
+					Strategy:    pipeline.MaterializationStrategyDDL,
+					ClusterBy:   []string{"id"},
+					PartitionBy: "event_date",
 				},
 				StarRocks: pipeline.StarRocksConfig{
-					DistributedBy: []string{"id"},
-					PartitionBy:   []string{"event_date"},
-					Buckets:       4,
+					Buckets: 4,
 				},
 				Columns: []pipeline.Column{
 					{Name: "id", Type: "INT"},
@@ -189,7 +189,7 @@ func TestMaterializer_Render(t *testing.T) {
 				"`event_date` DATE\n" +
 				")\n" +
 				"DUPLICATE KEY(`id`)\n" +
-				"PARTITION BY (`event_date`)\n" +
+				"PARTITION BY (event_date)\n" +
 				"DISTRIBUTED BY HASH(`id`) BUCKETS 4\n" +
 				"PROPERTIES (\"replication_num\" = \"1\");",
 		},
@@ -271,13 +271,13 @@ func TestMaterializer_Render(t *testing.T) {
 			asset: &pipeline.Asset{
 				Name: "analytics.accounts",
 				Materialization: pipeline.Materialization{
-					Type:     pipeline.MaterializationTypeTable,
-					Strategy: pipeline.MaterializationStrategyMerge,
+					Type:      pipeline.MaterializationTypeTable,
+					Strategy:  pipeline.MaterializationStrategyMerge,
+					ClusterBy: []string{"account_id"},
 				},
 				StarRocks: pipeline.StarRocksConfig{
-					DistributedBy: []string{"account_id"},
-					Buckets:       2,
-					Properties:    map[string]string{"compression": "zstd"},
+					Buckets:    2,
+					Properties: map[string]string{"compression": "zstd"},
 				},
 				Columns: []pipeline.Column{
 					{Name: "status", Type: "VARCHAR(20)", UpdateOnMerge: true},


### PR DESCRIPTION
StarRocks carried its own `distributed_by` and `partition_by` fields under the `starrocks` asset config block, duplicating notions that Bruin already models at the materialization level and that every other platform reads from there.

This drops both StarRocks-specific fields and sources the DDL from the shared materialization config instead:

- `PARTITION BY (...)` now comes from `materialization.partition_by` (a free-form string), so expression partitioning such as `date_trunc('day', ts)` works in addition to a plain column.
- `DISTRIBUTED BY HASH(...)` now comes from `materialization.cluster_by`, the same "columns that decide row layout" concept exposed on the other platforms, still falling back to the key columns when unset.

Only StarRocks-specific layout with no materialization equivalent (`table_model`, `buckets`, `properties`) remains under `starrocks`. Doris is left untouched.

## Example

```yaml
materialization:
  type: table
  strategy: create+replace
  cluster_by: [account_id]      # DISTRIBUTED BY HASH(account_id)
  partition_by: event_date      # PARTITION BY (event_date)

starrocks:
  table_model: primary_key
  buckets: 8
  properties:
    replication_num: "1"
```