### PR TITLE
fix ClickHouse merge failure handling

### DIFF
--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -285,11 +285,16 @@ ORDER BY average_rating DESC;
 ClickHouse has no `MERGE INTO` statement, so Bruin implements the `merge` strategy with a delete+insert pattern keyed on the asset's primary key column(s):
 
 - the query result is staged in a temporary table
+- an empty insert validates the staged result against the target table before any target rows are deleted
 - rows in the target whose primary key matches a staged row are deleted
 - the staged rows are inserted into the target
 - the temporary table is dropped
 
 This upserts rows by primary key: existing rows are replaced and new rows are added, while untouched rows remain. The optional `incremental_predicate` is appended to the delete condition to scope which target rows are considered for replacement.
+
+The compatibility check catches errors such as a different number of staged and target columns before the delete. If a later statement fails, Bruin makes a best-effort attempt to drop the per-run staging table. The merge still consists of independent ClickHouse statements rather than a transaction, so an operational failure during the real insert can leave the matching target rows deleted; fix the failure and rerun the asset to restore them.
+
+Unlike merge implementations that expose `source` and `target` aliases, ClickHouse's `DELETE` statement has no target alias. A ClickHouse `incremental_predicate` must therefore reference target columns without qualification, for example `event_date >= toDate('2026-07-01')` rather than `target.event_date >= toDate('2026-07-01')`.
 
 Merge assets must declare `columns` and at least one `primary_key` column. Composite primary keys are supported. On a full refresh, Bruin falls back to `create+replace` (creating the table from the query result) so the target exists for subsequent incremental merges.
 

--- a/integration-tests/cloud-integration-tests/clickhouse/merge_test.go
+++ b/integration-tests/cloud-integration-tests/clickhouse/merge_test.go
@@ -3,6 +3,7 @@ package clickhouse_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -202,6 +203,134 @@ FROM merge_fr_seed
 		{"row_2", int32(200)},
 		{"row_4", int32(400)},
 	}, rows)
+}
+
+// TestMergeInsertFailurePreservesTargetAndCleansUpStaging protects the
+// failure path of merge materialization. A staged query whose shape does not
+// match the target must fail before matching target rows are deleted, and the
+// staging table must be removed even though the run failed.
+func TestMergeInsertFailurePreservesTargetAndCleansUpStaging(t *testing.T) {
+	host, port := startClickHouse(t)
+	configPath := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_failure_target (row_id String, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_failure_seed (row_id String, amount Int32, unexpected String) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_failure_target VALUES ('row_1', 10), ('row_2', 20)",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_failure_seed VALUES ('row_1', 100, 'extra')",
+	)
+
+	assetPath := writeMergePipeline(t, "clickhouse-merge-failure-test", `/* @bruin
+name: merge_failure_target
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: merge
+columns:
+  - name: row_id
+    type: String
+    primary_key: true
+  - name: amount
+    type: Int32
+@bruin */
+
+SELECT row_id, amount, unexpected
+FROM merge_failure_seed
+`)
+
+	output := runBruinExpectFailure(t, binary, configPath, "run", assetPath)
+	require.Contains(t, output, "Number of columns doesn't match")
+
+	client := newClient(t, host, port)
+	rows, err := client.Select(t.Context(), &query.Query{
+		Query: "SELECT row_id, amount FROM merge_failure_target ORDER BY row_id",
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{
+		{"row_1", int32(10)},
+		{"row_2", int32(20)},
+	}, rows)
+
+	requireNoMergeStagingTables(t, client)
+}
+
+// TestMergeDeleteFailureCleansUpStaging verifies that a failure after staging
+// creation still removes the per-run staging table. ClickHouse DELETE does not
+// expose the target alias used by other merge implementations, so a qualified
+// incremental predicate deliberately exercises this path.
+func TestMergeDeleteFailureCleansUpStaging(t *testing.T) {
+	host, port := startClickHouse(t)
+	configPath := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_predicate_target (row_id String, event_date Date, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"CREATE TABLE merge_predicate_seed (row_id String, event_date Date, amount Int32) ENGINE = MergeTree ORDER BY row_id",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_predicate_target VALUES ('row_1', toDate('2026-07-20'), 10)",
+	)
+	runBruinQuery(t, binary, configPath,
+		"INSERT INTO merge_predicate_seed VALUES ('row_1', toDate('2026-07-20'), 100)",
+	)
+
+	assetPath := writeMergePipeline(t, "clickhouse-merge-predicate-failure-test", `/* @bruin
+name: merge_predicate_target
+type: clickhouse.sql
+materialization:
+  type: table
+  strategy: merge
+  incremental_predicate: target.event_date >= toDate('2026-07-01')
+columns:
+  - name: row_id
+    type: String
+    primary_key: true
+  - name: event_date
+    type: Date
+  - name: amount
+    type: Int32
+@bruin */
+
+SELECT row_id, event_date, amount
+FROM merge_predicate_seed
+`)
+
+	output := runBruinExpectFailure(t, binary, configPath, "run", assetPath)
+	require.Contains(t, output, "target.event_date")
+
+	client := newClient(t, host, port)
+	requireNoMergeStagingTables(t, client)
+}
+
+func requireNoMergeStagingTables(t *testing.T, client *clickhouse.Client) {
+	t.Helper()
+
+	rows, err := client.Select(t.Context(), &query.Query{
+		Query: "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE '__bruin_tmp_%'",
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]interface{}{{uint64(0)}}, rows)
+}
+
+func runBruinExpectFailure(t *testing.T, binary, configPath string, args ...string) string {
+	t.Helper()
+
+	commandArgs := []string{args[0], "--config-file", configPath}
+	commandArgs = append(commandArgs, args[1:]...)
+	cmd := exec.CommandContext(t.Context(), binary, commandArgs...)
+	cmd.Env = append(os.Environ(), "DISABLE_TELEMETRY=true", "INGESTR_DISABLE_TELEMETRY=true")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "bruin %s unexpectedly succeeded:\n%s", commandArgs[0], output)
+	return string(output)
 }
 
 func newClient(t *testing.T, host string, port int) *clickhouse.Client {

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -136,8 +136,11 @@ func buildMergeQuery(task *pipeline.Asset, query string) ([]string, error) {
 		deleteCondition += " AND (" + pred + ")"
 	}
 
+	// Validate that ClickHouse can plan an insert from the staged schema before
+	// deleting target rows. LIMIT 0 performs no write and avoids deduplication.
 	queries := []string{
 		fmt.Sprintf("CREATE TABLE %s ENGINE = MergeTree() PRIMARY KEY (%s) AS %s", tempTableName, keys, query),
+		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s LIMIT 0", task.Name, tempTableName),
 		fmt.Sprintf("DELETE FROM %s WHERE %s", task.Name, deleteCondition),
 		fmt.Sprintf("INSERT INTO %s SETTINGS insert_deduplicate = 0 SELECT * FROM %s", task.Name, tempTableName),
 		"DROP TABLE IF EXISTS " + tempTableName,

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -200,6 +200,7 @@ func TestMaterializer_Render(t *testing.T) {
 			query: "SELECT 1 as id, 'a' as name",
 			want: []string{
 				"CREATE TABLE my.__bruin_tmp_abcefghi ENGINE = MergeTree() PRIMARY KEY (id) AS SELECT 1 as id, 'a' as name",
+				"INSERT INTO my.asset SELECT * FROM my.__bruin_tmp_abcefghi LIMIT 0",
 				"DELETE FROM my.asset WHERE id IN (SELECT id FROM my.__bruin_tmp_abcefghi)",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
 				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
@@ -222,6 +223,7 @@ func TestMaterializer_Render(t *testing.T) {
 			query: "SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
 			want: []string{
 				"CREATE TABLE my.__bruin_tmp_abcefghi ENGINE = MergeTree() PRIMARY KEY (id, dt) AS SELECT 1 as id, '2026-01-01' as dt, 'a' as name",
+				"INSERT INTO my.asset SELECT * FROM my.__bruin_tmp_abcefghi LIMIT 0",
 				"DELETE FROM my.asset WHERE (id, dt) IN (SELECT id, dt FROM my.__bruin_tmp_abcefghi)",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
 				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",
@@ -243,6 +245,7 @@ func TestMaterializer_Render(t *testing.T) {
 			query: "SELECT 1 as id",
 			want: []string{
 				"CREATE TABLE my.__bruin_tmp_abcefghi ENGINE = MergeTree() PRIMARY KEY (id) AS SELECT 1 as id",
+				"INSERT INTO my.asset SELECT * FROM my.__bruin_tmp_abcefghi LIMIT 0",
 				"DELETE FROM my.asset WHERE id IN (SELECT id FROM my.__bruin_tmp_abcefghi) AND (dt >= '2026-01-01')",
 				"INSERT INTO my.asset SETTINGS insert_deduplicate = 0 SELECT * FROM my.__bruin_tmp_abcefghi",
 				"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi",

--- a/pkg/clickhouse/materializer.go
+++ b/pkg/clickhouse/materializer.go
@@ -40,6 +40,31 @@ func (m *Materializer) Render(asset *pipeline.Asset, query string) ([]string, er
 	return []string{}, fmt.Errorf("unsupported materialization type - strategy combination: (`%s` - `%s`)", mat.Type, mat.Strategy)
 }
 
+// RenderWithCleanup returns the normal materialization statements together
+// with idempotent cleanup statements that the operator should execute if a
+// statement fails before the normal cleanup point is reached.
+func (m *Materializer) RenderWithCleanup(asset *pipeline.Asset, query string) ([]string, []string, error) {
+	queries, err := m.Render(asset, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	strategy := asset.Materialization.Strategy
+	if m.fullRefresh && asset.Materialization.Type == pipeline.MaterializationTypeTable && strategy != pipeline.MaterializationStrategyDDL {
+		strategy = pipeline.MaterializationStrategyCreateReplace
+	}
+
+	if strategy != pipeline.MaterializationStrategyMerge && strategy != pipeline.MaterializationStrategyDeleteInsert {
+		return queries, nil, nil
+	}
+
+	if len(queries) == 0 {
+		return queries, nil, nil
+	}
+
+	return queries, []string{queries[len(queries)-1]}, nil
+}
+
 func NewMaterializer(fullRefresh bool) *Materializer {
 	return &Materializer{
 		MaterializationMap: matMap,

--- a/pkg/clickhouse/materializer_test.go
+++ b/pkg/clickhouse/materializer_test.go
@@ -73,3 +73,40 @@ func TestLogIfFullRefreshAndDDL(t *testing.T) {
 		})
 	}
 }
+
+func TestMaterializer_RenderWithCleanup(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "my.asset",
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyMerge,
+		},
+		Columns: []pipeline.Column{{Name: "id", PrimaryKey: true}},
+	}
+
+	queries, cleanup, err := NewMaterializer(false).RenderWithCleanup(asset, "SELECT 1 AS id")
+	require.NoError(t, err)
+	require.NotEmpty(t, queries)
+	require.Equal(t, []string{"DROP TABLE IF EXISTS my.__bruin_tmp_abcefghi"}, cleanup)
+	require.Equal(t, cleanup[0], queries[len(queries)-1])
+}
+
+func TestMaterializer_RenderWithCleanupFullRefreshDoesNotReturnMergeCleanup(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "my.asset",
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyMerge,
+		},
+		Columns: []pipeline.Column{{Name: "id", PrimaryKey: true}},
+	}
+
+	queries, cleanup, err := NewMaterializer(true).RenderWithCleanup(asset, "SELECT 1 AS id")
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Empty(t, cleanup)
+}

--- a/pkg/clickhouse/operator.go
+++ b/pkg/clickhouse/operator.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/config"
@@ -17,6 +18,10 @@ import (
 type materializer interface {
 	Render(task *pipeline.Asset, query string) ([]string, error)
 	LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error
+}
+
+type materializerWithCleanup interface {
+	RenderWithCleanup(task *pipeline.Asset, query string) ([]string, []string, error)
 }
 
 type ClickHouseClient interface {
@@ -66,7 +71,12 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	q := queries[0]
-	materializedQueries, err := o.materializer.Render(t, q.String())
+	var materializedQueries, cleanupQueries []string
+	if cleanupMaterializer, ok := o.materializer.(materializerWithCleanup); ok {
+		materializedQueries, cleanupQueries, err = cleanupMaterializer.RenderWithCleanup(t, q.String())
+	} else {
+		materializedQueries, err = o.materializer.Render(t, q.String())
+	}
 	if err != nil {
 		return err
 	}
@@ -99,7 +109,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		if o.devEnv != nil {
 			q, err = o.devEnv.Modify(ctx, p, t, q)
 			if err != nil {
-				return err
+				return o.cleanupAfterFailure(ctx, p, t, conn, writer, cleanupQueries, err)
 			}
 		}
 
@@ -107,7 +117,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 
 		err = conn.RunQueryWithoutResult(ctx, q)
 		if err != nil {
-			return err
+			return o.cleanupAfterFailure(ctx, p, t, conn, writer, cleanupQueries, err)
 		}
 		lastQuery = q
 	}
@@ -126,6 +136,41 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	return nil
+}
+
+func (o BasicOperator) cleanupAfterFailure(
+	ctx context.Context,
+	p *pipeline.Pipeline,
+	t *pipeline.Asset,
+	conn ClickHouseClient,
+	writer interface{},
+	cleanupQueries []string,
+	originalErr error,
+) error {
+	if len(cleanupQueries) == 0 {
+		return originalErr
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	for _, queryString := range cleanupQueries {
+		cleanupQuery := &query.Query{Query: queryString}
+		if o.devEnv != nil {
+			var err error
+			cleanupQuery, err = o.devEnv.Modify(cleanupCtx, p, t, cleanupQuery)
+			if err != nil {
+				return errors.Wrapf(originalErr, "failed to prepare cleanup query after ClickHouse query failure: %v", err)
+			}
+		}
+
+		ansisql.LogQueryIfVerbose(cleanupCtx, writer, cleanupQuery.Query)
+		if err := conn.RunQueryWithoutResult(cleanupCtx, cleanupQuery); err != nil {
+			return errors.Wrapf(originalErr, "failed to clean up after ClickHouse query failure: %v", err)
+		}
+	}
+
+	return originalErr
 }
 
 func NewBasicOperator(conn config.ConnectionGetter, extractor query.QueryExtractor, materializer materializer, parser *sqlparser.SQLParser) *BasicOperator {

--- a/pkg/clickhouse/operator_test.go
+++ b/pkg/clickhouse/operator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockExtractor struct {
@@ -39,6 +40,24 @@ func (m *mockMaterializer) Render(t *pipeline.Asset, query string) ([]string, er
 }
 
 func (m *mockMaterializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
+	return nil
+}
+
+type mockMaterializerWithCleanup struct {
+	mock.Mock
+}
+
+func (m *mockMaterializerWithCleanup) Render(t *pipeline.Asset, query string) ([]string, error) {
+	res := m.Called(t, query)
+	return res.Get(0).([]string), res.Error(1)
+}
+
+func (m *mockMaterializerWithCleanup) RenderWithCleanup(t *pipeline.Asset, query string) ([]string, []string, error) {
+	res := m.Called(t, query)
+	return res.Get(0).([]string), res.Get(1).([]string), res.Error(2)
+}
+
+func (m *mockMaterializerWithCleanup) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
 	return nil
 }
 
@@ -226,4 +245,51 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBasicOperator_RunTaskCleansUpAfterQueryFailure(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Type: pipeline.AssetTypeClickHouse,
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "test-file.sql",
+			Content: "some query",
+		},
+	}
+	client := new(mockQuerierWithResult)
+	extractor := new(mockExtractor)
+	mat := new(mockMaterializerWithCleanup)
+	conn := new(mockConnectionFetcher)
+
+	extractor.On("ExtractQueriesFromString", "some query").
+		Return([]*query.Query{{Query: "select * from users"}}, nil)
+	mat.On("RenderWithCleanup", asset, "select * from users").
+		Return(
+			[]string{"CREATE TABLE temp", "INSERT INTO target SELECT * FROM temp"},
+			[]string{"DROP TABLE IF EXISTS temp"},
+			nil,
+		)
+	conn.On("GetConnection", mock.Anything).Return(client)
+	createCall := client.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "CREATE TABLE temp"}).
+		Return(nil).
+		Once()
+	insertCall := client.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "INSERT INTO target SELECT * FROM temp"}).
+		Return(errors.New("insert failed")).
+		Once().
+		NotBefore(createCall)
+	client.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "DROP TABLE IF EXISTS temp"}).
+		Return(nil).
+		Once().
+		NotBefore(insertCall)
+
+	o := BasicOperator{
+		connection:   conn,
+		extractor:    extractor,
+		materializer: mat,
+	}
+
+	err := o.RunTask(t.Context(), &pipeline.Pipeline{}, asset)
+	require.EqualError(t, err, "insert failed")
+	client.AssertExpectations(t)
 }

--- a/pkg/dataproc_serverless/job_test.go
+++ b/pkg/dataproc_serverless/job_test.go
@@ -57,7 +57,8 @@ func TestBuildBatchConfig_Autotuning(t *testing.T) {
 		AutotuningScenarios: []dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 	}).buildBatchConfig(ws)
 	assert.Equal(t, "my-pipeline-my-asset-staging", req.GetBatch().GetRuntimeConfig().GetCohort())
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		[]dataprocpb.AutotuningConfig_Scenario{dataprocpb.AutotuningConfig_AUTO},
 		req.GetBatch().GetRuntimeConfig().GetAutotuningConfig().GetScenarios(),
 	)

--- a/pkg/pipeline/materializer.go
+++ b/pkg/pipeline/materializer.go
@@ -151,6 +151,27 @@ func (m HookWrapperMaterializerList) Render(asset *Asset, query string) ([]strin
 	return wrapHookQueriesList(materialized, asset.Hooks, m.Hoister, asset.Type), nil
 }
 
+// RenderWithCleanup renders the materialization and returns any idempotent
+// cleanup queries that should be retried if execution stops early. List-based
+// materializers that do not provide cleanup metadata retain the normal Render
+// behavior and return no cleanup queries.
+func (m HookWrapperMaterializerList) RenderWithCleanup(asset *Asset, query string) ([]string, []string, error) {
+	cleanupMaterializer, ok := m.Mat.(interface {
+		RenderWithCleanup(asset *Asset, query string) ([]string, []string, error)
+	})
+	if !ok {
+		materialized, err := m.Render(asset, query)
+		return materialized, nil, err
+	}
+
+	materialized, cleanup, err := cleanupMaterializer.RenderWithCleanup(asset, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return wrapHookQueriesList(materialized, asset.Hooks, m.Hoister, asset.Type), cleanup, nil
+}
+
 func (m HookWrapperMaterializerList) LogIfFullRefreshAndDDL(writer interface{}, asset *Asset) error {
 	if m.Mat == nil {
 		return errors.New("hook wrapper materializer requires a base materializer")

--- a/pkg/pipeline/materializer_test.go
+++ b/pkg/pipeline/materializer_test.go
@@ -108,6 +108,19 @@ func (m listMaterializer) Render(_ *Asset, _ string) ([]string, error) {
 	return m.out, nil
 }
 
+type listMaterializerWithCleanup struct {
+	out     []string
+	cleanup []string
+}
+
+func (m listMaterializerWithCleanup) Render(_ *Asset, _ string) ([]string, error) {
+	return m.out, nil
+}
+
+func (m listMaterializerWithCleanup) RenderWithCleanup(_ *Asset, _ string) ([]string, []string, error) {
+	return m.out, m.cleanup, nil
+}
+
 type listWithLocationMaterializer struct {
 	out         []string
 	gotLocation string
@@ -154,6 +167,29 @@ func TestHookWrapperMaterializerList_Render(t *testing.T) {
 	got, err := wrapper.Render(asset, "ignored")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"select 1;", "select 3", "select 2;"}, got)
+}
+
+func TestHookWrapperMaterializerList_RenderWithCleanup(t *testing.T) {
+	t.Parallel()
+
+	asset := &Asset{
+		Hooks: Hooks{
+			Pre:  []Hook{{Query: "select 1"}},
+			Post: []Hook{{Query: "select 2"}},
+		},
+	}
+
+	wrapper := HookWrapperMaterializerList{
+		Mat: listMaterializerWithCleanup{
+			out:     []string{"select 3", "drop table temp"},
+			cleanup: []string{"drop table temp"},
+		},
+	}
+
+	got, cleanup, err := wrapper.RenderWithCleanup(asset, "ignored")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"select 1;", "select 3", "drop table temp", "select 2;"}, got)
+	assert.Equal(t, []string{"drop table temp"}, cleanup)
 }
 
 func TestHookWrapperMaterializerListWithLocation_Render(t *testing.T) {


### PR DESCRIPTION
## What
Prevent ClickHouse merge failures from deleting target rows on predictable insert incompatibilities or leaking staging tables.

## Changes
- Validate staged rows against the target with a zero-row insert before `DELETE`.
- Retry idempotent staging cleanup on failures, with unit and integration coverage.
- Document non-atomic behavior and ClickHouse predicate qualification; include required formatter output.

## How to test
1. `make build-no-duckdb`
2. `make format`
3. `make test`
4. Run the ClickHouse `TestMerge*` cloud integration suite.

## Risk & rollback
- **Risk:** Medium; merge runs one extra validation query and cleanup is best-effort.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Affected ClickHouse integration tests pass
- [x] No unintended changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
Closes #2425
