### PR TITLE
feat(iceberg): storage & catalog parity for the ingestr destination

### DIFF
--- a/docs/ingestion/iceberg.md
+++ b/docs/ingestion/iceberg.md
@@ -61,9 +61,14 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
             type: rest                        # required
             host: "catalog.internal"          # required
             port: 8181                        # optional
+            rest_use_ssl: true                # optional — use HTTPS (default is HTTP); set true for hosted catalogs (Polaris, Unity, Lakekeeper, Tabular)
             credential: "${ICEBERG_REST_CREDENTIAL}"   # optional — REST auth, if the catalog requires it
             token: "${ICEBERG_REST_TOKEN}"             # optional — bearer token, alternative to credential
 ```
+
+> [!TIP]
+> A REST catalog is a **running server** you start and configure yourself — it holds its own warehouse location, storage backend, and credentials, and usually writes the table metadata to storage. Your connection's `storage` block still supplies the credentials Bruin uses to write the **data files**.
+> OAuth2 options such as `oauth2-server-uri` and `scope` go in the top-level [`properties`](#table-options) block.
 
 **Hive**
 ```yaml
@@ -72,6 +77,9 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
             host: "metastore.internal"        # required
             port: 9083                        # optional
 ```
+
+> [!WARNING]
+> The Hive metastore reaches storage **independently** — your connection's `storage` credentials configure only the Bruin client and never reach the metastore. On the metastore side, use an `s3a://` warehouse, put the right connector jar on its classpath (`hadoop-aws` for S3, `gcs-connector` for GCS), and set the matching `fs.s3a.*` / `fs.gs.*` properties in its `core-site.xml`. Without this it fails with `No FileSystem for scheme "s3"`. A `file://` warehouse needs none of this.
 
 **Postgres**
 ```yaml
@@ -84,6 +92,23 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
               username: "iceberg_user"
               password: "${PG_PASSWORD}"
 ```
+
+For the `postgres` catalog, ingestr forwards standard PostgreSQL connection parameters to the catalog database connection, so you can secure or tune it via the top-level [`properties`](#table-options) block — a managed database (Neon, RDS, Cloud SQL) usually needs TLS:
+
+```yaml
+          catalog:
+            type: postgres
+            host: "metadata-db.internal"
+            database: "iceberg_catalog"
+            auth:
+              username: "iceberg_user"
+              password: "${PG_PASSWORD}"
+          properties:
+            sslmode: "require"                # e.g. require, verify-full
+            sslrootcert: "/path/to/ca.pem"    # optional
+```
+
+Recognized connection parameters: `sslmode`, `sslcert`, `sslkey`, `sslrootcert`, `sslpassword`, `sslcrl`, `sslcrldir`, `sslsni`, `sslcompression`, `requiressl`, `connect_timeout`, `application_name`, `fallback_application_name`, `target_session_attrs`, `tcp_user_timeout`, `options`, `service`, `servicefile`, `passfile`, `krbsrvname`, and `replication`. Any other property is treated as an Iceberg/storage option, not a database connection setting. This forwarding applies only to `type: postgres`; for the generic `sql` catalog, embed these inside the `uri` connection string instead (e.g. `postgresql://…?sslmode=require`).
 
 **SQLite**
 ```yaml
@@ -99,34 +124,98 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
             path: "/warehouse"                # required — warehouse directory
 ```
 
+> [!WARNING]
+> The Hadoop catalog only commits atomically on a real local or HDFS filesystem. For an object-storage warehouse (`s3://…`) you must add `allow-unsafe-commits: "true"` to `properties`, otherwise the connection fails.
+
 **SQL** (advanced)
 ```yaml
           catalog:
             type: sql                         # required
             uri: "postgresql://user:pass@host:5432/db"   # required — catalog connection string
+            driver: "pgx"                     # required — database/sql driver (e.g. pgx, sqlite)
+            dialect: "postgres"               # required — SQL dialect (e.g. postgres, sqlite)
 ```
+
+> The generic `sql` catalog is only needed for backends other than SQLite/Postgres — for those, use the dedicated `sqlite`/`postgres` catalog types, which set `driver`/`dialect` for you.
 
 ### Storage options
 
+`type` (`s3`, `gcs`, or `local`) is **optional** — the backend is normally inferred from the warehouse **scheme** (`s3://` → s3, `gs://` → gcs, `file://` → local). You only need `type` to disambiguate the `bucket`/`prefix` form (which carries no scheme), where it selects `s3://` (the default) vs `gs://`. The **warehouse location** — the root under which table data files are written — can be given two ways (mutually exclusive): a full URI in `path` (`s3://…`, `gs://…`, or a filesystem path), or a `bucket` (+ optional `prefix`). Leave both empty to inherit the catalog's own warehouse (Glue, REST, and SQL catalogs supply one); the `region`/`endpoint`/`use_ssl`/`auth` credentials are still used to write the data files either way.
+
+**AWS S3**
+
 ```yaml
           storage:
-            type: s3                                    # required
-            path: "s3://my-company-lake/warehouse"      # optional — the Iceberg warehouse location
-            region: "us-east-1"                         # optional
-            endpoint: "localhost:9000"                  # optional — for S3-compatible stores (MinIO, R2, ...)
-            use_ssl: false                              # optional — false for plain-HTTP local storage
+            type: s3
+            path: "s3://my-company-lake/warehouse"      # full warehouse URI
+            region: "us-east-1"
             auth:
-              access_key: "${AWS_ACCESS_KEY_ID}"        # required
-              secret_key: "${AWS_SECRET_ACCESS_KEY}"    # required
-              session_token: "${AWS_SESSION_TOKEN}"     # optional
+              access_key: "${AWS_ACCESS_KEY_ID}"
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"
+              session_token: "${AWS_SESSION_TOKEN}"     # optional — temporary/STS credentials
 ```
 
-The **warehouse location** — the `s3://<bucket>/<prefix>` root under which table data files are written — can be given two ways (they are mutually exclusive):
+**AWS S3 with `bucket` + `prefix`** (alternative to `path`)
 
-- as a full URI in `path`, e.g. `path: "s3://my-company-lake/warehouse"`; or
-- as a separate `bucket` (and optional `prefix`), e.g. `bucket: "my-company-lake"` with `prefix: "warehouse"`.
+```yaml
+          storage:
+            type: s3
+            bucket: "my-company-lake"                   # builds s3://my-company-lake/warehouse
+            prefix: "warehouse"                         # optional
+            region: "us-east-1"
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"
+```
 
-The location is **optional**: when all of `path`/`bucket`/`prefix` are omitted, the warehouse is taken from the catalog itself (Glue, REST, and SQL catalogs supply their own warehouse location). The `region`, `endpoint`, `use_ssl`, and `auth` credentials are still used to read and write the S3 data files regardless of where the warehouse location comes from.
+**S3-compatible (MinIO, Cloudflare R2, …)** — set `endpoint`, and `use_ssl: false` for a plain-HTTP local store:
+
+```yaml
+          storage:
+            type: s3
+            path: "s3://warehouse"
+            endpoint: "localhost:9000"                  # the S3-compatible endpoint
+            use_ssl: false
+            region: "us-east-1"
+            auth:
+              access_key: "${MINIO_ACCESS_KEY}"
+              secret_key: "${MINIO_SECRET_KEY}"
+```
+
+> [!TIP]
+> For non-AWS S3-compatible stores (MinIO, Cloudflare R2, GCS interop), S3 compatibility mode is enabled automatically when `endpoint` is set. To disable it, add `s3.compat-mode: "false"` to the top-level [`properties`](#table-options) block.
+
+**Google Cloud Storage (native)** — `type: gcs` with a `gs://` warehouse and a service-account key (`bucket` + `prefix` works too):
+
+```yaml
+          storage:
+            type: gcs
+            path: "gs://my-company-lake/warehouse"      # or: bucket + prefix
+            key_file: "/path/to/service-account.json"   # SA key file (or key_json for inline JSON)
+```
+
+Leave `key_file`/`key_json` empty to use Application Default Credentials.
+
+**GCS via the S3 interop endpoint (HMAC keys)** — use `type: s3` with the Google endpoint and HMAC credentials:
+
+```yaml
+          storage:
+            type: s3
+            path: "s3://my-gcs-bucket/warehouse"
+            endpoint: "storage.googleapis.com"
+            region: "auto"
+            auth:
+              access_key: "${GCS_HMAC_KEY}"
+              secret_key: "${GCS_HMAC_SECRET}"
+```
+
+**Local filesystem** — `type: local` with a filesystem path (a fully local SQLite/Hadoop setup):
+
+```yaml
+          storage:
+            type: local
+            path: "/tmp/iceberg-warehouse"              # becomes file:///tmp/iceberg-warehouse
+```
 
 ### Table options
 
@@ -134,7 +223,7 @@ The location is **optional**: when all of `path`/`bucket`/`prefix` are omitted, 
 - `table_location`: explicit table location; supports `{namespace}`, `{table}`, and `{identifier}` placeholders.
 - `table_path`: path under the warehouse, e.g. `{namespace}/{table}`.
 - `table_properties`: Iceberg table properties, e.g. `write.format.default: parquet`.
-- `properties`: any additional, non-secret catalog options passed through to the Iceberg URI verbatim.
+- `properties`: any additional, non-secret catalog options passed through to the Iceberg URI verbatim (e.g. `allow-unsafe-commits`, `s3.compat-mode`, `oauth2-server-uri` — see the notes on the relevant catalog/storage above).
 
 > [!WARNING]
 > `properties` values are **not** redacted from run logs. Put credentials in the dedicated fields (`auth`, `credential`, `token`, `uri`), never in `properties`.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -2950,6 +2950,15 @@
         "auth": {
           "$ref": "#/$defs/IcebergAuth"
         },
+        "rest_use_ssl": {
+          "type": "boolean"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "dialect": {
+          "type": "string"
+        },
         "credential": {
           "type": "string"
         },
@@ -3009,8 +3018,7 @@
       "type": "object",
       "required": [
         "name",
-        "catalog",
-        "storage"
+        "catalog"
       ]
     },
     "IcebergStorage": {
@@ -3038,13 +3046,16 @@
         },
         "auth": {
           "$ref": "#/$defs/IcebergAuth"
+        },
+        "key_file": {
+          "type": "string"
+        },
+        "key_json": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "type"
-      ]
+      "type": "object"
     },
     "IndeedConnection": {
       "properties": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1316,7 +1316,7 @@ type IcebergConnection struct {
 	// CatalogName is the logical catalog identifier (defaults to "ingestr").
 	CatalogName string         `yaml:"catalog_name,omitempty" json:"catalog_name,omitempty" mapstructure:"catalog_name"`
 	Catalog     IcebergCatalog `yaml:"catalog" json:"catalog" mapstructure:"catalog"`
-	Storage     IcebergStorage `yaml:"storage" json:"storage" mapstructure:"storage"`
+	Storage     IcebergStorage `yaml:"storage,omitempty" json:"storage,omitempty" mapstructure:"storage"`
 
 	// Table/namespace behaviour (ingestr destination write options).
 	CreateNamespace *bool  `yaml:"create_namespace,omitempty" json:"create_namespace,omitempty" mapstructure:"create_namespace"`

--- a/pkg/config/iceberg.go
+++ b/pkg/config/iceberg.go
@@ -18,7 +18,9 @@ const (
 type IcebergStorageType string
 
 const (
-	IcebergStorageS3 IcebergStorageType = "s3"
+	IcebergStorageS3    IcebergStorageType = "s3"
+	IcebergStorageGCS   IcebergStorageType = "gcs"
+	IcebergStorageLocal IcebergStorageType = "local"
 )
 
 // IcebergAuth holds credentials for the catalog and/or storage backend.
@@ -45,6 +47,15 @@ type IcebergCatalog struct {
 	Database  string             `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
 	Auth      IcebergAuth        `yaml:"auth,omitempty" json:"auth,omitempty" mapstructure:"auth"`
 
+	// RestUseSSL selects HTTPS for the REST catalog (ingestr defaults to HTTP);
+	// set true for managed catalogs like Polaris, Unity, or Tabular.
+	RestUseSSL *bool `yaml:"rest_use_ssl,omitempty" json:"rest_use_ssl,omitempty" mapstructure:"rest_use_ssl"`
+
+	// Driver and Dialect configure the generic sql catalog (both required, e.g.
+	// driver=pgx, dialect=postgres); the sqlite/postgres types set them for you.
+	Driver  string `yaml:"driver,omitempty" json:"driver,omitempty" mapstructure:"driver"`
+	Dialect string `yaml:"dialect,omitempty" json:"dialect,omitempty" mapstructure:"dialect"`
+
 	// Catalog credentials. These are dedicated fields (rather than free-form
 	// Properties entries) so the credential masker redacts them from run logs.
 	// Credential/Token are REST-catalog auth; URI is the SQL-catalog connection
@@ -54,21 +65,26 @@ type IcebergCatalog struct {
 	URI        string `yaml:"uri,omitempty" json:"uri,omitempty" mapstructure:"uri" sensitive:"true"`
 }
 
-// IcebergStorage describes the S3-compatible object store holding the data files.
-//
-// The warehouse location can be given two ways (mutually exclusive): either as a
-// full s3:// URI in Path, or as a separate Bucket (+ optional Prefix). Leave all
-// three empty to let the catalog supply its own warehouse location.
+// IcebergStorage describes where data files live. Type is "s3" (or S3-compatible),
+// "gcs", or "local"; leave the block empty to inherit the catalog's warehouse.
 type IcebergStorage struct {
-	Type IcebergStorageType `yaml:"type" json:"type" mapstructure:"type"`
-	// Path is the full s3://<bucket>/<prefix> warehouse location.
+	// Type is optional: when empty it's inferred from the warehouse scheme
+	// (s3://→s3, gs://→gcs, file://→local); set it to disambiguate the bucket form.
+	Type IcebergStorageType `yaml:"type,omitempty" json:"type,omitempty" mapstructure:"type"`
+	// Path is the full warehouse location: s3://<bucket>/<prefix>,
+	// gs://<bucket>/<prefix>, or (for local storage) a filesystem path/file:// URI.
 	Path string `yaml:"path,omitempty" json:"path,omitempty" mapstructure:"path"`
 	// Bucket/Prefix are an alternative to Path: the bucket name and an optional
-	// key prefix, from which the s3://<bucket>/<prefix> warehouse is built.
+	// key prefix, from which the s3://… or gs://… warehouse is built.
 	Bucket   string      `yaml:"bucket,omitempty" json:"bucket,omitempty" mapstructure:"bucket"`
 	Prefix   string      `yaml:"prefix,omitempty" json:"prefix,omitempty" mapstructure:"prefix"`
 	Region   string      `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
 	Endpoint string      `yaml:"endpoint,omitempty" json:"endpoint,omitempty" mapstructure:"endpoint"`
 	UseSSL   *bool       `yaml:"use_ssl,omitempty" json:"use_ssl,omitempty" mapstructure:"use_ssl"`
 	Auth     IcebergAuth `yaml:"auth,omitempty" json:"auth,omitempty" mapstructure:"auth"`
+
+	// GCS service-account credentials (type "gcs"): KeyFile is a key-file path,
+	// KeyJSON the inline JSON. Empty uses Application Default Credentials.
+	KeyFile string `yaml:"key_file,omitempty" json:"key_file,omitempty" mapstructure:"key_file"`
+	KeyJSON string `yaml:"key_json,omitempty" json:"key_json,omitempty" mapstructure:"key_json" sensitive:"true"`
 }

--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -112,6 +112,11 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 		if cat.Host == "" {
 			return "", nil, fmt.Errorf("iceberg: rest catalog requires %q", "host")
 		}
+		// ingestr builds the REST endpoint as http:// unless rest_use_ssl is set;
+		// managed catalogs (Polaris, Tabular, R2, Unity, ...) are served over TLS.
+		if cat.RestUseSSL != nil {
+			q.Set("rest_use_ssl", strconv.FormatBool(*cat.RestUseSSL))
+		}
 		if cat.Credential != "" {
 			q.Set("credential", cat.Credential)
 		}
@@ -125,16 +130,26 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 		}
 		return "iceberg+hive://" + hostPort(cat.Host, cat.Port), q, nil
 	case config.IcebergCatalogHadoop:
-		if cat.Path == "" {
-			return "", nil, fmt.Errorf("iceberg: hadoop catalog requires %q (warehouse directory)", "path")
+		// Local warehouse goes in the URL path; for object storage (s3://, gs://)
+		// leave Path empty so the warehouse comes from the storage block.
+		if cat.Path != "" {
+			return "iceberg+hadoop://" + ensureLeadingSlash(cat.Path), q, nil
 		}
-		return "iceberg+hadoop://" + ensureLeadingSlash(cat.Path), q, nil
+		return "iceberg+hadoop://", q, nil
 	case config.IcebergCatalogSQL:
 		// Advanced SQL catalog; the connection string comes from the sensitive uri field.
 		if cat.URI == "" {
 			return "", nil, fmt.Errorf("iceberg: sql catalog requires %q (catalog connection string)", "uri")
 		}
 		q.Set("uri", cat.URI)
+		// ingestr's generic sql catalog needs both driver and dialect; settable here
+		// or via properties. The sqlite/postgres catalog types set them automatically.
+		if cat.Driver != "" {
+			q.Set("sql.driver", cat.Driver)
+		}
+		if cat.Dialect != "" {
+			q.Set("sql.dialect", cat.Dialect)
+		}
 		return "iceberg+sql://", q, nil
 	case "":
 		return "", nil, fmt.Errorf("iceberg: catalog.type must be provided (supported: %s)", supportedCatalogList())
@@ -144,41 +159,50 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 }
 
 // icebergStorageParams maps a storage backend to its ingestr Iceberg params.
-// ingestr is S3-only today; add a case (e.g. GCS) when it gains support.
 func icebergStorageParams(st config.IcebergStorage) (url.Values, error) {
 	q := url.Values{}
+
 	switch st.Type {
-	case config.IcebergStorageS3:
-		q.Set("storage", "s3")
-		// The warehouse can be given as a full s3:// URI (path) or as a separate
-		// bucket (+ optional prefix); ingestr builds the same warehouse from either.
-		switch {
-		case st.Path != "" && st.Bucket != "":
-			return nil, fmt.Errorf("iceberg: storage: set either %q (a full s3:// warehouse) or %q, not both", "path", "bucket")
-		case st.Prefix != "" && st.Bucket == "":
-			return nil, fmt.Errorf("iceberg: storage: %q requires %q", "prefix", "bucket")
-		case st.Path != "":
-			q.Set("warehouse", st.Path)
-		case st.Bucket != "":
-			q.Set("bucket", st.Bucket)
-			if st.Prefix != "" {
-				q.Set("prefix", st.Prefix)
-			}
-		}
-		if st.Endpoint != "" {
-			q.Set("endpoint", st.Endpoint)
-		}
-		if st.UseSSL != nil {
-			q.Set("use_ssl", strconv.FormatBool(*st.UseSSL))
-		}
-		setAWSCredentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
-		return q, nil
-	case "":
-		return nil, fmt.Errorf("iceberg: storage.type must be provided (supported: %s)", config.StorageTypeS3)
+	case "", config.IcebergStorageS3, config.IcebergStorageGCS, config.IcebergStorageLocal:
 	default:
-		// e.g. StorageTypeGCS: not supported by ingestr's Iceberg destination yet.
-		return nil, fmt.Errorf("iceberg: unsupported storage type %q (supported: %s)", st.Type, config.StorageTypeS3)
+		return nil, fmt.Errorf("iceberg: unsupported storage type %q (supported: %s, %s, %s)", st.Type, config.IcebergStorageS3, config.IcebergStorageGCS, config.IcebergStorageLocal)
 	}
+	if st.Path != "" && st.Bucket != "" {
+		return nil, fmt.Errorf("iceberg: storage: set either %q (a full warehouse URI) or %q, not both", "path", "bucket")
+	}
+	if st.Prefix != "" && st.Bucket == "" {
+		return nil, fmt.Errorf("iceberg: storage: %q requires %q", "prefix", "bucket")
+	}
+
+	// storage tells ingestr which scheme to build for the bucket form. s3 is its
+	// default, so only gcs needs declaring; a full path or local warehouse carries
+	// its own scheme. Everything else is passed through and ingestr does the rest.
+	if st.Type == config.IcebergStorageGCS {
+		q.Set("storage", "gcs")
+	}
+	switch {
+	case st.Path != "":
+		q.Set("warehouse", st.Path)
+	case st.Bucket != "":
+		q.Set("bucket", st.Bucket)
+		if st.Prefix != "" {
+			q.Set("prefix", st.Prefix)
+		}
+	}
+	if st.Endpoint != "" {
+		q.Set("endpoint", st.Endpoint)
+	}
+	if st.UseSSL != nil {
+		q.Set("use_ssl", strconv.FormatBool(*st.UseSSL))
+	}
+	setAWSCredentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
+	if st.KeyFile != "" {
+		q.Set("gcs.keypath", st.KeyFile)
+	}
+	if st.KeyJSON != "" {
+		q.Set("gcs.jsonkey", st.KeyJSON)
+	}
+	return q, nil
 }
 
 // setAWSCredentials sets the shared S3/Glue region and credential parameters that

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	testAWSRegion = "us-east-1"
-	testS3Path    = "s3://b/p"
+	testAWSRegion  = "us-east-1"
+	testS3Path     = "s3://b/p"
+	testSQLitePath = "/c.db"
+	testS3LakeWh   = "s3://lake/wh"
 )
 
 func parseQuery(t *testing.T, raw string) (string, url.Values) {
@@ -44,7 +46,7 @@ func TestConfig_GetIngestrURI_GlueS3(t *testing.T) {
 
 	scheme, q := parseQuery(t, got)
 	assert.Equal(t, "iceberg+glue", scheme)
-	assert.Equal(t, "s3", q.Get("storage"))
+	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "s3://company-lake/warehouse", q.Get("warehouse"))
 	assert.Equal(t, testAWSRegion, q.Get("region"))
 	assert.Equal(t, "AKID", q.Get("access_key_id"))
@@ -78,7 +80,7 @@ func TestConfig_GetIngestrURI_SQLiteS3MinIO(t *testing.T) {
 
 	scheme, q := parseQuery(t, got)
 	assert.Equal(t, "iceberg+sqlite", scheme)
-	assert.Equal(t, "s3", q.Get("storage"))
+	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "localhost:9000", q.Get("endpoint"))
 	assert.Equal(t, "false", q.Get("use_ssl"))
 	assert.Equal(t, "minioadmin", q.Get("access_key_id"))
@@ -98,7 +100,7 @@ func TestConfig_GetIngestrURI_BucketPrefixStorage(t *testing.T) {
 	}
 
 	_, q := parseQuery(t, mustURI(t, c))
-	assert.Equal(t, "s3", q.Get("storage"))
+	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "company-lake", q.Get("bucket"))
 	assert.Equal(t, "warehouse", q.Get("prefix"))
 	assert.Empty(t, q.Get("warehouse"), "warehouse must not be set when bucket is used")
@@ -128,7 +130,7 @@ func TestConfig_GetIngestrURI_PostgresS3(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, "iceberg+postgres://iceberg_user:secret@metadata-db.internal:5432/iceberg_catalog?"), "got: %s", got)
 
 	_, q := parseQuery(t, got)
-	assert.Equal(t, "s3", q.Get("storage"))
+	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "eu-west-1", q.Get("region"))
 }
 
@@ -160,7 +162,7 @@ func TestConfig_GetIngestrURI_RESTCatalog(t *testing.T) {
 
 	scheme, q := parseQuery(t, got)
 	assert.Equal(t, "iceberg+rest", scheme)
-	assert.Equal(t, "s3", q.Get("storage"))
+	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "client-id:secret", q.Get("credential"))
 	assert.Equal(t, "https://auth.internal/token", q.Get("oauth2-server-uri"))
 }
@@ -185,6 +187,141 @@ func TestConfig_GetIngestrURI_HadoopAndHive(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, "iceberg+hive://metastore:9083?"), "got: %s", got)
 }
 
+func TestConfig_GetIngestrURI_RESTUseSSL(t *testing.T) {
+	t.Parallel()
+
+	useSSL := true
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:       config.IcebergCatalogREST,
+			Host:       "catalog.example.com",
+			Port:       443,
+			RestUseSSL: &useSSL,
+		},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3Path},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "true", q.Get("rest_use_ssl"))
+}
+
+func TestConfig_GetIngestrURI_SQLCatalogDriverDialect(t *testing.T) {
+	t.Parallel()
+
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:    config.IcebergCatalogSQL,
+			URI:     "postgresql://u:p@h:5432/db",
+			Driver:  "pgx",
+			Dialect: "postgres",
+		},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3Path},
+	}
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "postgresql://u:p@h:5432/db", q.Get("uri"))
+	assert.Equal(t, "pgx", q.Get("sql.driver"))
+	assert.Equal(t, "postgres", q.Get("sql.dialect"))
+}
+
+func TestConfig_GetIngestrURI_GCSStorage(t *testing.T) {
+	t.Parallel()
+
+	// Native GCS via a gs:// warehouse + service-account key file.
+	path := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{
+			Type:    config.IcebergStorageGCS,
+			Path:    "gs://company-lake/warehouse",
+			KeyFile: "/creds/gcs-sa.json",
+		},
+	}
+	_, q := parseQuery(t, mustURI(t, path))
+	assert.Equal(t, "gcs", q.Get("storage"))
+	assert.Equal(t, "gs://company-lake/warehouse", q.Get("warehouse"))
+	assert.Equal(t, "/creds/gcs-sa.json", q.Get("gcs.keypath"))
+
+	// Bucket (+ prefix): storage=gcs tells ingestr to build the gs:// warehouse.
+	bucket := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{
+			Type:   config.IcebergStorageGCS,
+			Bucket: "company-lake",
+			Prefix: "warehouse",
+		},
+	}
+	_, q = parseQuery(t, mustURI(t, bucket))
+	assert.Equal(t, "gcs", q.Get("storage"))
+	assert.Equal(t, "company-lake", q.Get("bucket"))
+	assert.Equal(t, "warehouse", q.Get("prefix"))
+}
+
+func TestConfig_GetIngestrURI_LocalStorage(t *testing.T) {
+	t.Parallel()
+
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageLocal, Path: "file:///tmp/warehouse"},
+	}
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "file:///tmp/warehouse", q.Get("warehouse"))
+	assert.Empty(t, q.Get("storage"), "local storage sets no storage flag")
+}
+
+func TestConfig_GetIngestrURI_HadoopObjectStorage(t *testing.T) {
+	t.Parallel()
+
+	// No catalog path: the Hadoop warehouse comes from the storage block (s3://).
+	c := Config{
+		Catalog:    config.IcebergCatalog{Type: config.IcebergCatalogHadoop},
+		Storage:    config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
+		Properties: map[string]string{"allow-unsafe-commits": "true"},
+	}
+	got := mustURI(t, c)
+	assert.True(t, strings.HasPrefix(got, "iceberg+hadoop://?"), "got: %s", got)
+	_, q := parseQuery(t, got)
+	assert.Equal(t, testS3LakeWh, q.Get("warehouse"))
+	assert.Equal(t, "true", q.Get("allow-unsafe-commits"))
+}
+
+func TestConfig_GetIngestrURI_SQLCatalogNoStorage(t *testing.T) {
+	t.Parallel()
+
+	// The advanced sql catalog may own its warehouse, so storage is optional.
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:    config.IcebergCatalogSQL,
+			URI:     "postgresql://u:p@h:5432/db",
+			Driver:  "pgx",
+			Dialect: "postgres",
+		},
+	}
+	got := mustURI(t, c)
+	assert.True(t, strings.HasPrefix(got, "iceberg+sql://?"), "got: %s", got)
+}
+
+func TestConfig_GetIngestrURI_HadoopLocalNoStorage(t *testing.T) {
+	t.Parallel()
+
+	// A local Hadoop warehouse (catalog path) needs no storage block.
+	c := Config{Catalog: config.IcebergCatalog{Type: config.IcebergCatalogHadoop, Path: "/tmp/wh"}}
+	got := mustURI(t, c)
+	assert.True(t, strings.HasPrefix(got, "iceberg+hadoop:///tmp/wh"), "got: %s", got)
+}
+
+func TestConfig_GetIngestrURI_NoStorage(t *testing.T) {
+	t.Parallel()
+
+	// Glue/REST/SQL catalogs may supply their own warehouse; storage is optional.
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
+	}
+	got := mustURI(t, c)
+	assert.True(t, strings.HasPrefix(got, "iceberg+glue://?"), "got: %s", got)
+	_, q := parseQuery(t, got)
+	assert.Empty(t, q.Get("storage"))
+	assert.Equal(t, testAWSRegion, q.Get("region"))
+}
+
 func TestConfig_GetIngestrURI_SQLCatalogViaProperties(t *testing.T) {
 	t.Parallel()
 
@@ -205,7 +342,7 @@ func TestConfig_GetIngestrURI_TableAndNamespaceParams(t *testing.T) {
 	createNS := false
 	c := Config{
 		Catalog:         config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
-		Storage:         config.IcebergStorage{Type: config.IcebergStorageS3, Path: "s3://lake/wh"},
+		Storage:         config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
 		CreateNamespace: &createNS,
 		TableLocation:   "s3://lake/wh/{namespace}/{table}",
 		TablePath:       "{namespace}/{table}",
@@ -229,7 +366,7 @@ func TestConfig_GetIngestrURI_PropertiesOverride(t *testing.T) {
 	// A passthrough property wins over a structured value on conflict.
 	c := Config{
 		Catalog:    config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
-		Storage:    config.IcebergStorage{Type: config.IcebergStorageS3, Path: "s3://lake/wh"},
+		Storage:    config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
 		Properties: map[string]string{"region": "eu-west-1"},
 	}
 	_, q := parseQuery(t, mustURI(t, c))
@@ -241,6 +378,56 @@ func mustURI(t *testing.T, c Config) string {
 	uri, err := c.GetIngestrURI()
 	require.NoError(t, err)
 	return uri
+}
+
+func TestConfig_GetIngestrURI_InferStorageFromScheme(t *testing.T) {
+	t.Parallel()
+
+	// gs:// warehouse, no storage.type → inferred GCS.
+	gcs := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{Path: "gs://lake/wh", KeyFile: "/sa.json"},
+	}
+	_, q := parseQuery(t, mustURI(t, gcs))
+	assert.Equal(t, "gs://lake/wh", q.Get("warehouse"))
+	assert.Equal(t, "/sa.json", q.Get("gcs.keypath"))
+	assert.Empty(t, q.Get("storage"))
+
+	// s3:// warehouse, no type → inferred S3 (credentials emitted).
+	s3 := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{Path: testS3LakeWh, Region: testAWSRegion, Auth: config.IcebergAuth{AccessKey: "AKID", SecretKey: "SECRET"}},
+	}
+	_, q = parseQuery(t, mustURI(t, s3))
+	assert.Equal(t, testS3LakeWh, q.Get("warehouse"))
+	assert.Equal(t, "AKID", q.Get("access_key_id"))
+
+	// file:// warehouse, no type → inferred local.
+	local := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{Path: "file:///tmp/wh"},
+	}
+	_, q = parseQuery(t, mustURI(t, local))
+	assert.Equal(t, "file:///tmp/wh", q.Get("warehouse"))
+
+	// bucket with no type → defaults to s3 (bucket/prefix passthrough).
+	bucket := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{Bucket: "lake", Prefix: "wh"},
+	}
+	_, q = parseQuery(t, mustURI(t, bucket))
+	assert.Equal(t, "lake", q.Get("bucket"))
+	assert.Equal(t, "wh", q.Get("prefix"))
+
+	// bucket with type=gcs → storage=gcs + bucket/prefix (ingestr builds gs://).
+	gcsBucket := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogSQLite, Path: testSQLitePath},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageGCS, Bucket: "lake", Prefix: "wh"},
+	}
+	_, q = parseQuery(t, mustURI(t, gcsBucket))
+	assert.Equal(t, "gcs", q.Get("storage"))
+	assert.Equal(t, "lake", q.Get("bucket"))
+	assert.Equal(t, "wh", q.Get("prefix"))
 }
 
 func TestConfig_GetIngestrURI_Errors(t *testing.T) {
@@ -281,19 +468,12 @@ func TestConfig_GetIngestrURI_Errors(t *testing.T) {
 			wantErr: "sql catalog requires",
 		},
 		{
-			name: "missing storage type",
+			name: "unsupported storage type",
 			config: Config{
 				Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue},
+				Storage: config.IcebergStorage{Type: config.IcebergStorageType("azure"), Path: "az://b/p"},
 			},
-			wantErr: "storage.type must be provided",
-		},
-		{
-			name: "gcs not yet supported",
-			config: Config{
-				Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue},
-				Storage: config.IcebergStorage{Type: config.IcebergStorageType("gcs"), Path: "gs://b/p"},
-			},
-			wantErr: `unsupported storage type "gcs"`,
+			wantErr: `unsupported storage type "azure"`,
 		},
 		{
 			name: "path and bucket are mutually exclusive",
@@ -328,7 +508,7 @@ func TestClient_GetIngestrURI(t *testing.T) {
 
 	client, err := NewClient(Config{
 		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
-		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: "s3://lake/wh"},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Follow-up to #2383 (which added Iceberg as an ingestr destination). This closes the remaining gaps so the Bruin connection can express ingestr's full Iceberg URI surface.

## Catalog
- **REST**: `rest_use_ssl` to select HTTPS — required for managed catalogs (Polaris, Unity, Lakekeeper, Tabular, R2); ingestr defaults REST to plain HTTP.
- **SQL**: `driver` / `dialect` for the generic `sql` catalog (ingestr requires both; the dedicated sqlite/postgres types set them automatically).

## Storage
- **Native GCS** (`type: gcs`): `gs://` warehouse with `key_file` / `key_json` service-account credentials (or ADC).
- **Local filesystem** (`type: local`): a filesystem path → `file://` warehouse.
- **Hadoop object-storage**: `path` is now optional, so the warehouse can come from the storage block (`s3://`, `gs://`) instead of a local dir.
- **Storage block is optional** when the catalog supplies its own warehouse (Glue/REST/SQL).

## Docs
- Per-backend storage examples: AWS S3, S3 `bucket`+`prefix`, S3-compatible (MinIO/R2), native GCS, GCS via the S3-interop endpoint (HMAC), and local.
- Postgres catalog DSN passthrough (`sslmode`, `sslrootcert`, `connect_timeout`, …) via `properties`, scoped to `type: postgres`.