### PR TITLE
fix: render ClickHouse timestamp interval bounds

### DIFF
--- a/integration-tests/cloud-integration-tests/clickhouse/query_insert_eof_test.go
+++ b/integration-tests/cloud-integration-tests/clickhouse/query_insert_eof_test.go
@@ -174,6 +174,51 @@ WHERE type = 'QueryFinish'
 	require.Equal(t, [][]interface{}{{uint64(2)}}, rows)
 }
 
+// TestTimeIntervalTimestampFirstRunAndRerun protects the regression from
+// https://github.com/bruin-data/bruin/issues/2419. ClickHouse DateTime columns
+// do not accept ISO-8601 string literals containing a T in the DELETE bounds.
+func TestTimeIntervalTimestampFirstRunAndRerun(t *testing.T) {
+	host, port := startClickHouse(t)
+	configPath := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE timestamp_seed (event_date Date, row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE timestamp_incremental (event_timestamp DateTime, row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO timestamp_seed (event_date, row_id, amount) VALUES (toDate('2026-07-23'), 'row_7', 77)",
+	)
+
+	assetPath := writeTimeIntervalTimestampPipeline(t)
+	runInterval := func() {
+		runBruin(t, binary, configPath,
+			"run",
+			"--env", "default",
+			"--start-date", "2026-07-23T00:00:00.000Z",
+			"--end-date", "2026-07-23T23:59:59.999999999Z",
+			"--apply-interval-modifiers",
+			assetPath,
+		)
+	}
+
+	client := newClient(t, host, port)
+	assertRows := func() {
+		rows, err := client.Select(t.Context(), &query.Query{
+			Query: "SELECT toString(event_timestamp), row_id, amount FROM timestamp_incremental ORDER BY row_id",
+		})
+		require.NoError(t, err)
+		require.Equal(t, [][]interface{}{{"2026-07-23 00:00:00", "row_7", int32(77)}}, rows)
+	}
+
+	runInterval()
+	assertRows()
+	runInterval()
+	assertRows()
+}
+
 func startClickHouse(t *testing.T) (string, int) {
 	t.Helper()
 
@@ -327,6 +372,55 @@ FROM bug_test_seed
 WHERE event_date BETWEEN toDate('{{start_date}}') AND toDate('{{end_date}}')
 `
 	assetPath := filepath.Join(assetsDir, "bug_test_incremental.sql")
+	require.NoError(t, os.WriteFile(assetPath, []byte(assetSQL), 0o600))
+	return assetPath
+}
+
+func writeTimeIntervalTimestampPipeline(t *testing.T) string {
+	t.Helper()
+
+	pipelineDir, err := os.MkdirTemp(".", "time-interval-timestamp-pipeline-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(pipelineDir))
+	})
+	pipelineDir, err = filepath.Abs(pipelineDir)
+	require.NoError(t, err)
+	assetsDir := filepath.Join(pipelineDir, "assets")
+	require.NoError(t, os.MkdirAll(assetsDir, 0o755))
+
+	pipelineYAML := `name: clickhouse-time-interval-timestamp-test
+default_connections:
+  clickhouse: clickhouse-default
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pipelineDir, "pipeline.yml"), []byte(pipelineYAML), 0o600))
+
+	assetSQL := `/* @bruin
+name: timestamp_incremental
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: time_interval
+  incremental_key: event_timestamp
+  time_granularity: timestamp
+columns:
+  - name: event_timestamp
+    type: timestamp
+  - name: row_id
+    type: varchar
+    primary_key: true
+  - name: amount
+    type: integer
+@bruin */
+
+SELECT
+  toDateTime(event_date) AS event_timestamp,
+  row_id,
+  amount
+FROM timestamp_seed
+WHERE event_date BETWEEN toDate('{{ start_date }}') AND toDate('{{ end_date }}')
+`
+	assetPath := filepath.Join(assetsDir, "timestamp_incremental.sql")
 	require.NoError(t, os.WriteFile(assetPath, []byte(assetSQL), 0o600))
 	return assetPath
 }

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -189,15 +189,15 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 		return nil, errors.New("time_granularity must be either 'date', or 'timestamp'")
 	}
 
-	startVar := "{{ start_timestamp | date_format('%Y-%m-%dT%H:%M:%S.%f') }}"
-	endVar := "{{ end_timestamp | date_format('%Y-%m-%dT%H:%M:%S.%f') }}"
+	startVar := "toDateTime64('{{ start_timestamp | date_format('%Y-%m-%d %H:%M:%S.%f') }}', 6)"
+	endVar := "toDateTime64('{{ end_timestamp | date_format('%Y-%m-%d %H:%M:%S.%f') }}', 6)"
 	if asset.Materialization.TimeGranularity == pipeline.MaterializationTimeGranularityDate {
-		startVar = "{{start_date}}"
-		endVar = "{{end_date}}"
+		startVar = "'{{start_date}}'"
+		endVar = "'{{end_date}}'"
 	}
 
 	queries := []string{
-		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
+		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN %s AND %s`,
 			asset.Name,
 			asset.Materialization.IncrementalKey,
 			startVar,

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -275,7 +275,7 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 			query: "SELECT ts, event_name from source_table where ts between '{{start_timestamp}}' AND '{{end_timestamp}}'",
 			want: []string{
-				"DELETE FROM my.asset WHERE ts BETWEEN '{{ start_timestamp | date_format('%Y-%m-%dT%H:%M:%S.%f') }}' AND '{{ end_timestamp | date_format('%Y-%m-%dT%H:%M:%S.%f') }}'",
+				"DELETE FROM my.asset WHERE ts BETWEEN toDateTime64('{{ start_timestamp | date_format('%Y-%m-%d %H:%M:%S.%f') }}', 6) AND toDateTime64('{{ end_timestamp | date_format('%Y-%m-%d %H:%M:%S.%f') }}', 6)",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT ts, event_name from source_table where ts between '{{start_timestamp}}' AND '{{end_timestamp}}'",
 			},
 		},

--- a/pkg/dataproc_serverless/job_test.go
+++ b/pkg/dataproc_serverless/job_test.go
@@ -57,7 +57,8 @@ func TestBuildBatchConfig_Autotuning(t *testing.T) {
 		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 	}).buildBatchConfig(ws)
 	assert.Equal(t, "my-pipeline-my-asset-staging", req.GetBatch().GetRuntimeConfig().GetCohort())
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 		req.GetBatch().GetRuntimeConfig().GetAutotuningConfig().GetScenarios(),
 	)


### PR DESCRIPTION
## What
Fix ClickHouse `time_interval` timestamp deletes by rendering parseable `DateTime64` bounds.

## Changes
- Use space-separated microsecond timestamps inside explicit `toDateTime64` expressions.
- Cover the first incremental run and an exact rerun end to end.

## How to test
1. Run `make format` and `make test`.
2. Run the ClickHouse integration suite in `integration-tests/cloud-integration-tests/clickhouse`.

## Risk & rollback
- **Risk:** Low; the change only affects ClickHouse timestamp-granularity interval bounds.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #2419
