### PR TITLE
Add --agent-id to `bruin cloud dashboards create`

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3156,6 +3156,12 @@ func cloudDashboardsCreate() *cli.Command {
 			} else {
 				infoPrinter.Printf("Created dashboard %d (%s) as a draft — publish it from the Bruin Cloud UI.\n", dashboard.ID, title)
 			}
+			// No agent resolved (neither an explicit --agent-id nor the token's
+			// agent), so the dashboard opens without a chat panel. Warn and point
+			// at the fix instead of leaving it a silent surprise.
+			if dashboard.AgentID == nil || *dashboard.AgentID <= 0 {
+				errorPrinter.Println("Warning: no agent bound — this dashboard opens without a chat panel. Pass --agent-id <id> (see 'bruin cloud agents list').")
+			}
 			return nil
 		},
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3082,6 +3082,14 @@ func cloudDashboardsCreate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
+			// Reject an explicit non-positive --agent-id rather than silently
+			// dropping it (which would fall back to the token agent, or none, and
+			// create a dashboard with no chat against the caller's intent).
+			if c.IsSet("agent-id") && c.Int("agent-id") <= 0 {
+				printError(fmt.Errorf("--agent-id must be a positive integer, got %d", c.Int("agent-id")), output, "Invalid --agent-id")
+				return cli.Exit("", 1)
+			}
+
 			// The definition can come inline (--state) or from a file (--state-file),
 			// but not both — otherwise a stale file could silently override the flag.
 			// Check whether each flag was provided (not its value) so an explicit

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3059,6 +3059,10 @@ func cloudDashboardsCreate() *cli.Command {
 				Name:  "visibility",
 				Usage: "team or private (default: team)",
 			},
+			&cli.IntFlag{
+				Name:  "agent-id",
+				Usage: "the agent to bind for canvas chat and refresh (defaults to the token's agent)",
+			},
 			&cli.StringFlag{
 				Name:  "state",
 				Usage: "the dashboard definition as a JSON or YAML string",
@@ -3123,7 +3127,7 @@ func cloudDashboardsCreate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			dashboard, err := client.CreateDashboard(ctx, c.String("title"), visibility, state)
+			dashboard, err := client.CreateDashboard(ctx, c.String("title"), visibility, c.Int("agent-id"), state)
 			if err != nil {
 				printError(err, output, "Failed to create dashboard")
 				return cli.Exit("", 1)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -252,7 +252,8 @@ func TestCloudDashboardsCreate_RejectsNonPositiveAgentID(t *testing.T) {
 		cmd := cloudDashboardsCreate()
 		exitCode := 0
 		cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, err error) {
-			if ec, ok := err.(cli.ExitCoder); ok {
+			var ec cli.ExitCoder
+			if errors.As(err, &ec) {
 				exitCode = ec.ExitCode()
 			}
 		}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -242,6 +242,25 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "update")
 }
 
+func TestCloudDashboardsCreate_RejectsNonPositiveAgentID(t *testing.T) {
+	t.Parallel()
+	// An explicit non-positive --agent-id must fail fast (before any request)
+	// rather than being silently dropped into the token-agent fallback. The
+	// command signals failure via a non-zero exit code, so capture it through
+	// the exit handler instead of Run's return value.
+	for _, v := range []string{"0", "-3"} {
+		cmd := cloudDashboardsCreate()
+		exitCode := 0
+		cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, err error) {
+			if ec, ok := err.(cli.ExitCoder); ok {
+				exitCode = ec.ExitCode()
+			}
+		}
+		_ = cmd.Run(t.Context(), []string{"create", "--title", "T", "--api-key", "k", "--agent-id", v})
+		assert.Equalf(t, 1, exitCode, "agent-id %q should be rejected", v)
+	}
+}
+
 func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	t.Parallel()
 	cmd := CloudScheduledAgents()

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -627,9 +627,16 @@ bruin cloud dashboards get --dashboard-id 42 --output json
 Create a dashboard from a definition. The definition is written to the dashboard's
 **draft** — it is never published automatically; publish it from the Bruin Cloud UI.
 
+Pass `--agent-id` to bind the dashboard to an agent so its canvas chat and refresh
+work. If omitted, the server falls back to the agent encoded in a Cloud-CLI token;
+a generic team token has none, so the dashboard opens without a chat panel.
+
 ```bash
 # Title only (empty draft)
 bruin cloud dashboards create --title "Q1 Revenue"
+
+# Bind an agent so the dashboard's chat works
+bruin cloud dashboards create --title "Q1 Revenue" --agent-id 7
 
 # With a definition, inline or from a file
 bruin cloud dashboards create --title "Q1 Revenue" --visibility team --state '{"widgets":[]}'

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -585,10 +585,15 @@ func (c *APIClient) GetDashboard(ctx context.Context, dashboardID int) (*Dashboa
 // CreateDashboard creates a dashboard from a definition. The server writes the
 // definition to the draft only (never published). Empty optional fields are
 // omitted so the server applies its defaults.
-func (c *APIClient) CreateDashboard(ctx context.Context, title, visibility string, state map[string]any) (*Dashboard, error) {
+func (c *APIClient) CreateDashboard(ctx context.Context, title, visibility string, agentID int, state map[string]any) (*Dashboard, error) {
 	body := map[string]any{"title": title}
 	if visibility != "" {
 		body["visibility"] = visibility
+	}
+	// Bind the dashboard to an agent so canvas chat and refresh work; omit to let
+	// the server fall back to the agent encoded in a Cloud-CLI token.
+	if agentID > 0 {
+		body["agent_id"] = agentID
 	}
 	if state != nil {
 		body["state"] = state

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -794,13 +794,17 @@ func TestCreateDashboard(t *testing.T) {
 
 		w.WriteHeader(http.StatusCreated)
 		title := "New Dash"
-		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private", URL: "https://cloud.getbruin.com/acme/dashboards/9?mode=edit"})
+		boundAgent := 7
+		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private", URL: "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", AgentID: &boundAgent})
 	})
 
 	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", 7, map[string]any{"widgets": []any{}})
 	require.NoError(t, err)
 	assert.Equal(t, 9, dashboard.ID)
 	assert.Equal(t, "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", dashboard.URL)
+	// The bound agent comes back on the response so the CLI can warn when none resolved.
+	require.NotNil(t, dashboard.AgentID)
+	assert.Equal(t, 7, *dashboard.AgentID)
 }
 
 func TestCreateDashboardOmitsAgentIDWhenZero(t *testing.T) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -803,6 +803,25 @@ func TestCreateDashboard(t *testing.T) {
 	assert.Equal(t, "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", dashboard.URL)
 }
 
+func TestCreateDashboardOmitsAgentIDWhenZero(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		// No agent id given, so the field is omitted and the server applies its
+		// token-agent fallback rather than clearing the binding.
+		_, hasAgentID := body["agent_id"]
+		assert.False(t, hasAgentID)
+
+		w.WriteHeader(http.StatusCreated)
+		title := "New Dash"
+		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "team"})
+	})
+
+	_, err := client.CreateDashboard(t.Context(), "New Dash", "", 0, nil)
+	require.NoError(t, err)
+}
+
 func TestUpdateDashboard(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -789,6 +789,7 @@ func TestCreateDashboard(t *testing.T) {
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		assert.Equal(t, "New Dash", body["title"])
 		assert.Equal(t, "private", body["visibility"])
+		assert.EqualValues(t, 7, body["agent_id"])
 		assert.NotNil(t, body["state"])
 
 		w.WriteHeader(http.StatusCreated)
@@ -796,7 +797,7 @@ func TestCreateDashboard(t *testing.T) {
 		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private", URL: "https://cloud.getbruin.com/acme/dashboards/9?mode=edit"})
 	})
 
-	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", map[string]any{"widgets": []any{}})
+	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", 7, map[string]any{"widgets": []any{}})
 	require.NoError(t, err)
 	assert.Equal(t, 9, dashboard.ID)
 	assert.Equal(t, "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", dashboard.URL)

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -253,6 +253,7 @@ type Dashboard struct {
 	Visibility string          `json:"visibility"`
 	UpdatedAt  *string         `json:"updated_at"`
 	URL        string          `json:"url"`
+	AgentID    *int            `json:"agent_id"`
 	State      json.RawMessage `json:"state,omitempty"`
 }
 


### PR DESCRIPTION
A dashboard created with a generic team token had no agent bound, so it opened with no canvas chat.

Add an optional `--agent-id` flag to `bruin cloud dashboards create` that sends `agent_id` in the create body, binding the dashboard to the given agent. Omit it to keep the server's existing token-agent fallback.

Pairs with the cloud API change that accepts `agent_id` on dashboard create (bruin-data/cloud#2744).