### PR TITLE
fix generic connection credential masking

### DIFF
--- a/.agents/skills/record-vhs-demo/SKILL.md
+++ b/.agents/skills/record-vhs-demo/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: record-vhs-demo
+description: Create, update, render, and visually verify polished Bruin CLI terminal demos with VHS. Use when recording a terminal walkthrough, adding or editing a .tape file, exporting a demo video or GIF, improving terminal-demo styling or readability, or reproducing a Bruin command sequence for documentation or social media.
+---
+
+# Record VHS Demo
+
+Create concise, deterministic terminal recordings whose source remains reusable in the repository.
+
+## Repository layout
+
+- Store every canonical `.tape` file under `<repo>/resources/`, using a descriptive kebab-case name.
+- Store stable demo fixtures under `<repo>/resources/<demo-name>/` when the tape needs them.
+- Store generated videos, GIFs, screenshots, and contact sheets under `<repo>/.context/vhs-demos/` unless the user explicitly requests a tracked documentation asset.
+- Confirm `.context/` is ignored with `git check-ignore`. If it is not, add `.context/` to the repository's local `.git/info/exclude`; do not add generated demo artifacts to the tracked `.gitignore` merely for a recording.
+- Never put real credentials, tokens, personal paths, or production data in a tape or fixture. Use unmistakably fake values.
+
+## Workflow
+
+1. Confirm the short story the recording should tell. Show only commands and output that support it.
+2. Validate the underlying Bruin behavior outside VHS before recording it.
+3. Build the appropriate binary:
+   - Prefer `make build-no-duckdb` and `bin/bruin-no-duckdb` for demos that do not need DuckDB.
+   - Use `make build` and `bin/bruin` when the demo needs DuckDB.
+4. Create or edit the canonical tape under `resources/`. Put any reproducible fixtures beside it under a demo-specific directory.
+5. Render from the tape's directory with the bundled script:
+
+   ```bash
+   python3 .agents/skills/record-vhs-demo/scripts/render_demo.py resources/<demo-name>.tape
+   ```
+
+6. Inspect the generated contact sheet with an image-viewing tool. Extract and inspect a full-resolution frame when text color, masking, alignment, or spacing needs closer review.
+7. Iterate until the recording has no command failures, accidental secrets, unreadable ANSI colors, clipped lines, excessive dead time, or irrelevant output.
+
+## Visual defaults
+
+Start with these settings unless the user asks for a different format:
+
+```text
+Set Shell bash
+Set FontSize 20
+Set Width 1280
+Set Height 720
+Set Margin 0
+Set Padding 28
+Set LineHeight 1.15
+Set TypingSpeed 30ms
+Set Framerate 30
+Set CursorBlink false
+Set Theme "GitHub Dark"
+```
+
+- Use a plain dark terminal canvas without a window frame, title bar, or outer margin.
+- Keep internal padding so text does not touch the video edge.
+- Prefer Bash for predictable prompts and hidden setup.
+- Use a leading newline in `PS1` to add space between prompt blocks without changing regular output line spacing:
+
+  ```bash
+  export PS1="$(tput setaf 6)\n❯$(tput sgr0) "
+  ```
+
+- In the hidden setup, run `unset NO_COLOR`, set `TERM=xterm-256color`, and set `CLICOLOR=1`. The agent environment may otherwise suppress Bruin's ANSI output.
+- Do not add `--no-color` to a demo command.
+- For a one-asset Bruin demo, make worker coloring deterministic by wrapping the binary with `--workers 1` during hidden setup. This avoids a random worker selecting an unreadable ANSI color while keeping the visible command clean.
+- Hide setup commands, paths, fixture preparation, aliases/functions, and terminal clearing.
+- Do not show `--help`, installation steps, decorative titles, or commentary that delays the feature demonstration unless requested.
+- Use `--no-validation`, `--no-timestamp`, or `--minimal-logs` only when they remove irrelevant output without hiding the behavior being demonstrated.
+- Add short sleeps after meaningful output, not after every command. Keep social clips compact.
+
+## Reliable tape setup
+
+- Run tapes from their own directory. Resolve repository files from `git rev-parse --show-toplevel`, not fragile multi-level relative aliases.
+- Use `mktemp -d` for disposable working fixtures. Copy tracked examples into the temporary directory during hidden setup.
+- Create the `Output` directory before rendering. The bundled script does this automatically.
+- Keep the visible commands representative of what a user would actually type.
+
+## Verification bar
+
+Do not call a demo complete until all of the following are true:
+
+- `vhs validate` passes.
+- VHS exits successfully and produces a non-empty artifact.
+- VHS reports no internal `error:` line; some versions can emit a partial video after an EOF error while still exiting with status 0.
+- `ffprobe` reports a valid duration.
+- The contact sheet has been visually inspected.
+- A full-resolution output frame is inspected when color or text readability matters.
+- Every command in the recording succeeds.
+- Expected values are visible and any credentials are masked.
+- Prompt spacing affects prompt blocks only, not ordinary output lines.
+- ANSI colors have sufficient contrast on the selected dark theme.
+
+The renderer reports the artifact and QA image paths; include the final artifact path in the handoff.

--- a/.agents/skills/record-vhs-demo/agents/openai.yaml
+++ b/.agents/skills/record-vhs-demo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Record VHS Demo"
+  short_description: "Record polished Bruin terminal demos"
+  default_prompt: "Use $record-vhs-demo to record and visually verify a polished Bruin terminal demo."

--- a/.agents/skills/record-vhs-demo/scripts/render_demo.py
+++ b/.agents/skills/record-vhs-demo/scripts/render_demo.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Validate, render, probe, and create a contact sheet for a VHS demo tape."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+MEDIA_SUFFIXES = {".gif", ".mp4", ".webm"}
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run(command: list[str], *, cwd: Path) -> None:
+    print("+ " + shlex.join(command))
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def run_captured(command: list[str], *, cwd: Path) -> str:
+    print("+ " + shlex.join(command))
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    if result.returncode != 0:
+        fail(f"command exited with status {result.returncode}: {shlex.join(command)}")
+    return result.stdout + result.stderr
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip()).resolve()
+
+
+def tape_outputs(tape: Path) -> list[str]:
+    outputs: list[str] = []
+    for line_number, raw_line in enumerate(tape.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(line)
+        except ValueError as exc:
+            fail(f"cannot parse {tape}:{line_number}: {exc}")
+        if parts and parts[0] == "Output":
+            if len(parts) != 2:
+                fail(f"expected one Output path at {tape}:{line_number}")
+            outputs.append(parts[1])
+    if not outputs:
+        fail(f"{tape} has no Output directive")
+    return outputs
+
+
+def require_tools() -> None:
+    missing = [
+        name for name in ("vhs", "ffmpeg", "ffprobe") if shutil.which(name) is None
+    ]
+    if missing:
+        fail("missing required tools: " + ", ".join(missing))
+
+
+def require_ignored_context(repo_root: Path) -> None:
+    probe = ".context/vhs-demos/.ignore-probe"
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", probe],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        fail(
+            ".context/ is not ignored; add '.context/' to the repository's "
+            "local .git/info/exclude before rendering"
+        )
+
+
+def probe(media: Path) -> tuple[float, int]:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration,size",
+            "-of",
+            "json",
+            str(media),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(result.stdout)["format"]
+    duration = float(data["duration"])
+    size = int(data["size"])
+    if duration <= 0 or size <= 0:
+        fail(f"invalid rendered artifact: {media}")
+    return duration, size
+
+
+def contact_sheet(media: Path, destination: Path, duration: float) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    frames_per_second = 6 / duration
+    run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-i",
+            str(media),
+            "-vf",
+            f"fps={frames_per_second:.8f},scale=640:-1,tile=3x2",
+            "-frames:v",
+            "1",
+            str(destination),
+        ],
+        cwd=media.parent,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "tape", type=Path, help="tape stored under the repository resources directory"
+    )
+    args = parser.parse_args()
+
+    require_tools()
+    repo_root = repository_root()
+    require_ignored_context(repo_root)
+    resources_root = (repo_root / "resources").resolve()
+    tape = args.tape.resolve()
+
+    try:
+        tape.relative_to(resources_root)
+    except ValueError:
+        fail(f"canonical tapes must live under {resources_root}")
+    if tape.suffix != ".tape" or not tape.is_file():
+        fail(f"not a VHS tape file: {tape}")
+
+    output_values = tape_outputs(tape)
+    output_paths = [(tape.parent / value).resolve() for value in output_values]
+    for output in output_paths:
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+    run(["vhs", "validate", tape.name], cwd=tape.parent)
+    render_log = run_captured(["vhs", tape.name], cwd=tape.parent)
+    if any(line.lower().startswith("error:") for line in render_log.splitlines()):
+        fail("VHS reported an internal error and may have produced a partial artifact")
+
+    media_paths = [
+        path for path in output_paths if path.suffix.lower() in MEDIA_SUFFIXES
+    ]
+    if not media_paths:
+        fail("the tape has no GIF, MP4, or WebM output to inspect")
+
+    qa_root = repo_root / ".context" / "vhs-demos" / "qa"
+    for media in media_paths:
+        if not media.is_file():
+            fail(f"VHS did not create expected output: {media}")
+        duration, size = probe(media)
+        qa_path = qa_root / f"{tape.stem}-{media.stem}-contact-sheet.png"
+        contact_sheet(media, qa_path, duration)
+        print(f"artifact: {media}")
+        print(f"duration: {duration:.2f}s")
+        print(f"size: {size} bytes")
+        print(f"qa: {qa_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1060,7 +1060,7 @@ func (c ApplovinMaxConnection) GetName() string {
 
 type GenericConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
-	Value              string `yaml:"value,omitempty" json:"value" mapstructure:"value"`
+	Value              string `yaml:"value,omitempty" json:"value" mapstructure:"value" sensitive:"true"`
 }
 
 func (c GenericConnection) MarshalJSON() ([]byte, error) {

--- a/pkg/config/connections_sensitive_test.go
+++ b/pkg/config/connections_sensitive_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -43,7 +46,7 @@ func TestIcebergConnectionSecretsAreMasked(t *testing.T) {
 
 // secretNamePattern flags credential-looking field names. A match MUST carry
 // `sensitive:"true"` or be listed in safeNonSecretKeys, else the test fails.
-var secretNamePattern = regexp.MustCompile(`(?i)(password|secret|token|api[_]?key|access[_]?key|private[_]?key|account[_]?key|credential|passphrase|auth|grant_key|key_base64|service_account_json|^key$)`)
+var secretNamePattern = regexp.MustCompile(`(?i)(password|secret|token|api[_]?key|access[_]?key|private[_]?key|account[_]?key|credential|passphrase|auth|grant_key|key_base64|service_account_json|^dsn$|^key$|^uri$|^value$)`)
 
 // safeNonSecretKeys are fields whose names look secret-ish but hold
 // identifiers, file paths, or booleans — not credential values.
@@ -64,11 +67,49 @@ var safeNonSecretKeys = map[string]bool{
 
 func TestConnectionSensitiveTagsComplete(t *testing.T) {
 	t.Parallel()
-	visited := map[reflect.Type]bool{}
 	connsType := reflect.TypeOf(Connections{})
 	for i := range connsType.NumField() {
-		checkSensitiveTags(t, unwrapToStruct(connsType.Field(i).Type), visited)
+		field := connsType.Field(i)
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+		t.Run(connectionFieldName(field), func(t *testing.T) {
+			t.Parallel()
+			checkSensitiveTags(t, unwrapToStruct(field.Type), map[reflect.Type]bool{})
+		})
 	}
+}
+
+// TestConnectionSensitiveValuesAreCollected exercises every registered connection
+// independently. Each tagged inline value and credential-file content must reach
+// the masker; this catches collector regressions in nested connection structs.
+func TestConnectionSensitiveValuesAreCollected(t *testing.T) {
+	t.Parallel()
+	connsType := reflect.TypeOf(Connections{})
+	for i := range connsType.NumField() {
+		field := connsType.Field(i)
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+		t.Run(connectionFieldName(field), func(t *testing.T) {
+			t.Parallel()
+			conn := reflect.New(unwrapToStruct(field.Type))
+			expected := make([]string, 0)
+			setSensitiveTestValues(t, conn.Elem(), conn.Elem().Type().Name(), &expected)
+
+			actual, unreadable := mask.SensitiveValues(conn.Interface())
+			assert.Empty(t, unreadable)
+			assert.ElementsMatch(t, expected, actual)
+		})
+	}
+}
+
+func connectionFieldName(field reflect.StructField) string {
+	name, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+	if name != "" {
+		return name
+	}
+	return field.Name
 }
 
 // unwrapToStruct peels slice/array/pointer/map layers to reach the element type.
@@ -93,6 +134,11 @@ func checkSensitiveTags(t *testing.T, st reflect.Type, visited map[reflect.Type]
 		if !f.IsExported() {
 			continue
 		}
+		for _, tag := range []string{"sensitive", "sensitive_file"} {
+			if value := f.Tag.Get(tag); value != "" && value != "true" {
+				t.Errorf("%s.%s has invalid `%s:%q`; the only supported value is true", st.Name(), f.Name, tag, value)
+			}
+		}
 		if inner := unwrapToStruct(f.Type); inner.Kind() == reflect.Struct {
 			checkSensitiveTags(t, inner, visited)
 			continue
@@ -114,6 +160,54 @@ func checkSensitiveTags(t *testing.T, st reflect.Type, visited map[reflect.Type]
 			t.Errorf("%s.%s (key=%q) looks like a credential but is not tagged `sensitive:\"true\"`.\n"+
 				"Add the tag, or if it is NOT a secret add %q to safeNonSecretKeys.",
 				st.Name(), f.Name, key, key)
+		}
+	}
+}
+
+func setSensitiveTestValues(t *testing.T, value reflect.Value, path string, expected *[]string) {
+	t.Helper()
+	typeOfValue := value.Type()
+	for i := range typeOfValue.NumField() {
+		field := typeOfValue.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		fieldValue := value.Field(i)
+		fieldPath := path + "." + field.Name
+		if fieldValue.Kind() == reflect.String {
+			isInline := field.Tag.Get("sensitive") == "true"
+			isFile := field.Tag.Get("sensitive_file") == "true"
+			if isInline && isFile {
+				t.Errorf("%s cannot be both sensitive and sensitive_file", fieldPath)
+				continue
+			}
+			switch {
+			case isInline:
+				secret := "inline-secret::" + fieldPath
+				fieldValue.SetString(secret)
+				*expected = append(*expected, secret)
+			case isFile:
+				secret := "file-secret::" + fieldPath
+				filePath := filepath.Join(t.TempDir(), fmt.Sprintf("credential-%d", i))
+				if err := os.WriteFile(filePath, []byte(secret), 0o600); err != nil {
+					t.Fatalf("write credential fixture for %s: %v", fieldPath, err)
+				}
+				fieldValue.SetString(filePath)
+				*expected = append(*expected, secret)
+			}
+			continue
+		}
+
+		switch fieldValue.Kind() { //nolint:exhaustive // only nested config structs can contain sensitive tags
+		case reflect.Struct:
+			if fieldValue.Type().PkgPath() == typeOfValue.PkgPath() {
+				setSensitiveTestValues(t, fieldValue, fieldPath, expected)
+			}
+		case reflect.Pointer:
+			if fieldValue.Type().Elem().Kind() == reflect.Struct && fieldValue.Type().Elem().PkgPath() == typeOfValue.PkgPath() {
+				fieldValue.Set(reflect.New(fieldValue.Type().Elem()))
+				setSensitiveTestValues(t, fieldValue.Elem(), fieldPath, expected)
+			}
 		}
 	}
 }

--- a/resources/credential-masking-demo/bruin.yml
+++ b/resources/credential-masking-demo/bruin.yml
@@ -1,0 +1,8 @@
+default_environment: default
+
+environments:
+  default:
+    connections:
+      generic:
+        - name: demo-api
+          value: "sk_demo_social_7K9m+Q2pX="

--- a/resources/credential-masking-demo/pipeline/assets/show_secret.py
+++ b/resources/credential-masking-demo/pipeline/assets/show_secret.py
@@ -1,0 +1,20 @@
+"""@bruin
+
+name: show_secret
+
+secrets:
+  - key: demo-api
+    inject_as: DEMO_API_TOKEN
+
+@bruin"""
+
+import base64
+import os
+import urllib.parse
+
+
+token = os.environ["DEMO_API_TOKEN"]
+
+print(f"raw token:     {token}")
+print(f"URL-encoded:   {urllib.parse.quote(token)}")
+print(f"base64 token:  {base64.b64encode(token.encode()).decode()}")

--- a/resources/credential-masking-demo/pipeline/pipeline.yml
+++ b/resources/credential-masking-demo/pipeline/pipeline.yml
@@ -1,0 +1,1 @@
+name: credential-masking-demo

--- a/resources/credential-masking.tape
+++ b/resources/credential-masking.tape
@@ -1,0 +1,29 @@
+Output ../.context/vhs-demos/credential-masking/bruin-credential-masking.mp4
+
+Require rg
+
+Set Shell bash
+Set FontSize 20
+Set Width 1280
+Set Height 720
+Set Margin 0
+Set Padding 28
+Set LineHeight 1.15
+Set TypingSpeed 30ms
+Set Framerate 30
+Set CursorBlink false
+Set Theme "GitHub Dark"
+
+Hide
+Type 'repo_root="$(git rev-parse --show-toplevel)"; demo_root="$(mktemp -d "${TMPDIR:-/tmp}/bruin-vhs-credential.XXXXXX")"; cp -R "$repo_root/resources/credential-masking-demo/." "$demo_root"; mv "$demo_root/bruin.yml" "$demo_root/.bruin.yml"; git -C "$demo_root" init -q; cd "$demo_root"; unset NO_COLOR; export TERM=xterm-256color; export CLICOLOR=1; export PS1="$(tput setaf 6)\n❯$(tput sgr0) "; export BRUIN_CONFIG_FILE=.bruin.yml; bruin() { "$repo_root/bin/bruin-no-duckdb" "$@" --workers 1; }; shopt -s interactive_comments; clear'
+Enter
+Show
+Type "# A demo token is stored as a generic Bruin secret"
+Enter
+Type "rg 'value:' .bruin.yml"
+Enter
+Sleep 2s
+
+Type "bruin run pipeline --no-validation --no-timestamp --minimal-logs"
+Enter
+Sleep 8s


### PR DESCRIPTION
## What

Masks generic connection values and adds exhaustive per-connection regression coverage.

## Changes

- Marked `GenericConnection.Value` as sensitive.
- Validated sensitive tags and collected values separately across all 141 registered connection types.

## How to test

1. `make format`
2. `make test`
3. `make build-no-duckdb`

## Risk & rollback

- **Risk:** Low; the runtime change only adds an existing masking tag.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`) — not affected
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

None.
