### PR TITLE
Fix BigQuery pre-hook variable scope validation

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -196,6 +196,16 @@ func Lint(isDebug *bool) *cli.Command {
 				defer p.Close()
 			}
 
+			var hookHoister pipeline.DeclareHoister
+			if p, err := sqlparser.NewRustSQLParser(false); err != nil {
+				printError(err, c.String("output"), "Could not initialize hook SQL parser")
+			} else if err := p.Start(); err != nil {
+				printError(err, c.String("output"), "Could not start hook SQL parser")
+			} else {
+				hookHoister = p
+				defer p.Close()
+			}
+
 			rules, err := lint.GetRules(fs, &git.RepoFinder{}, c.Bool("exclude-warnings"), parser, true)
 			if err != nil {
 				printError(err, c.String("output"), "An error occurred while building the validation rules")
@@ -203,7 +213,7 @@ func Lint(isDebug *bool) *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			rules = append(rules, queryValidatorRules(logger, cm, connectionManager, fullRefresh)...)
+			rules = append(rules, queryValidatorRules(logger, cm, connectionManager, fullRefresh, hookHoister)...)
 			rules = append(rules, lint.GetCustomCheckQueryDryRunRule(connectionManager, renderer))
 			rules = append(rules, lint.GetHookQueryDryRunRule(connectionManager))
 			rules = append(rules, SeedAssetsValidator)
@@ -472,7 +482,7 @@ func flattenErrors(err error) []string {
 	return foundErrors
 }
 
-func queryValidatorRules(logger logger.Logger, cfg *config.Config, connectionManager config.ConnectionGetter, fullRefresh bool) []lint.Rule {
+func queryValidatorRules(logger logger.Logger, cfg *config.Config, connectionManager config.ConnectionGetter, fullRefresh bool, hookHoister pipeline.DeclareHoister) []lint.Rule {
 	rules := []lint.Rule{}
 	renderer := jinja.NewRendererWithYesterday("your-pipeline-name", "your-run-id")
 	if len(cfg.SelectedEnvironment.Connections.GoogleCloudPlatform) > 0 {
@@ -488,8 +498,10 @@ func queryValidatorRules(logger logger.Logger, cfg *config.Config, connectionMan
 				materializer: bigquery.NewMaterializer(fullRefresh),
 				renderer:     renderer,
 			},
-			WorkerCount: 32,
-			Logger:      logger,
+			HookRenderer: renderer,
+			HookHoister:  hookHoister,
+			WorkerCount:  32,
+			Logger:       logger,
 		})
 	} else {
 		logger.Debug("no GCP connections found, skipping BigQuery validation")

--- a/pkg/lint/query.go
+++ b/pkg/lint/query.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/logger"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
@@ -35,6 +36,8 @@ type QueryValidatorRule struct {
 	Connections  connectionManager
 	Extractor    queryExtractor
 	Materializer materializer
+	HookRenderer jinja.RendererInterface
+	HookHoister  pipeline.DeclareHoister
 	WorkerCount  int
 	Logger       logger.Logger
 }
@@ -54,6 +57,24 @@ func (q *QueryValidatorRule) GetApplicableLevels() []Level {
 
 func (q *QueryValidatorRule) GetSeverity() ValidatorSeverity {
 	return ValidatorSeverityCritical
+}
+
+func (q *QueryValidatorRule) wrapRenderedHooks(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset, sql string) (string, error) {
+	if q.HookRenderer == nil || asset.Hooks.IsZero() {
+		return sql, nil
+	}
+
+	assetRenderer, err := q.HookRenderer.CloneForAsset(ctx, p, asset)
+	if err != nil {
+		return "", fmt.Errorf("failed to create hook renderer: %w", err)
+	}
+
+	renderedHooks, err := pipeline.ResolveHookTemplatesToNew(asset.Hooks, assetRenderer)
+	if err != nil {
+		return "", err
+	}
+
+	return pipeline.WrapHooks(sql, renderedHooks, q.HookHoister, asset.Type), nil
 }
 
 func (q *QueryValidatorRule) ValidateAsset(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
@@ -116,6 +137,16 @@ func (q *QueryValidatorRule) ValidateAsset(ctx context.Context, p *pipeline.Pipe
 		}
 		foundQuery.Query = materialized
 	}
+
+	queryWithHooks, err := q.wrapRenderedHooks(ctx, p, asset, foundQuery.Query)
+	if err != nil {
+		issues = append(issues, &Issue{
+			Task:        asset,
+			Description: fmt.Sprintf("Failed to render hooks: %s", err),
+		})
+		return issues, nil
+	}
+	foundQuery.Query = queryWithHooks
 
 	assetConnectionName, err := p.GetConnectionNameForAsset(asset)
 	if err != nil {
@@ -230,6 +261,18 @@ func (q *QueryValidatorRule) validateTask(ctx context.Context, p *pipeline.Pipel
 				}
 				foundQuery.Query = materialized
 			}
+
+			queryWithHooks, err := q.wrapRenderedHooks(ctx, p, task, foundQuery.Query)
+			if err != nil {
+				mu.Lock()
+				issues = append(issues, &Issue{
+					Task:        task,
+					Description: fmt.Sprintf("Failed to render hooks: %s", err),
+				})
+				mu.Unlock()
+				return
+			}
+			foundQuery.Query = queryWithHooks
 
 			assetConnectionName, err := p.GetConnectionNameForAsset(task)
 			if err != nil {

--- a/pkg/lint/query_test.go
+++ b/pkg/lint/query_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,80 @@ type mockMaterializer struct {
 func (m *mockMaterializer) Render(task *pipeline.Asset, query string) (string, error) {
 	res := m.Called(task, query)
 	return res.Get(0).(string), res.Error(1)
+}
+
+func TestQueryValidatorRule_ValidateAssetWithHookScope(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)
+	executionDate := endDate
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, executionDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
+
+	asset := &pipeline.Asset{
+		Name: "dashboard.repro1",
+		Type: pipeline.AssetTypeBigqueryQuery,
+		ExecutableFile: pipeline.ExecutableFile{
+			Content: "asset query",
+		},
+		Hooks: pipeline.Hooks{
+			Pre: []pipeline.Hook{{
+				Query: "DECLARE window_start DATE DEFAULT date_sub(date '{{ end_date }}', INTERVAL 30 DAY)",
+			}},
+		},
+	}
+	p := &pipeline.Pipeline{
+		Name:   "test-pipeline",
+		Assets: []*pipeline.Asset{asset},
+		DefaultConnections: map[string]string{
+			"google_cloud_platform": "gcp-conn",
+		},
+	}
+
+	extractor := new(mockExtractor)
+	extractor.On("CloneForAsset", mock.Anything, p, asset).Return(extractor, nil)
+	extractor.On("ExtractQueriesFromString", "asset query").Return(
+		[]*query.Query{{Query: "select window_start, date '2024-01-31' as window_end"}},
+		nil,
+	)
+
+	materializer := new(mockMaterializer)
+	materializer.On(
+		"Render",
+		asset,
+		"select window_start, date '2024-01-31' as window_end",
+	).Return(
+		"CREATE OR REPLACE TABLE dashboard.repro1 AS\nselect window_start, date '2024-01-31' as window_end",
+		nil,
+	)
+
+	expectedQuery := &query.Query{Query: "DECLARE window_start DATE DEFAULT date_sub(date '2024-01-31', INTERVAL 30 DAY);\n" +
+		"CREATE OR REPLACE TABLE dashboard.repro1 AS\nselect window_start, date '2024-01-31' as window_end;"}
+	validator := new(mockValidator)
+	validator.On("IsValid", mock.Anything, expectedQuery).Return(true, nil)
+
+	connections := new(mockConnectionManager)
+	connections.On("GetConnection", "gcp-conn").Return(validator)
+
+	rule := &QueryValidatorRule{
+		TaskType:     pipeline.AssetTypeBigqueryQuery,
+		Connections:  connections,
+		Extractor:    extractor,
+		Materializer: materializer,
+		HookRenderer: jinja.NewRendererWithStartEndDates(&startDate, &endDate, &executionDate, "test-pipeline", "test-run-id", nil),
+		Logger:       zap.NewNop().Sugar(),
+	}
+
+	issues, err := rule.ValidateAsset(ctx, p, asset)
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+	validator.AssertExpectations(t)
+	extractor.AssertExpectations(t)
+	materializer.AssertExpectations(t)
+	connections.AssertExpectations(t)
 }
 
 func TestQueryValidatorRule_Validate(t *testing.T) {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1993,6 +1993,13 @@ func ValidateHookQueryDryRun(connections connectionManager) AssetValidator {
 			return issues, nil
 		}
 
+		// The BigQuery query validator dry-runs the complete materialized script,
+		// including hooks. Validating hooks independently would break shared
+		// script scope, such as a pre-hook DECLARE referenced by the asset query.
+		if asset.Type == pipeline.AssetTypeBigqueryQuery {
+			return issues, nil
+		}
+
 		connName, err := p.GetConnectionNameForAsset(asset)
 		if err != nil { //nolint
 			return issues, nil

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3844,7 +3844,7 @@ func TestValidateHookQueryDryRun(t *testing.T) {
 
 	sqlAssetWithHooks := &pipeline.Asset{
 		Name: "asset_with_hooks",
-		Type: pipeline.AssetTypeBigqueryQuery,
+		Type: pipeline.AssetTypeSnowflakeQuery,
 		Hooks: pipeline.Hooks{
 			Pre: []pipeline.Hook{
 				{Query: "SELECT 1"},
@@ -3866,9 +3866,16 @@ func TestValidateHookQueryDryRun(t *testing.T) {
 			Pre: []pipeline.Hook{{Query: "SELECT 1"}},
 		},
 	}
+	bigQueryAssetWithHooks := &pipeline.Asset{
+		Name: "bigquery_asset_with_hooks",
+		Type: pipeline.AssetTypeBigqueryQuery,
+		Hooks: pipeline.Hooks{
+			Pre: []pipeline.Hook{{Query: "DECLARE window_start DATE"}},
+		},
+	}
 
 	p := &pipeline.Pipeline{
-		Assets: []*pipeline.Asset{sqlAssetWithHooks, sqlAssetWithoutHooks, pythonAssetWithHooks},
+		Assets: []*pipeline.Asset{sqlAssetWithHooks, sqlAssetWithoutHooks, pythonAssetWithHooks, bigQueryAssetWithHooks},
 	}
 
 	t.Run("valid hook queries", func(t *testing.T) {
@@ -3920,6 +3927,16 @@ func TestValidateHookQueryDryRun(t *testing.T) {
 		cm := &fakeConnectionManager{validator: &fakeQueryValidator{isValid: false}}
 		validator := ValidateHookQueryDryRun(cm)
 		issues, err := validator(t.Context(), p, pythonAssetWithHooks)
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+
+	t.Run("BigQuery hooks are validated with the complete asset script", func(t *testing.T) {
+		t.Parallel()
+
+		cm := &fakeConnectionManager{validator: &fakeQueryValidator{isValid: false}}
+		validator := ValidateHookQueryDryRun(cm)
+		issues, err := validator(t.Context(), p, bigQueryAssetWithHooks)
 		require.NoError(t, err)
 		assert.Empty(t, issues)
 	})


### PR DESCRIPTION
## What
Validate BigQuery hooks with the materialized asset query so pre-hook declarations remain in scope during linting.

## Changes
- Render and wrap BigQuery hooks before query dry-run validation.
- Skip the separate BigQuery hook dry-run and add regression coverage.

## How to test
1. `make format`
2. `make test`
3. `make build-no-duckdb`

## Risk & rollback
- **Risk:** Low; limited to BigQuery lint dry-runs.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`) — not affected
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.