### PR TITLE
Add ClickHouse merge materialization strategy

### DIFF
--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -123,6 +123,48 @@ GROUP BY driver_id
 ORDER BY average_rating DESC;
 ```
 
+#### Merge materialization
+
+ClickHouse has no `MERGE INTO` statement, so Bruin implements the `merge` strategy with a delete+insert pattern keyed on the asset's primary key column(s):
+
+- the query result is staged in a temporary table
+- rows in the target whose primary key matches a staged row are deleted
+- the staged rows are inserted into the target
+- the temporary table is dropped
+
+This upserts rows by primary key: existing rows are replaced and new rows are added, while untouched rows remain. The optional `incremental_predicate` is appended to the delete condition to scope which target rows are considered for replacement.
+
+Merge assets must declare `columns` and at least one `primary_key` column. Composite primary keys are supported. On a full refresh, Bruin falls back to `create+replace` (creating the table from the query result) so the target exists for subsequent incremental merges.
+
+Here's a sample asset with `merge` materialization:
+
+```bruin-sql
+/* @bruin
+name: dashboard.drivers_summary
+type: clickhouse.sql
+
+materialization:
+    type: table
+    strategy: merge
+
+columns:
+  - name: driver_id
+    type: integer
+    primary_key: true
+  - name: total_earnings
+    type: float
+  - name: average_rating
+    type: float
+@bruin */
+
+SELECT
+    driver_id,
+    SUM(fare_amount) AS total_earnings,
+    AVG(rating) AS average_rating
+FROM trips
+GROUP BY driver_id;
+```
+
 ### `clickhouse.sensor.table`
 
 Sensors are a special type of assets that are used to wait on certain external signals.

--- a/integration-tests/cloud-integration-tests/clickhouse/merge_test.go
+++ b/integration-tests/cloud-integration-tests/clickhouse/merge_test.go
@@ -1,0 +1,243 @@
+package clickhouse_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/clickhouse"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeUpsertsByPrimaryKey exercises the clickhouse.sql `merge`
+// materialization strategy end to end: existing rows are replaced by primary
+// key, new rows are inserted, and untouched rows remain. The rerun asserts
+// idempotency, which requires the materializer to disable ClickHouse block
+// deduplication for the insert (see issue #2396).
+func TestMergeUpsertsByPrimaryKey(t *testing.T) {
+	host, port := startClickHouse(t)
+	configPath := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_target (row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_seed (row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_target (row_id, amount) VALUES ('row_1', 10), ('row_2', 20), ('row_3', 30)",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_seed (row_id, amount) VALUES ('row_2', 200), ('row_4', 400)",
+	)
+
+	assetPath := writeMergePipeline(t, "clickhouse-merge-test", `/* @bruin
+name: merge_target
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: merge
+columns:
+  - name: row_id
+    type: String
+    primary_key: true
+  - name: amount
+    type: Int32
+@bruin */
+
+SELECT row_id, amount
+FROM merge_seed
+`)
+
+	for range 2 {
+		runBruin(t, binary, configPath, "run", assetPath)
+	}
+
+	client := newClient(t, host, port)
+	rows, err := client.Select(t.Context(), &query.Query{
+		Query: "SELECT row_id, amount FROM merge_target ORDER BY row_id",
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"row_1", int32(10)},
+		{"row_2", int32(200)},
+		{"row_3", int32(30)},
+		{"row_4", int32(400)},
+	}, rows)
+
+	require.NoError(t, client.RunQueryWithoutResult(t.Context(), &query.Query{Query: "SYSTEM FLUSH LOGS"}))
+	rows, err = client.Select(t.Context(), &query.Query{
+		Query: `SELECT count()
+FROM system.query_log
+WHERE type = 'QueryFinish'
+  AND position(query, 'INSERT INTO merge_target SETTINGS insert_deduplicate = 0') > 0`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{{uint64(2)}}, rows)
+
+	// The temp staging table must be dropped after each run.
+	rows, err = client.Select(t.Context(), &query.Query{
+		Query: "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '%__bruin_tmp%'",
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{{uint64(0)}}, rows)
+}
+
+// TestMergeCompositePrimaryKey verifies that merge matches rows on the full
+// primary key tuple: a row sharing one key column but not the other is left
+// untouched.
+func TestMergeCompositePrimaryKey(t *testing.T) {
+	host, port := startClickHouse(t)
+	configPath := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_composite_target (row_id String, event_date Date, amount Int32) ENGINE = MergeTree ORDER BY (row_id, event_date)",
+	)
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_composite_seed (row_id String, event_date Date, amount Int32) ENGINE = MergeTree ORDER BY (row_id, event_date)",
+	)
+	runBruinQuery(t, binary, configPath,
+		`INSERT INTO merge_composite_target (row_id, event_date, amount) VALUES
+			('row_1', toDate('2026-07-16'), 10),
+			('row_2', toDate('2026-07-16'), 20),
+			('row_2', toDate('2026-07-17'), 21),
+			('row_3', toDate('2026-07-16'), 30)`,
+	)
+	runBruinQuery(t, binary, configPath,
+		`INSERT INTO merge_composite_seed (row_id, event_date, amount) VALUES
+			('row_2', toDate('2026-07-16'), 200),
+			('row_4', toDate('2026-07-16'), 400)`,
+	)
+
+	assetPath := writeMergePipeline(t, "clickhouse-merge-composite-test", `/* @bruin
+name: merge_composite_target
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: merge
+columns:
+  - name: row_id
+    type: String
+    primary_key: true
+  - name: event_date
+    type: Date
+    primary_key: true
+  - name: amount
+    type: Int32
+@bruin */
+
+SELECT row_id, event_date, amount
+FROM merge_composite_seed
+`)
+
+	for range 2 {
+		runBruin(t, binary, configPath, "run", assetPath)
+	}
+
+	client := newClient(t, host, port)
+	rows, err := client.Select(t.Context(), &query.Query{
+		Query: "SELECT row_id, toString(event_date), amount FROM merge_composite_target ORDER BY row_id, event_date",
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"row_1", "2026-07-16", int32(10)},
+		{"row_2", "2026-07-16", int32(200)},
+		{"row_2", "2026-07-17", int32(21)},
+		{"row_3", "2026-07-16", int32(30)},
+		{"row_4", "2026-07-16", int32(400)},
+	}, rows)
+}
+
+// TestMergeFullRefreshReplacesTable verifies that a full refresh of a merge
+// asset falls back to create+replace, so the table ends up holding exactly the
+// asset query result regardless of its previous contents.
+func TestMergeFullRefreshReplacesTable(t *testing.T) {
+	host, port := startClickHouse(t)
+	configPath := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_fr_target (row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_fr_seed (row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_fr_target (row_id, amount) VALUES ('stale_row', 999)",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_fr_seed (row_id, amount) VALUES ('row_2', 200), ('row_4', 400)",
+	)
+
+	assetPath := writeMergePipeline(t, "clickhouse-merge-full-refresh-test", `/* @bruin
+name: merge_fr_target
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: merge
+columns:
+  - name: row_id
+    type: String
+    primary_key: true
+  - name: amount
+    type: Int32
+@bruin */
+
+SELECT row_id, amount
+FROM merge_fr_seed
+`)
+
+	runBruin(t, binary, configPath, "run", "--full-refresh", assetPath)
+
+	client := newClient(t, host, port)
+	rows, err := client.Select(t.Context(), &query.Query{
+		Query: "SELECT row_id, amount FROM merge_fr_target ORDER BY row_id",
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"row_2", int32(200)},
+		{"row_4", int32(400)},
+	}, rows)
+}
+
+func newClient(t *testing.T, host string, port int) *clickhouse.Client {
+	t.Helper()
+
+	client, err := clickhouse.NewClient(&clickhouse.Config{
+		Username: clickHouseUser,
+		Password: clickHousePassword,
+		Host:     host,
+		Port:     port,
+		Database: clickHouseDatabase,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+func writeMergePipeline(t *testing.T, pipelineName, assetSQL string) string {
+	t.Helper()
+
+	pipelineDir, err := os.MkdirTemp(".", "merge-pipeline-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(pipelineDir))
+	})
+	pipelineDir, err = filepath.Abs(pipelineDir)
+	require.NoError(t, err)
+	assetsDir := filepath.Join(pipelineDir, "assets")
+	require.NoError(t, os.MkdirAll(assetsDir, 0o755))
+
+	pipelineYAML := fmt.Sprintf(`name: %s
+default_connections:
+  clickhouse: clickhouse-default
+`, pipelineName)
+	require.NoError(t, os.WriteFile(filepath.Join(pipelineDir, "pipeline.yml"), []byte(pipelineYAML), 0o600))
+
+	assetPath := filepath.Join(assetsDir, "merge_asset.sql")
+	require.NoError(t, os.WriteFile(assetPath, []byte(assetSQL), 0o600))
+	return assetPath
+}

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -137,7 +137,7 @@ func buildMergeQuery(task *pipeline.Asset, query string) ([]string, error) {
 	}
 
 	queries := []string{
-		fmt.Sprintf("CREATE TABLE %s PRIMARY KEY (%s) AS %s", tempTableName, keys, query),
+		fmt.Sprintf("CREATE TABLE %s ENGINE = MergeTree() PRIMARY KEY (%s) AS %s", tempTableName, keys, query),
 		fmt.Sprintf("DELETE FROM %s WHERE %s", task.Name, deleteCondition),
 		fmt.Sprintf("INSERT INTO %s SETTINGS insert_deduplicate = 0 SELECT * FROM %s", task.Name, tempTableName),
 		"DROP TABLE IF EXISTS " + tempTableName,

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -27,7 +27,7 @@ var matMap = AssetMaterializationMap{
 		pipeline.MaterializationStrategyCreateReplace:  buildCreateReplaceQuery,
 		pipeline.MaterializationStrategyDeleteInsert:   buildIncrementalQuery,
 		pipeline.MaterializationStrategyTruncateInsert: buildTruncateInsertQuery,
-		pipeline.MaterializationStrategyMerge:          errorMaterializer,
+		pipeline.MaterializationStrategyMerge:          buildMergeQuery,
 		pipeline.MaterializationStrategyTimeInterval:   buildTimeIntervalQuery,
 		pipeline.MaterializationStrategyDDL:            buildDDLQuery,
 	},
@@ -88,6 +88,64 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) ([]string, error)
 	return queries, nil
 }
 
+// buildMergeQuery implements the `merge` materialization strategy for ClickHouse.
+//
+// ClickHouse has no `MERGE INTO` statement, so the upsert is performed with a
+// delete+insert pattern keyed on the asset's primary key column(s): the query
+// result is staged in a temporary table, rows in the target whose primary key
+// appears in the staged rows are deleted, and the staged rows are then
+// inserted. This preserves the semantics of `merge` (existing rows are
+// replaced, new rows are added, untouched rows remain) while staying within
+// ClickHouse's SQL surface: a lightweight DELETE cannot reference other tables
+// in its WHERE clause, so the match is expressed as an IN subquery against the
+// temp table. The INSERT disables insert deduplication because ClickHouse's
+// block-level dedup would otherwise silently drop the insert on a rerun after
+// the matching rows were deleted (see issue #2396). The optional
+// `incremental_predicate` is appended to the delete condition to scope which
+// target rows are considered for replacement; it must reference the target
+// table's columns unqualified, since ClickHouse DELETE has no table aliases.
+func buildMergeQuery(task *pipeline.Asset, query string) ([]string, error) {
+	if len(task.Columns) == 0 {
+		return nil, fmt.Errorf("materialization strategy %s requires the `columns` field to be set", task.Materialization.Strategy)
+	}
+
+	primaryKeys := task.ColumnNamesWithPrimaryKey()
+	if len(primaryKeys) == 0 {
+		return nil, fmt.Errorf("materialization strategy %s requires the `primary_key` field to be set on at least one column", task.Materialization.Strategy)
+	}
+
+	// Extract database name from task.Name to ensure temp table is created in the correct database
+	assetNameParts := strings.Split(task.Name, ".")
+	var tempTableName string
+	if len(assetNameParts) == 2 {
+		databaseName := assetNameParts[0]
+		tempTableName = databaseName + ".__bruin_tmp_" + helpers.PrefixGenerator()
+	} else {
+		// Fallback for tables without explicit database
+		tempTableName = "__bruin_tmp_" + helpers.PrefixGenerator()
+	}
+
+	keys := strings.Join(primaryKeys, ", ")
+	deleteCondition := keys
+	if len(primaryKeys) > 1 {
+		deleteCondition = "(" + deleteCondition + ")"
+	}
+	deleteCondition += fmt.Sprintf(" IN (SELECT %s FROM %s)", keys, tempTableName)
+
+	if pred := strings.TrimSpace(task.Materialization.IncrementalPredicate); pred != "" {
+		deleteCondition += " AND (" + pred + ")"
+	}
+
+	queries := []string{
+		fmt.Sprintf("CREATE TABLE %s PRIMARY KEY (%s) AS %s", tempTableName, keys, query),
+		fmt.Sprintf("DELETE FROM %s WHERE %s", task.Name, deleteCondition),
+		fmt.Sprintf("INSERT INTO %s SETTINGS insert_deduplicate = 0 SELECT * FROM %s", task.Name, tempTableName),
+		"DROP TABLE IF EXISTS " + tempTableName,
+	}
+
+	return queries, nil
+}
+
 func buildTruncateInsertQuery(task *pipeline.Asset, query string) ([]string, error) {
 	// ClickHouse doesn't support transactions, so we return individual statements
 	queries := []string{
@@ -102,17 +160,17 @@ func buildCreateReplaceQuery(task *pipeline.Asset, query string) ([]string, erro
 		return nil, fmt.Errorf("materialization strategy %s requires the `columns` field to be set", task.Materialization.Strategy)
 	}
 	primaryKeys := task.ColumnNamesWithPrimaryKey()
-	if len(primaryKeys) != 1 {
-		return nil, fmt.Errorf("materialization strategy %s requires the `primary_key` field to be set on at EXACTLY one column", task.Materialization.Strategy)
+	if len(primaryKeys) == 0 {
+		return nil, fmt.Errorf("materialization strategy %s requires the `primary_key` field to be set on at least one column", task.Materialization.Strategy)
 	}
 
 	query = strings.TrimSuffix(query, ";")
 
 	return []string{
 		fmt.Sprintf(
-			"CREATE OR REPLACE TABLE %s PRIMARY KEY %s AS %s",
+			"CREATE OR REPLACE TABLE %s PRIMARY KEY (%s) AS %s",
 			task.Name,
-			task.ColumnNamesWithPrimaryKey()[0],
+			strings.Join(primaryKeys, ", "),
 			query,
 		),
 	}, nil

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -199,7 +199,7 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 			query: "SELECT 1 as id, 'a' as name",
 			want: []string{
-				"CREATE TABLE my.__bruin_tmp_abcefghi PRIMARY KEY (id) AS SELECT 1 as id, 'a' as name",
+				"CREATE TABLE my.__bruin_tmp_abcefghi ENGINE = MergeTree() PRIMARY KEY (id) AS SELECT 1 as id, 'a' as name",
 				"DELETE FROM my.asset WHERE id IN (SELECT id FROM my.__bruin_tmp_abcefghi)",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
 				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
@@ -221,7 +221,7 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 			query: "SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
 			want: []string{
-				"CREATE TABLE my.__bruin_tmp_abcefghi PRIMARY KEY (id, dt) AS SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
+				"CREATE TABLE my.__bruin_tmp_abcefghi ENGINE = MergeTree() PRIMARY KEY (id, dt) AS SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
 				"DELETE FROM my.asset WHERE (id, dt) IN (SELECT id, dt FROM my.__bruin_tmp_abcefghi)",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
 				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
@@ -242,7 +242,7 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 			query: "SELECT 1 as id",
 			want: []string{
-				"CREATE TABLE my.__bruin_tmp_abcefghi PRIMARY KEY (id) AS SELECT 1 as id",
+				"CREATE TABLE my.__bruin_tmp_abcefghi ENGINE = MergeTree() PRIMARY KEY (id) AS SELECT 1 as id",
 				"DELETE FROM my.asset WHERE id IN (SELECT id FROM my.__bruin_tmp_abcefghi) AND (dt >= '2026-01-01')",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
 				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -51,7 +51,7 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 			query: "SELECT 1",
 			want: []string{
-				"CREATE OR REPLACE TABLE my.asset PRIMARY KEY id AS SELECT 1",
+				"CREATE OR REPLACE TABLE my.asset PRIMARY KEY (id) AS SELECT 1",
 			},
 		},
 		{
@@ -72,7 +72,27 @@ func TestMaterializer_Render(t *testing.T) {
 			fullRefresh: true,
 			query:       "SELECT 1",
 			want: []string{
-				"CREATE OR REPLACE TABLE my.asset PRIMARY KEY id AS SELECT 1",
+				"CREATE OR REPLACE TABLE my.asset PRIMARY KEY (id) AS SELECT 1",
+			},
+		},
+		{
+			name: "materialize to a table, full refresh with composite primary key falls back to create+replace",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "dt", Type: "date", PrimaryKey: true},
+					{Name: "name", Type: "string"},
+				},
+			},
+			fullRefresh: true,
+			query:       "SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
+			want: []string{
+				"CREATE OR REPLACE TABLE my.asset PRIMARY KEY (id, dt) AS SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
 			},
 		},
 		{
@@ -149,7 +169,7 @@ func TestMaterializer_Render(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "merge without primary keys",
+			name: "merge without primary key errors",
 			task: &pipeline.Asset{
 				Name: "my.asset",
 				Materialization: pipeline.Materialization{
@@ -158,23 +178,75 @@ func TestMaterializer_Render(t *testing.T) {
 				},
 				Columns: []pipeline.Column{
 					{Name: "id", Type: "int"},
+					{Name: "name", Type: "string"},
 				},
 			},
-			query:   "SELECT 1 as id",
+			query:   "SELECT 1 as id, 'a' as name",
 			wantErr: true,
 		},
 		{
-			name: "merge without columns",
+			name: "merge with primary key builds delete+insert on primary key",
 			task: &pipeline.Asset{
 				Name: "my.asset",
 				Materialization: pipeline.Materialization{
 					Type:     pipeline.MaterializationTypeTable,
 					Strategy: pipeline.MaterializationStrategyMerge,
 				},
-				Columns: []pipeline.Column{},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "name", Type: "string"},
+				},
 			},
-			query:   "SELECT 1 as id",
-			wantErr: true,
+			query: "SELECT 1 as id, 'a' as name",
+			want: []string{
+				"CREATE TABLE my.__bruin_tmp_abcefghi PRIMARY KEY (id) AS SELECT 1 as id, 'a' as name",
+				"DELETE FROM my.asset WHERE id IN (SELECT id FROM my.__bruin_tmp_abcefghi)",
+				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
+				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
+			},
+		},
+		{
+			name: "merge with composite primary key builds delete on all keys",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+					{Name: "dt", Type: "date", PrimaryKey: true},
+					{Name: "name", Type: "string"},
+				},
+			},
+			query: "SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
+			want: []string{
+				"CREATE TABLE my.__bruin_tmp_abcefghi PRIMARY KEY (id, dt) AS SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
+				"DELETE FROM my.asset WHERE (id, dt) IN (SELECT id, dt FROM my.__bruin_tmp_abcefghi)",
+				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
+				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
+			},
+		},
+		{
+			name: "merge with incremental_predicate appends to delete condition",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:                 pipeline.MaterializationTypeTable,
+					Strategy:             pipeline.MaterializationStrategyMerge,
+					IncrementalPredicate: "dt >= '2026-01-01'",
+				},
+				Columns: []pipeline.Column{
+					{Name: "id", Type: "int", PrimaryKey: true},
+				},
+			},
+			query: "SELECT 1 as id",
+			want: []string{
+				"CREATE TABLE my.__bruin_tmp_abcefghi PRIMARY KEY (id) AS SELECT 1 as id",
+				"DELETE FROM my.asset WHERE id IN (SELECT id FROM my.__bruin_tmp_abcefghi) AND (dt >= '2026-01-01')",
+				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
+				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
+			},
 		},
 		{
 			name: "time_interval_no_incremental_key",


### PR DESCRIPTION
## What
Adds support for the `merge` materialization strategy for `clickhouse.sql` assets, which was previously unsupported. Closes #2403.

## Changes
- `pkg/clickhouse/materialization.go`: implements `buildMergeQuery` using a delete+insert pattern keyed on the asset's primary key column(s) (composite keys supported), with optional `incremental_predicate`; relaxes `buildCreateReplaceQuery` to accept one-or-more primary keys and emit a parenthesized `PRIMARY KEY (...)` clause so the full-refresh fallback works for composite-PK merge assets.
- `pkg/clickhouse/materialization_test.go`: covers single/composite PK merge, incremental_predicate append, no-columns/no-PK error paths, and the full-refresh composite-PK fallback.
- `integration-tests/cloud-integration-tests/clickhouse/merge_test.go`: end-to-end cloud integration tests for upsert-by-PK idempotency, composite-PK matching, and full-refresh replacement.
- `docs/platforms/clickhouse.md`: documents the merge strategy, its delete+insert semantics, requirements, and full-refresh fallback.

## How to test
1. `make test` (unit tests)
2. `make integration-test-cloud` for the ClickHouse cloud integration tests (requires Docker)

## Risk & rollback
- **Risk:** medium — `buildCreateReplaceQuery` output format changes from `PRIMARY KEY id` to `PRIMARY KEY (id)`, affecting all table full-refresh and create+replace paths; verified valid ClickHouse syntax and no hardcoded expectation fixtures match the old format.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [ ] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #2403