### PR TITLE
docs: update ClickHouse reference

### DIFF
--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -65,6 +65,132 @@ parameters:
 
 Runs a materialized clickhouse asset or an SQL script. For detailed parameters, you can check [Definition Schema](../assets/definition-schema.md) page.
 
+### Materialization and incremental strategies
+
+`clickhouse.sql` supports table and view materializations. For a table with no explicit strategy, Bruin uses `create+replace`.
+
+| Strategy | Support | How Bruin executes it |
+| --- | --- | --- |
+| `create+replace` | Supported | Creates a temporary table from the asset query, drops the target table, then renames the temporary table to the target name. Requires `columns` and exactly one column marked `primary_key: true`. |
+| `append` | Supported | Runs `INSERT INTO <target> <asset query>`. Bruin does not add filtering or deduplicate rows; make the asset query select only the new rows. |
+| `delete+insert` | Supported | Refreshes the values returned for an `incremental_key`: it writes the query result to a temporary table, deletes target rows whose incremental-key value occurs in that table, inserts the temporary-table rows, then drops the temporary table. Requires `incremental_key`, `columns`, and exactly one `primary_key: true` column. |
+| `time_interval` | Supported | On a normal run, deletes target rows in the requested date or timestamp interval, then inserts the asset query result. Requires `incremental_key`, `time_granularity` (`date` or `timestamp`), and an existing target table. The asset query must filter itself to the same interval. A `--full-refresh` runs `create+replace` instead, which requires `columns` and exactly one `primary_key: true` column. |
+| `truncate+insert` | Supported | Truncates the existing table, then inserts the asset query result. This is a full-table refresh that preserves the table definition; it is not an incremental strategy. |
+| `ddl` | Supported | Creates the table if it does not already exist from the defined columns, primary key, and optional `partition_by`. Do not include a query in a DDL asset. |
+| `merge`, `scd2_by_column`, `scd2_by_time` | Not supported | Use `delete+insert`, `time_interval`, or an explicit ClickHouse SQL implementation instead. |
+
+Create the target table with `create+replace` or `ddl` before its first `append`, `delete+insert`, `time_interval`, or `truncate+insert` run. `create+replace`, including a `--full-refresh` of a `time_interval` asset, requires `columns` and exactly one `primary_key: true` column. The primary key defines the temporary table; Bruin does not use it to deduplicate or merge rows.
+
+View materializations support only the default strategy, which creates or replaces the view. Table-only strategies, including all incremental strategies, are not supported for views.
+
+> [!NOTE]
+> ClickHouse statements are executed one at a time and are not wrapped in a transaction. In particular, a failed `delete+insert`, `time_interval`, or `truncate+insert` run can leave the target table between steps. Use idempotent, date- or partition-bounded queries and rerun the asset to recover.
+
+#### `delete+insert` example
+
+Use `delete+insert` when the query returns complete replacements for one or more incremental-key values. For example, this refreshes every `dt` returned by the query:
+
+```bruin-sql
+/* @bruin
+name: analytics.daily_orders
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: delete+insert
+  incremental_key: dt
+columns:
+  - name: order_id
+    type: UInt64
+    primary_key: true
+  - name: dt
+    type: Date
+@bruin */
+
+SELECT
+  order_id,
+  toDate(created_at) AS dt
+FROM raw.orders
+WHERE toDate(created_at) BETWEEN '{{ start_date }}' AND '{{ end_date }}'
+```
+
+The temporary table is created in the same database as the target. Bruin deletes existing `analytics.daily_orders` rows for the distinct `dt` values in that temporary table, then inserts the replacement rows.
+
+#### `time_interval` example
+
+Use `time_interval` for a known run window. Bruin uses the run's `start_date` and `end_date` values for a `date` key, or `start_timestamp` and `end_timestamp` for a `timestamp` key. The bounds are inclusive.
+
+```bruin-sql
+/* @bruin
+name: analytics.daily_orders
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: time_interval
+  incremental_key: dt
+  time_granularity: date
+@bruin */
+
+SELECT
+  order_id,
+  toDate(created_at) AS dt
+FROM raw.orders
+WHERE toDate(created_at) BETWEEN '{{ start_date }}' AND '{{ end_date }}'
+```
+
+Bruin deletes `analytics.daily_orders` rows whose `dt` falls within that interval, then inserts the query result. It does not automatically add the `WHERE` clause shown above.
+
+#### Full refresh behavior
+
+Running `bruin run --full-refresh` changes every ClickHouse table materialization except `ddl` to `create+replace`. This includes `time_interval`: it does **not** use interval-based deletion during a full refresh. The rebuild creates a temporary table, drops the target, then renames the temporary table. It requires `columns` and exactly one `primary_key: true` column. A `ddl` asset remains `CREATE TABLE IF NOT EXISTS` during a full refresh.
+
+### Column data types
+
+Bruin does not translate or validate ClickHouse column types against its own allowlist. For `ddl` materializations, it passes `columns[].type` through to ClickHouse. `precision`/`scale` or `length` are added to an unparameterized type when you provide them separately. ClickHouse is therefore the authority for whether a type is available on your server version and configuration; see its [data type reference](https://clickhouse.com/docs/sql-reference/data-types) for the complete, current list.
+
+For `create+replace`, `delete+insert`, and a `--full-refresh`, ClickHouse derives the temporary table's column types from the asset query's `SELECT` result. For `append`, `truncate+insert`, and normal `time_interval` runs, ClickHouse uses the existing target table's schema.
+
+Common ClickHouse column types include:
+
+| Family | Types and examples |
+| --- | --- |
+| Integers | `Int8`, `Int16`, `Int32`, `Int64`, `Int128`, `Int256`; `UInt8`, `UInt16`, `UInt32`, `UInt64`, `UInt128`, `UInt256` |
+| Floating point and exact numeric | `Float32`, `Float64`, `BFloat16`, `Decimal(P, S)` |
+| Text and categorical | `String`, `FixedString(N)`, `Enum8(...)`, `Enum16(...)`, `LowCardinality(String)` |
+| Date and time | `Date`, `Date32`, `DateTime`, `DateTime('UTC')`, `DateTime64(P, 'UTC')` |
+| Scalar identifiers | `Bool`, `UUID`, `IPv4`, `IPv6` |
+| Nullable and composite | `Nullable(T)`, `Array(T)`, `Tuple(...)`, `Map(K, V)`, `Nested(...)` |
+| Version- or setting-dependent types | `JSON`, `Dynamic`, `Variant(...)`, `Time`, `Time64`, `QBit`, geo types, `AggregateFunction(...)`, `SimpleAggregateFunction(...)` |
+
+For a DDL asset, use ClickHouse-native type syntax directly:
+
+```bruin-sql
+/* @bruin
+name: analytics.events
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: ddl
+columns:
+  - name: event_id
+    type: UInt64
+    primary_key: true
+  - name: occurred_at
+    type: DateTime64(3, 'UTC')
+  - name: amount
+    type: Decimal
+    precision: 12
+    scale: 2
+  - name: tags
+    type: Array(String)
+  - name: attributes
+    type: Map(String, String)
+  - name: payload
+    type: Nullable(String)
+@bruin */
+```
+
+This renders `amount` as `Decimal(12, 2)` and preserves the parameterized type declarations exactly as written.
+
 ### Examples
 
 Create a view to determine the top 10 earning drivers in a taxi company:

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -16,6 +16,7 @@ connections:
       host: "some-clickhouse-host.somedomain.com"
       port: 9440
       database: "dev" # Default database for direct ClickHouse assets and unqualified seeds.
+      http_port: 8443 # Optional; used only for ingestr and defaults to 8443.
       secure: 1 # Set to 1 for ClickHouse Cloud or another TLS connection.
 ```
 
@@ -224,7 +225,7 @@ Create a view to determine the top 10 earning drivers in a taxi company:
 name: highest_earning_drivers
 type: clickhouse.sql
 materialization:
-    type: view
+  type: view
 @bruin */
 
 SELECT 
@@ -243,7 +244,7 @@ View Top 5 Customers by Spending:
 name: top_five_customers
 type: clickhouse.sql
 materialization:
-    type: view
+  type: view
 @bruin */
 
 SELECT 

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -1,30 +1,29 @@
-# Clickhouse
+# ClickHouse
 
-[Clickhouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database management system for online analytical processing.
-Bruin supports Clickhouse as both a source and a destination.
+[ClickHouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database management system for online analytical processing.
+Bruin supports ClickHouse as both a source and a destination.
 
 ## Connection
 
-In order to set up a Clickhouse connection, you need to add a configuration item to `connections` in the `.bruin.yml` file complying with the following schema:
+To set up a ClickHouse connection, add a configuration item to `connections` in `.bruin.yml`:
 
 ```yaml
 connections:
-    clickhouse:
-        - name: "connection_name"
-          username: "clickhouse"
-          password: "XXXXXXXXXX"
-          host: "some-clickhouse-host.somedomain.com"   
-          port: 9440
-          database: "dev" #Optional for other assets. Ignored when using ClickHouse as an ingestr destination/source, as ingestr takes the database name from the asset file. 
-          http_port: 8443 #Only specify if you are using ClickHouse as ingestr destination, by default it is 8443.
-          secure: 1 #Required for ClickHouse Cloud
+  clickhouse:
+    - name: "connection_name"
+      username: "clickhouse"
+      password: "XXXXXXXXXX"
+      host: "some-clickhouse-host.somedomain.com"
+      port: 9440
+      database: "dev" # Default database for direct ClickHouse assets and unqualified seeds.
+      secure: 1 # Set to 1 for ClickHouse Cloud or another TLS connection.
 ```
+
+Bruin uses `database` for direct ClickHouse assets and unqualified `clickhouse.seed` asset names. For an `ingestr` asset, the generated ClickHouse URI does not include this database: use `database.table` in the asset `name` when ClickHouse is the destination, or in `source_table` when it is the source. An unqualified ingestr table uses ClickHouse's `default` database.
 
 ## Ingestr Assets
 
-After adding connection in `bruin.yml`. To ingest data to clickhouse, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., stripe_ingestion.yml) inside the assets folder and add the following content:
-
-###
+After adding a connection in `.bruin.yml`, create an [asset configuration](/assets/ingestr#asset-structure) file such as `stripe_ingestion.asset.yml` inside the `assets` directory. This file defines the flow from the source to the destination:
 
 ```yaml
 name: publicDB.stripe
@@ -36,7 +35,7 @@ parameters:
   destination: clickhouse
 ```
 
-In this case, the Clickhouse database is `publicDB`. Please ensure that the necessary permissions are granted to the user. For more details on obtaining credentials and setting up permissions, you can refer to this [guide](https://dlthub.com/docs/dlt-ecosystem/destinations/clickhouse#2-setup-clickhouse-database)
+In this case, the ClickHouse database is `publicDB`. Ensure the configured user has the required permissions. For more details on credentials and permissions, see this [guide](https://dlthub.com/docs/dlt-ecosystem/destinations/clickhouse#2-setup-clickhouse-database).
 
 ### Engine Settings
 
@@ -56,14 +55,39 @@ parameters:
 
 | Parameter | Description |
 |-----------|-------------|
-| `engine` | The ClickHouse table engine to use (e.g. `merge_tree`, `replicated_merge_tree`). |
-| `engine.<setting>` | Engine-specific settings passed directly to ClickHouse (e.g. `engine.index_granularity`). |
+| `engine` | The ClickHouse table engine: `merge_tree`, `replacing_merge_tree`, `shared_merge_tree`, or `replicated_merge_tree`. If omitted, ingestr uses `ReplacingMergeTree()` when the schema has a primary key and `MergeTree()` otherwise. |
+| `engine.<setting>` | An engine setting rendered in ClickHouse's `SETTINGS` clause (e.g. `engine.index_granularity`). |
 
-## Clickhouse Assets
+### ClickHouse-native column hints
+
+When loading into ClickHouse, `columns` can use supported ClickHouse-native type syntax. Bruin converts these declarations into ingestr-compatible type hints; it does not copy them directly into destination DDL. Parameterized types such as `DateTime64(3)` and `FixedString(16)` are supported, and `Nullable(T)` and `LowCardinality(T)` resolve to the inner type.
+
+For an `ingestr` asset, set `parameters.enforce_schema: true` to emit the hints. A `clickhouse.seed` asset emits hints for declared columns by default; set `parameters.enforce_schema: false` to opt out.
+
+```yaml
+name: publicDB.events
+type: ingestr
+
+parameters:
+  source_connection: stripe-default
+  source_table: events
+  destination: clickhouse
+  enforce_schema: true
+
+columns:
+  - name: event_id
+    type: UInt64
+  - name: occurred_at
+    type: DateTime64(3, 'UTC')
+  - name: properties
+    type: Nullable(String)
+```
+
+## ClickHouse Assets
 
 ### `clickhouse.sql`
 
-Runs a materialized clickhouse asset or an SQL script. For detailed parameters, you can check [Definition Schema](../assets/definition-schema.md) page.
+Runs a materialized ClickHouse asset or an SQL script. An unmaterialized asset can run statements that return no rows, such as `ALTER`, `INSERT`, or `OPTIMIZE`, as well as queries whose result is discarded. For detailed parameters, see the [Definition Schema](../assets/definition-schema.md).
 
 ### Materialization and incremental strategies
 
@@ -71,20 +95,20 @@ Runs a materialized clickhouse asset or an SQL script. For detailed parameters, 
 
 | Strategy | Support | How Bruin executes it |
 | --- | --- | --- |
-| `create+replace` | Supported | Creates a temporary table from the asset query, drops the target table, then renames the temporary table to the target name. Requires `columns` and exactly one column marked `primary_key: true`. |
+| `create+replace` | Supported | Runs `CREATE OR REPLACE TABLE <target> PRIMARY KEY <key> AS <asset query>`. Requires `columns` and exactly one column marked `primary_key: true`. |
 | `append` | Supported | Runs `INSERT INTO <target> <asset query>`. Bruin does not add filtering or deduplicate rows; make the asset query select only the new rows. |
 | `delete+insert` | Supported | Refreshes the values returned for an `incremental_key`: it writes the query result to a temporary table, deletes target rows whose incremental-key value occurs in that table, inserts the temporary-table rows, then drops the temporary table. Requires `incremental_key`, `columns`, and exactly one `primary_key: true` column. |
-| `time_interval` | Supported | On a normal run, deletes target rows in the requested date or timestamp interval, then inserts the asset query result. Requires `incremental_key`, `time_granularity` (`date` or `timestamp`), and an existing target table. The asset query must filter itself to the same interval. A `--full-refresh` runs `create+replace` instead, which requires `columns` and exactly one `primary_key: true` column. |
+| `time_interval` | Supported | On a normal run, deletes target rows in the requested date or timestamp interval, then inserts the asset query result with `SETTINGS insert_deduplicate = 0` so a rerun of the same interval is not suppressed by ClickHouse insert deduplication. Requires `incremental_key`, `time_granularity` (`date` or `timestamp`), and an existing target table. The asset query must filter itself to the same interval. A `--full-refresh` runs `create+replace` instead, which requires `columns` and exactly one `primary_key: true` column. |
 | `truncate+insert` | Supported | Truncates the existing table, then inserts the asset query result. This is a full-table refresh that preserves the table definition; it is not an incremental strategy. |
 | `ddl` | Supported | Creates the table if it does not already exist from the defined columns, primary key, and optional `partition_by`. Do not include a query in a DDL asset. |
 | `merge`, `scd2_by_column`, `scd2_by_time` | Not supported | Use `delete+insert`, `time_interval`, or an explicit ClickHouse SQL implementation instead. |
 
-Create the target table with `create+replace` or `ddl` before its first `append`, `delete+insert`, `time_interval`, or `truncate+insert` run. `create+replace`, including a `--full-refresh` of a `time_interval` asset, requires `columns` and exactly one `primary_key: true` column. The primary key defines the temporary table; Bruin does not use it to deduplicate or merge rows.
+Create the target table with `create+replace` or `ddl` before its first `append`, `delete+insert`, `time_interval`, or `truncate+insert` run. `create+replace`, including a `--full-refresh` of a `time_interval` asset, requires `columns` and exactly one `primary_key: true` column. The primary key is used in the `CREATE OR REPLACE TABLE` statement; Bruin does not use it to deduplicate or merge rows.
 
 View materializations support only the default strategy, which creates or replaces the view. Table-only strategies, including all incremental strategies, are not supported for views.
 
 > [!NOTE]
-> ClickHouse statements are executed one at a time and are not wrapped in a transaction. In particular, a failed `delete+insert`, `time_interval`, or `truncate+insert` run can leave the target table between steps. Use idempotent, date- or partition-bounded queries and rerun the asset to recover.
+> ClickHouse statements are executed one at a time and are not wrapped in a transaction. `create+replace` is a single `CREATE OR REPLACE TABLE` statement, but a failed `delete+insert`, `time_interval`, or `truncate+insert` run can leave the target table between steps. Use idempotent, date- or partition-bounded queries and rerun the asset to recover.
 
 #### `delete+insert` example
 
@@ -117,7 +141,7 @@ The temporary table is created in the same database as the target. Bruin deletes
 
 #### `time_interval` example
 
-Use `time_interval` for a known run window. Bruin uses the run's `start_date` and `end_date` values for a `date` key, or `start_timestamp` and `end_timestamp` for a `timestamp` key. The bounds are inclusive.
+Use `time_interval` for a known run window. Bruin uses the run's `start_date` and `end_date` values for a `date` key, or `start_timestamp` and `end_timestamp` for a `timestamp` key. The bounds are inclusive. Timestamp delete bounds are rendered with microsecond precision and no time-zone suffix.
 
 ```bruin-sql
 /* @bruin
@@ -137,17 +161,17 @@ FROM raw.orders
 WHERE toDate(created_at) BETWEEN '{{ start_date }}' AND '{{ end_date }}'
 ```
 
-Bruin deletes `analytics.daily_orders` rows whose `dt` falls within that interval, then inserts the query result. It does not automatically add the `WHERE` clause shown above.
+Bruin deletes `analytics.daily_orders` rows whose `dt` falls within that interval, then inserts the query result with `SETTINGS insert_deduplicate = 0`. This lets a rerun reinsert the interval after deletion, including on ClickHouse deployments that would otherwise deduplicate the repeated insert. Bruin does not automatically add the `WHERE` clause shown above.
 
 #### Full refresh behavior
 
-Running `bruin run --full-refresh` changes every ClickHouse table materialization except `ddl` to `create+replace`. This includes `time_interval`: it does **not** use interval-based deletion during a full refresh. The rebuild creates a temporary table, drops the target, then renames the temporary table. It requires `columns` and exactly one `primary_key: true` column. A `ddl` asset remains `CREATE TABLE IF NOT EXISTS` during a full refresh.
+Running `bruin run --full-refresh` changes every ClickHouse table materialization except `ddl` to `create+replace`, unless the asset has `full_refresh_restricted: true` (or its `refresh_restricted` alias). This includes `time_interval`: it does **not** use interval-based deletion during a full refresh. The rebuild runs `CREATE OR REPLACE TABLE` and requires `columns` and exactly one `primary_key: true` column. A `ddl` asset remains `CREATE TABLE IF NOT EXISTS` during a full refresh.
 
 ### Column data types
 
 Bruin does not translate or validate ClickHouse column types against its own allowlist. For `ddl` materializations, it passes `columns[].type` through to ClickHouse. `precision`/`scale` or `length` are added to an unparameterized type when you provide them separately. ClickHouse is therefore the authority for whether a type is available on your server version and configuration; see its [data type reference](https://clickhouse.com/docs/sql-reference/data-types) for the complete, current list.
 
-For `create+replace`, `delete+insert`, and a `--full-refresh`, ClickHouse derives the temporary table's column types from the asset query's `SELECT` result. For `append`, `truncate+insert`, and normal `time_interval` runs, ClickHouse uses the existing target table's schema.
+For `create+replace`, `delete+insert`, and a `--full-refresh`, ClickHouse derives a new table's column types from the asset query's `SELECT` result. For `append`, `truncate+insert`, and normal `time_interval` runs, ClickHouse uses the existing target table's schema.
 
 Common ClickHouse column types include:
 
@@ -235,10 +259,16 @@ Table with average driver rating:
 
 ```bruin-sql
 /* @bruin
-name: average_Rating
+name: average_rating
 type: clickhouse.sql
 materialization:
-    type: table
+  type: table
+columns:
+  - name: driver_id
+    type: UInt64
+    primary_key: true
+  - name: average_rating
+    type: Float64
 @bruin */
 
 SELECT 
@@ -253,39 +283,39 @@ ORDER BY average_rating DESC;
 
 Sensors are a special type of assets that are used to wait on certain external signals.
 
-Checks if a table exists in Clickhouse, runs by default every 30 seconds until this table is available.
+Checks whether a table exists in ClickHouse. The default sensor mode is `once`, which checks once and fails if the table is unavailable. Run with `bruin run --sensor-mode wait` to retry every 30 seconds by default until it becomes available.
 
 ```yaml
-name: string
-type: string
+name: upstream_table_available
+type: clickhouse.sensor.table
 parameters:
-    table: string
-    poke_interval: int (optional)
-    timeout: duration (optional)
+  table: database.table
+  poke_interval: 30 # Optional
+  timeout: 24h # Optional
 ```
 
 **Parameters**:
 
-- `table`: `database.table_id` or (if using `default` database or a database specified in config file) `table_id` format.
+- `table`: `database.table_id` or, when using the `default` database or a database specified in the connection, `table_id`.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
 - `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
 ### `clickhouse.sensor.query`
 
-Checks if a query returns any results in Clickhouse, runs by default every 30 seconds until this query returns any results.
+Checks a ClickHouse query that returns exactly one boolean or numeric scalar. The sensor succeeds when the result is `true` or greater than zero. The default sensor mode is `once`; run with `bruin run --sensor-mode wait` to retry every 30 seconds by default until it succeeds.
 
 ```yaml
-name: string
-type: string
+name: upstream_data_available
+type: clickhouse.sensor.query
 parameters:
-    query: string
-    poke_interval: int (optional)
-    timeout: duration (optional)
+  query: SELECT exists(SELECT 1 FROM upstream_table)
+  poke_interval: 30 # Optional
+  timeout: 24h # Optional
 ```
 
 **Parameters**:
 
-- `query`: Query you expect to return any results
+- `query`: A query that returns exactly one boolean or numeric scalar, such as `SELECT exists(...)` or `SELECT count() ...`.
 - `poke_interval`: The interval between retries in seconds (default 30 seconds).
 - `timeout`: How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
 
@@ -313,7 +343,7 @@ parameters:
 
 ### `clickhouse.seed`
 
-`clickhouse.seed` is a special type of asset used to represent CSV files that contain data that is prepared outside of your pipeline that will be loaded into your Clickhouse database. Bruin supports seed assets natively, allowing you to simply drop a CSV file in your pipeline and ensuring the data is loaded to the Clickhouse database.
+`clickhouse.seed` represents data prepared outside the pipeline and loads it into ClickHouse. Local seed files can be CSV, Parquet (`.parquet` or `.pq`), JSON, JSONL/NDJSON, or Avro. Bruin infers the format from a known file extension unless you set `file_type` explicitly; an unknown or missing extension falls back to CSV.
 
 You can define seed assets in a file ending with `.asset.yml` or `.asset.yaml`:
 
@@ -322,19 +352,23 @@ name: dashboard.hello
 type: clickhouse.seed
 
 parameters:
-    path: seed.csv
+  path: seed.csv
+  # file_type: csv # Optional; supported values are csv, parquet (or pq), json, jsonl, ndjson, and avro.
 ```
 
 **Parameters**:
 
-- `path`: The path to the CSV file that will be loaded into the data platform. This can be a relative file path (relative to the asset definition file) or an HTTP/HTTPS URL to a publicly accessible CSV file.
+- `path`: A local file path, relative to the asset definition file, or an HTTP/HTTPS URL passed to ingestr unchanged.
+- `file_type`: Optional format for a local file: `csv`, `parquet` (or `pq`), `json`, `jsonl`, `ndjson`, or `avro`. When omitted, Bruin infers it from a known file extension and otherwise uses CSV.
+
+When a seed declares `columns`, Bruin emits ClickHouse-aware ingestr type hints by default. See [ClickHouse-native column hints](#clickhouse-native-column-hints) for supported type syntax and how to opt out.
 
 > [!WARNING]
 > When using a URL path, column validation is skipped during `bruin validate`. Column mismatches will be caught at runtime.
 
-#### Examples: Load csv into a Clickhouse database
+#### Example: Load a CSV into a ClickHouse database
 
-The examples below show how to load a CSV into a Clickhouse database:
+The example below loads a CSV into a ClickHouse database:
 
 ```yaml
 name: dashboard.hello
@@ -354,14 +388,14 @@ B,LinkedIn,SDE 2,2024-01-01
 
 ### `clickhouse.source`
 
-Defines Clickhouse source assets for documenting existing tables and views in your Clickhouse database. These assets are no-op (they don't execute), but are useful for:
+Defines ClickHouse source assets for documenting existing tables and views in your ClickHouse database. These assets are no-op (they don't execute), but are useful for:
 
-- Documenting existing Clickhouse tables and views
+- Documenting existing ClickHouse tables and views
 - Adding column descriptions and metadata
 - Establishing lineage relationships
 - Query preview functionality in the VSCode extension
 
-#### Example: Document an existing Clickhouse table
+#### Example: Document an existing ClickHouse table
 
 ```yaml
 name: analytics.page_views


### PR DESCRIPTION
## Summary

- Align the ClickHouse platform guide with the current materialization and rerun behavior.
- Document ClickHouse-native column type hints for ingestr and seed assets.
- Correct connection, seed, sensor, and materialization examples.

## Why

Recent ClickHouse changes use `CREATE OR REPLACE TABLE` for table rebuilds and disable insert deduplication for `time_interval` reruns. The guide still described the previous temporary-table replacement flow and did not cover native type hints.

## User impact

Users can now configure ClickHouse materializations, interval reruns, schema hints, and seeds using behavior that matches the current CLI implementation.

## Validation

- `npx markdownlint-cli2 --no-globs docs/platforms/clickhouse.md`
- `npm run docs:build`
- `go test -tags="no_duckdb_arrow" ./pkg/clickhouse ./pkg/ingestr ./pkg/python`
- Verified the local ClickHouse docs route returns HTTP 200.
