### PR TITLE
Remove templated date filter from firebase stg_events template

### DIFF
--- a/templates/firebase/assets/events/stg_events.sql
+++ b/templates/firebase/assets/events/stg_events.sql
@@ -80,4 +80,3 @@ SELECT
     event_value_in_usd,
 from `analytics_123456789.events_*` -- TODO: Change 123456789 to your analytics ID
 where replace(_TABLE_SUFFIX, 'intraday_', '') between '20200101' and '21000101'
-  and replace(_TABLE_SUFFIX, 'intraday_', '') between '{{ start_date_nodash }}' and '{{ end_date | add_days(1) | date_format("%Y%m%d") }}'


### PR DESCRIPTION
## What
Removes the templated `start_date`/`end_date` filter from the Firebase `stg_events` staging view template so the view is no longer bound to the pipeline run's date range.

## Changes
- `templates/firebase/assets/events/stg_events.sql`: dropped the `between '{{ start_date_nodash }}' and '{{ end_date | add_days(1) | date_format("%Y%m%d") }}'` predicate, keeping the static `20200101`–`21000101` partition-pruning guard.

## How to test
1. Inspect `templates/firebase/assets/events/stg_events.sql` and confirm the templated date predicate is gone.
2. `./bin/bruin render templates/firebase/assets/events/stg_events.sql` renders without the Jinja date filter.

## Risk & rollback
- **Risk:** low — template-only change; does not affect the Bruin binary/runtime behavior.
- **Rollback:** Revert the merge commit.

## Checklist
- [ ] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [ ] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
