### PR TITLE
feat(cloud): send message_pair_id on scheduled-agents create

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
@@ -3381,6 +3382,10 @@ func cloudScheduledAgentsCreate() *cli.Command {
 			}
 			fields["agent_id"] = c.Int("agent-id")
 
+			if id, ok := messagePairIDFromEnv(); ok {
+				fields["message_pair_id"] = id
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
@@ -3469,6 +3474,19 @@ func scheduledAgentPlanFlags() []cli.Flag {
 		&cli.StringFlag{Name: "state", Usage: "the full plan as a JSON or YAML object string"},
 		&cli.StringFlag{Name: "state-file", Usage: "path to a file with the full plan as JSON or YAML"},
 	}
+}
+
+// messagePairIDFromEnv reads BRUIN_MESSAGE_PAIR_ID; false when unset or non-numeric.
+func messagePairIDFromEnv() (int, bool) {
+	v := strings.TrimSpace(os.Getenv("BRUIN_MESSAGE_PAIR_ID"))
+	if v == "" {
+		return 0, false
+	}
+	id, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
 }
 
 // buildScheduledAgentFields assembles the request body from an optional full plan

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3476,14 +3476,14 @@ func scheduledAgentPlanFlags() []cli.Flag {
 	}
 }
 
-// messagePairIDFromEnv reads BRUIN_MESSAGE_PAIR_ID; false when unset or non-numeric.
+// messagePairIDFromEnv reads BRUIN_MESSAGE_PAIR_ID; false when unset, non-numeric or non-positive.
 func messagePairIDFromEnv() (int, bool) {
 	v := strings.TrimSpace(os.Getenv("BRUIN_MESSAGE_PAIR_ID"))
 	if v == "" {
 		return 0, false
 	}
 	id, err := strconv.Atoi(v)
-	if err != nil {
+	if err != nil || id <= 0 {
 		return 0, false
 	}
 	return id, true

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -258,6 +258,27 @@ func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "update")
 }
 
+func TestMessagePairIDFromEnv(t *testing.T) {
+	t.Run("reads a numeric value", func(t *testing.T) {
+		t.Setenv("BRUIN_MESSAGE_PAIR_ID", " 42 ")
+		id, ok := messagePairIDFromEnv()
+		require.True(t, ok)
+		assert.Equal(t, 42, id)
+	})
+
+	t.Run("skips when unset", func(t *testing.T) {
+		t.Setenv("BRUIN_MESSAGE_PAIR_ID", "")
+		_, ok := messagePairIDFromEnv()
+		assert.False(t, ok)
+	})
+
+	t.Run("skips a non-numeric value", func(t *testing.T) {
+		t.Setenv("BRUIN_MESSAGE_PAIR_ID", "abc")
+		_, ok := messagePairIDFromEnv()
+		assert.False(t, ok)
+	})
+}
+
 func TestParseDashboardState(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -277,6 +277,14 @@ func TestMessagePairIDFromEnv(t *testing.T) {
 		_, ok := messagePairIDFromEnv()
 		assert.False(t, ok)
 	})
+
+	t.Run("skips zero and negative values", func(t *testing.T) {
+		for _, v := range []string{"0", "-5"} {
+			t.Setenv("BRUIN_MESSAGE_PAIR_ID", v)
+			_, ok := messagePairIDFromEnv()
+			assert.Falsef(t, ok, "value %q should be skipped", v)
+		}
+	})
 }
 
 func TestParseDashboardState(t *testing.T) {


### PR DESCRIPTION
When the agent-runner exports `BRUIN_MESSAGE_PAIR_ID` (a mid-chat agent run), `cloud scheduled-agents create` now includes it in the request body. Cloud uses it to link the draft to the originating conversation so the inline "scheduled agent created" card renders — parity with the retiring webhook path.

Unset or non-numeric (outside a chat run) is skipped: the linkage is cosmetic and never blocks the create.

Paired with cloud #2612 (accepts the field) and an agent-runner change (exports the env var).