### PR TITLE
Add configurable SharePoint download timeout

### DIFF
--- a/docs/ingestion/sharepoint.md
+++ b/docs/ingestion/sharepoint.md
@@ -20,6 +20,7 @@ connections:
       library: Documents # optional
       max_file_size: 104857600 # optional, bytes
       max_files: 10000 # optional, use 0 for unlimited
+      download_timeout: 30m # optional, Go duration
 ```
 
 - `tenant_id`: Azure AD tenant ID for the app registration.
@@ -30,6 +31,7 @@ connections:
 - `library`: optional document library name. If omitted, ingestr uses the site's default Documents library.
 - `max_file_size`: optional maximum bytes for a single downloaded file. Use `0` for unlimited.
 - `max_files`: optional maximum number of files a glob may match. Defaults to `10000`; use `0` for unlimited.
+- `download_timeout`: optional per-request HTTP timeout as a Go duration, such as `30m` or `600s`. It defaults to `10m`; raise it for large files on slow connections.
 
 Authentication uses the OAuth2 client-credentials flow. The app registration needs application permission to read the site's files, such as `Sites.Read.All` or `Files.Read.All`, granted with admin consent.
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -4359,6 +4359,9 @@
         },
         "max_files": {
           "type": "integer"
+        },
+        "download_timeout": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1292,6 +1292,7 @@ type SharePointConnection struct {
 	Library            string `yaml:"library,omitempty" json:"library,omitempty" mapstructure:"library"`
 	MaxFileSize        *int64 `yaml:"max_file_size,omitempty" json:"max_file_size,omitempty" mapstructure:"max_file_size"`
 	MaxFiles           *int64 `yaml:"max_files,omitempty" json:"max_files,omitempty" mapstructure:"max_files"`
+	DownloadTimeout    string `yaml:"download_timeout,omitempty" json:"download_timeout,omitempty" mapstructure:"download_timeout"`
 }
 
 func (c SharePointConnection) GetName() string {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -931,6 +931,7 @@ func TestLoadFromFile(t *testing.T) {
 					Library:            "Documents",
 					MaxFileSize:        &sharePointMaxFileSize,
 					MaxFiles:           &sharePointMaxFiles,
+					DownloadTimeout:    "30m",
 				},
 			},
 			APIFootball: []APIFootballConnection{
@@ -1671,12 +1672,13 @@ func TestConfig_AddConnection(t *testing.T) {
 			connType: "sharepoint",
 			connName: "sharepoint-conn",
 			creds: map[string]interface{}{
-				"tenant_id":     "tenant-id",
-				"client_id":     "client-id",
-				"client_secret": "client-secret",
-				"hostname":      "example.sharepoint.com",
-				"site":          "sites/Example",
-				"library":       "Documents",
+				"tenant_id":        "tenant-id",
+				"client_id":        "client-id",
+				"client_secret":    "client-secret",
+				"hostname":         "example.sharepoint.com",
+				"site":             "sites/Example",
+				"library":          "Documents",
+				"download_timeout": "30m",
 			},
 			expectedErr: false,
 		},
@@ -1782,6 +1784,7 @@ func TestConfig_AddConnection(t *testing.T) {
 					assert.Equal(t, tt.creds["hostname"], env.Connections.SharePoint[0].Hostname)
 					assert.Equal(t, tt.creds["site"], env.Connections.SharePoint[0].Site)
 					assert.Equal(t, tt.creds["library"], env.Connections.SharePoint[0].Library)
+					assert.Equal(t, tt.creds["download_timeout"], env.Connections.SharePoint[0].DownloadTimeout)
 				}
 			}
 		})

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -586,6 +586,7 @@ environments:
           library: "Documents"
           max_file_size: 104857600
           max_files: 10000
+          download_timeout: "30m"
       apifootball:
         - name: "apifootball-1"
           api_key: "test-api-key"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -587,6 +587,7 @@ environments:
           library: "Documents"
           max_file_size: 104857600
           max_files: 10000
+          download_timeout: "30m"
       apifootball:
         - name: "apifootball-1"
           api_key: "test-api-key"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -901,14 +901,15 @@ func (m *Manager) AddSharePointConnectionFromConfig(connection *config.SharePoin
 	m.mutex.Unlock()
 
 	client, err := sharepoint.NewClient(sharepoint.Config{
-		TenantID:     connection.TenantID,
-		ClientID:     connection.ClientID,
-		ClientSecret: connection.ClientSecret,
-		Hostname:     connection.Hostname,
-		Site:         connection.Site,
-		Library:      connection.Library,
-		MaxFileSize:  connection.MaxFileSize,
-		MaxFiles:     connection.MaxFiles,
+		TenantID:        connection.TenantID,
+		ClientID:        connection.ClientID,
+		ClientSecret:    connection.ClientSecret,
+		Hostname:        connection.Hostname,
+		Site:            connection.Site,
+		Library:         connection.Library,
+		MaxFileSize:     connection.MaxFileSize,
+		MaxFiles:        connection.MaxFiles,
+		DownloadTimeout: connection.DownloadTimeout,
 	})
 	if err != nil {
 		return err

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -465,6 +465,7 @@ func Test_AddSharePointConnectionFromConfig(t *testing.T) {
 		Site:               "sites/Example",
 		Library:            "Documents",
 		MaxFiles:           &maxFiles,
+		DownloadTimeout:    "30m",
 	}
 
 	err := m.AddSharePointConnectionFromConfig(configuration)
@@ -478,6 +479,7 @@ func Test_AddSharePointConnectionFromConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, uri, "sharepoint://?")
 	assert.Contains(t, uri, "max_files=0")
+	assert.Contains(t, uri, "download_timeout=30m")
 	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
 }
 

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.0.78"
+	IngestrVersionV1 = "1.1.1"
 	sqlfluffVersion  = "3.4.1"
 )
 

--- a/pkg/sharepoint/config.go
+++ b/pkg/sharepoint/config.go
@@ -6,17 +6,19 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type Config struct {
-	TenantID     string
-	ClientID     string
-	ClientSecret string
-	Hostname     string
-	Site         string
-	Library      string
-	MaxFileSize  *int64
-	MaxFiles     *int64
+	TenantID        string
+	ClientID        string
+	ClientSecret    string
+	Hostname        string
+	Site            string
+	Library         string
+	MaxFileSize     *int64
+	MaxFiles        *int64
+	DownloadTimeout string
 }
 
 func (c Config) GetIngestrURI() (string, error) {
@@ -59,6 +61,14 @@ func (c Config) GetIngestrURI() (string, error) {
 			return "", errors.New("sharepoint: max_files cannot be negative")
 		}
 		params.Set("max_files", strconv.FormatInt(*c.MaxFiles, 10))
+	}
+
+	if downloadTimeout := strings.TrimSpace(c.DownloadTimeout); downloadTimeout != "" {
+		duration, err := time.ParseDuration(downloadTimeout)
+		if err != nil || duration < 0 {
+			return "", fmt.Errorf("sharepoint: invalid download_timeout %q: must be a non-negative Go duration such as 30m or 600s", downloadTimeout)
+		}
+		params.Set("download_timeout", downloadTimeout)
 	}
 
 	return "sharepoint://?" + params.Encode(), nil

--- a/pkg/sharepoint/config_test.go
+++ b/pkg/sharepoint/config_test.go
@@ -13,14 +13,15 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 	maxFileSize := int64(1048576)
 	maxFiles := int64(0)
 	cfg := Config{
-		TenantID:     "tenant-id",
-		ClientID:     "client-id",
-		ClientSecret: "secret with spaces",
-		Hostname:     "example.sharepoint.com",
-		Site:         "sites/Example",
-		Library:      "Shared Documents",
-		MaxFileSize:  &maxFileSize,
-		MaxFiles:     &maxFiles,
+		TenantID:        "tenant-id",
+		ClientID:        "client-id",
+		ClientSecret:    "secret with spaces",
+		Hostname:        "example.sharepoint.com",
+		Site:            "sites/Example",
+		Library:         "Shared Documents",
+		MaxFileSize:     &maxFileSize,
+		MaxFiles:        &maxFiles,
+		DownloadTimeout: "30m",
 	}
 
 	uri, err := cfg.GetIngestrURI()
@@ -40,6 +41,7 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 	require.Equal(t, "Shared Documents", query.Get("library"))
 	require.Equal(t, "1048576", query.Get("max_file_size"))
 	require.Equal(t, "0", query.Get("max_files"))
+	require.Equal(t, "30m", query.Get("download_timeout"))
 }
 
 func TestConfig_GetIngestrURI_RequiresCredentials(t *testing.T) {
@@ -64,6 +66,29 @@ func TestConfig_GetIngestrURI_RejectsNegativeLimits(t *testing.T) {
 
 	_, err := cfg.GetIngestrURI()
 	require.ErrorContains(t, err, "max_files cannot be negative")
+}
+
+func TestConfig_GetIngestrURI_RejectsInvalidDownloadTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"invalid", "-5m"}
+	for _, downloadTimeout := range tests {
+		t.Run(downloadTimeout, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{
+				TenantID:        "tenant-id",
+				ClientID:        "client-id",
+				ClientSecret:    "secret",
+				Hostname:        "example.sharepoint.com",
+				Site:            "sites/Example",
+				DownloadTimeout: downloadTimeout,
+			}
+
+			_, err := cfg.GetIngestrURI()
+			require.ErrorContains(t, err, "invalid download_timeout")
+		})
+	}
 }
 
 func TestClient_GetIngestrURI(t *testing.T) {


### PR DESCRIPTION
## What
Adds a configurable SharePoint download timeout for large files.

## Changes
- Add `download_timeout` to SharePoint credentials and ingestr URI validation.
- Update schemas, docs, tests, and pin ingestr v1 to `1.1.1`.

## How to test
1. `make format`
2. `make test`
3. `make build-no-duckdb`

## Risk & rollback
- **Risk:** Low; the field is optional and existing defaults are unchanged.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
- https://github.com/bruin-data/ingestr/pull/985
