### PR TITLE
docs(salesforce): note field-level security controls which fields are ingested

### DIFF
--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -22,7 +22,8 @@ Use a Salesforce user that has:
 - Permission to log in through API/SOAP if using username/password/security-token auth
 - **Read** field-level security (FLS) on every field you want to ingest
 
-Salesforce only exposes fields the connecting user is allowed to read. Any field the user lacks Read FLS on is silently omitted from ingestion and arrives empty (NULL) in the destination, even if it holds data in Salesforce. Grant Read access via the user's profile or a permission set.
+> [!WARNING]
+> ingestr only ingests the fields the connecting user is permitted to read. If a field you expect is missing, make sure the user has Read access to it (via its profile or a permission set) — otherwise Salesforce won't return it and it stays empty in the destination.
 
 Common Salesforce objects include:
 
@@ -255,10 +256,10 @@ Fix one of the following:
 
 Individual fields come through empty even though they have data in Salesforce, and the run reports no error.
 
-This is field-level security (FLS). Salesforce builds the query from the fields the connecting user can read and omits the rest, so ingestr never fetches them.
+ingestr only fetches the fields the connecting user is permitted to read (its query is built from what Salesforce returns for that user). A common reason a field is skipped is that the user lacks Read access to it, for example due to field-level security (FLS).
 
-Fix:
+To ingest a field that's coming through empty:
 
-- Grant the Salesforce user **Read** access to those fields, via its profile or an assigned permission set.
-- Confirm what the user can see by describing the object as that user (e.g. `GET /services/data/v59.0/sobjects/<object>/describe`) — only the listed fields are ingested.
+- Make sure the Salesforce user has **Read** access to it, via its profile or an assigned permission set.
+- You can check which fields the user can see by describing the object as that user (e.g. `GET /services/data/v59.0/sobjects/<object>/describe`) — only the listed fields are ingested.
 - Re-run the asset.

--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -23,7 +23,7 @@ Use a Salesforce user that has:
 - **Read** field-level security (FLS) on every field you want to ingest
 
 > [!WARNING]
-> ingestr only ingests the fields the connecting user is permitted to read. If a field you expect is missing, make sure the user has Read access to it (via its profile or a permission set) — otherwise Salesforce won't return it and it stays empty in the destination.
+> ingestr only ingests the fields the connecting user is permitted to read. If you want a field to be ingested, make sure the user has Read access to it, through its profile or a permission set. If the user does not have permission to a field, Salesforce does not return it and ingestr does not fetch it.
 
 Common Salesforce objects include:
 
@@ -252,14 +252,14 @@ Fix one of the following:
 - Rename the Bruin Cloud connection to match the asset.
 - Or update the asset to reference the Bruin Cloud connection name.
 
-### Some fields ingest as empty (NULL)
+### Some fields are not ingested
 
-Individual fields come through empty even though they have data in Salesforce, and the run reports no error.
+A field is not ingested even though it has data in Salesforce, and the run reports no error.
 
 ingestr only fetches the fields the connecting user is permitted to read (its query is built from what Salesforce returns for that user). A common reason a field is skipped is that the user lacks Read access to it, for example due to field-level security (FLS).
 
-To ingest a field that's coming through empty:
+To ingest a field that is missing:
 
-- Make sure the Salesforce user has **Read** access to it, via its profile or an assigned permission set.
-- You can check which fields the user can see by describing the object as that user (e.g. `GET /services/data/v59.0/sobjects/<object>/describe`) — only the listed fields are ingested.
-- Re-run the asset.
+- Make sure the Salesforce user has **Read** access to it, through its profile or an assigned permission set.
+- You can check which fields the user can see by describing the object as that user (for example `GET /services/data/v59.0/sobjects/<object>/describe`). Only the fields listed in the response are ingested.
+- Run the asset again.

--- a/docs/ingestion/salesforce.md
+++ b/docs/ingestion/salesforce.md
@@ -20,6 +20,9 @@ Use a Salesforce user that has:
 - API access
 - Access to the Salesforce objects you want to ingest
 - Permission to log in through API/SOAP if using username/password/security-token auth
+- **Read** field-level security (FLS) on every field you want to ingest
+
+Salesforce only exposes fields the connecting user is allowed to read. Any field the user lacks Read FLS on is silently omitted from ingestion and arrives empty (NULL) in the destination, even if it holds data in Salesforce. Grant Read access via the user's profile or a permission set.
 
 Common Salesforce objects include:
 
@@ -247,3 +250,15 @@ Fix one of the following:
 
 - Rename the Bruin Cloud connection to match the asset.
 - Or update the asset to reference the Bruin Cloud connection name.
+
+### Some fields ingest as empty (NULL)
+
+Individual fields come through empty even though they have data in Salesforce, and the run reports no error.
+
+This is field-level security (FLS). Salesforce builds the query from the fields the connecting user can read and omits the rest, so ingestr never fetches them.
+
+Fix:
+
+- Grant the Salesforce user **Read** access to those fields, via its profile or an assigned permission set.
+- Confirm what the user can see by describing the object as that user (e.g. `GET /services/data/v59.0/sobjects/<object>/describe`) — only the listed fields are ingested.
+- Re-run the asset.


### PR DESCRIPTION
## What

Documents that Salesforce field-level security (FLS) determines which fields get ingested. Adds a bullet + note to **Step 1 (Confirm Salesforce user access)** and a new **Troubleshooting** entry ("Some fields ingest as empty (NULL)").

## Why

A Salesforce custom-object load returned several columns fully empty (NULL) with no error, even though the fields held data. Root cause: the connecting user lacked **Read** FLS on those fields, so Salesforce omitted them from the `describe` response and ingestr never queried them.

This is Salesforce-side behavior, but it's silent and easily mistaken for a fetch bug. The docs now explain it and show how to confirm (describe as the connecting user) and fix (grant Read FLS + re-run).

## Notes

Docs-only change. Companion PR on the ingestr repo adds the same note to the ingestr Salesforce source docs (bruin-data/ingestr#1011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)