### PR TITLE
docs(cloud-mcp): Claude custom connector (OAuth) + tool inventory

### DIFF
--- a/docs/cloud/mcp-setup.md
+++ b/docs/cloud/mcp-setup.md
@@ -116,7 +116,7 @@ Once the Bruin Cloud MCP server is connected, you can ask in natural language, f
 
 ### Available tools
 
-Read-only tools only query data; write tools change state (trigger runs, mark statuses, manage connections) and are annotated as destructive so your assistant asks before calling them.
+Read-only tools only query data; write tools change state (trigger runs, mark statuses, manage connections) and are annotated as destructive so compatible assistants can apply additional safeguards before calling them.
 
 | Tool | Access | Purpose |
 | --- | --- | --- |

--- a/docs/cloud/mcp-setup.md
+++ b/docs/cloud/mcp-setup.md
@@ -1,6 +1,6 @@
 # Cloud MCP
 
-This guide shows how to connect **Cursor**, **Claude Code** and **Codex** to the **Bruin Cloud MCP** so your AI assistant can securely call Bruin Cloud tools (for example: listing pipelines, inspecting runs, or triggering actions) directly from chat.
+This guide shows how to connect **Claude** (Desktop & Web), **Cursor**, **Claude Code** and **Codex** to the **Bruin Cloud MCP** so your AI assistant can securely call Bruin Cloud tools (for example: listing pipelines, inspecting runs, or triggering actions) directly from chat.
 
 Bruin Cloud MCP is optional. The Bruin CLI already supports Cloud operations through [`bruin cloud`](/commands/cloud), which is usually the right interface when an assistant has shell access and a configured API key or `.bruin.yml`. Use Bruin Cloud MCP when your assistant is set up for MCP tool calls, when you want structured Cloud tools available directly in chat, or when the assistant should not shell out to the local CLI.
 
@@ -64,6 +64,22 @@ claude mcp remove bruin_cloud
 Inside Claude Code, type **`/mcp`** to see MCP status and connected servers.
 
 
+## Claude (Desktop & Web)
+
+The Claude Desktop and Web apps connect to Bruin Cloud as a **custom connector** over OAuth — you sign in to Bruin Cloud and approve access, so there is **no API token to create or paste** (you can skip the token step above).
+
+1. In Claude, open **Settings → Connectors → Add custom connector**.
+2. For **Remote MCP server URL**, enter:
+
+   `https://cloud.getbruin.com/mcp`
+
+3. Leave **Advanced settings** (OAuth Client ID / Secret) empty — Claude registers itself automatically.
+4. Click **Add**. Claude opens a Bruin Cloud sign-in page.
+5. Sign in, choose which **team** to connect, and approve.
+
+Claude returns to the connectors list showing **Connected**, and the Bruin Cloud tools become available in chat. The connection is scoped to the team you selected and carries the same `mcp:token` ability as a static token; access tokens are short-lived and refresh automatically.
+
+
 ## Codex CLI
 
 Edit your Codex configuration file at `~/.codex/config.toml`:
@@ -98,6 +114,31 @@ Once the Bruin Cloud MCP server is connected, you can ask in natural language, f
 - "Create a new generic connection called my-secret with value X."
 - "Delete the connection named my-secret."
 
+### Available tools
+
+Read-only tools only query data; write tools change state (trigger runs, mark statuses, manage connections) and are annotated as destructive so your assistant asks before calling them.
+
+| Tool | Access | Purpose |
+| --- | --- | --- |
+| `pipeline-list` | read | List pipelines, or fetch one pipeline's details. |
+| `pipeline-run-list` | read | List pipeline runs, or fetch one run's details. |
+| `asset-list` | read | List assets, or fetch one asset's details and dependencies. |
+| `asset-instance-list` | read | List asset instances (per-asset status) within a run. |
+| `asset-instance-logs` | read | Fetch execution logs for a step of an asset instance. |
+| `asset-runs` | read | Show run history for an asset. |
+| `connection-list` | read | List connections (metadata only — never secret values). |
+| `validation-error-list` | read | List pipeline validation errors. |
+| `pipeline-trigger` | write | Trigger a new pipeline run. |
+| `pipeline-rerun` | write | Rerun an existing pipeline run. |
+| `pipeline-toggle` | write | Enable or disable (pause/resume) a pipeline. |
+| `asset-rerun` | write | Rerun a single asset. |
+| `backfill-trigger` | write | Trigger a backfill over a date range. |
+| `mark-pipeline-run` | write | Mark a pipeline run's status. |
+| `mark-asset-run` | write | Mark an asset run's status. |
+| `mark-external-dependency` | write | Mark an external dependency's status. |
+| `connection-create` | write | Create a connection. |
+| `connection-delete` | write | Delete a connection. |
+
 
 ## Troubleshooting
 
@@ -106,6 +147,7 @@ Once the Bruin Cloud MCP server is connected, you can ask in natural language, f
 - **Cursor, tools not showing:** Ensure `.cursor/mcp.json` is valid JSON and restart Cursor.
 - **Claude Code, server not found:** Run `claude mcp list` to confirm the server is configured; use `claude mcp get bruin_cloud` to check its URL and headers.
 - **Codex CLI, tools not available:** Ensure `~/.codex/config.toml` is valid toml and restart Codex CLI.
+- **Claude custom connector, stuck or "disconnected":** Re-run **Add custom connector**, sign in to Bruin Cloud, and make sure you approve access for a team you belong to. Leave the OAuth Client ID/Secret fields empty.
 
 ## Related
 


### PR DESCRIPTION
The Cloud MCP page only documented static-token setup for Cursor / Claude Code / Codex. It did not cover connecting Bruin Cloud as a **claude.ai custom connector** (the OAuth flow), which is the path used for Claude Desktop/Web and for the Anthropic connector directory. It also lacked an explicit tool inventory.

This adds:
- A **Claude (Desktop & Web)** section for the OAuth custom-connector flow (paste `https://cloud.getbruin.com/mcp`, leave Advanced settings empty, sign in, pick a team) — no API token to create/paste.
- An **Available tools** table listing all 18 tools labelled read vs write (matches the `readOnlyHint`/`destructiveHint` annotations the server now returns).
- A troubleshooting note for the connector path.

Supports the Claude connector directory submission (docs must cover usage + which tools read/write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)