### PR TITLE
ingestr: wire MongoDB and SQL Server CDC

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -83,6 +83,7 @@ parameters:
   enforce_schema: true|false # Will ensure that the columns defined in the asset are present in the destination and with the desired types (see https://getbruin.com/docs/bruin/assets/columns.html)
   cdc: "true"|"false"
   cdc_mode: stream | batch
+  cdc_sql_capture: cdc | change_tracking
   cdc_publication: string
   cdc_slot: string
   cdc_server_id: string
@@ -90,6 +91,10 @@ parameters:
   cdc_grpc_port: string
   cdc_grpc_host: string
   cdc_grpc_tls: string
+  cdc_capture_instance: string
+  cdc_poll_interval: string
+  cdc_max_await_time: string
+  cdc_schema_sample_size: integer
   cdc_dest_schema: string
   cdc_stream_metrics_addr: string
   cdc_stream_flush_interval: string
@@ -133,8 +138,9 @@ parameters:
 | `flush_interval` | No | `--flush-interval` | Flush interval for streaming mode, such as `30s`. CDC assets can set `cdc_stream_flush_interval` instead, which takes precedence. |
 | `flush_records` | No | `--flush-records` | Number of buffered records that triggers a flush in streaming mode. CDC assets can set `cdc_stream_flush_records` instead, which takes precedence. |
 | `enforce_schema` | No | `--columns` | When set to `true`, enforces the column types defined in the asset's `columns` section. Ingestr will create or update the destination table with the specified schema. |
-| `cdc` | No | source URI scheme | Enables Bruin's CDC URI handling for PostgreSQL, MySQL/MariaDB, Vitess, and PlanetScale sources when set to `"true"`. CDC assets must use `merge`; Bruin sets it automatically when omitted and rejects other strategies. |
+| `cdc` | No | source URI scheme | Enables Bruin's CDC URI handling for PostgreSQL, MySQL/MariaDB, Vitess, PlanetScale, MongoDB, and SQL Server (log-based CDC and Change Tracking) sources when set to `"true"`. CDC assets must use `merge`; Bruin sets it automatically when omitted and rejects other strategies. |
 | `cdc_mode` | No | source URI query | CDC mode, either `stream` or `batch`. |
+| `cdc_sql_capture` | No | source URI scheme | SQL Server capture mechanism, either `cdc` (log-based, `mssql+cdc`; default) or `change_tracking` (`mssql+ct`). |
 | `cdc_publication` | No | source URI query | PostgreSQL publication name. |
 | `cdc_slot` | No | source URI query | PostgreSQL replication slot name. |
 | `cdc_server_id` | No | source URI query | MySQL-family binlog replication server ID. |
@@ -142,6 +148,10 @@ parameters:
 | `cdc_grpc_port` | No | source URI query | Vitess VStream gRPC port override. |
 | `cdc_grpc_host` | No | source URI query | Vitess VStream gRPC host override. |
 | `cdc_grpc_tls` | No | source URI query | Vitess VStream TLS setting. |
+| `cdc_capture_instance` | No | source URI query | SQL Server log-based CDC capture instance name. |
+| `cdc_poll_interval` | No | source URI query | SQL Server log-based CDC poll interval, such as `10s`. |
+| `cdc_max_await_time` | No | source URI query | MongoDB change-stream maximum await time, such as `5s`. |
+| `cdc_schema_sample_size` | No | source URI query | MongoDB number of documents sampled to infer the schema. |
 | `cdc_dest_schema` | No | source URI query | Destination schema used for multi-table CDC runs. |
 | `cdc_stream_metrics_addr` | No | `--metrics-addr` | Address on which a streaming CDC asset serves replication lag and rows-synced metrics at `/debug/vars`, such as `127.0.0.1:6060`. Requires `stream: true`. See [PostgreSQL CDC](../platforms/postgres.md#cdc-change-data-capture). |
 | `cdc_stream_flush_interval` | No | `--flush-interval` | Flush interval for a streaming CDC asset. Takes precedence over `flush_interval`. |

--- a/docs/ingestion/mongo.md
+++ b/docs/ingestion/mongo.md
@@ -84,6 +84,46 @@ As a result of this command, Bruin will ingest data from the given MongoDB table
 
 <img width="1017" alt="image" src="https://github.com/user-attachments/assets/2bad9131-baa1-4f20-8e3d-eed4329e7f90">
 
+## Change Data Capture (CDC)
+
+Bruin supports MongoDB CDC through the `ingestr` asset type. CDC uses MongoDB [change streams](https://www.mongodb.com/docs/manual/changeStreams/) to capture inserts, updates, and deletes and replicate them to the destination. It works with both the `mongo` and `mongo_atlas` connection types.
+
+### Prerequisites
+
+- The source MongoDB deployment must be a **replica set** (or sharded cluster). Change streams are not available on standalone servers.
+- The source collection must expose `_id` as its primary key — MongoDB CDC requires it because delete events only carry the document key.
+
+### Parameters
+
+CDC is enabled by setting `cdc: "true"` on an `ingestr` asset with a MongoDB source connection.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `cdc` | Yes | Set to `"true"` to enable CDC mode |
+| `cdc_mode` | No | `"stream"` for continuous streaming or `"batch"` for batch replication |
+| `cdc_max_await_time` | No | Maximum time the change stream waits for new events, such as `5s` |
+| `cdc_schema_sample_size` | No | Number of documents sampled to infer the schema |
+| `cdc_dest_schema` | No | Destination schema to use for the replicated collection |
+| `source_table` | Yes | Source namespace in `database.collection` format (aggregation pipelines are not supported in CDC mode) |
+| `incremental_strategy` | No | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
+
+> [!NOTE]
+> When CDC is enabled, primary key columns do not need to be specified in the asset definition — MongoDB CDC always keys on `_id`.
+
+### Example
+
+```yaml
+name: public.users
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: localMongo
+  source_table: 'users.details'
+  destination: postgres
+  cdc: "true"
+```
+
 ## Querying
 
 Beyond ingestion, you can run ad-hoc queries against a MongoDB connection with the [`query` command](/commands/query) and verify it with [`bruin connections test`](/commands/connections). Because MongoDB is not SQL, the query is a JSON object describing a find or aggregation against one collection:

--- a/docs/platforms/mssql.md
+++ b/docs/platforms/mssql.md
@@ -318,3 +318,76 @@ columns:
     type: "BIT"
     description: "Whether the customer account is currently active"
 ```
+
+## Change Data Capture (CDC)
+
+Bruin supports SQL Server CDC through the `ingestr` asset type, capturing row-level changes (inserts, updates, deletes) and replicating them to a destination. SQL Server offers two capture mechanisms, selected with the `cdc_sql_capture` parameter:
+
+- **Log-based CDC** (`cdc_sql_capture: cdc`, the default) reads the SQL Server CDC change tables.
+- **Change Tracking** (`cdc_sql_capture: change_tracking`) uses the lighter-weight Change Tracking feature.
+
+### Prerequisites
+
+For log-based CDC, enable CDC on the source database:
+
+```sql
+EXEC sys.sp_cdc_enable_db;
+-- then enable CDC on each table you want to replicate
+EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'users', @role_name = NULL;
+```
+
+For Change Tracking, enable it on the database and each table:
+
+```sql
+ALTER DATABASE MyDatabase SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
+ALTER TABLE dbo.users ENABLE CHANGE_TRACKING;
+```
+
+Change Tracking requires each source table to have a primary key, and does not support streaming.
+
+### Parameters
+
+CDC is enabled by setting `cdc: "true"` on an `ingestr` asset with a SQL Server source connection.
+
+| Parameter | Required | Applies to | Description |
+|-----------|----------|------------|-------------|
+| `cdc` | Yes | both | Set to `"true"` to enable CDC mode |
+| `cdc_sql_capture` | No | both | `"cdc"` (log-based, default) or `"change_tracking"` |
+| `cdc_mode` | No | log-based CDC | `"stream"` for continuous streaming or `"batch"` for batch replication |
+| `cdc_capture_instance` | No | log-based CDC | Capture instance name to read from |
+| `cdc_poll_interval` | No | log-based CDC | Poll interval for change tables, such as `10s` |
+| `cdc_dest_schema` | No | log-based CDC | Destination schema to use for multi-table CDC runs |
+| `source_table` | Yes | both | Source table in `schema.table` format |
+| `incremental_strategy` | No | both | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
+
+> [!NOTE]
+> When CDC is enabled, primary key columns do not need to be declared in the asset — log-based CDC and Change Tracking both determine keys from the source table.
+
+### Examples
+
+#### Log-based CDC
+```yaml
+name: dbo.users
+type: ingestr
+connection: bigquery
+
+parameters:
+  source_connection: mssql_prod
+  source_table: dbo.users
+  destination: bigquery
+  cdc: "true"
+```
+
+#### Change Tracking
+```yaml
+name: dbo.users
+type: ingestr
+connection: bigquery
+
+parameters:
+  source_connection: mssql_prod
+  source_table: dbo.users
+  destination: bigquery
+  cdc: "true"
+  cdc_sql_capture: change_tracking
+```

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -270,9 +270,10 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		if tls, _ := asset.Parameters.GetString("cdc_tls"); tls != "" {
 			q.Set("tls", tls)
 		}
-		// SQL Server log-based CDC parameters. Change Tracking (+ct) ignores query
+		// SQL Server log-based CDC parameters, confined to the mssql source so they
+		// cannot leak into other CDC URIs. Change Tracking (+ct) ignores query
 		// parameters, so these are only forwarded for the mssql+cdc source.
-		if !changeTracking {
+		if isMSSQLScheme(baseScheme) && !changeTracking {
 			if captureInstance, _ := asset.Parameters.GetString("cdc_capture_instance"); captureInstance != "" {
 				q.Set("capture_instance", captureInstance)
 			}
@@ -280,12 +281,14 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 				q.Set("poll_interval", pollInterval)
 			}
 		}
-		// MongoDB change-stream parameters.
-		if maxAwaitTime, _ := asset.Parameters.GetString("cdc_max_await_time"); maxAwaitTime != "" {
-			q.Set("max_await_time", maxAwaitTime)
-		}
-		if sampleSize, _ := asset.Parameters.GetString("cdc_schema_sample_size"); sampleSize != "" {
-			q.Set("schema_sample_size", sampleSize)
+		// MongoDB change-stream parameters, confined to the mongodb source.
+		if isMongoDBScheme(baseScheme) {
+			if maxAwaitTime, _ := asset.Parameters.GetString("cdc_max_await_time"); maxAwaitTime != "" {
+				q.Set("max_await_time", maxAwaitTime)
+			}
+			if sampleSize, _ := asset.Parameters.GetString("cdc_schema_sample_size"); sampleSize != "" {
+				q.Set("schema_sample_size", sampleSize)
+			}
 		}
 		// Shared parameters.
 		if mode, _ := asset.Parameters.GetString("cdc_mode"); mode != "" {
@@ -560,6 +563,12 @@ func isCDCAsset(asset *pipeline.Asset) bool {
 // the only source that offers the Change Tracking (+ct) capture mode.
 func isMSSQLScheme(scheme string) bool {
 	return strings.HasPrefix(scheme, "mssql") || strings.HasPrefix(scheme, "sqlserver")
+}
+
+// isMongoDBScheme reports whether scheme belongs to the MongoDB family (mongodb,
+// mongodb+srv), which understands the change-stream CDC parameters.
+func isMongoDBScheme(scheme string) bool {
+	return strings.HasPrefix(scheme, "mongodb")
 }
 
 func hasIngestrIncrementalKey(asset *pipeline.Asset, mat pipeline.Materialization) bool {

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -230,7 +230,19 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		}
 
 		// An unsupported scheme is left alone here, and ingestr rejects it downstream.
-		parsedURI.Scheme, _ = ingestruri.CDCScheme(parsedURI.Scheme)
+		baseScheme := parsedURI.Scheme
+		parsedURI.Scheme, _ = ingestruri.CDCScheme(baseScheme)
+
+		// SQL Server exposes two capture mechanisms. Log-based CDC (mssql+cdc) is the
+		// default; Change Tracking (mssql+ct) is selected per-asset because it can't be
+		// derived from the scheme alone. The +ct source takes no query parameters and is
+		// driven purely by --primary-key / --incremental-strategy merge, so its
+		// source-specific parameters below are skipped.
+		sqlCapture, _ := asset.Parameters.GetString("cdc_sql_capture")
+		changeTracking := isMSSQLScheme(baseScheme) && sqlCapture == "change_tracking"
+		if changeTracking {
+			parsedURI.Scheme = strings.TrimSuffix(parsedURI.Scheme, "+cdc") + "+ct"
+		}
 
 		q := parsedURI.Query()
 		// PostgreSQL logical-replication parameters.
@@ -257,6 +269,23 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		}
 		if tls, _ := asset.Parameters.GetString("cdc_tls"); tls != "" {
 			q.Set("tls", tls)
+		}
+		// SQL Server log-based CDC parameters. Change Tracking (+ct) ignores query
+		// parameters, so these are only forwarded for the mssql+cdc source.
+		if !changeTracking {
+			if captureInstance, _ := asset.Parameters.GetString("cdc_capture_instance"); captureInstance != "" {
+				q.Set("capture_instance", captureInstance)
+			}
+			if pollInterval, _ := asset.Parameters.GetString("cdc_poll_interval"); pollInterval != "" {
+				q.Set("poll_interval", pollInterval)
+			}
+		}
+		// MongoDB change-stream parameters.
+		if maxAwaitTime, _ := asset.Parameters.GetString("cdc_max_await_time"); maxAwaitTime != "" {
+			q.Set("max_await_time", maxAwaitTime)
+		}
+		if sampleSize, _ := asset.Parameters.GetString("cdc_schema_sample_size"); sampleSize != "" {
+			q.Set("schema_sample_size", sampleSize)
 		}
 		// Shared parameters.
 		if mode, _ := asset.Parameters.GetString("cdc_mode"); mode != "" {
@@ -525,6 +554,12 @@ func applyCDCStreamParameters(params pipeline.ParameterMap) {
 func isCDCAsset(asset *pipeline.Asset) bool {
 	cdc, _ := asset.Parameters.GetString("cdc")
 	return cdc == "true"
+}
+
+// isMSSQLScheme reports whether scheme belongs to the SQL Server family, which is
+// the only source that offers the Change Tracking (+ct) capture mode.
+func isMSSQLScheme(scheme string) bool {
+	return strings.HasPrefix(scheme, "mssql") || strings.HasPrefix(scheme, "sqlserver")
 }
 
 func hasIngestrIncrementalKey(asset *pipeline.Asset, mat pipeline.Materialization) bool {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1470,6 +1470,171 @@ func TestBasicOperator_MySQLCDCMode(t *testing.T) {
 	}
 }
 
+func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
+	t.Parallel()
+
+	// Bruin's mongo/mongo_atlas connections emit mongodb:// and mongodb+srv:// URIs, and the
+	// mssql connection emits mssql://. All three follow the plain "+cdc" suffix rule, while
+	// SQL Server Change Tracking is selected per-asset and rewrites the suffix to "+ct".
+	mockMongo := new(mockConnection)
+	mockMongo.On("GetIngestrURI").Return("mongodb://user:pass@localhost:27017/db", nil)
+	mockAtlas := new(mockConnection)
+	mockAtlas.On("GetIngestrURI").Return("mongodb+srv://user:pass@cluster.mongodb.net/db", nil)
+	mockMS := new(mockConnection)
+	mockMS.On("GetIngestrURI").Return("mssql://user:pass@localhost:1433/db", nil)
+	mockBq := new(mockConnection)
+	mockBq.On("GetIngestrURI").Return("bigquery://uri-here", nil)
+
+	fetcher := simpleConnectionFetcher{
+		connections: map[string]*mockConnection{
+			"mongo": mockMongo,
+			"atlas": mockAtlas,
+			"ms":    mockMS,
+			"bq":    mockBq,
+		},
+	}
+
+	finder := new(mockFinder)
+
+	tests := []struct {
+		name  string
+		asset *pipeline.Asset
+		want  []string
+	}{
+		{
+			name: "MongoDB CDC transforms URI and auto-sets merge strategy",
+			asset: &pipeline.Asset{
+				Name:       "cdc-mongo-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "mongo",
+					"source_table":      "users.details",
+					"destination":       "bigquery",
+					"cdc":               "true",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mongodb+cdc://user:pass@localhost:27017/db",
+				"--source-table", "users.details",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "cdc-mongo-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			name: "MongoDB Atlas CDC adds change-stream parameters",
+			asset: &pipeline.Asset{
+				Name:       "cdc-atlas-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection":      "atlas",
+					"source_table":           "users.details",
+					"destination":            "bigquery",
+					"cdc":                    "true",
+					"cdc_max_await_time":     "5s",
+					"cdc_schema_sample_size": "100",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mongodb+srv+cdc://user:pass@cluster.mongodb.net/db?max_await_time=5s&schema_sample_size=100",
+				"--source-table", "users.details",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "cdc-atlas-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			name: "SQL Server log-based CDC adds capture instance and poll interval",
+			asset: &pipeline.Asset{
+				Name:       "cdc-mssql-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection":    "ms",
+					"source_table":         "dbo.users",
+					"destination":          "bigquery",
+					"cdc":                  "true",
+					"cdc_capture_instance": "dbo_users",
+					"cdc_poll_interval":    "10s",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mssql+cdc://user:pass@localhost:1433/db?capture_instance=dbo_users&poll_interval=10s",
+				"--source-table", "dbo.users",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "cdc-mssql-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			// Change Tracking uses the +ct scheme and ignores query parameters, so
+			// capture_instance/poll_interval must not leak into the emitted URI.
+			name: "SQL Server Change Tracking uses +ct scheme without query params",
+			asset: &pipeline.Asset{
+				Name:       "ct-mssql-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection":    "ms",
+					"source_table":         "dbo.users",
+					"destination":          "bigquery",
+					"cdc":                  "true",
+					"cdc_sql_capture":      "change_tracking",
+					"cdc_capture_instance": "dbo_users",
+					"cdc_poll_interval":    "10s",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mssql+ct://user:pass@localhost:1433/db",
+				"--source-table", "dbo.users",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "ct-mssql-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := new(mockRunner)
+			runner.On("RunIngestr", mock.Anything, tt.want, []string(nil), repo).Return(nil)
+
+			startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			executionDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			o := &BasicOperator{
+				conn:          &fetcher,
+				finder:        finder,
+				runner:        runner,
+				jinjaRenderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, &executionDate, "ingestr-test", "ingestr-test", nil),
+			}
+
+			ti := scheduler.AssetInstance{
+				Pipeline: &pipeline.Pipeline{},
+				Asset:    tt.asset,
+			}
+
+			ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+
+			err := o.Run(ctx, &ti)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestBasicOperator_VitessPlanetScaleCDCMode(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ingestruri/uri.go
+++ b/pkg/ingestruri/uri.go
@@ -107,8 +107,14 @@ func Parse(uri string) (*url.URL, error) {
 // This is not a plain "+cdc" suffix: PostgreSQL's ingestr URI uses the
 // "postgresql" scheme but its CDC scheme is "postgres+cdc".
 //
-// Supported today: PostgreSQL, the MySQL family (mysql, mariadb), Vitess, and
-// PlanetScale (ps_mysql).
+// Supported today: PostgreSQL, the MySQL family (mysql, mariadb), Vitess,
+// PlanetScale (ps_mysql), MongoDB (mongodb, mongodb+srv), and SQL Server (mssql).
+//
+// MongoDB and SQL Server both follow the plain "+cdc" suffix rule, which yields
+// exactly what ingestr expects: "mongodb+cdc", "mongodb+srv+cdc", "mssql+cdc".
+// SQL Server Change Tracking ("mssql+ct") is not selected here because it depends
+// on an asset parameter rather than the scheme alone; the ingestr operator swaps
+// the suffix for that mode.
 func CDCScheme(scheme string) (string, bool) {
 	switch {
 	case strings.HasSuffix(scheme, "+cdc"):
@@ -116,7 +122,9 @@ func CDCScheme(scheme string) (string, bool) {
 	case strings.Contains(scheme, "postgresql"):
 		return strings.ReplaceAll(scheme, "postgresql", "postgres+cdc"), true
 	case strings.HasPrefix(scheme, "mysql"), strings.HasPrefix(scheme, "mariadb"),
-		strings.HasPrefix(scheme, "vitess"), strings.HasPrefix(scheme, "ps_mysql"):
+		strings.HasPrefix(scheme, "vitess"), strings.HasPrefix(scheme, "ps_mysql"),
+		strings.HasPrefix(scheme, "mongodb"),
+		strings.HasPrefix(scheme, "mssql"), strings.HasPrefix(scheme, "sqlserver"):
 		return scheme + "+cdc", true
 	}
 

--- a/pkg/ingestruri/uri_test.go
+++ b/pkg/ingestruri/uri_test.go
@@ -166,10 +166,16 @@ func TestCDCScheme(t *testing.T) {
 		{scheme: "mariadb", want: "mariadb+cdc", wantOK: true},
 		{scheme: "vitess", want: "vitess+cdc", wantOK: true},
 		{scheme: "ps_mysql", want: "ps_mysql+cdc", wantOK: true},
+		{scheme: "mongodb", want: "mongodb+cdc", wantOK: true},
+		{scheme: "mongodb+srv", want: "mongodb+srv+cdc", wantOK: true},
+		{scheme: "mssql", want: "mssql+cdc", wantOK: true},
+		{scheme: "sqlserver", want: "sqlserver+cdc", wantOK: true},
 
 		// already a cdc scheme
 		{scheme: "postgres+cdc", want: "postgres+cdc", wantOK: true},
 		{scheme: "mysql+cdc", want: "mysql+cdc", wantOK: true},
+		{scheme: "mongodb+cdc", want: "mongodb+cdc", wantOK: true},
+		{scheme: "mssql+cdc", want: "mssql+cdc", wantOK: true},
 
 		// no cdc counterpart
 		{scheme: "bigquery", want: "bigquery", wantOK: false},
@@ -191,7 +197,7 @@ func TestCDCScheme(t *testing.T) {
 func TestCDCScheme_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	for _, scheme := range []string{"postgresql", "mysql", "mariadb", "vitess", "ps_mysql"} {
+	for _, scheme := range []string{"postgresql", "mysql", "mariadb", "vitess", "ps_mysql", "mongodb", "mongodb+srv", "mssql"} {
 		once, ok := CDCScheme(scheme)
 		require.True(t, ok)
 
@@ -230,6 +236,21 @@ func TestCDC(t *testing.T) {
 			name: "vitess keeps its grpc_port",
 			uri:  "vitess://u:p@vtgate.internal:15306/commerce?grpc_port=15991",
 			want: "vitess+cdc://u:p@vtgate.internal:15306/commerce?grpc_port=15991",
+		},
+		{
+			name: "mongodb",
+			uri:  "mongodb://u:p@h:27017/db",
+			want: "mongodb+cdc://u:p@h:27017/db",
+		},
+		{
+			name: "mongodb+srv",
+			uri:  "mongodb+srv://u:p@cluster.mongodb.net/db",
+			want: "mongodb+srv+cdc://u:p@cluster.mongodb.net/db",
+		},
+		{
+			name: "mssql keeps its odbc query",
+			uri:  "mssql://u:p@h:1433/db?driver=ODBC+Driver+18+for+SQL+Server",
+			want: "mssql+cdc://u:p@h:1433/db?driver=ODBC+Driver+18+for+SQL+Server",
 		},
 		{
 			name:    "unsupported scheme is an error rather than a silent passthrough",

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -324,6 +324,12 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 			Description: "Invalid 'cdc_mode' value: must be 'stream' or 'batch'",
 		})
 	}
+	if capture, exists := asset.Parameters.GetString("cdc_sql_capture"); exists && capture != "cdc" && capture != "change_tracking" {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: "Invalid 'cdc_sql_capture' value: must be 'cdc' or 'change_tracking'",
+		})
+	}
 	if v, exists := asset.Parameters.GetString("version"); exists && v != "" && !ingestrVersionPattern.MatchString(v) {
 		issues = append(issues, &Issue{
 			Task:        asset,


### PR DESCRIPTION
## What

Enables change data capture (CDC) for MongoDB and SQL Server ingestr assets, reusing the existing `cdc: "true"` machinery.

Bruin already supported CDC for PostgreSQL, MySQL/MariaDB, Vitess and PlanetScale: `cdc: "true"` rewrites the source URI onto its `+cdc` scheme, auto-selects `merge`, and forwards `cdc_*` parameters as URI query values. MongoDB and SQL Server were never added to the scheme map, so CDC silently failed for them despite ingestr shipping the corresponding sources.

## Changes

- **Scheme mapping** (`pkg/ingestruri/uri.go`): `CDCScheme` now maps `mongodb` / `mongodb+srv` and `mssql` / `sqlserver` onto their `+cdc` counterparts (`mongodb+cdc`, `mongodb+srv+cdc`, `mssql+cdc`). This also enables `bruin ingestr-uri --cdc` for these connections.
- **Source-specific params** (`pkg/ingestr/operator.go`): forward `cdc_capture_instance` / `cdc_poll_interval` for SQL Server log-based CDC and `cdc_max_await_time` / `cdc_schema_sample_size` for MongoDB change streams.
- **SQL Server Change Tracking**: adds a `cdc_sql_capture: cdc | change_tracking` selector. Change Tracking uses the `mssql+ct` scheme, which can't be derived from the scheme alone, so the operator rewrites the suffix to `+ct`. The `+ct` source takes no query parameters and is driven purely by `--primary-key` and `--incremental-strategy merge`, both already emitted by Bruin.
- **Validation** (`pkg/lint/rules.go`): rejects invalid `cdc_sql_capture` values.
- **Docs**: parameter reference in `docs/assets/ingestr.md`; new CDC sections in `docs/ingestion/mongo.md` and `docs/platforms/mssql.md` (log-based CDC and Change Tracking prerequisites).

## Tests

- `pkg/ingestruri/uri_test.go`: `CDCScheme` / `CDC` cases for the new schemes, including ODBC query-string preservation.
- `pkg/ingestr/operator_test.go`: `TestBasicOperator_MongoMSSQLCDCMode` covering MongoDB, MongoDB Atlas, SQL Server log-based CDC, and Change Tracking (asserting no query params leak into `+ct`).

## Notes

Both mechanisms determine primary keys from the source (Mongo keys on `_id`; SQL Server CDC/CT require a source PK), so PK columns need not be declared on the asset. One behavior that needs a live CDC-enabled SQL Server to confirm: whether ingestr's `mssql+cdc`/`+ct` source tolerates the ODBC `driver`/`TrustServerCertificate` query params carried on Bruin's MSSQL URI.