### PR TITLE
fix: pass microsecond precision for ingestr interval timestamps

### DIFF
--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
+const ingestrIntervalTimestampFormat = "2006-01-02T15:04:05.999999Z07:00"
+
 var ingestrValueParameterFlags = []string{
 	"incremental_key",
 	"incremental_strategy",
@@ -90,7 +92,7 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 			if ok && applyModifiers {
 				startTime = pipeline.ModifyDate(startTimeInstance, asset.IntervalModifiers.Start)
 			}
-			cmdArgs = append(cmdArgs, "--interval-start", startTime.Format(time.RFC3339))
+			cmdArgs = append(cmdArgs, "--interval-start", startTime.Format(ingestrIntervalTimestampFormat))
 		}
 	}
 
@@ -105,7 +107,7 @@ func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs 
 			if ok && applyModifiers {
 				endTime = pipeline.ModifyDate(endTimeInstance, asset.IntervalModifiers.End)
 			}
-			cmdArgs = append(cmdArgs, "--interval-end", endTime.Format(time.RFC3339))
+			cmdArgs = append(cmdArgs, "--interval-end", endTime.Format(ingestrIntervalTimestampFormat))
 		}
 	}
 

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -169,11 +169,15 @@ func TestConsolidatedParameters_StreamGating(t *testing.T) {
 	t.Run("interval-end is kept for a non-streaming asset", func(t *testing.T) {
 		t.Parallel()
 		asset := &pipeline.Asset{Parameters: pipeline.ParameterMap{}}
-		ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
-		ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+		ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, time.Date(2026, 7, 24, 15, 0, 0, 123456000, time.UTC))
+		ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, time.Date(2026, 7, 24, 15, 59, 59, 999000000, time.UTC))
 		result, err := ConsolidatedParameters(ctx, asset, []string{"--existing"}, nil)
 		require.NoError(t, err)
-		assert.Contains(t, result, "--interval-end")
+		assert.Equal(t, []string{
+			"--existing",
+			"--interval-start", "2026-07-24T15:00:00.123456Z",
+			"--interval-end", "2026-07-24T15:59:59.999Z",
+		}, result)
 	})
 }
 


### PR DESCRIPTION
## What
Ingestr interval start/end flags were formatted with RFC3339, which drops sub-second precision and can miss rows at interval boundaries.

## Changes
- `pkg/python/helper.go` — use a microsecond-precision timestamp format for `--interval-start` and `--interval-end`
- `pkg/python/helper_test.go` — assert exact formatted interval values

## How to test
1. `go test ./pkg/python/... -run TestConsolidatedParameters_StreamGating`

## Risk & rollback
- **Risk:** low — only changes how interval timestamps are formatted for ingestr
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues


Made with [Cursor](https://cursor.com)