### PR TITLE
python: bump default ingestr version to 1.1.8

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.6"
+	IngestrVersionV1 = "1.1.8"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
Bumps the default ingestr V1 pin (`IngestrVersionV1`) from `1.1.6` to `1.1.8`, the latest release on PyPI. This is the version used by default and for `parameters.version=v1` ingestr assets.