### PR TITLE
python: bump ingestr to 1.1.11

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.9"
+	IngestrVersionV1 = "1.1.11"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
## Summary
- Update the default v1 ingestr package pin to 1.1.11.

## Why
- Keeps Bruin's default ingestr runtime aligned with the latest published release.