### PR TITLE
Speed up local Go checks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Setup Rust
         if: steps.rust-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
-      - run: make test
+      - name: Run full test suite
+        run: make test-full
   end2end:
     strategy:
       matrix:
@@ -200,11 +201,9 @@ jobs:
           key: golangci-lint-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
           restore-keys: |
             golangci-lint-${{ runner.os }}-${{ hashFiles('go.sum') }}-
-      - name: Install golangci-lint
-        run: |
-          VERSION=$(grep '^GOLANGCI_LINT_VERSION=' Makefile | cut -d= -f2)
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${VERSION}
-      - name: Run golangci-lint
-        run: golangci-lint run --timeout 10m60s --build-tags="no_duckdb_arrow" ./...
-      - name: Run golangci-lint (semantic-engine module)
-        run: cd semantic-engine && golangci-lint run --timeout 10m60s ./...
+      - name: Install linting tools
+        run: make setup
+      - name: Check formatting
+        run: make format-ci
+      - name: Run full lint suite
+        run: make lint-full

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         platform: [ depot-ubuntu-latest-4, depot-macos-15, depot-windows-latest-4 ]
-        suite: ["test", "integration-test"]
+        suite: ["test-full", "integration-test"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install R in background (Ubuntu)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,8 @@ make build-no-duckdb # Build without DuckDB (CGO_ENABLED=0)
 make deps           # Install dependencies and tools
 make clean          # Remove build artifacts
 make format         # Format Go/Python and run fast changed-package lint
-make lint-full      # Run all Go linters across both Go modules
+make lint           # Run fast lint on changed packages in every Go module
+make lint-full      # Run all Go linters across the primary Go modules
 make tools-update   # Update development tools
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,13 +101,15 @@ make build-no-duckdb # Build without DuckDB (CGO_ENABLED=0)
 ```bash
 make deps           # Install dependencies and tools
 make clean          # Remove build artifacts
-make format         # Format Go and Python code
+make format         # Format Go/Python and run fast changed-package lint
+make lint-full      # Run all Go linters across both Go modules
 make tools-update   # Update development tools
 ```
 
 #### Testing Targets
 ```bash
-make test                      # Run unit tests
+make test                      # Run fast unit tests
+make test-full                 # Run unit tests with race detection
 make test-unit                 # Run unit tests specifically
 make integration-test          # Full integration tests with ingestr
 make integration-test-light    # Light integration tests without ingestr
@@ -180,7 +182,7 @@ Each CLI command is implemented in its own file:
 #### Unit Tests
 - **Location**: Throughout `pkg/` packages with `*_test.go` files
 - **Execution**: `make test-unit`
-- **Coverage**: Race detection enabled, 10-minute timeout
+- **Coverage**: Fast local tests by default; `make test-full` adds race detection
 - **Scope**: Excludes cloud integration tests
 
 Use narrow test loops while developing, then run the required full checks before finishing:
@@ -220,8 +222,8 @@ Use `make integration-test-light` for changes that affect parsing, command workf
 Tools automatically installed and run via `make format`:
 - **`gci`**: Import organization
 - **`gofumpt`**: Stricter Go formatting
-- **`golangci-lint`**: Comprehensive linting (10m timeout)
-- **`go vet`**: Static analysis
+- **`golangci-lint`**: Fast changed-package linting; `make lint-full` runs the comprehensive suite
+- **`govet`**: Enabled through `golangci-lint`
 
 #### Python Code
 Tools run via `make lint-python`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,4 +41,5 @@ You can simply run it:
 
 ### Testing
 
-You can run the tests by running `make test`.
+Run `make test` for the fast local unit-test loop. Use `make test-full` to
+include race detection; CI runs the full target.

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ LINT_BUILD_TAGS ?= no_duckdb_arrow
 LINT_FAST_LINTERS ?= errcheck,govet,ineffassign
 TEST_CONCURRENCY ?= 4
 GO_FORMAT_PATHS := cmd pkg semantic-engine integration-tests/integration_test.go main.go
+LINT_MODULES := . $(patsubst %/go.mod,%,$(filter-out go.mod,$(shell git ls-files '*go.mod')))
 
 # Suppress CGO linker warnings on macOS (not needed on Linux/Windows)
 ifeq ($(shell go env GOOS),darwin)
@@ -143,8 +144,12 @@ format: lint-python
 # because govet is already enabled by golangci-lint.
 lint:
 	@echo "$(OK_COLOR)==> Running fast linters on packages changed since $(LINT_MERGE_BASE)$(NO_COLOR)"
-	@LINT_MODULE_DIR="." LINT_BUILD_TAGS="$(LINT_BUILD_TAGS)" LINT_MERGE_BASE="$(LINT_MERGE_BASE)" LINT_CONCURRENCY="$(LINT_CONCURRENCY)" LINT_TIMEOUT="$(LINT_TIMEOUT)" LINT_PARALLEL_FLAGS="$(LINT_PARALLEL_FLAGS)" LINT_ENABLE_ONLY="$(LINT_FAST_LINTERS)" ./hack/lint-changed.sh
-	@LINT_MODULE_DIR="semantic-engine" LINT_BUILD_TAGS="" LINT_MERGE_BASE="$(LINT_MERGE_BASE)" LINT_CONCURRENCY="$(LINT_CONCURRENCY)" LINT_TIMEOUT="$(LINT_TIMEOUT)" LINT_PARALLEL_FLAGS="$(LINT_PARALLEL_FLAGS)" LINT_ENABLE_ONLY="$(LINT_FAST_LINTERS)" ./hack/lint-changed.sh
+	@set -e; \
+	for module in $(LINT_MODULES); do \
+		build_tags=""; \
+		if [ "$$module" = "." ]; then build_tags="$(LINT_BUILD_TAGS)"; fi; \
+		LINT_MODULE_DIR="$$module" LINT_BUILD_TAGS="$$build_tags" LINT_MERGE_BASE="$(LINT_MERGE_BASE)" LINT_CONCURRENCY="$(LINT_CONCURRENCY)" LINT_TIMEOUT="$(LINT_TIMEOUT)" LINT_PARALLEL_FLAGS="$(LINT_PARALLEL_FLAGS)" LINT_ENABLE_ONLY="$(LINT_FAST_LINTERS)" ./hack/lint-changed.sh; \
+	done
 
 lint-fast: lint
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,28 @@ CURRENT_DIR=$(pwd)
 TELEMETRY_KEY=""
 FILES := $(wildcard *.yml *.txt *.py)
 OS_ARCH:=$(shell go env GOOS)_$(shell go env GOARCH)
-GOLANGCI_LINT_VERSION=v2.11.1
+LINT_MERGE_BASE ?= origin/main
+GCI_VERSION ?= v0.14.0
+GOFUMPT_VERSION ?= v0.10.0
+RUFF_VERSION ?= 0.15.4
+# Pinned, not @latest. v2.12.x made its cache checkout-independent, but cached
+# diagnostics still contain absolute paths from the checkout that produced
+# them. That makes shared-cache results unsafe across worktrees. Re-test before
+# bumping beyond the latest pre-change patch release.
+GOLANGCI_LINT_VERSION ?= v2.11.4
+# Build golangci-lint with the toolchain targeted by this module.
+GOLANGCI_LINT_INSTALL := GOTOOLCHAIN=go$(shell awk '/^go /{print $$2; exit}' go.mod) \
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+# golangci-lint uses a single global lock in the system temporary directory.
+# Its cache supports concurrent processes, so allow separate worktrees to lint
+# at the same time without one runner failing on lock contention.
+LINT_PARALLEL_FLAGS ?= --allow-parallel-runners
+LINT_CONCURRENCY ?= 4
+LINT_TIMEOUT ?= 10m
+LINT_BUILD_TAGS ?= no_duckdb_arrow
+LINT_FAST_LINTERS ?= errcheck,govet,ineffassign
+TEST_CONCURRENCY ?= 4
+GO_FORMAT_PATHS := cmd pkg semantic-engine integration-tests/integration_test.go main.go
 
 # Suppress CGO linker warnings on macOS (not needed on Linux/Windows)
 ifeq ($(shell go env GOOS),darwin)
@@ -21,7 +42,7 @@ endif
 
 JQ_REL_PATH = jq --arg prefix "$$(pwd)" 'walk(if type == "object" and has("path") and (.path | type == "string") then .path |= (if . == $$prefix then "integration-tests" elif startswith($$prefix + "/") then .[($$prefix | length + 1):] elif startswith($$prefix) then .[($$prefix | length):] elif startswith("integration-tests/") then .[16:] else . end) else . end)'
 
-.PHONY: all clean test build build-no-duckdb docs-app format pre-commit refresh-integration-expectations integration-test-cloud integration-test-mssql validate-links tools-update
+.PHONY: all clean test test-full test-unit build build-no-duckdb docs-app format format-ci lint lint-fast lint-full lint-ci pre-commit refresh-integration-expectations integration-test-cloud integration-test-mssql validate-links setup tools-update
 all: clean deps test build
 
 deps: 
@@ -90,11 +111,18 @@ clean:
 test: test-unit
 
 test-unit:
-	@echo "$(OK_COLOR)==> Running the unit tests$(NO_COLOR)"
+	@echo "$(OK_COLOR)==> Running the unit tests (fast)$(NO_COLOR)"
 	@$(MAKE) rustsqlparser-lib
-	@env SF_DISABLE_MINICORE=true go test -tags="no_duckdb_arrow" -race -p 50 -vet=off -timeout 10m ./cmd/... ./pkg/...
+	@env SF_DISABLE_MINICORE=true go test -tags="no_duckdb_arrow" -p "$(TEST_CONCURRENCY)" -vet=off -timeout 10m ./cmd/... ./pkg/...
 	@echo "$(OK_COLOR)==> Running the semantic-engine module tests$(NO_COLOR)"
-	@cd semantic-engine && env SF_DISABLE_MINICORE=true go test -race -timeout 10m ./...
+	@cd semantic-engine && env SF_DISABLE_MINICORE=true go test -p "$(TEST_CONCURRENCY)" -timeout 10m ./...
+
+test-full:
+	@echo "$(OK_COLOR)==> Running the unit tests (full)$(NO_COLOR)"
+	@$(MAKE) rustsqlparser-lib
+	@env SF_DISABLE_MINICORE=true go test -tags="no_duckdb_arrow" -race -p "$(TEST_CONCURRENCY)" -vet=off -timeout 10m ./cmd/... ./pkg/...
+	@echo "$(OK_COLOR)==> Running the semantic-engine module tests with race detection$(NO_COLOR)"
+	@cd semantic-engine && env SF_DISABLE_MINICORE=true go test -race -p "$(TEST_CONCURRENCY)" -timeout 10m ./...
 
 RUST_LIB = pkg/sqlparser/rustffi/target/release/libbruin_rustsqlparser.a
 
@@ -105,34 +133,62 @@ $(RUST_LIB): pkg/sqlparser/rustffi/Cargo.toml $(wildcard pkg/sqlparser/rustffi/s
 	@cargo build --release --manifest-path pkg/sqlparser/rustffi/Cargo.toml
 
 format: lint-python
-	@echo "$(OK_COLOR)>> [go vet] running$(NO_COLOR)" & \
-	go vet -tags="no_duckdb_arrow" ./... & 
+	@echo "$(OK_COLOR)>> [gci] formatting$(NO_COLOR)"
+	@go tool gci write $(GO_FORMAT_PATHS)
+	@echo "$(OK_COLOR)>> [gofumpt] formatting$(NO_COLOR)"
+	@go tool gofumpt -w $(GO_FORMAT_PATHS)
+	@$(MAKE) lint
 
-	@echo "$(OK_COLOR)>> [gci] running$(NO_COLOR)" & \
-	go tool gci write cmd pkg semantic-engine integration-tests/integration_test.go main.go &
+# Fast edit-loop check on changed Go packages. `go vet` is deliberately absent
+# because govet is already enabled by golangci-lint.
+lint:
+	@echo "$(OK_COLOR)==> Running fast linters on packages changed since $(LINT_MERGE_BASE)$(NO_COLOR)"
+	@LINT_MODULE_DIR="." LINT_BUILD_TAGS="$(LINT_BUILD_TAGS)" LINT_MERGE_BASE="$(LINT_MERGE_BASE)" LINT_CONCURRENCY="$(LINT_CONCURRENCY)" LINT_TIMEOUT="$(LINT_TIMEOUT)" LINT_PARALLEL_FLAGS="$(LINT_PARALLEL_FLAGS)" LINT_ENABLE_ONLY="$(LINT_FAST_LINTERS)" ./hack/lint-changed.sh
+	@LINT_MODULE_DIR="semantic-engine" LINT_BUILD_TAGS="" LINT_MERGE_BASE="$(LINT_MERGE_BASE)" LINT_CONCURRENCY="$(LINT_CONCURRENCY)" LINT_TIMEOUT="$(LINT_TIMEOUT)" LINT_PARALLEL_FLAGS="$(LINT_PARALLEL_FLAGS)" LINT_ENABLE_ONLY="$(LINT_FAST_LINTERS)" ./hack/lint-changed.sh
 
-	@echo "$(OK_COLOR)>> [gofumpt] running$(NO_COLOR)" & \
-	go tool gofumpt -w cmd pkg semantic-engine &
+lint-fast: lint
 
-	@echo "$(OK_COLOR)>> [golangci-lint] running$(NO_COLOR)" & \
-	golangci-lint run --timeout 10m60s --new-from-merge-base=origin/main --build-tags="no_duckdb_arrow" ./...  & \
-	cd semantic-engine && golangci-lint run --timeout 10m60s --new-from-merge-base=origin/main & \
-	wait
+# Full check for CI and pre-merge validation.
+lint-full:
+	@echo "$(OK_COLOR)==> Running all linters across the repository$(NO_COLOR)"
+	@golangci-lint run --timeout "$(LINT_TIMEOUT)" --concurrency "$(LINT_CONCURRENCY)" $(LINT_PARALLEL_FLAGS) --build-tags="$(LINT_BUILD_TAGS)" ./...
+	@cd semantic-engine && golangci-lint run --timeout "$(LINT_TIMEOUT)" --concurrency "$(LINT_CONCURRENCY)" $(LINT_PARALLEL_FLAGS) ./...
+
+# Check Go formatting without modifying files.
+format-ci:
+	@echo "$(OK_COLOR)==> Checking Go formatting$(NO_COLOR)"
+	@GCI_DIFF=$$(go tool gci list $(GO_FORMAT_PATHS) 2>&1); \
+	GOFUMPT_DIFF=$$(go tool gofumpt -d $(GO_FORMAT_PATHS) 2>&1); \
+	if [ -n "$$GCI_DIFF$$GOFUMPT_DIFF" ]; then \
+		echo "$(ERROR_COLOR)Files need formatting:$(NO_COLOR)"; \
+		[ -z "$$GCI_DIFF" ] || echo "$$GCI_DIFF"; \
+		[ -z "$$GOFUMPT_DIFF" ] || echo "$$GOFUMPT_DIFF"; \
+		exit 1; \
+	fi
+	@echo "$(OK_COLOR)All Go files are properly formatted$(NO_COLOR)"
+
+lint-ci: format-ci lint-full
+	@echo "$(OK_COLOR)All checks passed$(NO_COLOR)"
+
+setup:
+	@printf "$(OK_COLOR)==> Installing development tools$(NO_COLOR)\n"
+	@current_version="$$(golangci-lint version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($$i == "version") { print "v"$$(i+1); exit } }')"; \
+	if [ "$$current_version" != "$(GOLANGCI_LINT_VERSION)" ]; then $(GOLANGCI_LINT_INSTALL); fi
 
 tools-update:
-	go get github.com/daixiang0/gci@latest
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
-	go get mvdan.cc/gofumpt@latest
+	go get github.com/daixiang0/gci@$(GCI_VERSION)
+	go get mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
+	$(GOLANGCI_LINT_INSTALL)
 	@go mod tidy
 
 lint-python:
 	@[ -d .venv ] || uv venv --quiet
 	@uv pip install --quiet sqlglot==30.7.0
 	@echo "$(OK_COLOR)==> Running Python formatting with ruff...$(NO_COLOR)"
-	@uvx ruff format ./pythonsrc
+	@uvx ruff@$(RUFF_VERSION) format ./pythonsrc
 
 	@echo "$(OK_COLOR)==> Running Python linting with ruff...$(NO_COLOR)"
-	@uvx ruff check --fix ./pythonsrc
+	@uvx ruff@$(RUFF_VERSION) check --fix ./pythonsrc
 
 refresh-integration-expectations: build
 	@echo "$(OK_COLOR)==> Refreshing integration expectations...$(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ lint-full:
 # Check Go formatting without modifying files.
 format-ci:
 	@echo "$(OK_COLOR)==> Checking Go formatting$(NO_COLOR)"
-	@GCI_DIFF=$$(go tool gci list $(GO_FORMAT_PATHS) 2>&1); \
-	GOFUMPT_DIFF=$$(go tool gofumpt -d $(GO_FORMAT_PATHS) 2>&1); \
+	@GCI_DIFF=$$(go tool gci list $(GO_FORMAT_PATHS)) || exit $$?; \
+	GOFUMPT_DIFF=$$(go tool gofumpt -d $(GO_FORMAT_PATHS)) || exit $$?; \
 	if [ -n "$$GCI_DIFF$$GOFUMPT_DIFF" ]; then \
 		echo "$(ERROR_COLOR)Files need formatting:$(NO_COLOR)"; \
 		[ -z "$$GCI_DIFF" ] || echo "$$GCI_DIFF"; \

--- a/hack/lint-changed.sh
+++ b/hack/lint-changed.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+merge_base_ref="${LINT_MERGE_BASE:-origin/main}"
+module_dir="${LINT_MODULE_DIR:-.}"
+build_tags="${LINT_BUILD_TAGS:-}"
+concurrency="${LINT_CONCURRENCY:-4}"
+timeout="${LINT_TIMEOUT:-10m}"
+parallel_flags="${LINT_PARALLEL_FLAGS:---allow-parallel-runners}"
+enable_only="${LINT_ENABLE_ONLY:-}"
+
+merge_base="$(git merge-base "$merge_base_ref" HEAD)"
+
+changed_files=()
+while IFS= read -r file; do
+  changed_files+=("$file")
+done < <(
+  {
+    git diff --name-only --diff-filter=ACMRD "$merge_base" --
+    git ls-files --others --exclude-standard
+  } | sed '/^$/d' | LC_ALL=C sort -u
+)
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  echo "No changes found."
+  exit 0
+fi
+
+module_files=()
+while IFS= read -r file; do
+  module_files+=("$file")
+done < <(git ls-files '*go.mod' | LC_ALL=C sort)
+
+module_for_file() {
+  local file="$1"
+  local matched_module="."
+  local module_file candidate
+
+  for module_file in "${module_files[@]}"; do
+    [[ "$module_file" == "go.mod" ]] && continue
+    candidate="${module_file%/go.mod}"
+    if [[ "$file" == "$candidate" || "$file" == "$candidate/"* ]]; then
+      if [[ "$matched_module" == "." || ${#candidate} -gt ${#matched_module} ]]; then
+        matched_module="$candidate"
+      fi
+    fi
+  done
+
+  printf '%s\n' "$matched_module"
+}
+
+lint_all=false
+packages=()
+
+for file in "${changed_files[@]}"; do
+  case "$file" in
+    .golangci.yml)
+      lint_all=true
+      ;;
+    go.mod|go.sum)
+      if [[ "$module_dir" == "." ]]; then
+        lint_all=true
+      fi
+      ;;
+    "$module_dir"/go.mod|"$module_dir"/go.sum)
+      if [[ "$module_dir" != "." ]]; then
+        lint_all=true
+      fi
+      ;;
+    *.go)
+      if [[ "$(module_for_file "$file")" != "$module_dir" ]]; then
+        continue
+      fi
+
+      if [[ ! -e "$file" ]]; then
+        lint_all=true
+        continue
+      fi
+
+      relative_file="$file"
+      if [[ "$module_dir" != "." ]]; then
+        relative_file="${file#"$module_dir"/}"
+      fi
+
+      directory="$(dirname "$relative_file")"
+      if [[ "$directory" == "." ]]; then
+        packages+=("./")
+      else
+        packages+=("./$directory")
+      fi
+      ;;
+  esac
+done
+
+if [[ "$lint_all" == true ]]; then
+  packages=("./...")
+elif [[ ${#packages[@]} -eq 0 ]]; then
+  echo "No changed Go packages to lint in $module_dir."
+  exit 0
+else
+  unique_packages=()
+  while IFS= read -r package; do
+    unique_packages+=("$package")
+  done < <(printf '%s\n' "${packages[@]}" | LC_ALL=C sort -u)
+  packages=("${unique_packages[@]}")
+fi
+
+args=(run --timeout "$timeout" --concurrency "$concurrency")
+
+if [[ -n "$parallel_flags" ]]; then
+  read -r -a parsed_parallel_flags <<< "$parallel_flags"
+  args+=("${parsed_parallel_flags[@]}")
+fi
+
+if [[ -n "$build_tags" ]]; then
+  args+=(--build-tags "$build_tags")
+fi
+
+if [[ -n "$enable_only" ]]; then
+  args+=(--enable-only "$enable_only")
+fi
+
+echo "Module: $module_dir"
+echo "Packages: ${packages[*]}"
+
+if [[ "$module_dir" == "." ]]; then
+  exec golangci-lint "${args[@]}" "${packages[@]}"
+fi
+
+cd "$module_dir"
+exec golangci-lint "${args[@]}" "${packages[@]}"

--- a/main.go
+++ b/main.go
@@ -87,7 +87,6 @@ func main() {
 	}
 
 	err := app.Run(context.Background(), os.Args)
-
 	if err != nil {
 		cli.HandleExitCoder(err)
 		// Close the telemetry client manually as the defer is not called on os.Exit(1)


### PR DESCRIPTION
## What
Speed up local Go checks while keeping full race and lint coverage in CI.

## Changes
- Add changed-package linting, bounded concurrency, pinned tools, and fast/full targets.
- Move race testing to `make test-full` and use full checks in GitHub Actions.

## How to test
1. Run `make format`, `make lint-ci`, `make test`, and `make test-full`.

## Risk & rollback
- **Risk:** Low; this changes developer tooling and CI commands.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
