### PR TITLE
feat(ingestr): add FastSpring source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -302,6 +302,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Elasticsearch", link: "/ingestion/elasticsearch"},
                                     {text: "ESPN", link: "/ingestion/espn"},
                                     {text: "Facebook", link: "/ingestion/facebook-ads"},
+                                    {text: "FastSpring", link: "/ingestion/fastspring"},
                                     {text: "Fireflies", link: "/ingestion/fireflies"},
                                     {text: "Fluxx", link: "/ingestion/fluxx"},
                                     {text: "football-data.org", link: "/ingestion/footballdata"},

--- a/docs/ingestion/fastspring.md
+++ b/docs/ingestion/fastspring.md
@@ -1,0 +1,67 @@
+# FastSpring
+
+[FastSpring](https://fastspring.com/) is a merchant of record and e-commerce platform that handles payments, subscriptions, taxes, and invoicing for software and SaaS businesses.
+
+Bruin supports FastSpring as a source for [Ingestr assets](/assets/ingestr). You can ingest data from FastSpring into your data platform.
+
+To set up a FastSpring connection, add a configuration item in the `.bruin.yml` file and in your asset file. You authenticate with your API `username` and `password`, created under **Developer Tools > APIs > API Credentials** in the FastSpring app.
+
+Follow these steps to set up FastSpring and run ingestion.
+
+## Configuration
+
+### Step 1: Add a connection to the .bruin.yml file
+
+```yaml
+connections:
+  fastspring:
+    - name: "fastspring"
+      username: "your-api-username"
+      password: "your-api-password"
+```
+
+- `username`: (Required) FastSpring API username.
+- `password`: (Required) FastSpring API password.
+
+### Step 2: Create an asset file for data ingestion
+
+Create an [asset configuration](/assets/ingestr#asset-structure) file (e.g., `fastspring_ingestion.yml`) inside the assets folder with the following content:
+
+```yaml
+name: public.fastspring
+type: ingestr
+
+parameters:
+  source_connection: fastspring
+  source_table: 'orders'
+
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Always `ingestr` for FastSpring.
+- `source_connection`: The FastSpring connection name defined in `.bruin.yml`.
+- `source_table`: Name of the FastSpring table to ingest.
+- `destination`: The destination connection name.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| orders | id | changed | merge | Orders and their line items, payments, taxes, and returns. Supports date-range filtering. |
+| subscriptions | id | changed | merge | Recurring subscriptions, including status, billing period, and pricing. Supports date-range filtering. |
+| accounts | id | | replace | Customer accounts, including contact details and address. |
+| products | id | | replace | Products in your catalog, including pricing and fulfillment settings. |
+| coupons | id | | replace | Coupons and their discount configuration. |
+| subscription_report | subscription_id, transaction_date | sync_date | merge | Subscription metrics (MRR, ARR, subscribers, churn) grouped by the fields you choose. |
+| revenue_report | Order_ID, Transaction_Date | syncDate | merge | Revenue metrics grouped by the fields you choose. |
+
+`orders` and `subscriptions` support incremental date-range loads via `--interval-start` / `--interval-end`. Reports load incrementally on their sync-date column; customize a report's columns and grouping with the colon form `<report>:<columns>:<group_by>`.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/fastspring_ingestion.yml
+```
+
+Running this command ingests data from FastSpring into your Postgres database.

--- a/docs/ingestion/fastspring.md
+++ b/docs/ingestion/fastspring.md
@@ -54,7 +54,7 @@ parameters:
 | products | id | | replace | Products in your catalog, including pricing and fulfillment settings. |
 | coupons | id | | replace | Coupons and their discount configuration. |
 | subscription_report | subscription_id, transaction_date | sync_date | merge | Subscription metrics (MRR, ARR, subscribers, churn) grouped by the fields you choose. |
-| revenue_report | Order_ID, Transaction_Date | syncDate | merge | Revenue metrics grouped by the fields you choose. |
+| revenue_report | order_id, transaction_date | syncdate | merge | Revenue metrics grouped by the fields you choose. |
 
 `orders` and `subscriptions` support incremental date-range loads via `--interval-start` / `--interval-end`. Reports load incrementally on their sync-date column; customize a report's columns and grouping with the colon form `<report>:<columns>:<group_by>`.
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1236,6 +1236,12 @@
           },
           "type": "array"
         },
+        "fastspring": {
+          "items": {
+            "$ref": "#/$defs/FastspringConnection"
+          },
+          "type": "array"
+        },
         "clickup": {
           "items": {
             "$ref": "#/$defs/ClickupConnection"
@@ -2215,6 +2221,29 @@
         "name",
         "access_token",
         "account_id"
+      ]
+    },
+    "FastspringConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "username",
+        "password"
       ]
     },
     "FirefliesConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1342,6 +1342,16 @@ func (c AmplitudeConnection) GetName() string {
 	return c.Name
 }
 
+type FastspringConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	Username           string `yaml:"username,omitempty" json:"username" mapstructure:"username"`
+	Password           string `yaml:"password,omitempty" json:"password" mapstructure:"password" sensitive:"true"`
+}
+
+func (c FastspringConnection) GetName() string {
+	return c.Name
+}
+
 type ClickupConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	APIToken           string `yaml:"api_token,omitempty" json:"api_token" mapstructure:"api_token" sensitive:"true"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -107,6 +107,7 @@ type Connections struct {
 	Polymarket          []PolymarketConnection          `yaml:"polymarket,omitempty" json:"polymarket,omitempty" mapstructure:"polymarket"`
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
 	Amplitude           []AmplitudeConnection           `yaml:"amplitude,omitempty" json:"amplitude,omitempty" mapstructure:"amplitude"`
+	Fastspring          []FastspringConnection          `yaml:"fastspring,omitempty" json:"fastspring,omitempty" mapstructure:"fastspring"`
 	Clickup             []ClickupConnection             `yaml:"clickup,omitempty" json:"clickup,omitempty" mapstructure:"clickup"`
 	Jobtread            []JobtreadConnection            `yaml:"jobtread,omitempty" json:"jobtread,omitempty" mapstructure:"jobtread"`
 	Posthog             []PosthogConnection             `yaml:"posthog,omitempty" json:"posthog,omitempty" mapstructure:"posthog"`
@@ -1367,6 +1368,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Amplitude = append(env.Connections.Amplitude, conn)
+	case "fastspring":
+		var conn FastspringConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Fastspring = append(env.Connections.Fastspring, conn)
 	case "wise":
 		var conn WiseConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -1983,6 +1991,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Mixpanel = removeConnection(env.Connections.Mixpanel, connectionName)
 	case "amplitude":
 		env.Connections.Amplitude = removeConnection(env.Connections.Amplitude, connectionName)
+	case "fastspring":
+		env.Connections.Fastspring = removeConnection(env.Connections.Fastspring, connectionName)
 	case "pinterest":
 		env.Connections.Pinterest = removeConnection(env.Connections.Pinterest, connectionName)
 	case "trino":
@@ -2271,6 +2281,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Polymarket, source.Polymarket)
 	mergeConnectionList(&c.Mixpanel, source.Mixpanel)
 	mergeConnectionList(&c.Amplitude, source.Amplitude)
+	mergeConnectionList(&c.Fastspring, source.Fastspring)
 	mergeConnectionList(&c.Clickup, source.Clickup)
 	mergeConnectionList(&c.Jobtread, source.Jobtread)
 	mergeConnectionList(&c.Posthog, source.Posthog)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -629,6 +629,13 @@ func TestLoadFromFile(t *testing.T) {
 					Region:             "us",
 				},
 			},
+			Fastspring: []FastspringConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "fastspring-1"},
+					Username:           "user-123",
+					Password:           "pass-123",
+				},
+			},
 			Wise: []WiseConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "wise-1"},
@@ -2675,6 +2682,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Polymarket:          []PolymarketConnection{{ConnectionMetadata: ConnectionMetadata{Name: "polymarket1"}}},
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
 				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
+				Fastspring:          []FastspringConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fastspring1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
 				Posthog:             []PosthogConnection{{ConnectionMetadata: ConnectionMetadata{Name: "posthog1"}}},
@@ -2810,6 +2818,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Polymarket:          []PolymarketConnection{{ConnectionMetadata: ConnectionMetadata{Name: "polymarket1"}}},
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
 				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
+				Fastspring:          []FastspringConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fastspring1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
 				Posthog:             []PosthogConnection{{ConnectionMetadata: ConnectionMetadata{Name: "posthog1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -384,6 +384,10 @@ environments:
           api_key: "api-key-123"
           secret_key: "secret-key-123"
           region: "us"
+      fastspring:
+        - name: "fastspring-1"
+          username: "user-123"
+          password: "pass-123"
       wise:
         - name: "wise-1"
           api_key: "token-123"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -386,6 +386,10 @@ environments:
           api_key: "api-key-123"
           secret_key: "secret-key-123"
           region: "us"
+      fastspring:
+        - name: "fastspring-1"
+          username: "user-123"
+          password: "pass-123"
       wise:
         - name: "wise-1"
           api_key: "token-123"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -54,6 +54,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/espn"
 	fabric "github.com/bruin-data/bruin/pkg/fabric"
 	"github.com/bruin-data/bruin/pkg/facebookads"
+	"github.com/bruin-data/bruin/pkg/fastspring"
 	"github.com/bruin-data/bruin/pkg/fireflies"
 	"github.com/bruin-data/bruin/pkg/fluxx"
 	"github.com/bruin-data/bruin/pkg/footballdata"
@@ -231,6 +232,7 @@ type Manager struct {
 	Polymarket           map[string]*polymarket.Client
 	Mixpanel             map[string]*mixpanel.Client
 	Amplitude            map[string]*amplitude.Client
+	Fastspring           map[string]*fastspring.Client
 	Clickup              map[string]*clickup.Client
 	Jobtread             map[string]*jobtread.Client
 	Posthog              map[string]*posthog.Client
@@ -2953,6 +2955,28 @@ func (m *Manager) AddAmplitudeConnectionFromConfig(connection *config.AmplitudeC
 	return nil
 }
 
+func (m *Manager) AddFastspringConnectionFromConfig(connection *config.FastspringConnection) error {
+	m.mutex.Lock()
+	if m.Fastspring == nil {
+		m.Fastspring = make(map[string]*fastspring.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := fastspring.NewClient(fastspring.Config{
+		Username: connection.Username,
+		Password: connection.Password,
+	})
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Fastspring[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddGoogleAnalyticsConnectionFromConfig(connection *config.GoogleAnalyticsConnection) error {
 	m.mutex.Lock()
 	if m.GoogleAnalytics == nil {
@@ -4066,6 +4090,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Posthog, connectionManager.AddPosthogConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Mixpanel, connectionManager.AddMixpanelConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Amplitude, connectionManager.AddAmplitudeConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Fastspring, connectionManager.AddFastspringConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Pinterest, connectionManager.AddPinterestConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Trustpilot, connectionManager.AddTrustpilotConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.QuickBooks, connectionManager.AddQuickBooksConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/fastspring/client.go
+++ b/pkg/fastspring/client.go
@@ -1,0 +1,13 @@
+package fastspring
+
+type Client struct {
+	config Config
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{c}, nil
+}

--- a/pkg/fastspring/config.go
+++ b/pkg/fastspring/config.go
@@ -1,0 +1,38 @@
+package fastspring
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Config describes credentials for a FastSpring connection.
+type Config struct {
+	Username string `yaml:"username" json:"username" mapstructure:"username"`
+	Password string `yaml:"password" json:"password" mapstructure:"password"`
+}
+
+type requiredField struct {
+	key   string
+	value string
+}
+
+// GetIngestrURI builds the FastSpring ingestr URI.
+func (c *Config) GetIngestrURI() (string, error) {
+	params := url.Values{}
+
+	requiredFields := []requiredField{
+		{"username", c.Username},
+		{"password", c.Password},
+	}
+
+	for _, field := range requiredFields {
+		field.value = strings.TrimSpace(field.value)
+		if field.value == "" {
+			return "", fmt.Errorf("fastspring: %s must be provided", field.key)
+		}
+		params.Set(field.key, field.value)
+	}
+
+	return "fastspring://?" + params.Encode(), nil
+}

--- a/pkg/fastspring/config_test.go
+++ b/pkg/fastspring/config_test.go
@@ -1,0 +1,59 @@
+package fastspring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "all fields set",
+			config: Config{Username: "user", Password: "pass"},
+			want:   "fastspring://?password=pass&username=user",
+		},
+		{
+			name:    "missing username",
+			config:  Config{Password: "pass"},
+			wantErr: true,
+		},
+		{
+			name:    "missing password",
+			config:  Config{Username: "user"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.config.GetIngestrURI()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{Username: "user", Password: "pass"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "fastspring://?password=pass&username=user", uri)
+}

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -682,7 +682,7 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "products", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
 		{Name: "coupons", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
 		{Name: "subscription_report", PrimaryKey: "subscription_id, transaction_date", IncKey: "sync_date", IncStrategy: "merge"},
-		{Name: "revenue_report", PrimaryKey: "Order_ID, Transaction_Date", IncKey: "syncDate", IncStrategy: "merge"},
+		{Name: "revenue_report", PrimaryKey: "order_id, transaction_date", IncKey: "syncdate", IncStrategy: "merge"},
 	},
 
 	// Mixpanel - Analytics

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -674,6 +674,17 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "user_properties", PrimaryKey: "user_property", IncKey: "", IncStrategy: "replace"},
 	},
 
+	// FastSpring - Payments & Subscriptions
+	"fastspring": {
+		{Name: "orders", PrimaryKey: "id", IncKey: "changed", IncStrategy: "merge"},
+		{Name: "subscriptions", PrimaryKey: "id", IncKey: "changed", IncStrategy: "merge"},
+		{Name: "accounts", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "products", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "coupons", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "subscription_report", PrimaryKey: "subscription_id, transaction_date", IncKey: "sync_date", IncStrategy: "merge"},
+		{Name: "revenue_report", PrimaryKey: "Order_ID, Transaction_Date", IncKey: "syncDate", IncStrategy: "merge"},
+	},
+
 	// Mixpanel - Analytics
 	"mixpanel": {
 		{Name: "events", PrimaryKey: "distinct_id", IncKey: "time", IncStrategy: "merge"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -262,6 +262,7 @@ var defaultMapping = map[string]string{
 	"linear":                "linear-default",
 	"linkedinads":           "linkedinads-default",
 	"amplitude":             "amplitude-default",
+	"fastspring":            "fastspring-default",
 	"mailchimp":             "mailchimp-default",
 	"manifold":              "manifold-default",
 	"mixpanel":              "mixpanel-default",


### PR DESCRIPTION
Adds the FastSpring ingestr source (`fastspring://`) as a Bruin connection with `username` and `password` params.

Wires it across config (`FastspringConnection`), the connection manager, the source-table registry (orders, subscriptions, accounts, products, coupons, subscription_report, revenue_report), docs, testdata, and the regenerated connection-schema expectations.

Verified: `make build`, `go test ./pkg/fastspring/... ./pkg/config/...`, `go vet`, gofumpt all pass. Source itself tested end-to-end against a live FastSpring account into DuckDB and BigQuery.