### PR TITLE
Add Typeform connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -379,6 +379,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "TikTok Ads", link: "/ingestion/tiktokads"},
                                     {text: "Trello", link: "/ingestion/trello"},
                                     {text: "Twilio", link: "/ingestion/twilio"},
+                                    {text: "Typeform", link: "/ingestion/typeform"},
                                     {text: "Vitess", link: "/ingestion/vitess"},
                                     {text: "Wise", link: "/ingestion/wise"},
                                     {text: "Zendesk", link: "/ingestion/zendesk"},

--- a/docs/ingestion/typeform.md
+++ b/docs/ingestion/typeform.md
@@ -1,0 +1,76 @@
+# Typeform
+
+[Typeform](https://www.typeform.com/) is an online form and survey platform for building interactive forms and collecting responses.
+
+Bruin supports Typeform as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Typeform into your data platform.
+
+To set up a Typeform connection, you need to add a configuration entry to your `.bruin.yml` file and create an asset file for data ingestion. You'll need a `token` (personal access token) to authenticate.
+
+## Configuration
+
+### Step 1: Add a connection to the .bruin.yml file
+
+```yaml
+connections:
+  typeform:
+    - name: "my_typeform"
+      token: "your-personal-access-token"
+```
+
+- `token` (required): The personal access token used to authenticate with the Typeform API.
+- `region` (optional): The account region. Must be `us` (default) or `eu`.
+
+For EU accounts:
+
+```yaml
+connections:
+  typeform:
+    - name: "my_typeform_eu"
+      token: "your-personal-access-token"
+      region: "eu"
+```
+
+### Step 2: Create an asset file for data ingestion
+
+Create an [asset configuration](/assets/ingestr#asset-structure) file (e.g., `typeform.asset.yml`) inside the assets folder:
+
+```yaml
+name: public.typeform
+type: ingestr
+
+parameters:
+  source_connection: my_typeform
+  source_table: 'forms'
+
+  destination: postgres
+```
+
+- `source_connection`: The name of the Typeform connection defined in `.bruin.yml`.
+- `source_table`: The table to ingest from Typeform (see available tables below).
+- `destination`: The destination platform/type, for example `postgres`.
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/typeform.asset.yml
+```
+
+Running this command ingests data from Typeform into your destination.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+| ----- | -- | ------- | ------------ | ------- |
+| `forms` | id | last_updated_at | merge | All forms in the account with metadata (title, settings, theme, timestamps) |
+| `responses` | response_id | submitted_at | merge | Submitted responses with answers and metadata, collected per form |
+| `workspaces` | id | - | replace | Workspaces in the account |
+| `themes` | id | - | replace | Themes available in the account |
+
+Use these as the `source_table` parameter in the asset configuration.
+
+## Getting a Personal Access Token
+
+1. Log in to your Typeform account.
+2. Go to your [personal tokens settings](https://admin.typeform.com/user/tokens).
+3. Click **Generate a new token**, give it a name, and grant at least read access to forms, responses, workspaces, and themes.
+4. Copy the generated token.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1621,6 +1621,12 @@
           },
           "type": "array"
         },
+        "typeform": {
+          "items": {
+            "$ref": "#/$defs/TypeformConnection"
+          },
+          "type": "array"
+        },
         "dune": {
           "items": {
             "$ref": "#/$defs/DuneConnection"
@@ -5244,6 +5250,28 @@
       "required": [
         "name",
         "account_sid"
+      ]
+    },
+    "TypeformConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "token": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "token"
       ]
     },
     "VerticaConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -2177,3 +2177,13 @@ type SurveyMonkeyConnection struct {
 func (c SurveyMonkeyConnection) GetName() string {
 	return c.Name
 }
+
+type TypeformConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	Token              string `yaml:"token,omitempty" json:"token" mapstructure:"token" sensitive:"true"`
+	Region             string `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
+}
+
+func (c TypeformConnection) GetName() string {
+	return c.Name
+}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -167,6 +167,7 @@ type Connections struct {
 	BallDontLie         []BallDontLieConnection         `yaml:"balldontlie,omitempty" json:"balldontlie,omitempty" mapstructure:"balldontlie"`
 	Vertica             []VerticaConnection             `yaml:"vertica,omitempty" json:"vertica,omitempty" mapstructure:"vertica"`
 	SurveyMonkey        []SurveyMonkeyConnection        `yaml:"surveymonkey,omitempty" json:"surveymonkey,omitempty" mapstructure:"surveymonkey"`
+	Typeform            []TypeformConnection            `yaml:"typeform,omitempty" json:"typeform,omitempty" mapstructure:"typeform"`
 	Dune                []DuneConnection                `yaml:"dune,omitempty" json:"dune,omitempty" mapstructure:"dune"`
 	byKey               map[string]any
 	typeNameMap         map[string]string
@@ -1758,6 +1759,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.SurveyMonkey = append(env.Connections.SurveyMonkey, conn)
+	case "typeform":
+		var conn TypeformConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Typeform = append(env.Connections.Typeform, conn)
 	case "dune":
 		var conn DuneConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -2125,6 +2133,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Vertica = removeConnection(env.Connections.Vertica, connectionName)
 	case "surveymonkey":
 		env.Connections.SurveyMonkey = removeConnection(env.Connections.SurveyMonkey, connectionName)
+	case "typeform":
+		env.Connections.Typeform = removeConnection(env.Connections.Typeform, connectionName)
 	case "dune":
 		env.Connections.Dune = removeConnection(env.Connections.Dune, connectionName)
 	default:
@@ -2371,6 +2381,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.BallDontLie, source.BallDontLie)
 	mergeConnectionList(&c.Vertica, source.Vertica)
 	mergeConnectionList(&c.SurveyMonkey, source.SurveyMonkey)
+	mergeConnectionList(&c.Typeform, source.Typeform)
 	mergeConnectionList(&c.Dune, source.Dune)
 	c.buildConnectionKeyMap()
 	return nil

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -143,6 +143,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/trino"
 	"github.com/bruin-data/bruin/pkg/trustpilot"
 	"github.com/bruin-data/bruin/pkg/twilio"
+	"github.com/bruin-data/bruin/pkg/typeform"
 	"github.com/bruin-data/bruin/pkg/vertica"
 	"github.com/bruin-data/bruin/pkg/vitess"
 	"github.com/bruin-data/bruin/pkg/wise"
@@ -197,6 +198,7 @@ type Manager struct {
 	Recurly              map[string]*recurly.Client
 	GitLab               map[string]*gitlab.Client
 	SurveyMonkey         map[string]*surveymonkey.Client
+	Typeform             map[string]*typeform.Client
 	Appsflyer            map[string]*appsflyer.Client
 	Kafka                map[string]*kafka.Client
 	RabbitMQ             map[string]*rabbitmq.Client
@@ -1581,6 +1583,30 @@ func (m *Manager) AddSurveyMonkeyConnectionFromConfig(connection *config.SurveyM
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.SurveyMonkey[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
+func (m *Manager) AddTypeformConnectionFromConfig(connection *config.TypeformConnection) error {
+	m.mutex.Lock()
+	if m.Typeform == nil {
+		m.Typeform = make(map[string]*typeform.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := typeform.NewClient(typeform.Config{
+		Token:  connection.Token,
+		Region: connection.Region,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Typeform[connection.Name] = client
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection
 
@@ -4132,6 +4158,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Adjust, connectionManager.AddAdjustConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Adapty, connectionManager.AddAdaptyConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.SurveyMonkey, connectionManager.AddSurveyMonkeyConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Typeform, connectionManager.AddTypeformConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Anthropic, connectionManager.AddAnthropicConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Intercom, connectionManager.AddIntercomConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.FacebookAds, connectionManager.AddFacebookAdsConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -1088,6 +1088,14 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "contacts", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
 	},
 
+	// Typeform - Online form and survey platform
+	"typeform": {
+		{Name: "forms", PrimaryKey: "id", IncKey: "last_updated_at", IncStrategy: "merge"},
+		{Name: "responses", PrimaryKey: "response_id", IncKey: "submitted_at", IncStrategy: "merge"},
+		{Name: "workspaces", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "themes", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+	},
+
 	// TikTok Ads
 	"tiktokads": {
 		{Name: "custom:<dimensions>:<metrics>", PrimaryKey: "", IncKey: "", IncStrategy: "merge"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -298,6 +298,7 @@ var defaultMapping = map[string]string{
 	"surveymonkey":          "surveymonkey-default",
 	"trustpilot":            "trustpilot-default",
 	"twilio":                "twilio-default",
+	"typeform":              "typeform-default",
 	"wise":                  "wise-default",
 	"wistia":                "wistia-default",
 	"zoom":                  "zoom-default",

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.8"
+	IngestrVersionV1 = "1.1.9"
 	sqlfluffVersion  = "3.4.1"
 )
 

--- a/pkg/typeform/config.go
+++ b/pkg/typeform/config.go
@@ -1,0 +1,16 @@
+package typeform
+
+import "net/url"
+
+type Config struct {
+	Token  string
+	Region string
+}
+
+func (c *Config) GetIngestrURI() string {
+	uri := "typeform://?token=" + url.QueryEscape(c.Token)
+	if c.Region != "" {
+		uri += "&region=" + url.QueryEscape(c.Region)
+	}
+	return uri
+}

--- a/pkg/typeform/config_test.go
+++ b/pkg/typeform/config_test.go
@@ -1,0 +1,53 @@
+package typeform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   Config
+		expected string
+	}{
+		{
+			name:     "token only",
+			config:   Config{Token: "my-token"},
+			expected: "typeform://?token=my-token",
+		},
+		{
+			name:     "token with region",
+			config:   Config{Token: "my-token", Region: "eu"},
+			expected: "typeform://?token=my-token&region=eu",
+		},
+		{
+			name:     "escapes token",
+			config:   Config{Token: "tok/with+symbols"},
+			expected: "typeform://?token=tok%2Fwith%2Bsymbols",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, tt.config.GetIngestrURI())
+		})
+	}
+}
+
+func TestClient_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{Token: "my-token", Region: "us"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "typeform://?token=my-token&region=us", uri)
+}

--- a/pkg/typeform/db.go
+++ b/pkg/typeform/db.go
@@ -1,0 +1,19 @@
+package typeform
+
+type Client struct {
+	config Config
+}
+
+type TypeformConfig interface {
+	GetIngestrURI() string
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI(), nil
+}


### PR DESCRIPTION
Wires the Typeform ingestr source into Bruin as a new connection type, mirroring the `surveymonkey` connector.

Depends on the ingestr Typeform source (bruin-data/ingestr#1027) being released — Bruin runs a released ingestr version, so this becomes usable once that ships.

## Changes

- **`pkg/typeform/`** — new client package (`config.go` with `GetIngestrURI`, `db.go`, `config_test.go`)
- **`pkg/config/connections.go`** — `TypeformConnection` struct (`token` required + `sensitive`, `region` optional) + `GetName`
- **`pkg/config/manager.go`** — `Typeform` field on `Connections`, add/remove-connection cases, merge
- **`pkg/connection/connection.go`** — import, client map, `AddTypeformConnectionFromConfig`, `processConnections` registration
- **`pkg/ingestr/sources.go`** — `typeform` source table set
- **`pkg/pipeline/pipeline.go`** — `typeform` → `typeform-default` name mapping
- **`integration-tests/expectations/expected_connections_schema.json`** — regenerated from `bruin internal connections` (adds the `typeform` array + `TypeformConnection` definition, +28 lines)
- **docs** — `docs/ingestion/typeform.md` + sidebar entry

## Tables

| Table | PK | Inc key | Strategy |
|---|---|---|---|
| `forms` | id | last_updated_at | merge |
| `responses` | response_id | submitted_at | merge |
| `workspaces` | id | — | replace |
| `themes` | id | — | replace |

## Connection

```yaml
connections:
  typeform:
    - name: "my_typeform"
      token: "your-personal-access-token"
      region: "eu"   # optional: us (default) or eu
```

## Checks

`go build ./...`, `go vet`, `gofmt`, and tests for the affected packages (`typeform`, `config`, `connection`, `ingestr`) all pass. The connections schema golden was regenerated from the actual CLI output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)