### PR TITLE
fix generic connection credential masking

### DIFF
--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1060,7 +1060,7 @@ func (c ApplovinMaxConnection) GetName() string {
 
 type GenericConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
-	Value              string `yaml:"value,omitempty" json:"value" mapstructure:"value"`
+	Value              string `yaml:"value,omitempty" json:"value" mapstructure:"value" sensitive:"true"`
 }
 
 func (c GenericConnection) MarshalJSON() ([]byte, error) {

--- a/pkg/config/connections_sensitive_test.go
+++ b/pkg/config/connections_sensitive_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -43,7 +46,7 @@ func TestIcebergConnectionSecretsAreMasked(t *testing.T) {
 
 // secretNamePattern flags credential-looking field names. A match MUST carry
 // `sensitive:"true"` or be listed in safeNonSecretKeys, else the test fails.
-var secretNamePattern = regexp.MustCompile(`(?i)(password|secret|token|api[_]?key|access[_]?key|private[_]?key|account[_]?key|credential|passphrase|auth|grant_key|key_base64|service_account_json|^key$)`)
+var secretNamePattern = regexp.MustCompile(`(?i)(password|secret|token|api[_]?key|access[_]?key|private[_]?key|account[_]?key|credential|passphrase|auth|grant_key|key_base64|service_account_json|^dsn$|^key$|^uri$|^value$)`)
 
 // safeNonSecretKeys are fields whose names look secret-ish but hold
 // identifiers, file paths, or booleans — not credential values.
@@ -64,11 +67,49 @@ var safeNonSecretKeys = map[string]bool{
 
 func TestConnectionSensitiveTagsComplete(t *testing.T) {
 	t.Parallel()
-	visited := map[reflect.Type]bool{}
 	connsType := reflect.TypeOf(Connections{})
 	for i := range connsType.NumField() {
-		checkSensitiveTags(t, unwrapToStruct(connsType.Field(i).Type), visited)
+		field := connsType.Field(i)
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+		t.Run(connectionFieldName(field), func(t *testing.T) {
+			t.Parallel()
+			checkSensitiveTags(t, unwrapToStruct(field.Type), map[reflect.Type]bool{})
+		})
 	}
+}
+
+// TestConnectionSensitiveValuesAreCollected exercises every registered connection
+// independently. Each tagged inline value and credential-file content must reach
+// the masker; this catches collector regressions in nested connection structs.
+func TestConnectionSensitiveValuesAreCollected(t *testing.T) {
+	t.Parallel()
+	connsType := reflect.TypeOf(Connections{})
+	for i := range connsType.NumField() {
+		field := connsType.Field(i)
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+		t.Run(connectionFieldName(field), func(t *testing.T) {
+			t.Parallel()
+			conn := reflect.New(unwrapToStruct(field.Type))
+			expected := make([]string, 0)
+			setSensitiveTestValues(t, conn.Elem(), conn.Elem().Type().Name(), &expected)
+
+			actual, unreadable := mask.SensitiveValues(conn.Interface())
+			assert.Empty(t, unreadable)
+			assert.ElementsMatch(t, expected, actual)
+		})
+	}
+}
+
+func connectionFieldName(field reflect.StructField) string {
+	name, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+	if name != "" {
+		return name
+	}
+	return field.Name
 }
 
 // unwrapToStruct peels slice/array/pointer/map layers to reach the element type.
@@ -93,6 +134,11 @@ func checkSensitiveTags(t *testing.T, st reflect.Type, visited map[reflect.Type]
 		if !f.IsExported() {
 			continue
 		}
+		for _, tag := range []string{"sensitive", "sensitive_file"} {
+			if value := f.Tag.Get(tag); value != "" && value != "true" {
+				t.Errorf("%s.%s has invalid `%s:%q`; the only supported value is true", st.Name(), f.Name, tag, value)
+			}
+		}
 		if inner := unwrapToStruct(f.Type); inner.Kind() == reflect.Struct {
 			checkSensitiveTags(t, inner, visited)
 			continue
@@ -114,6 +160,54 @@ func checkSensitiveTags(t *testing.T, st reflect.Type, visited map[reflect.Type]
 			t.Errorf("%s.%s (key=%q) looks like a credential but is not tagged `sensitive:\"true\"`.\n"+
 				"Add the tag, or if it is NOT a secret add %q to safeNonSecretKeys.",
 				st.Name(), f.Name, key, key)
+		}
+	}
+}
+
+func setSensitiveTestValues(t *testing.T, value reflect.Value, path string, expected *[]string) {
+	t.Helper()
+	typeOfValue := value.Type()
+	for i := range typeOfValue.NumField() {
+		field := typeOfValue.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		fieldValue := value.Field(i)
+		fieldPath := path + "." + field.Name
+		if fieldValue.Kind() == reflect.String {
+			isInline := field.Tag.Get("sensitive") == "true"
+			isFile := field.Tag.Get("sensitive_file") == "true"
+			if isInline && isFile {
+				t.Errorf("%s cannot be both sensitive and sensitive_file", fieldPath)
+				continue
+			}
+			switch {
+			case isInline:
+				secret := "inline-secret::" + fieldPath
+				fieldValue.SetString(secret)
+				*expected = append(*expected, secret)
+			case isFile:
+				secret := "file-secret::" + fieldPath
+				filePath := filepath.Join(t.TempDir(), fmt.Sprintf("credential-%d", i))
+				if err := os.WriteFile(filePath, []byte(secret), 0o600); err != nil {
+					t.Fatalf("write credential fixture for %s: %v", fieldPath, err)
+				}
+				fieldValue.SetString(filePath)
+				*expected = append(*expected, secret)
+			}
+			continue
+		}
+
+		switch fieldValue.Kind() { //nolint:exhaustive // only nested config structs can contain sensitive tags
+		case reflect.Struct:
+			if fieldValue.Type().PkgPath() == typeOfValue.PkgPath() {
+				setSensitiveTestValues(t, fieldValue, fieldPath, expected)
+			}
+		case reflect.Pointer:
+			if fieldValue.Type().Elem().Kind() == reflect.Struct && fieldValue.Type().Elem().PkgPath() == typeOfValue.PkgPath() {
+				fieldValue.Set(reflect.New(fieldValue.Type().Elem()))
+				setSensitiveTestValues(t, fieldValue.Elem(), fieldPath, expected)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What

Masks generic connection values and adds exhaustive per-connection regression coverage.

## Changes

- Marked `GenericConnection.Value` as sensitive.
- Validated sensitive tags and collected values separately across all 141 registered connection types.

## How to test

1. `make format`
2. `make test`
3. `make build-no-duckdb`

## Risk & rollback

- **Risk:** Low; the runtime change only adds an existing masking tag.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`) — not affected
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

None.
