### PR TITLE
Add AI coding usage template

### DIFF
--- a/docs/getting-started/templates-docs/ai-coding-usage-README.md
+++ b/docs/getting-started/templates-docs/ai-coding-usage-README.md
@@ -1,0 +1,135 @@
+# AI coding usage to DuckDB
+
+This Bruin template ingests AI coding usage from the Anthropic and Cursor Admin APIs into DuckDB, normalizes both platforms to a shared user/day model, and builds organization-wide summaries.
+
+## Data model
+
+The three raw assets have no dependencies on one another, so Bruin schedules the Anthropic and Cursor API requests in parallel:
+
+- `raw.claude_code_usage`: Per-actor daily Claude Code usage from Anthropic.
+- `raw.cursor_daily_usage`: Per-user daily Cursor activity and productivity metrics.
+- `raw.cursor_usage_events`: Per-request Cursor token, model, and cost details.
+
+Each source has a typed staging model:
+
+- `staging.claude_code_usage`
+- `staging.cursor_daily_usage`
+- `staging.cursor_usage_events`
+
+The marts provide progressively broader reporting tables:
+
+- `marts.anthropic_usage_by_user_day`: One Anthropic record per user and day.
+- `marts.cursor_usage_by_user_day`: One Cursor record per user and day.
+- `marts.ai_coding_usage_by_user_day`: One normalized record per user, day, and platform.
+- `marts.ai_coding_user_daily_summary`: One cross-platform record per user and day.
+- `marts.ai_coding_daily_summary`: Organization-wide daily usage.
+- `marts.ai_coding_user_summary`: Per-user totals across loaded history.
+
+## Prerequisites
+
+Anthropic Claude Code usage requires an organization Admin API key beginning with `sk-ant-admin`. A standard key beginning with `sk-ant-api` cannot access organization usage reports. Create an Admin key in the [Anthropic Console](https://console.anthropic.com/settings/admin-keys).
+
+Cursor analytics requires a **team Admin API key** created in Cursor Dashboard → Settings → Cursor Admin API Keys. Other Cursor keys may use the same prefix but cannot access the team analytics endpoints. See the [Cursor Admin API documentation](https://docs.cursor.com/en/account/teams/admin-api).
+
+Export both credentials in your shell. The generated `.bruin.yml` contains only environment-variable references.
+
+```shell
+export ANTHROPIC_ADMIN_API_KEY="sk-ant-admin..."
+export CURSOR_ADMIN_API_KEY="crsr_..."
+```
+
+The template adds these connections to `.bruin.yml`:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      anthropic:
+        - name: anthropic-default
+          api_key: ${ANTHROPIC_ADMIN_API_KEY}
+      cursor:
+        - name: cursor-default
+          api_key: ${CURSOR_ADMIN_API_KEY}
+      duckdb:
+        - name: duckdb-default
+          path: claude_code_usage.duckdb
+        - name: duckdb-dashboard
+          path: claude_code_usage.duckdb
+          read_only: true
+```
+
+Change both DuckDB paths if you want the database file stored elsewhere. The pipeline writes through `duckdb-default`; DAC uses the parallel-safe, read-only `duckdb-dashboard` connection.
+
+## Run the pipeline
+
+Validate and run the previous UTC day's data:
+
+```shell
+bruin validate .
+bruin run .
+```
+
+Use an explicit interval to backfill historical data:
+
+```shell
+bruin run . --start-date 2025-01-01 --end-date 2025-01-30
+```
+
+Cursor limits each analytics request to 30 days. For longer backfills, run multiple non-overlapping intervals of at most 30 days. The per-platform marts use interval-aware materialization, so each run updates only its requested dates while preserving previously loaded history. Both APIs return UTC data.
+
+## Query the models
+
+Open the database with DuckDB:
+
+```shell
+duckdb claude_code_usage.duckdb
+```
+
+Query per-user/day consumption across platforms:
+
+```sql
+SELECT
+  usage_date,
+  user_id,
+  platform_count,
+  platforms_used,
+  sessions,
+  requests,
+  total_tokens,
+  estimated_cost_usd
+FROM marts.ai_coding_user_daily_summary
+ORDER BY usage_date DESC, user_id;
+```
+
+Query the organization-wide daily summary:
+
+```sql
+SELECT *
+FROM marts.ai_coding_daily_summary
+ORDER BY usage_date DESC;
+```
+
+## Open the dashboard
+
+The template includes a DAC dashboard with date and platform filters, headline adoption and consumption metrics, daily trends, platform comparisons, and a per-user table. Install the DAC CLI, then run these commands from the generated pipeline directory after the Bruin pipeline has populated DuckDB:
+
+```shell
+dac validate --dir dashboards
+dac check --dir dashboards
+dac serve --dir dashboards --open
+```
+
+To produce a standalone static dashboard with query results baked in:
+
+```shell
+dac build --dir dashboards --dashboard "AI Coding Usage" --output build
+```
+
+## Metric notes
+
+- User email addresses are lowercased so the same person can be joined across Anthropic and Cursor. Anthropic API actors retain their API key name and use `user_type = 'api_key'`.
+- Anthropic costs and Cursor token-based event costs are converted from cents to US dollars.
+- Cursor request totals prefer daily Composer, chat, and agent counts; usage-event counts are used when daily request totals are unavailable.
+- Cursor total line changes and accepted AI line changes are kept separately.
+- Anthropic usage covers the first-party Anthropic API and does not include Claude Code traffic routed through Amazon Bedrock or Google Vertex AI.

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -121,6 +121,12 @@ AI agent skills are installed separately with `bruin ai skills`; see [AI Skills]
 ### Source-to-warehouse ingestion
 
 <div class="template-grid">
+  <a class="template-card" href="./templates-docs/ai-coding-usage-README.html">
+    <span class="template-card__category">AI usage analytics</span>
+    <strong>ai-coding-usage</strong>
+    <span>Ingests Anthropic Claude Code and Cursor usage into DuckDB, then builds normalized summaries and a DAC dashboard.</span>
+    <span class="template-card__tags"><code>Anthropic</code><code>Cursor</code><code>DuckDB</code></span>
+  </a>
   <a class="template-card" href="./templates-docs/shopify-bigquery-README.html">
     <span class="template-card__category">Commerce source</span>
     <strong>shopify-bigquery</strong>
@@ -197,7 +203,7 @@ bruin init nyc-taxi my-taxi-pipeline
 | Goal | Start with |
 | --- | --- |
 | Learn Bruin locally without cloud credentials | `duckdb`, `python`, `frankfurter`, or `chess` |
-| Build a source-to-warehouse ingestion pipeline | `shopify-bigquery`, `gsheet-bigquery`, `notion`, or `gorgias` |
+| Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `gsheet-bigquery`, `notion`, or `gorgias` |
 | Explore a complete demo with generated data | `demo-snowflake-sales-analytics` or `demo-snowflake-salesforce` |
 | Scaffold ecommerce reporting | `ecommerce` |
 | Work with a specific database | `athena`, `clickhouse`, `bronze-silver-postgres`, `bigquery`, `databricks`, or `redshift` |

--- a/templates/ai-coding-usage/.bruin.yml
+++ b/templates/ai-coding-usage/.bruin.yml
@@ -1,0 +1,17 @@
+default_environment: default
+
+environments:
+  default:
+    connections:
+      anthropic:
+        - name: anthropic-default
+          api_key: ${ANTHROPIC_ADMIN_API_KEY}
+      cursor:
+        - name: cursor-default
+          api_key: ${CURSOR_ADMIN_API_KEY}
+      duckdb:
+        - name: duckdb-default
+          path: claude_code_usage.duckdb
+        - name: duckdb-dashboard
+          path: claude_code_usage.duckdb
+          read_only: true

--- a/templates/ai-coding-usage/README.md
+++ b/templates/ai-coding-usage/README.md
@@ -1,0 +1,135 @@
+# AI coding usage to DuckDB
+
+This Bruin template ingests AI coding usage from the Anthropic and Cursor Admin APIs into DuckDB, normalizes both platforms to a shared user/day model, and builds organization-wide summaries.
+
+## Data model
+
+The three raw assets have no dependencies on one another, so Bruin schedules the Anthropic and Cursor API requests in parallel:
+
+- `raw.claude_code_usage`: Per-actor daily Claude Code usage from Anthropic.
+- `raw.cursor_daily_usage`: Per-user daily Cursor activity and productivity metrics.
+- `raw.cursor_usage_events`: Per-request Cursor token, model, and cost details.
+
+Each source has a typed staging model:
+
+- `staging.claude_code_usage`
+- `staging.cursor_daily_usage`
+- `staging.cursor_usage_events`
+
+The marts provide progressively broader reporting tables:
+
+- `marts.anthropic_usage_by_user_day`: One Anthropic record per user and day.
+- `marts.cursor_usage_by_user_day`: One Cursor record per user and day.
+- `marts.ai_coding_usage_by_user_day`: One normalized record per user, day, and platform.
+- `marts.ai_coding_user_daily_summary`: One cross-platform record per user and day.
+- `marts.ai_coding_daily_summary`: Organization-wide daily usage.
+- `marts.ai_coding_user_summary`: Per-user totals across loaded history.
+
+## Prerequisites
+
+Anthropic Claude Code usage requires an organization Admin API key beginning with `sk-ant-admin`. A standard key beginning with `sk-ant-api` cannot access organization usage reports. Create an Admin key in the [Anthropic Console](https://console.anthropic.com/settings/admin-keys).
+
+Cursor analytics requires a **team Admin API key** created in Cursor Dashboard → Settings → Cursor Admin API Keys. Other Cursor keys may use the same prefix but cannot access the team analytics endpoints. See the [Cursor Admin API documentation](https://docs.cursor.com/en/account/teams/admin-api).
+
+Export both credentials in your shell. The generated `.bruin.yml` contains only environment-variable references.
+
+```shell
+export ANTHROPIC_ADMIN_API_KEY="sk-ant-admin..."
+export CURSOR_ADMIN_API_KEY="crsr_..."
+```
+
+The template adds these connections to `.bruin.yml`:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      anthropic:
+        - name: anthropic-default
+          api_key: ${ANTHROPIC_ADMIN_API_KEY}
+      cursor:
+        - name: cursor-default
+          api_key: ${CURSOR_ADMIN_API_KEY}
+      duckdb:
+        - name: duckdb-default
+          path: claude_code_usage.duckdb
+        - name: duckdb-dashboard
+          path: claude_code_usage.duckdb
+          read_only: true
+```
+
+Change both DuckDB paths if you want the database file stored elsewhere. The pipeline writes through `duckdb-default`; DAC uses the parallel-safe, read-only `duckdb-dashboard` connection.
+
+## Run the pipeline
+
+Validate and run the previous UTC day's data:
+
+```shell
+bruin validate .
+bruin run .
+```
+
+Use an explicit interval to backfill historical data:
+
+```shell
+bruin run . --start-date 2025-01-01 --end-date 2025-01-30
+```
+
+Cursor limits each analytics request to 30 days. For longer backfills, run multiple non-overlapping intervals of at most 30 days. The per-platform marts use interval-aware materialization, so each run updates only its requested dates while preserving previously loaded history. Both APIs return UTC data.
+
+## Query the models
+
+Open the database with DuckDB:
+
+```shell
+duckdb claude_code_usage.duckdb
+```
+
+Query per-user/day consumption across platforms:
+
+```sql
+SELECT
+  usage_date,
+  user_id,
+  platform_count,
+  platforms_used,
+  sessions,
+  requests,
+  total_tokens,
+  estimated_cost_usd
+FROM marts.ai_coding_user_daily_summary
+ORDER BY usage_date DESC, user_id;
+```
+
+Query the organization-wide daily summary:
+
+```sql
+SELECT *
+FROM marts.ai_coding_daily_summary
+ORDER BY usage_date DESC;
+```
+
+## Open the dashboard
+
+The template includes a DAC dashboard with date and platform filters, headline adoption and consumption metrics, daily trends, platform comparisons, and a per-user table. Install the DAC CLI, then run these commands from the generated pipeline directory after the Bruin pipeline has populated DuckDB:
+
+```shell
+dac validate --dir dashboards
+dac check --dir dashboards
+dac serve --dir dashboards --open
+```
+
+To produce a standalone static dashboard with query results baked in:
+
+```shell
+dac build --dir dashboards --dashboard "AI Coding Usage" --output build
+```
+
+## Metric notes
+
+- User email addresses are lowercased so the same person can be joined across Anthropic and Cursor. Anthropic API actors retain their API key name and use `user_type = 'api_key'`.
+- Anthropic costs and Cursor token-based event costs are converted from cents to US dollars.
+- Cursor request totals prefer daily Composer, chat, and agent counts; usage-event counts are used when daily request totals are unavailable.
+- Cursor total line changes and accepted AI line changes are kept separately.
+- Anthropic usage covers the first-party Anthropic API and does not include Claude Code traffic routed through Amazon Bedrock or Google Vertex AI.

--- a/templates/ai-coding-usage/assets/marts/ai_coding_daily_summary.sql
+++ b/templates/ai-coding-usage/assets/marts/ai_coding_daily_summary.sql
@@ -1,0 +1,61 @@
+/* @bruin
+
+name: marts.ai_coding_daily_summary
+type: duckdb.sql
+
+description: Organization-wide daily AI coding adoption, consumption, productivity, and cost metrics.
+
+materialization:
+  type: table
+
+depends:
+  - marts.ai_coding_usage_by_user_day
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: active_users
+    type: bigint
+    description: Distinct active users or API keys across all platforms.
+    checks:
+      - name: non_negative
+  - name: total_tokens
+    type: hugeint
+    description: Total tokens across platforms.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated cost across platforms in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+SELECT
+  usage_date,
+  COUNT(DISTINCT user_type || ':' || user_id) FILTER (WHERE is_active) AS active_users,
+  COUNT(DISTINCT platform) AS platform_count,
+  STRING_AGG(DISTINCT platform, ',' ORDER BY platform) AS platforms_used,
+  SUM(sessions) AS sessions,
+  SUM(requests) AS requests,
+  SUM(input_tokens) AS input_tokens,
+  SUM(output_tokens) AS output_tokens,
+  SUM(cache_read_tokens) AS cache_read_tokens,
+  SUM(cache_creation_tokens) AS cache_creation_tokens,
+  SUM(total_tokens) AS total_tokens,
+  SUM(estimated_cost_usd) AS estimated_cost_usd,
+  SUM(lines_added) AS lines_added,
+  SUM(lines_removed) AS lines_removed,
+  SUM(net_lines_changed) AS net_lines_changed,
+  SUM(ai_lines_added) AS ai_lines_added,
+  SUM(ai_lines_removed) AS ai_lines_removed,
+  SUM(commits_by_ai) AS commits_by_ai,
+  SUM(pull_requests_by_ai) AS pull_requests_by_ai
+FROM marts.ai_coding_usage_by_user_day
+GROUP BY usage_date;

--- a/templates/ai-coding-usage/assets/marts/ai_coding_usage_by_user_day.sql
+++ b/templates/ai-coding-usage/assets/marts/ai_coding_usage_by_user_day.sql
@@ -1,0 +1,102 @@
+/* @bruin
+
+name: marts.ai_coding_usage_by_user_day
+type: duckdb.sql
+
+description: Cross-platform fact table with one record per user, UTC day, and AI coding platform.
+
+materialization:
+  type: table
+
+depends:
+  - marts.anthropic_usage_by_user_day
+  - marts.cursor_usage_by_user_day
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Normalized user email or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_type
+    type: varchar
+    description: User or API key actor classification.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: platform
+    type: varchar
+    description: Anthropic or Cursor.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: total_tokens
+    type: hugeint
+    description: Input, output, cache-read, and cache-creation tokens combined.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated platform cost in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+SELECT
+  usage_date,
+  user_id,
+  user_type,
+  platform,
+  is_active,
+  sessions,
+  requests,
+  input_tokens,
+  output_tokens,
+  cache_read_tokens,
+  cache_creation_tokens,
+  total_tokens,
+  estimated_cost_usd,
+  lines_added,
+  lines_removed,
+  net_lines_changed,
+  ai_lines_added,
+  ai_lines_removed,
+  commits_by_ai,
+  pull_requests_by_ai,
+  primary_model
+FROM marts.anthropic_usage_by_user_day
+
+UNION ALL
+
+SELECT
+  usage_date,
+  user_id,
+  user_type,
+  platform,
+  is_active,
+  sessions,
+  requests,
+  input_tokens,
+  output_tokens,
+  cache_read_tokens,
+  cache_creation_tokens,
+  total_tokens,
+  estimated_cost_usd,
+  lines_added,
+  lines_removed,
+  net_lines_changed,
+  ai_lines_added,
+  ai_lines_removed,
+  commits_by_ai,
+  pull_requests_by_ai,
+  primary_model
+FROM marts.cursor_usage_by_user_day
+WHERE is_active;

--- a/templates/ai-coding-usage/assets/marts/ai_coding_user_daily_summary.sql
+++ b/templates/ai-coding-usage/assets/marts/ai_coding_user_daily_summary.sql
@@ -1,0 +1,76 @@
+/* @bruin
+
+name: marts.ai_coding_user_daily_summary
+type: duckdb.sql
+
+description: One cross-platform AI coding consumption summary per user and UTC day.
+
+materialization:
+  type: table
+
+depends:
+  - marts.ai_coding_usage_by_user_day
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Normalized user email or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_type
+    type: varchar
+    description: User or API key actor classification.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: platform_count
+    type: bigint
+    description: Number of AI coding platforms used that day.
+    checks:
+      - name: positive
+  - name: total_tokens
+    type: hugeint
+    description: Total tokens across platforms.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated cost across platforms in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+SELECT
+  usage_date,
+  user_id,
+  user_type,
+  COUNT(*) AS platform_count,
+  STRING_AGG(platform, ',' ORDER BY platform) AS platforms_used,
+  BOOL_OR(is_active) AS is_active,
+  SUM(sessions) AS sessions,
+  SUM(requests) AS requests,
+  SUM(input_tokens) AS input_tokens,
+  SUM(output_tokens) AS output_tokens,
+  SUM(cache_read_tokens) AS cache_read_tokens,
+  SUM(cache_creation_tokens) AS cache_creation_tokens,
+  SUM(total_tokens) AS total_tokens,
+  SUM(estimated_cost_usd) AS estimated_cost_usd,
+  SUM(lines_added) AS lines_added,
+  SUM(lines_removed) AS lines_removed,
+  SUM(net_lines_changed) AS net_lines_changed,
+  SUM(ai_lines_added) AS ai_lines_added,
+  SUM(ai_lines_removed) AS ai_lines_removed,
+  SUM(commits_by_ai) AS commits_by_ai,
+  SUM(pull_requests_by_ai) AS pull_requests_by_ai,
+  STRING_AGG(DISTINCT primary_model, ',' ORDER BY primary_model)
+    FILTER (WHERE primary_model IS NOT NULL AND primary_model <> '') AS models_used
+FROM marts.ai_coding_usage_by_user_day
+GROUP BY usage_date, user_id, user_type;

--- a/templates/ai-coding-usage/assets/marts/ai_coding_user_summary.sql
+++ b/templates/ai-coding-usage/assets/marts/ai_coding_user_summary.sql
@@ -1,0 +1,86 @@
+/* @bruin
+
+name: marts.ai_coding_user_summary
+type: duckdb.sql
+
+description: Cross-platform AI coding adoption and consumption metrics across loaded history for each user or API key.
+
+materialization:
+  type: table
+
+depends:
+  - marts.ai_coding_user_daily_summary
+  - marts.ai_coding_usage_by_user_day
+
+columns:
+  - name: user_id
+    type: varchar
+    description: Normalized user email or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_type
+    type: varchar
+    description: User or API key actor classification.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: active_days
+    type: bigint
+    description: Distinct active days across loaded history.
+    checks:
+      - name: positive
+  - name: total_tokens
+    type: hugeint
+    description: Total tokens across platforms and loaded history.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated cost across platforms and loaded history in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+WITH platform_rollup AS (
+  SELECT
+    user_id,
+    user_type,
+    STRING_AGG(DISTINCT platform, ',' ORDER BY platform) AS platforms_used
+  FROM marts.ai_coding_usage_by_user_day
+  GROUP BY user_id, user_type
+)
+
+SELECT
+  daily.user_id,
+  daily.user_type,
+  MIN(daily.usage_date) AS first_active_date,
+  MAX(daily.usage_date) AS last_active_date,
+  COUNT(*) FILTER (WHERE daily.is_active) AS active_days,
+  platform_rollup.platforms_used,
+  MAX(daily.platform_count) AS max_platforms_in_one_day,
+  SUM(daily.sessions) AS sessions,
+  SUM(daily.requests) AS requests,
+  SUM(daily.input_tokens) AS input_tokens,
+  SUM(daily.output_tokens) AS output_tokens,
+  SUM(daily.cache_read_tokens) AS cache_read_tokens,
+  SUM(daily.cache_creation_tokens) AS cache_creation_tokens,
+  SUM(daily.total_tokens) AS total_tokens,
+  SUM(daily.estimated_cost_usd) AS estimated_cost_usd,
+  SUM(daily.lines_added) AS lines_added,
+  SUM(daily.lines_removed) AS lines_removed,
+  SUM(daily.net_lines_changed) AS net_lines_changed,
+  SUM(daily.ai_lines_added) AS ai_lines_added,
+  SUM(daily.ai_lines_removed) AS ai_lines_removed,
+  SUM(daily.commits_by_ai) AS commits_by_ai,
+  SUM(daily.pull_requests_by_ai) AS pull_requests_by_ai,
+  SUM(daily.total_tokens)::DOUBLE
+    / NULLIF(COUNT(*) FILTER (WHERE daily.is_active), 0) AS tokens_per_active_day,
+  SUM(daily.estimated_cost_usd)
+    / NULLIF(COUNT(*) FILTER (WHERE daily.is_active), 0) AS estimated_cost_per_active_day_usd
+FROM marts.ai_coding_user_daily_summary AS daily
+INNER JOIN platform_rollup
+  ON daily.user_id = platform_rollup.user_id
+  AND daily.user_type = platform_rollup.user_type
+GROUP BY daily.user_id, daily.user_type, platform_rollup.platforms_used;

--- a/templates/ai-coding-usage/assets/marts/anthropic_usage_by_user_day.sql
+++ b/templates/ai-coding-usage/assets/marts/anthropic_usage_by_user_day.sql
@@ -1,0 +1,79 @@
+/* @bruin
+
+name: marts.anthropic_usage_by_user_day
+type: duckdb.sql
+
+description: One normalized Anthropic Claude Code consumption record per actor and UTC day.
+
+materialization:
+  type: table
+  strategy: time_interval
+  incremental_key: usage_date
+  time_granularity: date
+
+depends:
+  - staging.claude_code_usage
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Normalized user email or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_type
+    type: varchar
+    description: User or API key actor classification.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: sessions
+    type: hugeint
+    description: Claude Code sessions.
+    checks:
+      - name: non_negative
+  - name: total_tokens
+    type: hugeint
+    description: Input, output, cache-read, and cache-creation tokens combined.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated Anthropic cost in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+SELECT
+  usage_date,
+  user_id,
+  user_type,
+  'anthropic' AS platform,
+  TRUE AS is_active,
+  SUM(num_sessions) AS sessions,
+  CAST(0 AS HUGEINT) AS requests,
+  SUM(total_input_tokens) AS input_tokens,
+  SUM(total_output_tokens) AS output_tokens,
+  SUM(total_cache_read_tokens) AS cache_read_tokens,
+  SUM(total_cache_creation_tokens) AS cache_creation_tokens,
+  SUM(total_tokens) AS total_tokens,
+  SUM(estimated_cost_usd) AS estimated_cost_usd,
+  SUM(lines_added) AS lines_added,
+  SUM(lines_removed) AS lines_removed,
+  SUM(net_lines_changed) AS net_lines_changed,
+  SUM(lines_added) AS ai_lines_added,
+  SUM(lines_removed) AS ai_lines_removed,
+  SUM(commits_by_claude_code) AS commits_by_ai,
+  SUM(pull_requests_by_claude_code) AS pull_requests_by_ai,
+  ARG_MAX(models_used, num_sessions) AS primary_model,
+  COUNT(DISTINCT terminal_type) AS terminal_count
+FROM staging.claude_code_usage
+WHERE usage_date BETWEEN CAST('{{ start_date }}' AS DATE) AND CAST('{{ end_date }}' AS DATE)
+GROUP BY usage_date, user_id, user_type;

--- a/templates/ai-coding-usage/assets/marts/cursor_usage_by_user_day.sql
+++ b/templates/ai-coding-usage/assets/marts/cursor_usage_by_user_day.sql
@@ -1,0 +1,137 @@
+/* @bruin
+
+name: marts.cursor_usage_by_user_day
+type: duckdb.sql
+
+description: One normalized Cursor consumption and productivity record per user and UTC day.
+
+materialization:
+  type: table
+  strategy: time_interval
+  incremental_key: usage_date
+  time_granularity: date
+
+depends:
+  - staging.cursor_daily_usage
+  - staging.cursor_usage_events
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Lowercase Cursor team member email address.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: requests
+    type: hugeint
+    description: Cursor requests, preferring the daily activity total when available.
+    checks:
+      - name: non_negative
+  - name: total_tokens
+    type: hugeint
+    description: Input, output, cache-read, and cache-creation tokens from usage events.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Token-based Cursor cost in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+WITH daily_rollup AS (
+  SELECT
+    usage_date,
+    user_id,
+    BOOL_OR(is_active) AS is_active,
+    SUM(total_lines_added) AS lines_added,
+    SUM(total_lines_removed) AS lines_removed,
+    SUM(ai_lines_added) AS ai_lines_added,
+    SUM(ai_lines_removed) AS ai_lines_removed,
+    SUM(apply_operations) AS apply_operations,
+    SUM(suggestions_accepted) AS suggestions_accepted,
+    SUM(suggestions_rejected) AS suggestions_rejected,
+    SUM(tabs_shown) AS tabs_shown,
+    SUM(tabs_accepted) AS tabs_accepted,
+    SUM(composer_requests) AS composer_requests,
+    SUM(chat_requests) AS chat_requests,
+    SUM(agent_requests) AS agent_requests,
+    SUM(total_requests) AS total_requests,
+    SUM(cmdk_usages) AS cmdk_usages,
+    SUM(subscription_included_requests) AS subscription_included_requests,
+    SUM(api_key_requests) AS api_key_requests,
+    SUM(usage_based_requests) AS usage_based_requests,
+    SUM(bugbot_usages) AS bugbot_usages,
+    ARG_MAX(primary_model, total_requests) AS primary_model
+  FROM staging.cursor_daily_usage
+  GROUP BY usage_date, user_id
+),
+event_rollup AS (
+  SELECT
+    usage_date,
+    user_id,
+    COUNT(*) AS event_count,
+    SUM(input_tokens) AS input_tokens,
+    SUM(output_tokens) AS output_tokens,
+    SUM(cache_read_tokens) AS cache_read_tokens,
+    SUM(cache_creation_tokens) AS cache_creation_tokens,
+    SUM(total_tokens) AS total_tokens,
+    SUM(estimated_cost_usd) AS estimated_cost_usd,
+    SUM(request_cost_units) AS request_cost_units,
+    MODE(model) AS primary_model
+  FROM staging.cursor_usage_events
+  GROUP BY usage_date, user_id
+)
+
+SELECT
+  COALESCE(daily_rollup.usage_date, event_rollup.usage_date) AS usage_date,
+  COALESCE(daily_rollup.user_id, event_rollup.user_id) AS user_id,
+  'user' AS user_type,
+  'cursor' AS platform,
+  COALESCE(daily_rollup.is_active, FALSE)
+    OR event_rollup.user_id IS NOT NULL
+    OR COALESCE(daily_rollup.total_requests, 0) > 0 AS is_active,
+  CAST(0 AS HUGEINT) AS sessions,
+  CASE
+    WHEN COALESCE(daily_rollup.total_requests, 0) > 0 THEN daily_rollup.total_requests
+    ELSE COALESCE(event_rollup.event_count, 0)
+  END AS requests,
+  COALESCE(event_rollup.input_tokens, 0) AS input_tokens,
+  COALESCE(event_rollup.output_tokens, 0) AS output_tokens,
+  COALESCE(event_rollup.cache_read_tokens, 0) AS cache_read_tokens,
+  COALESCE(event_rollup.cache_creation_tokens, 0) AS cache_creation_tokens,
+  COALESCE(event_rollup.total_tokens, 0) AS total_tokens,
+  COALESCE(event_rollup.estimated_cost_usd, 0.0) AS estimated_cost_usd,
+  COALESCE(daily_rollup.lines_added, 0) AS lines_added,
+  COALESCE(daily_rollup.lines_removed, 0) AS lines_removed,
+  COALESCE(daily_rollup.lines_added, 0) - COALESCE(daily_rollup.lines_removed, 0) AS net_lines_changed,
+  COALESCE(daily_rollup.ai_lines_added, 0) AS ai_lines_added,
+  COALESCE(daily_rollup.ai_lines_removed, 0) AS ai_lines_removed,
+  CAST(0 AS HUGEINT) AS commits_by_ai,
+  CAST(0 AS HUGEINT) AS pull_requests_by_ai,
+  COALESCE(daily_rollup.primary_model, event_rollup.primary_model) AS primary_model,
+  COALESCE(daily_rollup.apply_operations, 0) AS apply_operations,
+  COALESCE(daily_rollup.suggestions_accepted, 0) AS suggestions_accepted,
+  COALESCE(daily_rollup.suggestions_rejected, 0) AS suggestions_rejected,
+  COALESCE(daily_rollup.tabs_shown, 0) AS tabs_shown,
+  COALESCE(daily_rollup.tabs_accepted, 0) AS tabs_accepted,
+  COALESCE(daily_rollup.composer_requests, 0) AS composer_requests,
+  COALESCE(daily_rollup.chat_requests, 0) AS chat_requests,
+  COALESCE(daily_rollup.agent_requests, 0) AS agent_requests,
+  COALESCE(daily_rollup.subscription_included_requests, 0) AS subscription_included_requests,
+  COALESCE(daily_rollup.api_key_requests, 0) AS api_key_requests,
+  COALESCE(daily_rollup.usage_based_requests, 0) AS usage_based_requests,
+  COALESCE(event_rollup.request_cost_units, 0.0) AS request_cost_units
+FROM daily_rollup
+FULL OUTER JOIN event_rollup
+  ON daily_rollup.usage_date = event_rollup.usage_date
+  AND daily_rollup.user_id = event_rollup.user_id
+WHERE COALESCE(daily_rollup.usage_date, event_rollup.usage_date)
+  BETWEEN CAST('{{ start_date }}' AS DATE) AND CAST('{{ end_date }}' AS DATE);

--- a/templates/ai-coding-usage/assets/raw/claude_code_usage.asset.yml
+++ b/templates/ai-coding-usage/assets/raw/claude_code_usage.asset.yml
@@ -1,0 +1,72 @@
+name: raw.claude_code_usage
+type: ingestr
+
+description: Daily Claude Code usage data from the Anthropic Admin API. This asset runs independently of the Cursor ingestion assets.
+
+columns:
+  - name: date
+    type: string
+    description: UTC date covered by the usage record.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: actor_type
+    type: string
+    description: Whether the actor is a user or an API key.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: actor_id
+    type: string
+    description: User email address or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: organization_id
+    type: string
+    description: Anthropic organization identifier.
+  - name: customer_type
+    type: string
+    description: Anthropic customer type, such as api or subscription.
+  - name: terminal_type
+    type: string
+    description: Terminal or environment where Claude Code was used.
+    primary_key: true
+  - name: num_sessions
+    type: integer
+    description: Number of distinct Claude Code sessions.
+  - name: lines_added
+    type: integer
+    description: Lines of code added with Claude Code.
+  - name: lines_removed
+    type: integer
+    description: Lines of code removed with Claude Code.
+  - name: commits_by_claude_code
+    type: integer
+    description: Git commits created through Claude Code.
+  - name: pull_requests_by_claude_code
+    type: integer
+    description: Pull requests created through Claude Code.
+  - name: total_input_tokens
+    type: integer
+    description: Input tokens used across all models.
+  - name: total_output_tokens
+    type: integer
+    description: Output tokens used across all models.
+  - name: total_cache_read_tokens
+    type: integer
+    description: Prompt cache read tokens used across all models.
+  - name: total_cache_creation_tokens
+    type: integer
+    description: Prompt cache creation tokens used across all models.
+  - name: total_estimated_cost_cents
+    type: numeric
+    description: Estimated cost in minor USD units (cents).
+  - name: models_used
+    type: string
+    description: Comma-separated Claude model names used by the actor.
+
+parameters:
+  source_connection: anthropic-default
+  source_table: claude_code_usage
+  destination: duckdb

--- a/templates/ai-coding-usage/assets/raw/cursor_daily_usage.asset.yml
+++ b/templates/ai-coding-usage/assets/raw/cursor_daily_usage.asset.yml
@@ -1,0 +1,90 @@
+name: raw.cursor_daily_usage
+type: ingestr
+
+description: Daily per-user activity and productivity metrics from the Cursor Admin API. This asset runs independently of the Anthropic ingestion asset.
+
+columns:
+  - name: date
+    type: bigint
+    description: UTC usage date as Unix epoch milliseconds.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: email
+    type: string
+    description: Cursor team member email address.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: isActive
+    type: boolean
+    description: Whether the user was active on this date.
+  - name: totalLinesAdded
+    type: bigint
+    description: Total lines added by the user.
+  - name: totalLinesDeleted
+    type: bigint
+    description: Total lines deleted by the user.
+  - name: acceptedLinesAdded
+    type: bigint
+    description: Lines added from accepted AI suggestions.
+  - name: acceptedLinesDeleted
+    type: bigint
+    description: Lines deleted from accepted AI suggestions.
+  - name: totalApplies
+    type: bigint
+    description: AI code apply operations.
+  - name: totalAccepts
+    type: bigint
+    description: Accepted AI suggestions.
+  - name: totalRejects
+    type: bigint
+    description: Rejected AI suggestions.
+  - name: totalTabsShown
+    type: bigint
+    description: Tab completions shown.
+  - name: totalTabsAccepted
+    type: bigint
+    description: Tab completions accepted.
+  - name: composerRequests
+    type: bigint
+    description: Composer or edit requests.
+  - name: chatRequests
+    type: bigint
+    description: Ask or chat requests.
+  - name: agentRequests
+    type: bigint
+    description: Agent requests.
+  - name: cmdkUsages
+    type: bigint
+    description: Command palette usages.
+  - name: subscriptionIncludedReqs
+    type: bigint
+    description: Requests included in the subscription.
+  - name: apiKeyReqs
+    type: bigint
+    description: Requests made with API keys.
+  - name: usageBasedReqs
+    type: bigint
+    description: Usage-based billing requests.
+  - name: bugbotUsages
+    type: bigint
+    description: Bugbot usages.
+  - name: mostUsedModel
+    type: string
+    description: Most frequently used model.
+  - name: applyMostUsedExtension
+    type: string
+    description: Most-used file extension for AI applies.
+  - name: tabMostUsedExtension
+    type: string
+    description: Most-used file extension for tab completions.
+  - name: clientVersion
+    type: string
+    description: Cursor client version.
+
+parameters:
+  source_connection: cursor-default
+  source_table: daily_usage_data
+  destination: duckdb
+  enforce_schema: "true"

--- a/templates/ai-coding-usage/assets/raw/cursor_usage_events.asset.yml
+++ b/templates/ai-coding-usage/assets/raw/cursor_usage_events.asset.yml
@@ -13,6 +13,7 @@ columns:
   - name: userEmail
     type: string
     description: Email address of the user who made the request.
+    primary_key: true
     checks:
       - name: not_null
   - name: model

--- a/templates/ai-coding-usage/assets/raw/cursor_usage_events.asset.yml
+++ b/templates/ai-coding-usage/assets/raw/cursor_usage_events.asset.yml
@@ -1,0 +1,44 @@
+name: raw.cursor_usage_events
+type: ingestr
+
+description: Per-request Cursor usage events with model, token, and cost information.
+
+columns:
+  - name: timestamp
+    type: string
+    description: Event timestamp as epoch milliseconds or an ISO timestamp.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: userEmail
+    type: string
+    description: Email address of the user who made the request.
+    checks:
+      - name: not_null
+  - name: model
+    type: string
+    description: Model used for the request.
+  - name: kind
+    type: string
+    description: Cursor usage or billing category.
+  - name: maxMode
+    type: boolean
+    description: Whether Cursor Max Mode was enabled.
+  - name: requestsCosts
+    type: numeric
+    description: Cursor request cost units.
+  - name: isTokenBasedCall
+    type: boolean
+    description: Whether token-level usage and cost are available.
+  - name: tokenUsage
+    type: json
+    description: Input, output, cache, and cost details for token-based calls.
+  - name: isFreeBugbot
+    type: boolean
+    description: Whether the event was a free Bugbot request.
+
+parameters:
+  source_connection: cursor-default
+  source_table: filtered_usage_events
+  destination: duckdb
+  enforce_schema: "true"

--- a/templates/ai-coding-usage/assets/staging/claude_code_usage.sql
+++ b/templates/ai-coding-usage/assets/staging/claude_code_usage.sql
@@ -1,0 +1,120 @@
+/* @bruin
+
+name: staging.claude_code_usage
+type: duckdb.sql
+
+description: Typed Anthropic Claude Code usage records with normalized user identifiers and reusable token, cost, and code-change metrics.
+
+materialization:
+  type: table
+
+depends:
+  - raw.claude_code_usage
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC date covered by the usage record.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: actor_type
+    type: varchar
+    description: Whether the actor is a user or an API key.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: actor_id
+    type: varchar
+    description: User email address or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Normalized user email or API key name used across platform models.
+    checks:
+      - name: not_null
+  - name: user_type
+    type: varchar
+    description: User or API key actor classification.
+  - name: terminal_type
+    type: varchar
+    description: Terminal or environment where Claude Code was used.
+    primary_key: true
+  - name: total_tokens
+    type: bigint
+    description: Input, output, cache-read, and cache-creation tokens combined.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated Claude Code cost in US dollars.
+    checks:
+      - name: non_negative
+  - name: cache_read_rate
+    type: double
+    description: Cache-read tokens divided by input plus cache-read tokens.
+  - name: net_lines_changed
+    type: bigint
+    description: Lines added minus lines removed.
+
+@bruin */
+
+WITH typed AS (
+  SELECT
+    TRY_CAST(date AS DATE) AS usage_date,
+    CAST(actor_type AS VARCHAR) AS actor_type,
+    CAST(actor_id AS VARCHAR) AS actor_id,
+    CAST(organization_id AS VARCHAR) AS organization_id,
+    CAST(customer_type AS VARCHAR) AS customer_type,
+    CAST(terminal_type AS VARCHAR) AS terminal_type,
+    COALESCE(TRY_CAST(num_sessions AS BIGINT), 0) AS num_sessions,
+    COALESCE(TRY_CAST(lines_added AS BIGINT), 0) AS lines_added,
+    COALESCE(TRY_CAST(lines_removed AS BIGINT), 0) AS lines_removed,
+    COALESCE(TRY_CAST(commits_by_claude_code AS BIGINT), 0) AS commits_by_claude_code,
+    COALESCE(TRY_CAST(pull_requests_by_claude_code AS BIGINT), 0) AS pull_requests_by_claude_code,
+    COALESCE(TRY_CAST(total_input_tokens AS BIGINT), 0) AS total_input_tokens,
+    COALESCE(TRY_CAST(total_output_tokens AS BIGINT), 0) AS total_output_tokens,
+    COALESCE(TRY_CAST(total_cache_read_tokens AS BIGINT), 0) AS total_cache_read_tokens,
+    COALESCE(TRY_CAST(total_cache_creation_tokens AS BIGINT), 0) AS total_cache_creation_tokens,
+    COALESCE(TRY_CAST(total_estimated_cost_cents AS DOUBLE), 0.0) AS total_estimated_cost_cents,
+    CAST(models_used AS VARCHAR) AS models_used
+  FROM raw.claude_code_usage
+)
+
+SELECT
+  usage_date,
+  actor_type,
+  actor_id,
+  CASE
+    WHEN actor_type = 'user_actor' THEN LOWER(TRIM(actor_id))
+    ELSE actor_id
+  END AS user_id,
+  CASE
+    WHEN actor_type = 'user_actor' THEN 'user'
+    WHEN actor_type = 'api_actor' THEN 'api_key'
+    ELSE actor_type
+  END AS user_type,
+  organization_id,
+  customer_type,
+  terminal_type,
+  num_sessions,
+  lines_added,
+  lines_removed,
+  lines_added - lines_removed AS net_lines_changed,
+  commits_by_claude_code,
+  pull_requests_by_claude_code,
+  total_input_tokens,
+  total_output_tokens,
+  total_cache_read_tokens,
+  total_cache_creation_tokens,
+  total_input_tokens
+    + total_output_tokens
+    + total_cache_read_tokens
+    + total_cache_creation_tokens AS total_tokens,
+  total_estimated_cost_cents / 100.0 AS estimated_cost_usd,
+  total_cache_read_tokens::DOUBLE
+    / NULLIF(total_input_tokens + total_cache_read_tokens, 0) AS cache_read_rate,
+  models_used
+FROM typed;

--- a/templates/ai-coding-usage/assets/staging/cursor_daily_usage.sql
+++ b/templates/ai-coding-usage/assets/staging/cursor_daily_usage.sql
@@ -1,0 +1,81 @@
+/* @bruin
+
+name: staging.cursor_daily_usage
+type: duckdb.sql
+
+description: Typed daily Cursor activity, productivity, request, and acceptance metrics.
+
+materialization:
+  type: table
+
+depends:
+  - raw.cursor_daily_usage
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Lowercase Cursor team member email address.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: total_requests
+    type: bigint
+    description: Composer, chat, and agent requests combined.
+    checks:
+      - name: non_negative
+  - name: suggestion_acceptance_rate
+    type: double
+    description: Accepted suggestions divided by accepted plus rejected suggestions.
+  - name: tab_acceptance_rate
+    type: double
+    description: Accepted tab completions divided by tab completions shown.
+
+@bruin */
+
+SELECT
+  CASE
+    WHEN TRY_CAST(date AS BIGINT) IS NOT NULL
+      THEN CAST(TO_TIMESTAMP(TRY_CAST(date AS BIGINT) / 1000.0) AS DATE)
+    ELSE TRY_CAST(date AS DATE)
+  END AS usage_date,
+  LOWER(TRIM(CAST(email AS VARCHAR))) AS user_id,
+  COALESCE(TRY_CAST("isActive" AS BOOLEAN), FALSE) AS is_active,
+  COALESCE(TRY_CAST("totalLinesAdded" AS BIGINT), 0) AS total_lines_added,
+  COALESCE(TRY_CAST("totalLinesDeleted" AS BIGINT), 0) AS total_lines_removed,
+  COALESCE(TRY_CAST("acceptedLinesAdded" AS BIGINT), 0) AS ai_lines_added,
+  COALESCE(TRY_CAST("acceptedLinesDeleted" AS BIGINT), 0) AS ai_lines_removed,
+  COALESCE(TRY_CAST("totalApplies" AS BIGINT), 0) AS apply_operations,
+  COALESCE(TRY_CAST("totalAccepts" AS BIGINT), 0) AS suggestions_accepted,
+  COALESCE(TRY_CAST("totalRejects" AS BIGINT), 0) AS suggestions_rejected,
+  COALESCE(TRY_CAST("totalTabsShown" AS BIGINT), 0) AS tabs_shown,
+  COALESCE(TRY_CAST("totalTabsAccepted" AS BIGINT), 0) AS tabs_accepted,
+  COALESCE(TRY_CAST("composerRequests" AS BIGINT), 0) AS composer_requests,
+  COALESCE(TRY_CAST("chatRequests" AS BIGINT), 0) AS chat_requests,
+  COALESCE(TRY_CAST("agentRequests" AS BIGINT), 0) AS agent_requests,
+  COALESCE(TRY_CAST("composerRequests" AS BIGINT), 0)
+    + COALESCE(TRY_CAST("chatRequests" AS BIGINT), 0)
+    + COALESCE(TRY_CAST("agentRequests" AS BIGINT), 0) AS total_requests,
+  COALESCE(TRY_CAST("cmdkUsages" AS BIGINT), 0) AS cmdk_usages,
+  COALESCE(TRY_CAST("subscriptionIncludedReqs" AS BIGINT), 0) AS subscription_included_requests,
+  COALESCE(TRY_CAST("apiKeyReqs" AS BIGINT), 0) AS api_key_requests,
+  COALESCE(TRY_CAST("usageBasedReqs" AS BIGINT), 0) AS usage_based_requests,
+  COALESCE(TRY_CAST("bugbotUsages" AS BIGINT), 0) AS bugbot_usages,
+  COALESCE(TRY_CAST("totalAccepts" AS DOUBLE), 0)
+    / NULLIF(
+      COALESCE(TRY_CAST("totalAccepts" AS DOUBLE), 0)
+        + COALESCE(TRY_CAST("totalRejects" AS DOUBLE), 0),
+      0
+    ) AS suggestion_acceptance_rate,
+  COALESCE(TRY_CAST("totalTabsAccepted" AS DOUBLE), 0)
+    / NULLIF(COALESCE(TRY_CAST("totalTabsShown" AS DOUBLE), 0), 0) AS tab_acceptance_rate,
+  CAST("mostUsedModel" AS VARCHAR) AS primary_model,
+  CAST("applyMostUsedExtension" AS VARCHAR) AS primary_apply_extension,
+  CAST("tabMostUsedExtension" AS VARCHAR) AS primary_tab_extension,
+  CAST("clientVersion" AS VARCHAR) AS client_version
+FROM raw.cursor_daily_usage;

--- a/templates/ai-coding-usage/assets/staging/cursor_usage_events.sql
+++ b/templates/ai-coding-usage/assets/staging/cursor_usage_events.sql
@@ -1,0 +1,81 @@
+/* @bruin
+
+name: staging.cursor_usage_events
+type: duckdb.sql
+
+description: Typed Cursor request events with token and USD cost fields extracted from the tokenUsage JSON object.
+
+materialization:
+  type: table
+
+depends:
+  - raw.cursor_usage_events
+
+columns:
+  - name: event_timestamp
+    type: timestamp
+    description: UTC event timestamp.
+    checks:
+      - name: not_null
+  - name: usage_date
+    type: date
+    description: UTC event date.
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Lowercase Cursor team member email address.
+    checks:
+      - name: not_null
+  - name: total_tokens
+    type: bigint
+    description: Input, output, cache-read, and cache-write tokens combined.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Token-based request cost converted from cents to US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+WITH typed AS (
+  SELECT
+    CASE
+      WHEN TRY_CAST("timestamp" AS BIGINT) IS NOT NULL
+        THEN TO_TIMESTAMP(TRY_CAST("timestamp" AS BIGINT) / 1000.0)
+      ELSE TRY_CAST("timestamp" AS TIMESTAMPTZ)
+    END AS event_timestamp,
+    LOWER(TRIM(CAST("userEmail" AS VARCHAR))) AS user_id,
+    CAST(model AS VARCHAR) AS model,
+    CAST(kind AS VARCHAR) AS usage_kind,
+    COALESCE(TRY_CAST("maxMode" AS BOOLEAN), FALSE) AS is_max_mode,
+    COALESCE(TRY_CAST("requestsCosts" AS DOUBLE), 0.0) AS request_cost_units,
+    COALESCE(TRY_CAST("isTokenBasedCall" AS BOOLEAN), FALSE) AS is_token_based_call,
+    COALESCE(TRY_CAST("isFreeBugbot" AS BOOLEAN), FALSE) AS is_free_bugbot,
+    TRY_CAST("tokenUsage" AS JSON) AS token_usage
+  FROM raw.cursor_usage_events
+)
+
+SELECT
+  event_timestamp,
+  CAST(event_timestamp AS DATE) AS usage_date,
+  user_id,
+  model,
+  usage_kind,
+  is_max_mode,
+  request_cost_units,
+  is_token_based_call,
+  is_free_bugbot,
+  COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.inputTokens') AS BIGINT), 0) AS input_tokens,
+  COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.outputTokens') AS BIGINT), 0) AS output_tokens,
+  COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.cacheReadTokens') AS BIGINT), 0) AS cache_read_tokens,
+  COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.cacheWriteTokens') AS BIGINT), 0) AS cache_creation_tokens,
+  COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.inputTokens') AS BIGINT), 0)
+    + COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.outputTokens') AS BIGINT), 0)
+    + COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.cacheReadTokens') AS BIGINT), 0)
+    + COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.cacheWriteTokens') AS BIGINT), 0) AS total_tokens,
+  COALESCE(TRY_CAST(JSON_EXTRACT_STRING(token_usage, '$.totalCents') AS DOUBLE), 0.0)
+    / 100.0 AS estimated_cost_usd
+FROM typed;

--- a/templates/ai-coding-usage/dashboards/ai-coding-usage.yml
+++ b/templates/ai-coding-usage/dashboards/ai-coding-usage.yml
@@ -1,0 +1,221 @@
+name: AI Coding Usage
+description: Cross-platform Anthropic Claude Code and Cursor adoption, consumption, cost, and productivity.
+connection: duckdb-dashboard
+
+filters:
+  - name: platform
+    type: select
+    default: All
+    options:
+      values: [All, anthropic, cursor]
+  - name: date_range
+    type: date-range
+    default: last_30_days
+
+queries:
+  daily_token_usage:
+    sql: |
+      SELECT
+        usage_date,
+        COALESCE(SUM(total_tokens) FILTER (WHERE platform = 'anthropic'), 0) AS anthropic_tokens,
+        COALESCE(SUM(total_tokens) FILTER (WHERE platform = 'cursor'), 0) AS cursor_tokens
+      FROM marts.ai_coding_usage_by_user_day
+      WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+        AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+      {% if filters.platform != 'All' %}
+        AND platform = '{{ filters.platform }}'
+      {% endif %}
+      GROUP BY usage_date
+      ORDER BY usage_date
+
+  platform_usage:
+    sql: |
+      SELECT
+        platform,
+        COUNT(DISTINCT user_type || ':' || user_id) FILTER (WHERE is_active) AS active_users,
+        SUM(requests) AS requests,
+        SUM(total_tokens) AS total_tokens,
+        ROUND(SUM(estimated_cost_usd), 2) AS estimated_cost_usd
+      FROM marts.ai_coding_usage_by_user_day
+      WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+        AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+      {% if filters.platform != 'All' %}
+        AND platform = '{{ filters.platform }}'
+      {% endif %}
+      GROUP BY platform
+      ORDER BY total_tokens DESC
+
+  daily_active_users:
+    sql: |
+      SELECT
+        usage_date,
+        COUNT(DISTINCT user_type || ':' || user_id) FILTER (WHERE is_active) AS active_users
+      FROM marts.ai_coding_usage_by_user_day
+      WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+        AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+      {% if filters.platform != 'All' %}
+        AND platform = '{{ filters.platform }}'
+      {% endif %}
+      GROUP BY usage_date
+      ORDER BY usage_date
+
+  user_summary:
+    sql: |
+      SELECT
+        user_id,
+        user_type,
+        STRING_AGG(DISTINCT platform, ',' ORDER BY platform) AS platforms,
+        COUNT(DISTINCT usage_date) FILTER (WHERE is_active) AS active_days,
+        SUM(sessions) AS sessions,
+        SUM(requests) AS requests,
+        SUM(total_tokens) AS total_tokens,
+        ROUND(SUM(estimated_cost_usd), 2) AS estimated_cost_usd,
+        SUM(ai_lines_added) AS ai_lines_added,
+        SUM(ai_lines_removed) AS ai_lines_removed
+      FROM marts.ai_coding_usage_by_user_day
+      WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+        AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+      {% if filters.platform != 'All' %}
+        AND platform = '{{ filters.platform }}'
+      {% endif %}
+      GROUP BY user_id, user_type
+      ORDER BY total_tokens DESC
+      LIMIT 50
+
+rows:
+  - widgets:
+      - name: Daily Tokens
+        type: chart
+        chart: bar
+        query: daily_token_usage
+        x: usage_date
+        y: [anthropic_tokens, cursor_tokens]
+        stacked: true
+        col: 12
+
+  - widgets:
+      - name: Active Users
+        type: metric
+        column: value
+        format: number
+        col: 3
+        sql: |
+          SELECT COUNT(DISTINCT user_type || ':' || user_id) AS value
+          FROM marts.ai_coding_usage_by_user_day
+          WHERE is_active
+            AND usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+            AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+          {% if filters.platform != 'All' %}
+            AND platform = '{{ filters.platform }}'
+          {% endif %}
+
+      - name: Total Tokens
+        type: metric
+        column: value
+        format: number
+        col: 3
+        sql: |
+          SELECT COALESCE(SUM(total_tokens), 0) AS value
+          FROM marts.ai_coding_usage_by_user_day
+          WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+            AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+          {% if filters.platform != 'All' %}
+            AND platform = '{{ filters.platform }}'
+          {% endif %}
+
+      - name: Estimated Cost
+        type: metric
+        column: value
+        prefix: "$"
+        format: number
+        col: 3
+        sql: |
+          SELECT ROUND(COALESCE(SUM(estimated_cost_usd), 0), 2) AS value
+          FROM marts.ai_coding_usage_by_user_day
+          WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+            AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+          {% if filters.platform != 'All' %}
+            AND platform = '{{ filters.platform }}'
+          {% endif %}
+
+      - name: Requests
+        type: metric
+        column: value
+        format: number
+        col: 3
+        sql: |
+          SELECT COALESCE(SUM(requests), 0) AS value
+          FROM marts.ai_coding_usage_by_user_day
+          WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+            AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+          {% if filters.platform != 'All' %}
+            AND platform = '{{ filters.platform }}'
+          {% endif %}
+
+  - widgets:
+      - name: Daily Token Consumption
+        type: chart
+        chart: area
+        query: daily_token_usage
+        x: usage_date
+        y: [anthropic_tokens, cursor_tokens]
+        col: 8
+
+      - name: Cost by Platform
+        type: chart
+        chart: bar
+        query: platform_usage
+        x: platform
+        y: [estimated_cost_usd]
+        col: 4
+
+  - widgets:
+      - name: Daily Active Users
+        type: chart
+        chart: line
+        query: daily_active_users
+        x: usage_date
+        y: [active_users]
+        col: 6
+
+      - name: Requests by Platform
+        type: chart
+        chart: bar
+        query: platform_usage
+        x: platform
+        y: [requests]
+        col: 6
+
+  - widgets:
+      - name: User Consumption
+        type: table
+        query: user_summary
+        col: 12
+        columns:
+          - name: user_id
+            label: User
+          - name: user_type
+            label: Type
+          - name: platforms
+            label: Platforms
+          - name: active_days
+            label: Active Days
+            format: number
+          - name: sessions
+            label: Sessions
+            format: number
+          - name: requests
+            label: Requests
+            format: number
+          - name: total_tokens
+            label: Tokens
+            format: number
+          - name: estimated_cost_usd
+            label: Estimated Cost
+            format: currency
+          - name: ai_lines_added
+            label: AI Lines Added
+            format: number
+          - name: ai_lines_removed
+            label: AI Lines Removed
+            format: number

--- a/templates/ai-coding-usage/pipeline.yml
+++ b/templates/ai-coding-usage/pipeline.yml
@@ -1,0 +1,12 @@
+name: ai-coding-usage
+schedule: daily
+start_date: "2025-01-01"
+catchup: false
+
+default_connections:
+  anthropic: anthropic-default
+  cursor: cursor-default
+  duckdb: duckdb-default
+
+default:
+  type: duckdb.sql


### PR DESCRIPTION
## What

Adds an `ai-coding-usage` template for loading Anthropic Claude Code and Cursor usage into DuckDB with a DAC dashboard.

## Changes

- Adds parallel ingestion, typed staging models, per-user/day marts, aggregate summaries, and dashboard views.
- Documents credential setup, historical backfills, and the new template catalog entry.

## How to test

1. Run `bruin validate templates/ai-coding-usage` with the documented connections.
2. Populate DuckDB, then run `dac validate` and `dac check` against the dashboard directory.

## Risk & rollback

- **Risk:** Low; this is an additive template and documentation change.
- **Rollback:** Revert the merge commit.

## Checklist

- [ ] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

None.
