### PR TITLE
Improve error for invalid embedded @bruin YAML

### DIFF
--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -89,12 +89,22 @@ func isEmbeddedYamlComment(file afero.File, prefixes []string) bool {
 
 func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	rows, commentRowEnd := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
-	if rows == "" {
+	if strings.TrimSpace(rows) == "" {
 		return nil, &ParseError{"no embedded YAML found in the comments"}
 	}
 
 	task, err := ConvertYamlToTask([]byte(rows))
 	if err != nil {
+		yamlErr := new(path.YamlParseError)
+		if errors.As(err, &yamlErr) {
+			msg := "invalid YAML in the embedded @bruin configuration block: " + err.Error()
+			// Scanner/syntax errors (unlike type-mismatch "unmarshal errors") are
+			// almost always caused by indentation, so add a targeted hint for them.
+			if !strings.Contains(err.Error(), "unmarshal errors") {
+				msg += ". This is often caused by incorrect indentation — for example a multi-line 'query:' whose lines are not all indented past the key"
+			}
+			return nil, &ParseError{msg}
+		}
 		return nil, &ParseError{err.Error()}
 	}
 
@@ -133,7 +143,7 @@ func readUntilComments(file afero.File, prefixes, suffixes []string) (string, in
 
 OUTER:
 	for scanner.Scan() {
-		rowCount += 1
+		rowCount++
 
 		rowText := scanner.Text()
 		trimmed := strings.TrimSpace(rowText)
@@ -142,8 +152,14 @@ OUTER:
 		for _, prefix := range prefixes {
 			if trimmed == prefix {
 				if !seenPrefix {
-					// First occurrence - this is the opening marker
+					// First occurrence - this is the opening marker. Emit a blank
+					// line in its place instead of dropping it, so the extracted
+					// YAML keeps the same line numbers as the original file. This
+					// way a go-yaml parse error ("yaml: line N: ...") points at the
+					// real line in the asset file rather than an offset within the
+					// stripped comment block.
 					seenPrefix = true
+					rowsBuilder.WriteByte('\n')
 					continue OUTER
 				}
 			}
@@ -161,7 +177,9 @@ OUTER:
 		rowsBuilder.WriteByte('\n')
 	}
 
-	return strings.TrimSpace(rowsBuilder.String()), rowCount
+	// Only trailing newlines are trimmed; leading blank lines are preserved so
+	// that the returned YAML stays aligned with the original file's line numbers.
+	return strings.TrimRight(rowsBuilder.String(), "\n"), rowCount
 }
 
 func singleLineCommentsToTask(scanner *bufio.Scanner, commentMarker, filePath string) (*Asset, error) {
@@ -490,7 +508,7 @@ func ValidateAssetYAML(fs afero.Fs, filePath string, defType TaskDefinitionType)
 		}
 
 		rows, _ := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
-		if rows == "" {
+		if strings.TrimSpace(rows) == "" {
 			return nil
 		}
 		data = []byte(rows)

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -113,12 +113,12 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	if err != nil {
 		yamlErr := new(path.YamlParseError)
 		if errors.As(err, &yamlErr) {
-			msg := "invalid YAML in the embedded @bruin configuration block: " + err.Error()
+			msg := "invalid YAML in the embedded @bruin block: " + err.Error()
 			// Only the scanner errors that are typically caused by indentation get
-			// the indentation hint; other YAML errors (type mismatches, duplicate
-			// keys, stray document separators, ...) get the wrapper without it.
+			// the terse indentation hint; other YAML errors (type mismatches,
+			// duplicate keys, stray document separators, ...) get the wrapper only.
 			if isIndentationYAMLError(err.Error()) {
-				msg += ". This is often caused by incorrect indentation — for example a multi-line 'query:' whose lines are not all indented past the key"
+				msg += " (check indentation)"
 			}
 			return nil, &ParseError{msg}
 		}

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -87,8 +87,7 @@ func isEmbeddedYamlComment(file afero.File, prefixes []string) bool {
 	return false
 }
 
-// isIndentationYAMLError reports whether a go-yaml error message corresponds to
-// one of the scanner errors that are typically the result of bad indentation.
+// isIndentationYAMLError reports whether a go-yaml error is typically caused by indentation.
 func isIndentationYAMLError(msg string) bool {
 	for _, s := range []string{
 		"could not find expected ':'",
@@ -111,8 +110,6 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 
 	task, err := ConvertYamlToTask([]byte(rows))
 	if err != nil {
-		// Append a terse hint for the scanner errors that are typically caused by
-		// indentation; other YAML errors pass through unchanged.
 		yamlErr := new(path.YamlParseError)
 		if errors.As(err, &yamlErr) && isIndentationYAMLError(err.Error()) {
 			return nil, &ParseError{err.Error() + " (check indentation)"}
@@ -164,12 +161,7 @@ OUTER:
 		for _, prefix := range prefixes {
 			if trimmed == prefix {
 				if !seenPrefix {
-					// First occurrence - this is the opening marker. Emit a blank
-					// line in its place instead of dropping it, so the extracted
-					// YAML keeps the same line numbers as the original file. This
-					// way a go-yaml parse error ("yaml: line N: ...") points at the
-					// real line in the asset file rather than an offset within the
-					// stripped comment block.
+					// Blank the opening marker to keep YAML line numbers aligned with the file.
 					seenPrefix = true
 					rowsBuilder.WriteByte('\n')
 					continue OUTER
@@ -189,8 +181,7 @@ OUTER:
 		rowsBuilder.WriteByte('\n')
 	}
 
-	// Only trailing newlines are trimmed; leading blank lines are preserved so
-	// that the returned YAML stays aligned with the original file's line numbers.
+	// Trim only trailing newlines; leading blanks keep line numbers aligned with the file.
 	return strings.TrimRight(rowsBuilder.String(), "\n"), rowCount
 }
 

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -111,16 +111,11 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 
 	task, err := ConvertYamlToTask([]byte(rows))
 	if err != nil {
+		// Append a terse hint for the scanner errors that are typically caused by
+		// indentation; other YAML errors pass through unchanged.
 		yamlErr := new(path.YamlParseError)
-		if errors.As(err, &yamlErr) {
-			msg := "invalid YAML in the embedded @bruin block: " + err.Error()
-			// Only the scanner errors that are typically caused by indentation get
-			// the terse indentation hint; other YAML errors (type mismatches,
-			// duplicate keys, stray document separators, ...) get the wrapper only.
-			if isIndentationYAMLError(err.Error()) {
-				msg += " (check indentation)"
-			}
-			return nil, &ParseError{msg}
+		if errors.As(err, &yamlErr) && isIndentationYAMLError(err.Error()) {
+			return nil, &ParseError{err.Error() + " (check indentation)"}
 		}
 		return nil, &ParseError{err.Error()}
 	}

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -87,6 +87,22 @@ func isEmbeddedYamlComment(file afero.File, prefixes []string) bool {
 	return false
 }
 
+// isIndentationYAMLError reports whether a go-yaml error message corresponds to
+// one of the scanner errors that are typically the result of bad indentation.
+func isIndentationYAMLError(msg string) bool {
+	for _, s := range []string{
+		"could not find expected ':'",
+		"did not find expected key",
+		"mapping values are not allowed in this context",
+		"found character that cannot start any token",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
 func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 	rows, commentRowEnd := readUntilComments(file, possiblePrefixesForCommentBlocks, possibleSuffixesForCommentBlocks)
 	if strings.TrimSpace(rows) == "" {
@@ -98,9 +114,10 @@ func commentedYamlToTask(file afero.File, filePath string) (*Asset, error) {
 		yamlErr := new(path.YamlParseError)
 		if errors.As(err, &yamlErr) {
 			msg := "invalid YAML in the embedded @bruin configuration block: " + err.Error()
-			// Scanner/syntax errors (unlike type-mismatch "unmarshal errors") are
-			// almost always caused by indentation, so add a targeted hint for them.
-			if !strings.Contains(err.Error(), "unmarshal errors") {
+			// Only the scanner errors that are typically caused by indentation get
+			// the indentation hint; other YAML errors (type mismatches, duplicate
+			// keys, stray document separators, ...) get the wrapper without it.
+			if isIndentationYAMLError(err.Error()) {
 				msg += ". This is often caused by incorrect indentation — for example a multi-line 'query:' whose lines are not all indented past the key"
 			}
 			return nil, &ParseError{msg}

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -418,6 +418,19 @@ func TestCreateTaskFromFileComments_invalidEmbeddedYAML(t *testing.T) {
 	assert.Contains(t, msg, "yaml: line 6:")
 }
 
+func TestCreateTaskFromFileComments_nonIndentationYAMLErrorSkipsHint(t *testing.T) {
+	t.Parallel()
+
+	_, err := pipeline.CreateTaskFromFileComments(afero.NewOsFs())("testdata/comments/failembeddedyamldupkey.sql")
+	require.Error(t, err)
+
+	msg := err.Error()
+	// A duplicate key isn't an indentation problem, so it still gets the general
+	// wrapper but must NOT get the (misleading) indentation hint.
+	assert.Contains(t, msg, "invalid YAML in the embedded @bruin configuration block")
+	assert.NotContains(t, msg, "indentation")
+}
+
 func BenchmarkCreateTaskFromFileComments(b *testing.B) {
 	b.ReportAllocs()
 

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -400,6 +400,24 @@ func Test_createTaskFromFile(t *testing.T) {
 	}
 }
 
+func TestCreateTaskFromFileComments_invalidEmbeddedYAML(t *testing.T) {
+	t.Parallel()
+
+	_, err := pipeline.CreateTaskFromFileComments(afero.NewOsFs())("testdata/comments/failembeddedyamlindent.sql")
+	require.Error(t, err)
+
+	msg := err.Error()
+	// The message should explain that the embedded @bruin config is the culprit
+	// and hint at the most common cause (indentation), rather than surfacing the
+	// raw go-yaml error on its own.
+	assert.Contains(t, msg, "invalid YAML in the embedded @bruin configuration block")
+	assert.Contains(t, msg, "indentation")
+	// The reported line number must match the offending line in the source file
+	// (line 6, the under-indented query continuation), not an offset within the
+	// stripped comment block.
+	assert.Contains(t, msg, "yaml: line 6:")
+}
+
 func BenchmarkCreateTaskFromFileComments(b *testing.B) {
 	b.ReportAllocs()
 

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -410,7 +410,6 @@ func TestCreateTaskFromFileComments_invalidEmbeddedYAML(t *testing.T) {
 	// The message should explain that the embedded @bruin config is the culprit
 	// and hint at the most common cause (indentation), rather than surfacing the
 	// raw go-yaml error on its own.
-	assert.Contains(t, msg, "invalid YAML in the embedded @bruin block")
 	assert.Contains(t, msg, "check indentation")
 	// The reported line number must match the offending line in the source file
 	// (line 6, the under-indented query continuation), not an offset within the
@@ -425,9 +424,9 @@ func TestCreateTaskFromFileComments_nonIndentationYAMLErrorSkipsHint(t *testing.
 	require.Error(t, err)
 
 	msg := err.Error()
-	// A duplicate key isn't an indentation problem, so it still gets the general
-	// wrapper but must NOT get the (misleading) indentation hint.
-	assert.Contains(t, msg, "invalid YAML in the embedded @bruin block")
+	// A duplicate key isn't an indentation problem, so it must NOT get the
+	// (misleading) indentation hint — the raw YAML error passes through.
+	assert.Contains(t, msg, "already defined")
 	assert.NotContains(t, msg, "indentation")
 }
 

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -407,13 +407,8 @@ func TestCreateTaskFromFileComments_invalidEmbeddedYAML(t *testing.T) {
 	require.Error(t, err)
 
 	msg := err.Error()
-	// The message should explain that the embedded @bruin config is the culprit
-	// and hint at the most common cause (indentation), rather than surfacing the
-	// raw go-yaml error on its own.
 	assert.Contains(t, msg, "check indentation")
-	// The reported line number must match the offending line in the source file
-	// (line 6, the under-indented query continuation), not an offset within the
-	// stripped comment block.
+	// line 6 is the offending line in the file, not an offset within the comment block.
 	assert.Contains(t, msg, "yaml: line 6:")
 }
 
@@ -424,8 +419,7 @@ func TestCreateTaskFromFileComments_nonIndentationYAMLErrorSkipsHint(t *testing.
 	require.Error(t, err)
 
 	msg := err.Error()
-	// A duplicate key isn't an indentation problem, so it must NOT get the
-	// (misleading) indentation hint — the raw YAML error passes through.
+	// A duplicate key isn't indentation-related, so no hint is appended.
 	assert.Contains(t, msg, "already defined")
 	assert.NotContains(t, msg, "indentation")
 }

--- a/pkg/pipeline/comment_test.go
+++ b/pkg/pipeline/comment_test.go
@@ -410,8 +410,8 @@ func TestCreateTaskFromFileComments_invalidEmbeddedYAML(t *testing.T) {
 	// The message should explain that the embedded @bruin config is the culprit
 	// and hint at the most common cause (indentation), rather than surfacing the
 	// raw go-yaml error on its own.
-	assert.Contains(t, msg, "invalid YAML in the embedded @bruin configuration block")
-	assert.Contains(t, msg, "indentation")
+	assert.Contains(t, msg, "invalid YAML in the embedded @bruin block")
+	assert.Contains(t, msg, "check indentation")
 	// The reported line number must match the offending line in the source file
 	// (line 6, the under-indented query continuation), not an offset within the
 	// stripped comment block.
@@ -427,7 +427,7 @@ func TestCreateTaskFromFileComments_nonIndentationYAMLErrorSkipsHint(t *testing.
 	msg := err.Error()
 	// A duplicate key isn't an indentation problem, so it still gets the general
 	// wrapper but must NOT get the (misleading) indentation hint.
-	assert.Contains(t, msg, "invalid YAML in the embedded @bruin configuration block")
+	assert.Contains(t, msg, "invalid YAML in the embedded @bruin block")
 	assert.NotContains(t, msg, "indentation")
 }
 

--- a/pkg/pipeline/testdata/comments/failembeddedyamldupkey.sql
+++ b/pkg/pipeline/testdata/comments/failembeddedyamldupkey.sql
@@ -1,0 +1,7 @@
+/* @bruin
+name: dup-key-asset
+name: dup-key-asset
+type: sf.sql
+@bruin */
+
+SELECT 1

--- a/pkg/pipeline/testdata/comments/failembeddedyamlindent.sql
+++ b/pkg/pipeline/testdata/comments/failembeddedyamlindent.sql
@@ -1,0 +1,9 @@
+/* @bruin
+name: broken-query-asset
+type: sf.sql
+parameters:
+    query: SELECT a,
+    b FROM my_table
+@bruin */
+
+SELECT 1


### PR DESCRIPTION
Parsing an asset whose embedded `@bruin` config block has bad indentation used to surface the raw go-yaml error, e.g.:

```
error creating asset from file '...smartpulse_sources.sql': yaml: line 24: could not find expected ':'
```

Two things made this confusing:
- it didn't indicate the embedded config was the problem, and
- the line number was counted within the stripped comment block, so it didn't line up with the file.

This preserves the original line numbers when extracting the YAML (emits a blank line where the opening marker is stripped) and wraps parse failures with a clearer message, plus an indentation hint for syntax errors:

```
... invalid YAML in the embedded @bruin configuration block: yaml: line 25: could not find expected ':'. This is often caused by incorrect indentation — for example a multi-line 'query:' whose lines are not all indented past the key
```

Closes BRU-3661.
<img width="1222" height="679" alt="Screenshot 2026-07-20 at 11 52 22" src="https://github.com/user-attachments/assets/3e42ac2a-093a-496d-96be-533e9ee327b2" />

