### PR TITLE
Harden Athena table metadata queries

### DIFF
--- a/pkg/athena/db.go
+++ b/pkg/athena/db.go
@@ -230,10 +230,10 @@ func (db *DB) GetTables(ctx context.Context, databaseName string) ([]string, err
 	q := fmt.Sprintf(`
 SELECT table_name
 FROM information_schema.tables
-WHERE table_schema = '%s'
+WHERE table_schema = %s
     AND table_type IN ('BASE TABLE', 'VIEW')
 ORDER BY table_name;
-`, databaseName)
+`, quoteAthenaStringLiteral(databaseName))
 
 	result, err := db.Select(ctx, &query.Query{Query: q})
 	if err != nil {
@@ -266,9 +266,9 @@ SELECT
     data_type,
     is_nullable
 FROM information_schema.columns
-WHERE table_schema = '%s' AND table_name = '%s'
+WHERE table_schema = %s AND table_name = %s
 ORDER BY ordinal_position;
-`, databaseName, tableName)
+`, quoteAthenaStringLiteral(databaseName), quoteAthenaStringLiteral(tableName))
 
 	result, err := db.Select(ctx, &query.Query{Query: q})
 	if err != nil {
@@ -406,15 +406,23 @@ func (db *DB) BuildTableExistsQuery(tableName string) (string, error) {
 
 	infoSchema := "information_schema"
 	if tn.Catalog != "" {
-		infoSchema = tn.Catalog + ".information_schema"
+		infoSchema = quoteAthenaIdentifier(tn.Catalog) + ".information_schema"
 	}
 
 	query := fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s.tables WHERE table_schema = '%s' AND table_name = '%s'",
+		"SELECT COUNT(*) FROM %s.tables WHERE table_schema = %s AND table_name = %s",
 		infoSchema,
-		tn.Schema,
-		tn.Table,
+		quoteAthenaStringLiteral(tn.Schema),
+		quoteAthenaStringLiteral(tn.Table),
 	)
 
 	return strings.TrimSpace(query), nil
+}
+
+func quoteAthenaStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func quoteAthenaIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }

--- a/pkg/athena/db_test.go
+++ b/pkg/athena/db_test.go
@@ -157,6 +157,57 @@ func TestDB_Ping(t *testing.T) {
 	}
 }
 
+func TestDB_GetTablesEscapesDatabaseName(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(`
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'dev_o''brien'
+    AND table_type IN ('BASE TABLE', 'VIEW')
+ORDER BY table_name;
+`).WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("orders"))
+
+	db := DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+	tables, err := db.GetTables(t.Context(), "dev_o'brien")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"orders"}, tables)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDB_GetColumnsEscapesDatabaseAndTableNames(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(`
+SELECT
+    column_name,
+    data_type,
+    is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'dev_o''brien' AND table_name = 'order''s'
+ORDER BY ordinal_position;
+`).WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable"}).AddRow("id", "bigint", "NO"))
+
+	db := DB{conn: sqlx.NewDb(mockDB, "sqlmock")}
+	columns, err := db.GetColumns(t.Context(), "dev_o'brien", "order's")
+
+	require.NoError(t, err)
+	require.Len(t, columns, 1)
+	require.Equal(t, "id", columns[0].Name)
+	require.Equal(t, "bigint", columns[0].Type)
+	require.False(t, columns[0].Nullable)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDB_SelectWithSchema(t *testing.T) {
 	t.Parallel()
 
@@ -313,7 +364,28 @@ func TestDB_BuildTableExistsQuery(t *testing.T) {
 			name:      "valid catalog.database.table format",
 			db:        &DB{config: &Config{Database: "test_db"}},
 			tableName: "catalog.database.table",
-			wantQuery: "SELECT COUNT(*) FROM catalog.information_schema.tables WHERE table_schema = 'database' AND table_name = 'table'",
+			wantQuery: "SELECT COUNT(*) FROM \"catalog\".information_schema.tables WHERE table_schema = 'database' AND table_name = 'table'",
+			wantErr:   false,
+		},
+		{
+			name:      "escapes schema and table string literals",
+			db:        &DB{config: &Config{Database: "test_db"}},
+			tableName: "dev_o'brien.order's",
+			wantQuery: "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'dev_o''brien' AND table_name = 'order''s'",
+			wantErr:   false,
+		},
+		{
+			name:      "escapes default database string literal",
+			db:        &DB{config: &Config{Database: "dev_o'brien"}},
+			tableName: "orders",
+			wantQuery: "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'dev_o''brien' AND table_name = 'orders'",
+			wantErr:   false,
+		},
+		{
+			name:      "quotes and escapes catalog identifier",
+			db:        &DB{config: &Config{Database: "test_db"}},
+			tableName: `cat"alog.database.table`,
+			wantQuery: `SELECT COUNT(*) FROM "cat""alog".information_schema.tables WHERE table_schema = 'database' AND table_name = 'table'`,
 			wantErr:   false,
 		},
 		{

--- a/pkg/dataproc_serverless/job_test.go
+++ b/pkg/dataproc_serverless/job_test.go
@@ -57,7 +57,8 @@ func TestBuildBatchConfig_Autotuning(t *testing.T) {
 		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 	}).buildBatchConfig(ws)
 	assert.Equal(t, "my-pipeline-my-asset-staging", req.GetBatch().GetRuntimeConfig().GetCohort())
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 		req.GetBatch().GetRuntimeConfig().GetAutotuningConfig().GetScenarios(),
 	)

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1798,9 +1798,8 @@ func ValidateTableSensorTableParameter(ctx context.Context, p *pipeline.Pipeline
 }
 
 // validateTableNameFormat validates a table sensor's `table` parameter against
-// the platform's table-name capability (the single source of truth shared with
-// asset-name validation, see EnsureAssetNameComponentCountIsValid). It returns an
-// empty string when the name is valid.
+// the platform's table-name capability and the character policy used for asset
+// names. It returns an empty string when the name is valid.
 func validateTableNameFormat(assetType pipeline.AssetType, tableName string) string {
 	platformName := platformNames[assetType]
 
@@ -1821,6 +1820,10 @@ func validateTableNameFormat(assetType pipeline.AssetType, tableName string) str
 
 	if err := capability.CheckName(tableName); err != nil {
 		return fmt.Sprintf("%s table sensor `table` parameter must be in format %s, '%s' given", platformName, capability.FormatDesc, tableName)
+	}
+
+	if !validIDRegexCompiled.MatchString(tableName) {
+		return fmt.Sprintf("%s table sensor `table` parameter must be made of alphanumeric characters, dashes, dots and underscores, %q given", platformName, tableName)
 	}
 
 	return ""

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1798,8 +1798,8 @@ func ValidateTableSensorTableParameter(ctx context.Context, p *pipeline.Pipeline
 }
 
 // validateTableNameFormat validates a table sensor's `table` parameter against
-// the platform's table-name capability and the character policy used for asset
-// names. It returns an empty string when the name is valid.
+// the platform's table-name capability. Athena additionally uses the character
+// policy applied to asset names. It returns an empty string when the name is valid.
 func validateTableNameFormat(assetType pipeline.AssetType, tableName string) string {
 	platformName := platformNames[assetType]
 
@@ -1822,7 +1822,7 @@ func validateTableNameFormat(assetType pipeline.AssetType, tableName string) str
 		return fmt.Sprintf("%s table sensor `table` parameter must be in format %s, '%s' given", platformName, capability.FormatDesc, tableName)
 	}
 
-	if !validIDRegexCompiled.MatchString(tableName) {
+	if assetType == pipeline.AssetTypeAthenaTableSensor && !validIDRegexCompiled.MatchString(tableName) {
 		return fmt.Sprintf("%s table sensor `table` parameter must be made of alphanumeric characters, dashes, dots and underscores, %q given", platformName, tableName)
 	}
 

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -5062,6 +5062,18 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			want:    []string{},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "Athena - table parameter with quote",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeAthenaTableSensor,
+				Parameters: pipeline.ParameterMap{
+					"table": "database.events'--",
+				},
+			},
+			want:    []string{"Athena table sensor `table` parameter must be made of alphanumeric characters, dashes, dots and underscores, \"database.events'--\" given"},
+			wantErr: assert.NoError,
+		},
 
 		// PostgreSQL tests
 		{
@@ -5379,6 +5391,18 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 				},
 			},
 			want:    []string{"BigQuery table sensor `table` parameter contains empty components, '.dataset.table' given"},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Valid table name characters",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypeBigqueryTableSensor,
+				Parameters: pipeline.ParameterMap{
+					"table": "my-project.data_set.table-name",
+				},
+			},
+			want:    []string{},
 			wantErr: assert.NoError,
 		},
 	}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -5121,6 +5121,18 @@ func TestValidateTableSensorTableParameter(t *testing.T) {
 			want:    []string{},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "PostgreSQL - valid table name with space",
+			asset: &pipeline.Asset{
+				Name: "task1",
+				Type: pipeline.AssetTypePostgresTableSensor,
+				Parameters: pipeline.ParameterMap{
+					"table": "public.Order Details",
+				},
+			},
+			want:    []string{},
+			wantErr: assert.NoError,
+		},
 
 		// Redshift tests
 		{


### PR DESCRIPTION
## What
Harden Athena metadata lookups and table sensor targets.

## Changes
- Escape Athena metadata string literals and quote catalog identifiers.
- Validate Athena table sensor names with the asset-name character policy.

## How to test
1. Run `make format`.
2. Run `make test`.
3. Run `make build-no-duckdb`.

## Risk & rollback
- **Risk:** Low; valid sensor names are unchanged, while unsupported characters now fail validation.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (not affected)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, tokens, or sensitive data are committed
- [x] No new dependencies added
- [x] Security implications considered and addressed

## Related issues
Closes #2426
