### PR TITLE
feat(ingestr): add Payrails source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -344,6 +344,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "MySQL", link: "/ingestion/mysql"},
                                     {text: "Notion", link: "/ingestion/notion"},
                                     {text: "Paddle", link: "/ingestion/paddle"},
+                                    {text: "Payrails", link: "/ingestion/payrails"},
                                     {text: "Personio", link: "/ingestion/personio"},
                                     {text: "PhantomBuster", link: "/ingestion/phantombuster"},
                                     {text: "Pipedrive", link: "/ingestion/pipedrive"},

--- a/docs/ingestion/payrails.md
+++ b/docs/ingestion/payrails.md
@@ -1,0 +1,85 @@
+# Payrails
+
+[Payrails](https://www.payrails.com/) is a payment operations and orchestration platform that lets enterprises connect and manage multiple payment providers through a single integration.
+
+Bruin supports Payrails as a source for [Ingestr assets](/assets/ingestr). You can ingest data from Payrails into your data platform.
+
+To set up a Payrails connection, add a configuration item in the `.bruin.yml` file and in your asset file. Payrails secures API traffic with mutual TLS (mTLS), so you provide a client certificate and key in addition to your `client_id` and `client_secret`, created under **Settings > API Credentials** in the Payrails Portal.
+
+Follow these steps to set up Payrails and run ingestion.
+
+## Configuration
+
+### Step 1: Add a connection to the .bruin.yml file
+
+```yaml
+connections:
+  payrails:
+    - name: "payrails"
+      client_id: "your-client-id"
+      client_secret: "your-client-secret"
+      cert_path: "/path/to/client.pem"
+      key_path: "/path/to/client.key"
+      environment: "production"
+```
+
+- `client_id`: (Required) Payrails API credential ID.
+- `client_secret`: (Required) Payrails API credential secret.
+- `cert_path` / `key_path`: (Required) Paths to your mTLS client certificate (`.pem`) and private key (`.key`).
+- `cert` / `key`: PEM contents of the certificate and key, as an alternative to `cert_path`/`key_path` when local files are not available.
+- `environment`: (Optional) `production` (default) or `sandbox`.
+- `base_url`: (Optional) Full API base URL; overrides `environment` for account-specific hosts.
+
+### Step 2: Create an asset file for data ingestion
+
+Create an [asset configuration](/assets/ingestr#asset-structure) file (e.g., `payrails_ingestion.yml`) inside the assets folder with the following content:
+
+```yaml
+name: public.payrails
+type: ingestr
+
+parameters:
+  source_connection: payrails
+  source_table: 'payments'
+
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Always `ingestr` for Payrails.
+- `source_connection`: The Payrails connection name defined in `.bruin.yml`.
+- `source_table`: Name of the Payrails table to ingest.
+- `destination`: The destination connection name.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------| ------- |
+| payments | id | createdAt | merge | Payments with their status, amount, references, and transaction metadata. |
+| instruments | id | createdAt | merge | Stored payment instruments (e.g. tokenized cards) with their status and metadata. |
+| executions | id | updatedAt | merge | Workflow executions with their status and references. |
+
+`payments` and `instruments` support incremental date-range loads via `--interval-start` / `--interval-end` (filtered on `createdAt`); `executions` is filtered on `updatedAt`.
+
+Payrails has no endpoint that lists all workflows, so for `executions` you must specify which workflow(s) to pull by appending the workflow code(s) to the table name after a colon. Each row includes a `workflow_code` column. For example:
+
+```yaml
+name: public.payrails_executions
+type: ingestr
+
+parameters:
+  source_connection: payrails
+  source_table: 'executions:payment-acceptance'
+
+  destination: postgres
+```
+
+Pass multiple workflow codes as a comma-separated list, e.g. `source_table: 'executions:payment-acceptance,payout'`.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/payrails_ingestion.yml
+```
+
+Running this command ingests data from Payrails into your Postgres database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1273,6 +1273,12 @@
           },
           "type": "array"
         },
+        "payrails": {
+          "items": {
+            "$ref": "#/$defs/PayrailsConnection"
+          },
+          "type": "array"
+        },
         "clickup": {
           "items": {
             "$ref": "#/$defs/ClickupConnection"
@@ -3596,6 +3602,47 @@
       "required": [
         "name",
         "api_key"
+      ]
+    },
+    "PayrailsConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "cert_path": {
+          "type": "string"
+        },
+        "key_path": {
+          "type": "string"
+        },
+        "cert": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "environment": {
+          "type": "string"
+        },
+        "base_url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "client_id",
+        "client_secret"
       ]
     },
     "PersonioConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1364,6 +1364,22 @@ func (c FastspringConnection) GetName() string {
 	return c.Name
 }
 
+type PayrailsConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	ClientID           string `yaml:"client_id,omitempty" json:"client_id" mapstructure:"client_id"`
+	ClientSecret       string `yaml:"client_secret,omitempty" json:"client_secret" mapstructure:"client_secret" sensitive:"true"`
+	CertPath           string `yaml:"cert_path,omitempty" json:"cert_path,omitempty" mapstructure:"cert_path"`
+	KeyPath            string `yaml:"key_path,omitempty" json:"key_path,omitempty" mapstructure:"key_path"`
+	Cert               string `yaml:"cert,omitempty" json:"cert,omitempty" mapstructure:"cert" sensitive:"true"`
+	Key                string `yaml:"key,omitempty" json:"key,omitempty" mapstructure:"key" sensitive:"true"`
+	Environment        string `yaml:"environment,omitempty" json:"environment,omitempty" mapstructure:"environment"`
+	BaseURL            string `yaml:"base_url,omitempty" json:"base_url,omitempty" mapstructure:"base_url"`
+}
+
+func (c PayrailsConnection) GetName() string {
+	return c.Name
+}
+
 type ClickupConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	APIToken           string `yaml:"api_token,omitempty" json:"api_token" mapstructure:"api_token" sensitive:"true"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -109,6 +109,7 @@ type Connections struct {
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
 	Amplitude           []AmplitudeConnection           `yaml:"amplitude,omitempty" json:"amplitude,omitempty" mapstructure:"amplitude"`
 	Fastspring          []FastspringConnection          `yaml:"fastspring,omitempty" json:"fastspring,omitempty" mapstructure:"fastspring"`
+	Payrails            []PayrailsConnection            `yaml:"payrails,omitempty" json:"payrails,omitempty" mapstructure:"payrails"`
 	Clickup             []ClickupConnection             `yaml:"clickup,omitempty" json:"clickup,omitempty" mapstructure:"clickup"`
 	Jobtread            []JobtreadConnection            `yaml:"jobtread,omitempty" json:"jobtread,omitempty" mapstructure:"jobtread"`
 	Posthog             []PosthogConnection             `yaml:"posthog,omitempty" json:"posthog,omitempty" mapstructure:"posthog"`
@@ -1383,6 +1384,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Fastspring = append(env.Connections.Fastspring, conn)
+	case "payrails":
+		var conn PayrailsConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Payrails = append(env.Connections.Payrails, conn)
 	case "wise":
 		var conn WiseConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -2003,6 +2011,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Amplitude = removeConnection(env.Connections.Amplitude, connectionName)
 	case "fastspring":
 		env.Connections.Fastspring = removeConnection(env.Connections.Fastspring, connectionName)
+	case "payrails":
+		env.Connections.Payrails = removeConnection(env.Connections.Payrails, connectionName)
 	case "pinterest":
 		env.Connections.Pinterest = removeConnection(env.Connections.Pinterest, connectionName)
 	case "trino":
@@ -2293,6 +2303,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Mixpanel, source.Mixpanel)
 	mergeConnectionList(&c.Amplitude, source.Amplitude)
 	mergeConnectionList(&c.Fastspring, source.Fastspring)
+	mergeConnectionList(&c.Payrails, source.Payrails)
 	mergeConnectionList(&c.Clickup, source.Clickup)
 	mergeConnectionList(&c.Jobtread, source.Jobtread)
 	mergeConnectionList(&c.Posthog, source.Posthog)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -645,6 +645,15 @@ func TestLoadFromFile(t *testing.T) {
 					Password:           "pass-123",
 				},
 			},
+			Payrails: []PayrailsConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "payrails-1"},
+					ClientID:           "client-123",
+					ClientSecret:       "secret-123",
+					CertPath:           "/tmp/client.pem",
+					KeyPath:            "/tmp/client.key",
+				},
+			},
 			Wise: []WiseConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "wise-1"},
@@ -2736,6 +2745,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
 				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
 				Fastspring:          []FastspringConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fastspring1"}}},
+				Payrails:            []PayrailsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "payrails1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
 				Posthog:             []PosthogConnection{{ConnectionMetadata: ConnectionMetadata{Name: "posthog1"}}},
@@ -2873,6 +2883,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
 				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
 				Fastspring:          []FastspringConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fastspring1"}}},
+				Payrails:            []PayrailsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "payrails1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
 				Posthog:             []PosthogConnection{{ConnectionMetadata: ConnectionMetadata{Name: "posthog1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -393,6 +393,12 @@ environments:
         - name: "fastspring-1"
           username: "user-123"
           password: "pass-123"
+      payrails:
+        - name: "payrails-1"
+          client_id: "client-123"
+          client_secret: "secret-123"
+          cert_path: "/tmp/client.pem"
+          key_path: "/tmp/client.key"
       wise:
         - name: "wise-1"
           api_key: "token-123"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -395,6 +395,12 @@ environments:
         - name: "fastspring-1"
           username: "user-123"
           password: "pass-123"
+      payrails:
+        - name: "payrails-1"
+          client_id: "client-123"
+          client_secret: "secret-123"
+          cert_path: "/tmp/client.pem"
+          key_path: "/tmp/client.key"
       wise:
         - name: "wise-1"
           api_key: "token-123"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -100,6 +100,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/onelake"
 	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/paddle"
+	"github.com/bruin-data/bruin/pkg/payrails"
 	"github.com/bruin-data/bruin/pkg/personio"
 	"github.com/bruin-data/bruin/pkg/phantombuster"
 	"github.com/bruin-data/bruin/pkg/pinterest"
@@ -235,6 +236,7 @@ type Manager struct {
 	Mixpanel             map[string]*mixpanel.Client
 	Amplitude            map[string]*amplitude.Client
 	Fastspring           map[string]*fastspring.Client
+	Payrails             map[string]*payrails.Client
 	Clickup              map[string]*clickup.Client
 	Jobtread             map[string]*jobtread.Client
 	Posthog              map[string]*posthog.Client
@@ -3005,6 +3007,34 @@ func (m *Manager) AddFastspringConnectionFromConfig(connection *config.Fastsprin
 	return nil
 }
 
+func (m *Manager) AddPayrailsConnectionFromConfig(connection *config.PayrailsConnection) error {
+	m.mutex.Lock()
+	if m.Payrails == nil {
+		m.Payrails = make(map[string]*payrails.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := payrails.NewClient(payrails.Config{
+		ClientID:     connection.ClientID,
+		ClientSecret: connection.ClientSecret,
+		CertPath:     connection.CertPath,
+		KeyPath:      connection.KeyPath,
+		Cert:         connection.Cert,
+		Key:          connection.Key,
+		Environment:  connection.Environment,
+		BaseURL:      connection.BaseURL,
+	})
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Payrails[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddGoogleAnalyticsConnectionFromConfig(connection *config.GoogleAnalyticsConnection) error {
 	m.mutex.Lock()
 	if m.GoogleAnalytics == nil {
@@ -4120,6 +4150,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Mixpanel, connectionManager.AddMixpanelConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Amplitude, connectionManager.AddAmplitudeConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Fastspring, connectionManager.AddFastspringConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Payrails, connectionManager.AddPayrailsConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Pinterest, connectionManager.AddPinterestConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Trustpilot, connectionManager.AddTrustpilotConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.QuickBooks, connectionManager.AddQuickBooksConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -686,6 +686,13 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "user_properties", PrimaryKey: "user_property", IncKey: "", IncStrategy: "replace"},
 	},
 
+	// Payrails - Payments
+	"payrails": {
+		{Name: "payments", PrimaryKey: "id", IncKey: "createdAt", IncStrategy: "merge"},
+		{Name: "instruments", PrimaryKey: "id", IncKey: "createdAt", IncStrategy: "merge"},
+		{Name: "executions", PrimaryKey: "id", IncKey: "updatedAt", IncStrategy: "merge"},
+	},
+
 	// FastSpring - Payments & Subscriptions
 	"fastspring": {
 		{Name: "orders", PrimaryKey: "id", IncKey: "changed", IncStrategy: "merge"},

--- a/pkg/payrails/config.go
+++ b/pkg/payrails/config.go
@@ -1,0 +1,66 @@
+package payrails
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// Config describes credentials for a Payrails connection. The mTLS material may
+// be supplied as local file paths (cert_path/key_path) or as PEM content
+// (cert/key); content is passed to ingestr base64-encoded so it works in
+// environments without local files, such as Bruin Cloud.
+type Config struct {
+	ClientID     string `yaml:"client_id" json:"client_id" mapstructure:"client_id"`
+	ClientSecret string `yaml:"client_secret" json:"client_secret" mapstructure:"client_secret"`
+	CertPath     string `yaml:"cert_path" json:"cert_path" mapstructure:"cert_path"`
+	KeyPath      string `yaml:"key_path" json:"key_path" mapstructure:"key_path"`
+	Cert         string `yaml:"cert" json:"cert" mapstructure:"cert"`
+	Key          string `yaml:"key" json:"key" mapstructure:"key"`
+	Environment  string `yaml:"environment" json:"environment" mapstructure:"environment"`
+	BaseURL      string `yaml:"base_url" json:"base_url" mapstructure:"base_url"`
+}
+
+// GetIngestrURI builds the Payrails ingestr URI.
+func (c *Config) GetIngestrURI() (string, error) {
+	params := url.Values{}
+
+	clientID := strings.TrimSpace(c.ClientID)
+	if clientID == "" {
+		return "", errors.New("payrails: client_id must be provided")
+	}
+	clientSecret := strings.TrimSpace(c.ClientSecret)
+	if clientSecret == "" {
+		return "", errors.New("payrails: client_secret must be provided")
+	}
+	params.Set("client_id", clientID)
+	params.Set("client_secret", clientSecret)
+
+	switch {
+	case strings.TrimSpace(c.Cert) != "":
+		params.Set("cert_base64", base64.StdEncoding.EncodeToString([]byte(c.Cert)))
+	case strings.TrimSpace(c.CertPath) != "":
+		params.Set("cert_path", strings.TrimSpace(c.CertPath))
+	default:
+		return "", errors.New("payrails: cert or cert_path must be provided")
+	}
+
+	switch {
+	case strings.TrimSpace(c.Key) != "":
+		params.Set("key_base64", base64.StdEncoding.EncodeToString([]byte(c.Key)))
+	case strings.TrimSpace(c.KeyPath) != "":
+		params.Set("key_path", strings.TrimSpace(c.KeyPath))
+	default:
+		return "", errors.New("payrails: key or key_path must be provided")
+	}
+
+	if v := strings.TrimSpace(c.Environment); v != "" {
+		params.Set("environment", v)
+	}
+	if v := strings.TrimSpace(c.BaseURL); v != "" {
+		params.Set("base_url", v)
+	}
+
+	return "payrails://?" + params.Encode(), nil
+}

--- a/pkg/payrails/config_test.go
+++ b/pkg/payrails/config_test.go
@@ -1,0 +1,79 @@
+package payrails
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "required fields set",
+			config: Config{ClientID: "cid", ClientSecret: "sec", CertPath: "/tmp/c.pem", KeyPath: "/tmp/c.key"},
+			want:   "payrails://?cert_path=%2Ftmp%2Fc.pem&client_id=cid&client_secret=sec&key_path=%2Ftmp%2Fc.key",
+		},
+		{
+			name:   "with optional environment and base_url",
+			config: Config{ClientID: "cid", ClientSecret: "sec", CertPath: "/tmp/c.pem", KeyPath: "/tmp/c.key", Environment: "sandbox", BaseURL: "https://api.payrails.io"},
+			want:   "payrails://?base_url=https%3A%2F%2Fapi.payrails.io&cert_path=%2Ftmp%2Fc.pem&client_id=cid&client_secret=sec&environment=sandbox&key_path=%2Ftmp%2Fc.key",
+		},
+		{
+			name:   "cert and key content sent base64",
+			config: Config{ClientID: "cid", ClientSecret: "sec", Cert: "cert", Key: "key"},
+			want:   "payrails://?cert_base64=Y2VydA%3D%3D&client_id=cid&client_secret=sec&key_base64=a2V5",
+		},
+		{
+			name:    "missing client_id",
+			config:  Config{ClientSecret: "sec", CertPath: "/tmp/c.pem", KeyPath: "/tmp/c.key"},
+			wantErr: true,
+		},
+		{
+			name:    "missing client_secret",
+			config:  Config{ClientID: "cid", CertPath: "/tmp/c.pem", KeyPath: "/tmp/c.key"},
+			wantErr: true,
+		},
+		{
+			name:    "missing cert_path",
+			config:  Config{ClientID: "cid", ClientSecret: "sec", KeyPath: "/tmp/c.key"},
+			wantErr: true,
+		},
+		{
+			name:    "missing key_path",
+			config:  Config{ClientID: "cid", ClientSecret: "sec", CertPath: "/tmp/c.pem"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.config.GetIngestrURI()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{ClientID: "cid", ClientSecret: "sec", CertPath: "/tmp/c.pem", KeyPath: "/tmp/c.key"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "payrails://?cert_path=%2Ftmp%2Fc.pem&client_id=cid&client_secret=sec&key_path=%2Ftmp%2Fc.key", uri)
+}

--- a/pkg/payrails/db.go
+++ b/pkg/payrails/db.go
@@ -1,0 +1,13 @@
+package payrails
+
+type Client struct {
+	config Config
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{c}, nil
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -269,6 +269,7 @@ var defaultMapping = map[string]string{
 	"linkedinads":           "linkedinads-default",
 	"amplitude":             "amplitude-default",
 	"fastspring":            "fastspring-default",
+	"payrails":              "payrails-default",
 	"mailchimp":             "mailchimp-default",
 	"manifold":              "manifold-default",
 	"mixpanel":              "mixpanel-default",


### PR DESCRIPTION
Wires the Payrails ingestr source (`payrails://`) end-to-end.

**Params:** `client_id`, `client_secret`, `cert_path`/`key_path` (mTLS) required; `environment` (production/sandbox) and `base_url` optional.

**Tables:** `payments` (id / createdAt / merge), `instruments` (id / createdAt / merge), `executions` (id / updatedAt / merge; needs a workflow code via `executions:<code>`).

Includes config + connection manager, source-table registry, default mapping, docs, testdata, and regenerated connection schema.