### PR TITLE
Register Athena sensor executors when sensors run standalone

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2401,13 +2401,15 @@ func SetupExecutors(
 	}
 
 	//nolint:dupl
-	if s.WillRunTaskOfType(pipeline.AssetTypeAthenaQuery) || estimateCustomCheckType == pipeline.AssetTypeAthenaQuery || s.WillRunTaskOfType(pipeline.AssetTypeAthenaSeed) {
+	if s.WillRunTaskOfType(pipeline.AssetTypeAthenaQuery) || estimateCustomCheckType == pipeline.AssetTypeAthenaQuery || s.WillRunTaskOfType(pipeline.AssetTypeAthenaSeed) ||
+		s.WillRunTaskOfType(pipeline.AssetTypeAthenaTableSensor) || s.WillRunTaskOfType(pipeline.AssetTypeAthenaSQLSensor) {
 		athenaOperator := athena.NewBasicOperator(conn, wholeFileExtractor, pipeline.HookWrapperMaterializerListWithLocation{
 			Mat:     athena.NewMaterializer(fullRefresh),
 			Hoister: hoister,
 		}, parser)
 		athenaCheckRunner := athena.NewColumnCheckOperator(conn)
 		athenaTableSensor := ansisql.NewTableSensor(conn, sensorMode, wholeFileExtractor)
+		athenaQuerySensor := ansisql.NewQuerySensor(conn, wholeFileExtractor, sensorMode)
 
 		mainExecutors[pipeline.AssetTypeAthenaQuery][scheduler.TaskInstanceTypeMain] = athenaOperator
 		mainExecutors[pipeline.AssetTypeAthenaQuery][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
@@ -2420,6 +2422,10 @@ func SetupExecutors(
 		mainExecutors[pipeline.AssetTypeAthenaTableSensor][scheduler.TaskInstanceTypeMain] = athenaTableSensor
 		mainExecutors[pipeline.AssetTypeAthenaTableSensor][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
 		mainExecutors[pipeline.AssetTypeAthenaTableSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
+
+		mainExecutors[pipeline.AssetTypeAthenaSQLSensor][scheduler.TaskInstanceTypeMain] = athenaQuerySensor
+		mainExecutors[pipeline.AssetTypeAthenaSQLSensor][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner
+		mainExecutors[pipeline.AssetTypeAthenaSQLSensor][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 
 		if estimateCustomCheckType == pipeline.AssetTypeAthenaQuery {
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = athenaCheckRunner


### PR DESCRIPTION
## What

Athena table/query sensors (`athena.sensor.table`, `athena.sensor.query`) silently reported `PASS` in 0s **without ever querying Athena** unless the same run also contained an `athena.sql` or `athena.seed` asset. A sensor-only run was effectively a no-op — a missing table still "passed".

## Root cause

`mainExecutors` starts from `executor.DefaultExecutorsV2`, where the Athena sensor's main task is a `NoOpOperator{}`. The real sensor operator only replaces that no-op inside a guard that checked **only** `AthenaQuery` / `AthenaSeed`:

```go
if s.WillRunTaskOfType(pipeline.AssetTypeAthenaQuery) || estimateCustomCheckType == ... || s.WillRunTaskOfType(pipeline.AssetTypeAthenaSeed) {
```

So when a pipeline/run contained only sensors, the guard was false, the `NoOpOperator` was never replaced, and the sensor "succeeded" instantly. Athena was the **only** platform with this gap — BigQuery, Snowflake, Postgres/Redshift, MSSQL/Synapse, Vertica, Fabric, and Databricks all already include their sensor types in the guard.

Separately, `athena.sensor.query` (`AthenaSQLSensor`) had **no operator registered at all**, so it always no-op'd even alongside a query/seed asset.
