### PR TITLE
feat(dataproc): support autotuning cohort and scenarios for serverless batches

### DIFF
--- a/docs/platforms/dataproc_serverless.md
+++ b/docs/platforms/dataproc_serverless.md
@@ -222,6 +222,17 @@ parameters:
   # timeout for the job (optional)
   # Uses Go duration format: 1h, 30m, 1h30m, etc.
   timeout: 1h
+
+  # Dataproc autotuning scenarios (optional)
+  # Comma-separated: auto, scaling, broadcast_hash_join, memory, none.
+  # Equivalent to gcloud's --autotuning-scenarios flag.
+  autotuning_scenarios: auto
+
+  # Cohort identifier grouping recurring runs of the same workload for
+  # autotuning (optional). Equivalent to gcloud's --cohort flag.
+  # Defaults to "<pipeline-name>-<asset-name>" when autotuning_scenarios
+  # is set, so each asset gets a stable per-asset cohort automatically.
+  cohort: daily-etl-job
 ```
 
 ### Parameters
@@ -233,6 +244,8 @@ parameters:
 | `args` | No | - | Space-separated arguments passed to the PySpark script |
 | `config` | No | - | Spark configuration in `--conf key=value` format |
 | `timeout` | No | - | Job timeout using Go duration format (e.g., `1h`, `30m`) |
+| `autotuning_scenarios` | No | - | [Dataproc autotuning](https://cloud.google.com/dataproc-serverless/docs/concepts/autotuning) scenarios, comma-separated (`auto`, `scaling`, `broadcast_hash_join`, `memory`, `none`). Equivalent to gcloud's `--autotuning-scenarios` |
+| `cohort` | No | derived | Cohort identifier grouping recurring runs for autotuning (equivalent to gcloud's `--cohort`). When `autotuning_scenarios` is set and no cohort is given, defaults to a sanitized `<pipeline-name>-<asset-name>` |
 
 ### Connection Fields
 

--- a/pkg/dataproc_serverless/job.go
+++ b/pkg/dataproc_serverless/job.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,20 +42,22 @@ func (e batchError) Error() string {
 }
 
 type JobRunParams struct {
-	Project          string
-	Region           string
-	RuntimeVersion   string
-	ContainerImage   string
-	Config           string
-	Args             []string
-	Timeout          time.Duration
-	Workspace        string
-	ExecutionRole    string
-	SubnetworkURI    string
-	NetworkTags      []string
-	KmsKey           string
-	StagingBucket    string
-	MetastoreService string
+	Project             string
+	Region              string
+	RuntimeVersion      string
+	ContainerImage      string
+	Config              string
+	Args                []string
+	Timeout             time.Duration
+	Workspace           string
+	ExecutionRole       string
+	SubnetworkURI       string
+	NetworkTags         []string
+	KmsKey              string
+	StagingBucket       string
+	MetastoreService    string
+	Cohort              string
+	AutotuningScenarios []dataprocpb.AutotuningConfig_Scenario
 }
 
 func parseParams(cfg *Client, params pipeline.ParameterMap) *JobRunParams {
@@ -88,6 +91,12 @@ func parseParams(cfg *Client, params pipeline.ParameterMap) *JobRunParams {
 			jobParams.Timeout = t
 		}
 	}
+	if cohort, _ := params.GetString("cohort"); cohort != "" {
+		jobParams.Cohort = strings.TrimSpace(cohort)
+	}
+	if scenarios, _ := params.GetString("autotuning_scenarios"); scenarios != "" {
+		jobParams.AutotuningScenarios = parseAutotuningScenarios(scenarios)
+	}
 	if args, _ := params.GetString("args"); args != "" {
 		arglist := strings.Split(strings.TrimSpace(args), " ")
 		for _, arg := range arglist {
@@ -98,6 +107,38 @@ func parseParams(cfg *Client, params pipeline.ParameterMap) *JobRunParams {
 		}
 	}
 	return &jobParams
+}
+
+// parseAutotuningScenarios parses a comma-separated list of autotuning
+// scenario names (e.g. "auto" or "scaling,broadcast_hash_join,memory").
+// Both gcloud-style hyphens and proto-style underscores are accepted.
+// Unknown values are skipped.
+func parseAutotuningScenarios(raw string) []dataprocpb.AutotuningConfig_Scenario {
+	var scenarios []dataprocpb.AutotuningConfig_Scenario
+	for _, name := range strings.Split(raw, ",") {
+		name = strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(name), "-", "_"))
+		if name == "" {
+			continue
+		}
+		if val, ok := dataprocpb.AutotuningConfig_Scenario_value[name]; ok && val != int32(dataprocpb.AutotuningConfig_SCENARIO_UNSPECIFIED) {
+			scenarios = append(scenarios, dataprocpb.AutotuningConfig_Scenario(val))
+		}
+	}
+	return scenarios
+}
+
+var cohortInvalidChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// defaultCohort derives a stable per-asset cohort identifier so that
+// successive runs of the same asset are grouped for autotuning.
+func defaultCohort(pipelineName, assetName string) string {
+	cohort := strings.ToLower(pipelineName + "-" + assetName)
+	cohort = cohortInvalidChars.ReplaceAllString(cohort, "-")
+	cohort = strings.Trim(cohort, "-")
+	if len(cohort) > 63 {
+		cohort = strings.Trim(cohort[:63], "-")
+	}
+	return cohort
 }
 
 type Job struct {
@@ -258,6 +299,19 @@ func (job Job) buildBatchConfig(ws *workspace) *dataprocpb.CreateBatchRequest {
 			Properties:     sparkProperties,
 		},
 		EnvironmentConfig: batchEnvironmentConfig(job.params),
+	}
+
+	cohort := job.params.Cohort
+	if cohort == "" && len(job.params.AutotuningScenarios) > 0 {
+		// Autotuning requires a cohort to group recurring runs of the same
+		// workload; derive a stable one from the pipeline and asset names.
+		cohort = defaultCohort(job.pipeline.Name, job.asset.Name)
+	}
+	batch.RuntimeConfig.Cohort = cohort
+	if len(job.params.AutotuningScenarios) > 0 {
+		batch.RuntimeConfig.AutotuningConfig = &dataprocpb.AutotuningConfig{
+			Scenarios: job.params.AutotuningScenarios,
+		}
 	}
 
 	return &dataprocpb.CreateBatchRequest{

--- a/pkg/dataproc_serverless/job_test.go
+++ b/pkg/dataproc_serverless/job_test.go
@@ -49,17 +49,17 @@ func TestBuildBatchConfig_Autotuning(t *testing.T) {
 
 	// no autotuning params: nothing set
 	req := newJob(&JobRunParams{}).buildBatchConfig(ws)
-	assert.Empty(t, req.Batch.RuntimeConfig.Cohort)
-	assert.Nil(t, req.Batch.RuntimeConfig.AutotuningConfig)
+	assert.Empty(t, req.GetBatch().GetRuntimeConfig().GetCohort())
+	assert.Nil(t, req.GetBatch().GetRuntimeConfig().GetAutotuningConfig())
 
 	// autotuning without explicit cohort: cohort derived from pipeline + asset
 	req = newJob(&JobRunParams{
 		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 	}).buildBatchConfig(ws)
-	assert.Equal(t, "my-pipeline-my-asset-staging", req.Batch.RuntimeConfig.Cohort)
+	assert.Equal(t, "my-pipeline-my-asset-staging", req.GetBatch().GetRuntimeConfig().GetCohort())
 	assert.Equal(t,
 		[]dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
-		req.Batch.RuntimeConfig.AutotuningConfig.Scenarios,
+		req.GetBatch().GetRuntimeConfig().GetAutotuningConfig().GetScenarios(),
 	)
 
 	// explicit cohort wins
@@ -67,12 +67,12 @@ func TestBuildBatchConfig_Autotuning(t *testing.T) {
 		Cohort:              "custom-cohort",
 		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_SCALING},
 	}).buildBatchConfig(ws)
-	assert.Equal(t, "custom-cohort", req.Batch.RuntimeConfig.Cohort)
+	assert.Equal(t, "custom-cohort", req.GetBatch().GetRuntimeConfig().GetCohort())
 
 	// cohort without autotuning is allowed
 	req = newJob(&JobRunParams{Cohort: "just-cohort"}).buildBatchConfig(ws)
-	assert.Equal(t, "just-cohort", req.Batch.RuntimeConfig.Cohort)
-	assert.Nil(t, req.Batch.RuntimeConfig.AutotuningConfig)
+	assert.Equal(t, "just-cohort", req.GetBatch().GetRuntimeConfig().GetCohort())
+	assert.Nil(t, req.GetBatch().GetRuntimeConfig().GetAutotuningConfig())
 }
 
 func TestDefaultCohort(t *testing.T) {

--- a/pkg/dataproc_serverless/job_test.go
+++ b/pkg/dataproc_serverless/job_test.go
@@ -1,0 +1,86 @@
+package dataprocserverless
+
+import (
+	"testing"
+
+	"cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseParams_Autotuning(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Client{Config: Config{ProjectID: "proj", Region: "region"}}
+
+	params := parseParams(cfg, pipeline.ParameterMap{
+		"cohort":               "daily-etl",
+		"autotuning_scenarios": "auto",
+	})
+	assert.Equal(t, "daily-etl", params.Cohort)
+	assert.Equal(t, []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO}, params.AutotuningScenarios)
+
+	params = parseParams(cfg, pipeline.ParameterMap{
+		"autotuning_scenarios": "scaling, broadcast-hash-join,MEMORY,bogus",
+	})
+	assert.Empty(t, params.Cohort)
+	assert.Equal(t, []dataprocpb.AutotuningConfig_Scenario{
+		dataprocpb.AutotuningConfig_SCALING,
+		dataprocpb.AutotuningConfig_BROADCAST_HASH_JOIN,
+		dataprocpb.AutotuningConfig_MEMORY,
+	}, params.AutotuningScenarios)
+
+	params = parseParams(cfg, pipeline.ParameterMap{})
+	assert.Empty(t, params.Cohort)
+	assert.Empty(t, params.AutotuningScenarios)
+}
+
+func TestBuildBatchConfig_Autotuning(t *testing.T) {
+	t.Parallel()
+
+	newJob := func(params *JobRunParams) Job {
+		return Job{
+			asset:    &pipeline.Asset{Name: "my_asset.staging"},
+			pipeline: &pipeline.Pipeline{Name: "My Pipeline"},
+			params:   params,
+		}
+	}
+	ws := &workspace{Entrypoint: "gs://bucket/main.py", Files: "gs://bucket/context.zip"}
+
+	// no autotuning params: nothing set
+	req := newJob(&JobRunParams{}).buildBatchConfig(ws)
+	assert.Empty(t, req.Batch.RuntimeConfig.Cohort)
+	assert.Nil(t, req.Batch.RuntimeConfig.AutotuningConfig)
+
+	// autotuning without explicit cohort: cohort derived from pipeline + asset
+	req = newJob(&JobRunParams{
+		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
+	}).buildBatchConfig(ws)
+	assert.Equal(t, "my-pipeline-my-asset-staging", req.Batch.RuntimeConfig.Cohort)
+	assert.Equal(t,
+		[]dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
+		req.Batch.RuntimeConfig.AutotuningConfig.Scenarios,
+	)
+
+	// explicit cohort wins
+	req = newJob(&JobRunParams{
+		Cohort:              "custom-cohort",
+		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_SCALING},
+	}).buildBatchConfig(ws)
+	assert.Equal(t, "custom-cohort", req.Batch.RuntimeConfig.Cohort)
+
+	// cohort without autotuning is allowed
+	req = newJob(&JobRunParams{Cohort: "just-cohort"}).buildBatchConfig(ws)
+	assert.Equal(t, "just-cohort", req.Batch.RuntimeConfig.Cohort)
+	assert.Nil(t, req.Batch.RuntimeConfig.AutotuningConfig)
+}
+
+func TestDefaultCohort(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "uk-data-gcp-healthcare-joining", defaultCohort("uk_data_gcp", "healthcare_joining"))
+	assert.Equal(t, "p-a-b", defaultCohort("P", "a.b"))
+
+	long := defaultCohort("pipeline", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	assert.LessOrEqual(t, len(long), 63)
+}


### PR DESCRIPTION
## What

Adds support for [Dataproc Serverless autotuning](https://cloud.google.com/dataproc-serverless/docs/concepts/autotuning) to `dataproc_serverless.pyspark` assets via two new optional parameters:

```yaml
parameters:
  # equivalent to gcloud's --autotuning-scenarios
  autotuning_scenarios: auto   # or: scaling,broadcast_hash_join,memory

  # equivalent to gcloud's --cohort; optional
  cohort: daily-etl-job
```

These map to `RuntimeConfig.Cohort` and `RuntimeConfig.AutotuningConfig.Scenarios` on the batch — both already present in the vendored `cloud.google.com/go/dataproc/v2` client, so no dependency changes.

## Why

Dataproc autotuning optimizes cost/runtime of recurring Spark workloads, but it requires a stable cohort ID to recognise successive runs of the same workload. Bruin currently offers no way to set these fields, so autotuning cannot be used at all from Bruin.

## Design notes

- Autotuning is useless without a cohort, so when `autotuning_scenarios` is set and no explicit `cohort` is given, a stable per-asset cohort is derived from the pipeline and asset names (lowercased, sanitized to `[a-z0-9-]`, capped at 63 chars). This means a single pipeline-level default:

  ```yaml
  default:
    parameters:
      autotuning_scenarios: auto
  ```

  enables autotuning for every pyspark asset in a pipeline, each with its own cohort.
- Scenario names accept both gcloud-style hyphens (`broadcast-hash-join`) and proto-style underscores; unknown values are skipped, matching the lenient parsing style of the existing params (e.g. `timeout`).
- No behavior change when the parameters are absent.
- Verified end-to-end against a real Dataproc Serverless batch: `runtimeConfig.cohort` and `autotuningConfig.scenarios: [AUTO]` present on the created batch, batch succeeds.

## Testing

- `go test ./pkg/dataproc_serverless/` — new tests cover param parsing, scenario name normalisation, cohort derivation/sanitisation, and batch request construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
