### PR TITLE
Indent quality check lifecycle logs

### DIFF
--- a/pkg/executor/concurrent.go
+++ b/pkg/executor/concurrent.go
@@ -40,6 +40,7 @@ const (
 	timeFormat = "15:04:05"
 
 	stillRunningLogInterval = 120 * time.Second
+	qualityCheckLogIndent   = "    "
 )
 
 // IsDebugMode reports whether the context carries a KeyIsDebug *bool set to true.
@@ -115,6 +116,15 @@ type worker struct {
 	formatOpts FormattingOptions
 }
 
+func taskLogIndent(task scheduler.TaskInstance) string {
+	switch task.GetType() {
+	case scheduler.TaskInstanceTypeColumnCheck, scheduler.TaskInstanceTypeCustomCheck:
+		return qualityCheckLogIndent
+	default:
+		return ""
+	}
+}
+
 func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstance, results chan<- *scheduler.TaskExecutionResult) {
 	for task := range taskChannel {
 		if w.formatOpts.OnTaskStart != nil {
@@ -135,10 +145,11 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 				runningPrinter = color.New(color.Faint)
 			}
 			if !w.formatOpts.MinimalLogs {
+				indent := taskLogIndent(task)
 				if w.formatOpts.DoNotLogTimestamp {
-					fmt.Printf("%s\n", runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
+					fmt.Printf("%s\n", runningPrinter.Sprintf("%sRunning:  %s", indent, task.GetHumanID()))
 				} else {
-					fmt.Printf("%s %s\n", timestampStr, runningPrinter.Sprintf("Running:  %s", task.GetHumanID()))
+					fmt.Printf("%s %s\n", timestampStr, runningPrinter.Sprintf("%sRunning:  %s", indent, task.GetHumanID()))
 				}
 			}
 			w.printLock.Unlock()
@@ -165,11 +176,12 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 						if !w.formatOpts.NoColor {
 							stillRunningPrinter = color.New(color.Faint)
 						}
+						indent := taskLogIndent(task)
 						if w.formatOpts.DoNotLogTimestamp {
-							fmt.Printf("%s\n", stillRunningPrinter.Sprintf("Still running: %s (%s)", task.GetHumanID(), elapsed))
+							fmt.Printf("%s\n", stillRunningPrinter.Sprintf("%sStill running: %s (%s)", indent, task.GetHumanID(), elapsed))
 						} else {
 							ts := whitePrinter("[%s]", time.Now().Format(timeFormat))
-							fmt.Printf("%s %s\n", ts, stillRunningPrinter.Sprintf("Still running: %s (%s)", task.GetHumanID(), elapsed))
+							fmt.Printf("%s %s\n", ts, stillRunningPrinter.Sprintf("%sStill running: %s (%s)", indent, task.GetHumanID(), elapsed))
 						}
 						w.printLock.Unlock()
 					case <-stopTicker:
@@ -231,11 +243,12 @@ func (w worker) run(ctx context.Context, taskChannel <-chan scheduler.TaskInstan
 			}
 
 			if !w.formatOpts.MinimalLogs {
+				indent := taskLogIndent(task)
 				if w.formatOpts.DoNotLogTimestamp {
-					fmt.Printf("%s\n", printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+					fmt.Printf("%s\n", printerInstance.Sprintf("%s%s: %s %s", indent, res, task.GetHumanID(), faint(durationString)))
 				} else {
 					timestampStr := whitePrinter("[%s]", time.Now().Format(timeFormat))
-					fmt.Printf("%s %s\n", timestampStr, printerInstance.Sprintf("%s: %s %s", res, task.GetHumanID(), faint(durationString)))
+					fmt.Printf("%s %s\n", timestampStr, printerInstance.Sprintf("%s%s: %s %s", indent, res, task.GetHumanID(), faint(durationString)))
 				}
 			}
 			w.printLock.Unlock()

--- a/pkg/executor/concurrent_test.go
+++ b/pkg/executor/concurrent_test.go
@@ -116,6 +116,47 @@ func TestConcurrent_StartTimesOutAsset(t *testing.T) {
 	require.Equal(t, scheduler.Failed, results[0].Instance.GetStatus())
 }
 
+func TestTaskLogIndent(t *testing.T) {
+	t.Parallel()
+
+	assetInstance := &scheduler.AssetInstance{}
+
+	tests := []struct {
+		name     string
+		task     scheduler.TaskInstance
+		expected string
+	}{
+		{
+			name:     "asset",
+			task:     assetInstance,
+			expected: "",
+		},
+		{
+			name:     "column quality check",
+			task:     &scheduler.ColumnCheckInstance{AssetInstance: assetInstance},
+			expected: qualityCheckLogIndent,
+		},
+		{
+			name:     "custom quality check",
+			task:     &scheduler.CustomCheckInstance{AssetInstance: assetInstance},
+			expected: qualityCheckLogIndent,
+		},
+		{
+			name:     "metadata push",
+			task:     &scheduler.MetadataPushInstance{AssetInstance: assetInstance},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, taskLogIndent(tt.task))
+		})
+	}
+}
+
 func TestWorkerWriter_Write(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Indent quality-check lifecycle output so column and custom checks are visually nested beneath their assets.

## Changes
- Add four-space indentation to Running, Still running, Finished, and Failed lines for quality checks
- Keep asset and metadata-push lifecycle output unchanged
- Add unit coverage for task-type indentation

## Output
[Indented quality-check CLI output](https://cursor.com/agents/bc-2ef3a048-fba2-5494-ae83-e188c2316029/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquality_check_log_indentation_output.png)

[quality_check_log_indentation_success.mp4](https://cursor.com/agents/bc-2ef3a048-fba2-5494-ae83-e188c2316029/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquality_check_log_indentation_success.mp4)

## How to test
1. Run `PATH="$HOME/.local/bin:$PATH" make format`.
2. Run `make test`.
3. Run `make integration-test-light`.
4. Build with `make build` and execute a DuckDB pipeline containing column and custom quality checks.

## Risk & rollback
- **Risk:** Low; this only changes CLI log presentation outside TUI and minimal-log modes.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build`, `make format`)
- [x] Integration tests pass if affected (`make integration-test-light`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (not applicable)

## Related issues
- BRU-3618

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1768918326217999?thread_ts=1768918326.217999&cid=C094932THFW)

<div><a href="https://cursor.com/agents/bc-2ef3a048-fba2-5494-ae83-e188c2316029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ef3a048-fba2-5494-ae83-e188c2316029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

