### PR TITLE
Add Shopify ClickHouse template

### DIFF
--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -60,6 +60,36 @@ func TestInitSelfHealDemoCopiesPipelineTemplate(t *testing.T) {
 	require.Contains(t, string(configContent), "path: self-heal-demo.duckdb")
 }
 
+func TestInitShopifyClickHouseCopiesPipelineTemplate(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+
+	gitInit := exec.CommandContext(t.Context(), "git", "init")
+	gitInit.Dir = targetRoot
+	out, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	err = Init().Run(t.Context(), []string{"init", "shopify-clickhouse"})
+	require.NoError(t, err)
+
+	pipelineRoot := filepath.Join(targetRoot, "shopify-clickhouse")
+	require.FileExists(t, filepath.Join(pipelineRoot, "README.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "pipeline.yml"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "assets", "t1", "t1_orders.asset.yml"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "assets", "t2", "t2_orders.sql"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "assets", "t3", "t3_daily_kpis.sql"))
+
+	pipeline, err := os.ReadFile(filepath.Join(pipelineRoot, "pipeline.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(pipeline), "name: shopify-clickhouse")
+	require.Contains(t, string(pipeline), "shopify: \"shopify-default\"")
+
+	ordersAsset, err := os.ReadFile(filepath.Join(pipelineRoot, "assets", "t1", "t1_orders.asset.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(ordersAsset), "name: shopify.t1_orders")
+	require.Contains(t, string(ordersAsset), "source_connection: shopify-default")
+}
+
 func TestSelfHealDemoTemplateContainsDataProblemScenarios(t *testing.T) {
 	t.Parallel()
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -130,11 +130,13 @@ You can run the following commands to get started:
     bruin validate bruin-pipeline
 ```
 
-### Initializing the Shopify-Bigquery template
+### Initializing a Shopify template
 
 ``` bash
-bruin init shopify-bigquery
+bruin init shopify-clickhouse
 ```
+
+The `shopify-clickhouse` template creates raw Shopify ingestion assets, conformed commerce models, and ClickHouse reporting marts. Configure the generated pipeline with your Shopify and ClickHouse connections before running it.
 
 #### Output
 

--- a/docs/getting-started/templates-docs/shopify-clickhouse-README.md
+++ b/docs/getting-started/templates-docs/shopify-clickhouse-README.md
@@ -1,0 +1,131 @@
+# Shopify to ClickHouse
+
+This template builds a Shopify analytics pipeline with Bruin, ingestr, and ClickHouse. It ingests Shopify customers, products, orders, inventory items, discounts, and events; then creates conformed models and reporting marts you can adapt for your store.
+
+The template uses the `shopify` ClickHouse database and the connection names `shopify-default` and `clickhouse-default`. Rename the database or connections consistently if they do not fit your project.
+
+## Project structure
+
+```text
+shopify-clickhouse/
+├── pipeline.yml
+├── README.md
+└── assets/
+    ├── t1/                         # Raw Shopify ingestion assets
+    │   ├── t1_customers.asset.yml
+    │   ├── t1_products.asset.yml
+    │   ├── t1_orders.asset.yml
+    │   ├── t1_inventory_items.asset.yml
+    │   ├── t1_discounts.asset.yml
+    │   └── t1_events.asset.yml
+    ├── t2/                         # Conformed commerce models
+    │   ├── t2_customers.sql
+    │   ├── t2_products.sql
+    │   ├── t2_inventory_items.sql
+    │   ├── t2_orders.sql
+    │   └── t2_order_line_items.sql
+    └── t3/                         # Analytics marts
+        ├── t3_daily_revenue.sql
+        ├── t3_daily_kpis.sql
+        ├── t3_payment_reconciliation.sql
+        ├── t3_customer_cohorts.sql
+        └── t3_product_performance.sql
+```
+
+## What it creates
+
+The pipeline is organized into three layers:
+
+- `t1`: raw Shopify API data, incrementally merged into ClickHouse.
+- `t2`: conformed customers, products, inventory items, orders, and order line items.
+- `t3`: daily revenue and KPI marts, payment-status reconciliation, customer cohorts, and product performance.
+
+All timestamps and reporting dates use UTC. Monetary metrics remain at Shopify currency grain: the template deliberately does not convert or combine currencies.
+
+## Before you begin
+
+1. Create a Shopify custom app, install it in your store, and give it the Admin API scopes required for the resources you want to ingest. See the [Shopify ingestion guide](https://getbruin.com/docs/ingestr/supported-sources/shopify.html) for the underlying connector requirements.
+2. Create a `shopify` database in ClickHouse, or replace every `shopify.` asset name with your preferred database name.
+3. Add the Shopify and ClickHouse connections to your project-root `.bruin.yml`. Do not commit credentials.
+
+For example:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      shopify:
+        - name: shopify-default
+          url: your-store.myshopify.com
+          api_key: <shopify-admin-api-access-token>
+      clickhouse:
+        - name: clickhouse-default
+          host: <clickhouse-host>
+          port: 8443
+          username: <clickhouse-username>
+          password: <clickhouse-password>
+          database: shopify
+          secure: 1
+```
+
+`secure: 1` is appropriate for ClickHouse Cloud and other TLS-enabled deployments. Adjust the connection values for your ClickHouse installation.
+
+Create the database before the first run:
+
+```sql
+CREATE DATABASE IF NOT EXISTS shopify;
+```
+
+## Run the pipeline
+
+Initialize the template:
+
+```bash
+bruin init shopify-clickhouse
+cd shopify-clickhouse
+```
+
+Set `start_date` in `pipeline.yml` to the earliest Shopify history you need, then validate the generated pipeline from the repository root:
+
+```bash
+bruin validate shopify-clickhouse
+```
+
+For the first load, run a full refresh over the same historical period. Replace the dates with your desired range:
+
+```bash
+bruin run shopify-clickhouse \
+  --full-refresh \
+  --start-date "2020-01-01 00:00:00" \
+  --end-date "YYYY-MM-DD 23:59:59.999999"
+```
+
+After the initial load, run the pipeline on its daily schedule or supply a bounded interval to safely reprocess changed records:
+
+```bash
+bruin run shopify-clickhouse \
+  --start-date "YYYY-MM-DD 00:00:00" \
+  --end-date "YYYY-MM-DD 23:59:59.999999"
+```
+
+## Customize it
+
+The T1 assets preserve Shopify structures that are useful as a starting point, including nested JSON for orders and products. T2 models expose analytics-friendly fields while omitting direct customer identifiers and street addresses. Review the selected API resources, column definitions, quality checks, and business rules before treating this as a production model.
+
+In particular, the payment reconciliation mart summarizes Shopify order financial statuses; it is not a payout or gateway-settlement ledger. Add Shopify Payments or another payment-source integration if you need settlement-level reporting.
+
+The template uses `merge` materializations for incrementally updated entities and daily marts. The customer-cohort and product-performance marts use `create+replace`, because they summarize the full available history.
+
+## Explore the marts
+
+After a successful run, start with the daily KPIs:
+
+```sql
+SELECT *
+FROM shopify.t3_daily_kpis
+ORDER BY metric_date DESC, currency
+LIMIT 10;
+```
+
+The marts are designed as a useful baseline, not a universal ecommerce semantic model. Extend them with your store's cancellation, fulfillment, tax, returns, and currency policies.

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -139,6 +139,12 @@ AI agent skills are installed separately with `bruin ai skills`; see [AI Skills]
     <span>Copies Shopify data into DuckDB for local ecommerce exploration.</span>
     <span class="template-card__tags"><code>Shopify</code><code>DuckDB</code><code>ingestr</code></span>
   </a>
+  <a class="template-card" href="./templates-docs/shopify-clickhouse-README.html">
+    <span class="template-card__category">Commerce analytics</span>
+    <strong>shopify-clickhouse</strong>
+    <span>Ingests Shopify data into ClickHouse and builds configurable models for orders, customers, products, and daily reporting.</span>
+    <span class="template-card__tags"><code>Shopify</code><code>ClickHouse</code><code>ingestr</code></span>
+  </a>
   <a class="template-card" href="./templates-docs/gsheet-bigquery-README.html">
     <span class="template-card__category">Spreadsheet source</span>
     <strong>gsheet-bigquery</strong>
@@ -203,7 +209,7 @@ bruin init nyc-taxi my-taxi-pipeline
 | Goal | Start with |
 | --- | --- |
 | Learn Bruin locally without cloud credentials | `duckdb`, `python`, `frankfurter`, or `chess` |
-| Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `gsheet-bigquery`, `notion`, or `gorgias` |
+| Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `shopify-clickhouse`, `gsheet-bigquery`, `notion`, or `gorgias` |
 | Explore a complete demo with generated data | `demo-snowflake-sales-analytics` or `demo-snowflake-salesforce` |
 | Scaffold ecommerce reporting | `ecommerce` |
 | Work with a specific database | `athena`, `clickhouse`, `bronze-silver-postgres`, `bigquery`, `databricks`, or `redshift` |

--- a/templates/shopify-clickhouse/README.md
+++ b/templates/shopify-clickhouse/README.md
@@ -1,0 +1,131 @@
+# Shopify to ClickHouse
+
+This template builds a Shopify analytics pipeline with Bruin, ingestr, and ClickHouse. It ingests Shopify customers, products, orders, inventory items, discounts, and events; then creates conformed models and reporting marts you can adapt for your store.
+
+The template uses the `shopify` ClickHouse database and the connection names `shopify-default` and `clickhouse-default`. Rename the database or connections consistently if they do not fit your project.
+
+## Project structure
+
+```text
+shopify-clickhouse/
+├── pipeline.yml
+├── README.md
+└── assets/
+    ├── t1/                         # Raw Shopify ingestion assets
+    │   ├── t1_customers.asset.yml
+    │   ├── t1_products.asset.yml
+    │   ├── t1_orders.asset.yml
+    │   ├── t1_inventory_items.asset.yml
+    │   ├── t1_discounts.asset.yml
+    │   └── t1_events.asset.yml
+    ├── t2/                         # Conformed commerce models
+    │   ├── t2_customers.sql
+    │   ├── t2_products.sql
+    │   ├── t2_inventory_items.sql
+    │   ├── t2_orders.sql
+    │   └── t2_order_line_items.sql
+    └── t3/                         # Analytics marts
+        ├── t3_daily_revenue.sql
+        ├── t3_daily_kpis.sql
+        ├── t3_payment_reconciliation.sql
+        ├── t3_customer_cohorts.sql
+        └── t3_product_performance.sql
+```
+
+## What it creates
+
+The pipeline is organized into three layers:
+
+- `t1`: raw Shopify API data, incrementally merged into ClickHouse.
+- `t2`: conformed customers, products, inventory items, orders, and order line items.
+- `t3`: daily revenue and KPI marts, payment-status reconciliation, customer cohorts, and product performance.
+
+All timestamps and reporting dates use UTC. Monetary metrics remain at Shopify currency grain: the template deliberately does not convert or combine currencies.
+
+## Before you begin
+
+1. Create a Shopify custom app, install it in your store, and give it the Admin API scopes required for the resources you want to ingest. See the [Shopify ingestion guide](https://getbruin.com/docs/ingestr/supported-sources/shopify.html) for the underlying connector requirements.
+2. Create a `shopify` database in ClickHouse, or replace every `shopify.` asset name with your preferred database name.
+3. Add the Shopify and ClickHouse connections to your project-root `.bruin.yml`. Do not commit credentials.
+
+For example:
+
+```yaml
+default_environment: default
+environments:
+  default:
+    connections:
+      shopify:
+        - name: shopify-default
+          url: your-store.myshopify.com
+          api_key: <shopify-admin-api-access-token>
+      clickhouse:
+        - name: clickhouse-default
+          host: <clickhouse-host>
+          port: 8443
+          username: <clickhouse-username>
+          password: <clickhouse-password>
+          database: shopify
+          secure: 1
+```
+
+`secure: 1` is appropriate for ClickHouse Cloud and other TLS-enabled deployments. Adjust the connection values for your ClickHouse installation.
+
+Create the database before the first run:
+
+```sql
+CREATE DATABASE IF NOT EXISTS shopify;
+```
+
+## Run the pipeline
+
+Initialize the template:
+
+```bash
+bruin init shopify-clickhouse
+cd shopify-clickhouse
+```
+
+Set `start_date` in `pipeline.yml` to the earliest Shopify history you need, then validate the generated pipeline from the repository root:
+
+```bash
+bruin validate shopify-clickhouse
+```
+
+For the first load, run a full refresh over the same historical period. Replace the dates with your desired range:
+
+```bash
+bruin run shopify-clickhouse \
+  --full-refresh \
+  --start-date "2020-01-01 00:00:00" \
+  --end-date "YYYY-MM-DD 23:59:59.999999"
+```
+
+After the initial load, run the pipeline on its daily schedule or supply a bounded interval to safely reprocess changed records:
+
+```bash
+bruin run shopify-clickhouse \
+  --start-date "YYYY-MM-DD 00:00:00" \
+  --end-date "YYYY-MM-DD 23:59:59.999999"
+```
+
+## Customize it
+
+The T1 assets preserve Shopify structures that are useful as a starting point, including nested JSON for orders and products. T2 models expose analytics-friendly fields while omitting direct customer identifiers and street addresses. Review the selected API resources, column definitions, quality checks, and business rules before treating this as a production model.
+
+In particular, the payment reconciliation mart summarizes Shopify order financial statuses; it is not a payout or gateway-settlement ledger. Add Shopify Payments or another payment-source integration if you need settlement-level reporting.
+
+The template uses `merge` materializations for incrementally updated entities and daily marts. The customer-cohort and product-performance marts use `create+replace`, because they summarize the full available history.
+
+## Explore the marts
+
+After a successful run, start with the daily KPIs:
+
+```sql
+SELECT *
+FROM shopify.t3_daily_kpis
+ORDER BY metric_date DESC, currency
+LIMIT 10;
+```
+
+The marts are designed as a useful baseline, not a universal ecommerce semantic model. Extend them with your store's cancellation, fulfillment, tax, returns, and currency policies.

--- a/templates/shopify-clickhouse/assets/t1/t1_customers.asset.yml
+++ b/templates/shopify-clickhouse/assets/t1/t1_customers.asset.yml
@@ -1,0 +1,125 @@
+name: shopify.t1_customers
+type: ingestr
+description: "Raw Shopify customer records, incrementally merged from the live shop."
+
+materialization:
+  type: table
+  strategy: merge
+  incremental_key: updated_at
+
+parameters:
+  source_connection: shopify-default
+  source_table: customers
+  destination: clickhouse
+  schema_contract: evolve
+  schema_naming: snake_case
+
+tags:
+  - t1
+  - source
+  - shopify
+  - customers
+  - pii
+domains:
+  - commerce
+  - customer
+meta:
+  grain: one row per Shopify customer
+  source_system: shopify
+  source_table: customers
+  data_classification: restricted
+  contains_pii: "true"
+  ingestion_strategy: merge on updated_at
+
+columns:
+  - name: id
+    type: Int64
+    description: "Shopify numeric identifier for the customer."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: admin_graphql_api_id
+    type: Nullable(String)
+    description: "Shopify Admin GraphQL global identifier for the customer."
+  - name: email
+    type: Nullable(String)
+    description: "Customer email address supplied to Shopify; contains personal data."
+  - name: first_name
+    type: Nullable(String)
+    description: "Customer given name supplied to Shopify; contains personal data."
+  - name: last_name
+    type: Nullable(String)
+    description: "Customer family name supplied to Shopify; contains personal data."
+  - name: phone
+    type: Nullable(String)
+    description: "Customer phone number supplied to Shopify; contains personal data."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the customer record was created in Shopify."
+  - name: updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the customer record; used as the incremental cursor."
+  - name: state
+    type: Nullable(String)
+    description: "Current Shopify customer-account state."
+  - name: note
+    type: Nullable(String)
+    description: "Merchant-entered note attached to the customer; may contain personal data."
+  - name: tags
+    type: Nullable(String)
+    description: "Serialized tags assigned to the customer in Shopify."
+  - name: tax_exempt
+    type: Nullable(Bool)
+    description: "Whether Shopify marks the customer as exempt from tax."
+  - name: tax_exemptions
+    type: Nullable(String)
+    description: "Serialized list of tax exemptions assigned to the customer."
+  - name: verified_email
+    type: Nullable(Bool)
+    description: "Whether Shopify considers the customer email address verified."
+  - name: multipass_identifier
+    type: Nullable(String)
+    description: "Shopify Multipass identifier for the customer when configured."
+  - name: accepts_marketing
+    type: Nullable(Bool)
+    description: "Legacy Shopify flag indicating whether the customer accepts marketing."
+  - name: accepts_marketing_updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the legacy marketing-acceptance state last changed."
+  - name: marketing_opt_in_level
+    type: Nullable(String)
+    description: "Marketing opt-in level recorded by Shopify."
+  - name: locale
+    type: Nullable(String)
+    description: "Customer locale recorded by Shopify."
+  - name: orders_count
+    type: Nullable(Int64)
+    description: "Number of orders Shopify associates with the customer."
+  - name: total_spent
+    type: Nullable(String)
+    description: "Lifetime amount spent as returned by Shopify in shop currency."
+  - name: currency
+    type: Nullable(String)
+    description: "ISO currency code associated with the customer's spending totals."
+  - name: default_address
+    type: Nullable(String)
+    description: "Serialized default postal address; contains personal data."
+  - name: addresses
+    type: Nullable(String)
+    description: "Serialized customer postal-address collection; contains personal data."
+  - name: email_marketing_consent
+    type: Nullable(String)
+    description: "Serialized Shopify email-marketing consent state."
+  - name: sms_marketing_consent
+    type: Nullable(String)
+    description: "Serialized Shopify SMS-marketing consent state."
+  - name: last_order_id
+    type: Nullable(Int64)
+    description: "Numeric identifier of the customer's most recent Shopify order."
+  - name: last_order_name
+    type: Nullable(String)
+    description: "Merchant-facing name of the customer's most recent Shopify order."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the record into ClickHouse."

--- a/templates/shopify-clickhouse/assets/t1/t1_discounts.asset.yml
+++ b/templates/shopify-clickhouse/assets/t1/t1_discounts.asset.yml
@@ -1,0 +1,53 @@
+name: shopify.t1_discounts
+type: ingestr
+description: "Raw Shopify discount definitions, incrementally merged from the live shop."
+
+materialization:
+  type: table
+  strategy: merge
+  incremental_key: updated_at
+
+parameters:
+  source_connection: shopify-default
+  source_table: discounts
+  destination: clickhouse
+  schema_contract: evolve
+  schema_naming: snake_case
+
+tags:
+  - t1
+  - source
+  - shopify
+  - discounts
+domains:
+  - commerce
+  - marketing
+  - finance
+meta:
+  grain: one row per Shopify discount definition
+  source_system: shopify
+  source_table: discounts
+  data_classification: internal
+  contains_pii: "false"
+  ingestion_strategy: merge on updated_at
+
+columns:
+  - name: id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the discount node."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: discount
+    type: Nullable(String)
+    description: "Serialized discount definition, including type, status, eligibility, value, dates, and redeem codes."
+  - name: metafields_first250
+    type: Nullable(String)
+    description: "Serialized first page of up to 250 metafields attached to the discount."
+  - name: updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the discount; used as the incremental cursor."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the record into ClickHouse."

--- a/templates/shopify-clickhouse/assets/t1/t1_events.asset.yml
+++ b/templates/shopify-clickhouse/assets/t1/t1_events.asset.yml
@@ -1,0 +1,72 @@
+name: shopify.t1_events
+type: ingestr
+description: "Raw Shopify audit events describing changes and actions across shop resources."
+
+materialization:
+  type: table
+  strategy: merge
+  incremental_key: created_at
+
+parameters:
+  source_connection: shopify-default
+  source_table: events
+  destination: clickhouse
+  schema_contract: evolve
+  schema_naming: snake_case
+
+tags:
+  - t1
+  - source
+  - shopify
+  - events
+  - audit
+domains:
+  - commerce
+  - operations
+  - governance
+meta:
+  grain: one row per Shopify audit event
+  source_system: shopify
+  source_table: events
+  data_classification: restricted
+  contains_pii: "true"
+  ingestion_strategy: merge on created_at
+
+columns:
+  - name: id
+    type: Int64
+    description: "Shopify numeric identifier for the audit event."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: subject_id
+    type: Nullable(Int64)
+    description: "Numeric identifier of the Shopify resource affected by the event."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify created the event; used as the incremental cursor."
+  - name: subject_type
+    type: Nullable(String)
+    description: "Shopify resource type affected by the event, such as Order or PriceRule."
+  - name: verb
+    type: Nullable(String)
+    description: "Action recorded by Shopify, such as create or confirmed."
+  - name: arguments
+    type: Nullable(String)
+    description: "Serialized arguments associated with the event."
+  - name: message
+    type: Nullable(String)
+    description: "Human-readable Shopify event message; may contain internal user information."
+  - name: author
+    type: Nullable(String)
+    description: "Author attributed to the event; may identify a staff user or application."
+  - name: description
+    type: Nullable(String)
+    description: "Additional human-readable description of the event."
+  - name: path
+    type: Nullable(String)
+    description: "Shopify Admin path associated with the affected resource."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the record into ClickHouse."

--- a/templates/shopify-clickhouse/assets/t1/t1_inventory_items.asset.yml
+++ b/templates/shopify-clickhouse/assets/t1/t1_inventory_items.asset.yml
@@ -1,0 +1,92 @@
+name: shopify.t1_inventory_items
+type: ingestr
+description: "Raw Shopify inventory item records, incrementally merged from the live shop."
+
+materialization:
+  type: table
+  strategy: merge
+  incremental_key: updated_at
+
+parameters:
+  source_connection: shopify-default
+  source_table: inventory_items
+  destination: clickhouse
+  schema_contract: evolve
+  schema_naming: snake_case
+
+tags:
+  - t1
+  - source
+  - shopify
+  - inventory
+domains:
+  - commerce
+  - merchandising
+  - fulfillment
+meta:
+  grain: one row per Shopify inventory item
+  source_system: shopify
+  source_table: inventory_items
+  data_classification: internal
+  contains_pii: "false"
+  ingestion_strategy: merge on updated_at
+
+columns:
+  - name: id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the inventory item."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the inventory item was created in Shopify."
+  - name: cost
+    type: Nullable(Float64)
+    description: "Unit cost recorded for the inventory item in shop currency."
+  - name: country_code_of_origin
+    type: Nullable(String)
+    description: "ISO country code where the inventory item originated."
+  - name: province_code_of_origin
+    type: Nullable(String)
+    description: "Province or state code where the inventory item originated."
+  - name: harmonized_system_code
+    type: Nullable(String)
+    description: "Harmonized System tariff code used for customs classification."
+  - name: duplicate_sku_count
+    type: Nullable(Int64)
+    description: "Number of other inventory items that use the same SKU."
+  - name: inventory_history_url
+    type: Nullable(String)
+    description: "Shopify Admin URL for the inventory item's history."
+  - name: legacy_resource_id
+    type: Nullable(String)
+    description: "Legacy numeric Shopify resource identifier represented as text."
+  - name: measurement
+    type: Nullable(String)
+    description: "Serialized inventory measurement, including weight and its unit."
+  - name: requires_shipping
+    type: Nullable(Bool)
+    description: "Whether the inventory item represents a physical item requiring shipping."
+  - name: sku
+    type: Nullable(String)
+    description: "Merchant-defined stock-keeping unit."
+  - name: tracked
+    type: Nullable(Bool)
+    description: "Whether Shopify tracks inventory quantities for the item."
+  - name: tracked_editable
+    type: Nullable(String)
+    description: "Serialized state explaining whether inventory tracking can be edited."
+  - name: updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the inventory item; used as the incremental cursor."
+  - name: inventory_levels
+    type: Nullable(String)
+    description: "Serialized per-location inventory quantities and location identifiers."
+  - name: variant
+    type: Nullable(String)
+    description: "Serialized Shopify product variant associated with the inventory item."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the record into ClickHouse."

--- a/templates/shopify-clickhouse/assets/t1/t1_orders.asset.yml
+++ b/templates/shopify-clickhouse/assets/t1/t1_orders.asset.yml
@@ -1,0 +1,316 @@
+name: shopify.t1_orders
+type: ingestr
+description: "Raw Shopify order records, including serialized line, customer, address, and refund structures."
+
+materialization:
+  type: table
+  strategy: merge
+  incremental_key: updated_at
+
+parameters:
+  source_connection: shopify-default
+  source_table: orders
+  destination: clickhouse
+  schema_contract: evolve
+  schema_naming: snake_case
+  enforce_schema: true
+
+tags:
+  - t1
+  - source
+  - shopify
+  - orders
+  - pii
+domains:
+  - commerce
+  - finance
+  - fulfillment
+meta:
+  grain: one row per Shopify order
+  source_system: shopify
+  source_table: orders
+  data_classification: restricted
+  contains_pii: "true"
+  ingestion_strategy: merge on updated_at
+
+columns:
+  - name: id
+    type: Int64
+    description: "Shopify numeric identifier for the order."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: admin_graphql_api_id
+    type: Nullable(String)
+    description: "Shopify Admin GraphQL global identifier for the order."
+  - name: app_id
+    type: Nullable(Int64)
+    description: "Identifier of the app that created the order."
+  - name: billing_address
+    type: Nullable(String)
+    description: "Serialized billing address for the order; contains personal data."
+  - name: browser_ip
+    type: Nullable(String)
+    description: "Browser IP address captured for the order; contains personal data."
+  - name: buyer_accepts_marketing
+    type: Nullable(Bool)
+    description: "Whether the buyer accepted marketing when the order was placed."
+  - name: cancel_reason
+    type: Nullable(String)
+    description: "Shopify cancellation-reason code when the order was cancelled."
+  - name: cancelled_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the order was cancelled."
+  - name: cart_token
+    type: Nullable(String)
+    description: "Token of the cart associated with the order."
+  - name: checkout_token
+    type: Nullable(String)
+    description: "Token of the checkout associated with the order."
+  - name: client_details
+    type: Nullable(String)
+    description: "Serialized browser and client details captured during checkout; may contain personal data."
+  - name: closed_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the order was closed."
+  - name: company
+    type: Nullable(String)
+    description: "Serialized Shopify B2B company information associated with the order."
+  - name: confirmation_number
+    type: Nullable(String)
+    description: "Customer-facing confirmation number assigned to the order."
+  - name: confirmed
+    type: Nullable(Bool)
+    description: "Whether Shopify has confirmed the order."
+  - name: contact_email
+    type: Nullable(String)
+    description: "Email address used to contact the buyer; contains personal data."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the order was created in Shopify."
+  - name: currency
+    type: Nullable(String)
+    description: "ISO code of the shop currency used for order amounts."
+  - name: current_subtotal_price
+    type: Nullable(String)
+    description: "Current line-item subtotal after discounts, returns, refunds, edits, and cancellations."
+  - name: current_subtotal_price_set
+    type: Nullable(String)
+    description: "Serialized current subtotal in shop and presentment currencies."
+  - name: current_total_additional_fees_set
+    type: Nullable(String)
+    description: "Serialized current additional fees in shop and presentment currencies."
+  - name: current_total_discounts
+    type: Nullable(String)
+    description: "Current order- and line-level discount total after returns and refunds."
+  - name: current_total_discounts_set
+    type: Nullable(String)
+    description: "Serialized current discount total in shop and presentment currencies."
+  - name: current_total_duties_set
+    type: Nullable(String)
+    description: "Serialized current duties total in shop and presentment currencies."
+  - name: current_total_price
+    type: Nullable(String)
+    description: "Current order total after returns, refunds, edits, and cancellations."
+  - name: current_total_price_set
+    type: Nullable(String)
+    description: "Serialized current order total in shop and presentment currencies."
+  - name: current_total_tax
+    type: Nullable(String)
+    description: "Current tax total after returns, refunds, edits, and cancellations."
+  - name: current_total_tax_set
+    type: Nullable(String)
+    description: "Serialized current tax total in shop and presentment currencies."
+  - name: customer
+    type: Nullable(String)
+    description: "Serialized Shopify customer associated with the order; contains personal data."
+  - name: customer_locale
+    type: Nullable(String)
+    description: "Buyer locale captured when the order was placed."
+  - name: discount_applications
+    type: Nullable(String)
+    description: "Serialized discount applications that explain how discounts were allocated."
+  - name: discount_codes
+    type: Nullable(String)
+    description: "Serialized discount codes applied to the order."
+  - name: email
+    type: Nullable(String)
+    description: "Buyer email address recorded on the order; contains personal data."
+  - name: estimated_taxes
+    type: Nullable(Bool)
+    description: "Whether taxes on the order are estimated."
+  - name: financial_status
+    type: Nullable(String)
+    description: "Shopify financial status of the order."
+  - name: fulfillment_status
+    type: Nullable(String)
+    description: "Shopify fulfillment status of the order."
+  - name: fulfillments
+    type: Nullable(String)
+    description: "Serialized fulfillment records associated with the order."
+  - name: gateway
+    type: Nullable(String)
+    description: "Legacy name of the primary payment gateway used for the order."
+  - name: landing_site
+    type: Nullable(String)
+    description: "Landing-site URL recorded for the buyer session."
+  - name: line_items
+    type: Nullable(String)
+    description: "Serialized order line items, including product, variant, quantity, price, tax, and discount details."
+  - name: location_id
+    type: Nullable(Int64)
+    description: "Shopify location identifier associated with the order."
+  - name: merchant_of_record_app_id
+    type: Nullable(Int64)
+    description: "Identifier of the app acting as merchant of record, when applicable."
+  - name: name
+    type: Nullable(String)
+    description: "Merchant-facing order name, typically including the configured prefix and order number."
+  - name: note
+    type: Nullable(String)
+    description: "Merchant or buyer note attached to the order; may contain personal data."
+  - name: note_attributes
+    type: Nullable(String)
+    description: "Serialized custom note attributes attached to the order."
+  - name: number
+    type: Nullable(Int64)
+    description: "Shopify order number without merchant-configured prefix or suffix."
+  - name: order_number
+    type: Nullable(Int64)
+    description: "Merchant-facing numeric order sequence."
+  - name: order_status_url
+    type: Nullable(String)
+    description: "Authenticated customer order-status URL; treat as sensitive."
+  - name: original_total_additional_fees_set
+    type: Nullable(String)
+    description: "Serialized original additional-fee total before later order changes."
+  - name: original_total_duties_set
+    type: Nullable(String)
+    description: "Serialized original duties total before later order changes."
+  - name: payment_gateway_names
+    type: Nullable(String)
+    description: "Serialized names of payment gateways used for the order."
+  - name: payment_terms
+    type: Nullable(String)
+    description: "Serialized payment terms associated with the order."
+  - name: phone
+    type: Nullable(String)
+    description: "Buyer phone number recorded on the order; contains personal data."
+  - name: po_number
+    type: Nullable(String)
+    description: "Purchase-order number associated with the order."
+  - name: presentment_currency
+    type: Nullable(String)
+    description: "ISO currency code presented to the buyer."
+  - name: processed_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify processed the order."
+  - name: referring_site
+    type: Nullable(String)
+    description: "Referring URL recorded for the buyer session."
+  - name: refunds
+    type: Nullable(String)
+    description: "Serialized refunds issued against the order."
+  - name: shipping_address
+    type: Nullable(String)
+    description: "Serialized shipping address for the order; contains personal data."
+  - name: shipping_lines
+    type: Nullable(String)
+    description: "Serialized shipping methods and charges applied to the order."
+  - name: source_identifier
+    type: Nullable(String)
+    description: "Identifier assigned to the order by its originating source."
+  - name: source_name
+    type: Nullable(String)
+    description: "Channel or application through which the order was created."
+  - name: source_url
+    type: Nullable(String)
+    description: "URL of the external source associated with the order."
+  - name: subtotal_price
+    type: Nullable(String)
+    description: "Original line-item subtotal after discounts and before shipping."
+  - name: subtotal_price_set
+    type: Nullable(String)
+    description: "Serialized original subtotal in shop and presentment currencies."
+  - name: tags
+    type: Nullable(String)
+    description: "Serialized tags assigned to the order."
+  - name: tax_exempt
+    type: Nullable(Bool)
+    description: "Whether the order is exempt from tax."
+  - name: tax_lines
+    type: Nullable(String)
+    description: "Serialized tax lines applied to the order."
+  - name: taxes_included
+    type: Nullable(Bool)
+    description: "Whether displayed prices include taxes."
+  - name: test
+    type: Nullable(Bool)
+    description: "Whether Shopify marks the order as a test order."
+  - name: token
+    type: Nullable(String)
+    description: "Shopify token identifying the order; treat as sensitive."
+  - name: total_discounts
+    type: Nullable(String)
+    description: "Original total discounts applied to the order."
+  - name: total_discounts_set
+    type: Nullable(String)
+    description: "Serialized original discount total in shop and presentment currencies."
+  - name: total_line_items_price
+    type: Nullable(String)
+    description: "Original total line-item price before order-level discounts."
+  - name: total_line_items_price_set
+    type: Nullable(String)
+    description: "Serialized original line-item total in shop and presentment currencies."
+  - name: total_outstanding
+    type: Nullable(String)
+    description: "Order total still owed by the buyer."
+  - name: total_price
+    type: Nullable(String)
+    description: "Original order total including taxes, shipping, and discounts."
+  - name: total_price_set
+    type: Nullable(String)
+    description: "Serialized original order total in shop and presentment currencies."
+  - name: total_shipping_price_set
+    type: Nullable(String)
+    description: "Serialized total shipping price in shop and presentment currencies."
+  - name: total_tax
+    type: Nullable(String)
+    description: "Original total tax charged on the order."
+  - name: total_tax_set
+    type: Nullable(String)
+    description: "Serialized original tax total in shop and presentment currencies."
+  - name: total_tip_received
+    type: Nullable(String)
+    description: "Total tips received for the order."
+  - name: total_weight
+    type: Nullable(String)
+    description: "Total line-item weight in the shop's configured weight unit."
+  - name: updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the order; used as the incremental cursor."
+  - name: user_id
+    type: Nullable(Int64)
+    description: "Identifier of the Shopify staff user associated with the order."
+  - name: duties_included
+    type: Nullable(Bool)
+    description: "Whether displayed prices include duties."
+  - name: merchant_business_entity_id
+    type: Nullable(String)
+    description: "Identifier of the merchant business entity responsible for the order."
+  - name: total_cash_rounding_payment_adjustment_set
+    type: Nullable(String)
+    description: "Serialized cash-rounding adjustment applied to order payments."
+  - name: total_cash_rounding_refund_adjustment_set
+    type: Nullable(String)
+    description: "Serialized cash-rounding adjustment applied to order refunds."
+  - name: checkout_id
+    type: Nullable(Int64)
+    description: "Numeric identifier of the checkout that produced the order."
+  - name: reference
+    type: Nullable(String)
+    description: "External reference attached to the order."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the record into ClickHouse."

--- a/templates/shopify-clickhouse/assets/t1/t1_products.asset.yml
+++ b/templates/shopify-clickhouse/assets/t1/t1_products.asset.yml
@@ -1,0 +1,115 @@
+name: shopify.t1_products
+type: ingestr
+description: "Raw Shopify product records, incrementally merged from the live shop."
+
+materialization:
+  type: table
+  strategy: merge
+  incremental_key: updated_at
+
+parameters:
+  source_connection: shopify-default
+  source_table: products
+  destination: clickhouse
+  schema_contract: evolve
+  schema_naming: snake_case
+
+tags:
+  - t1
+  - source
+  - shopify
+  - products
+domains:
+  - commerce
+  - merchandising
+meta:
+  grain: one row per Shopify product
+  source_system: shopify
+  source_table: products
+  data_classification: internal
+  contains_pii: "false"
+  ingestion_strategy: merge on updated_at
+
+columns:
+  - name: id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the product."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: available_publications_count
+    type: Nullable(String)
+    description: "Serialized count metadata for publications on which the product is available."
+  - name: category
+    type: Nullable(String)
+    description: "Serialized Shopify product-category assignment."
+  - name: compare_at_price_range
+    type: Nullable(String)
+    description: "Serialized range of variant compare-at prices."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the product was created in Shopify."
+  - name: default_cursor
+    type: Nullable(String)
+    description: "Shopify pagination cursor associated with the product."
+  - name: description
+    type: Nullable(String)
+    description: "Plain-text product description."
+  - name: description_html
+    type: Nullable(String)
+    description: "HTML-formatted product description."
+  - name: handle
+    type: Nullable(String)
+    description: "URL-safe Shopify product handle."
+  - name: metafields
+    type: Nullable(String)
+    description: "Serialized product metafields returned by Shopify."
+  - name: options
+    type: Nullable(String)
+    description: "Serialized product options such as size or color."
+  - name: price_range_v2
+    type: Nullable(String)
+    description: "Serialized range of current variant prices."
+  - name: product_type
+    type: Nullable(String)
+    description: "Merchant-defined product type."
+  - name: published_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the product was first published."
+  - name: requires_selling_plan
+    type: Nullable(Bool)
+    description: "Whether the product can be purchased only through a selling plan."
+  - name: status
+    type: Nullable(String)
+    description: "Current Shopify product status, such as active, draft, or archived."
+  - name: tags
+    type: Nullable(String)
+    description: "Serialized tags assigned to the product."
+  - name: template_suffix
+    type: Nullable(String)
+    description: "Theme-template suffix assigned to the product."
+  - name: title
+    type: Nullable(String)
+    description: "Merchant-facing product title."
+  - name: total_inventory
+    type: Nullable(Int64)
+    description: "Total sellable inventory reported across the product's variants."
+  - name: tracks_inventory
+    type: Nullable(Bool)
+    description: "Whether at least one product variant tracks inventory."
+  - name: updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the product; used as the incremental cursor."
+  - name: variants_count
+    type: Nullable(String)
+    description: "Serialized count metadata for product variants."
+  - name: variants_first250
+    type: Nullable(String)
+    description: "Serialized first page of up to 250 Shopify product variants."
+  - name: vendor
+    type: Nullable(String)
+    description: "Vendor assigned to the product."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the record into ClickHouse."

--- a/templates/shopify-clickhouse/assets/t2/t2_customers.sql
+++ b/templates/shopify-clickhouse/assets/t2/t2_customers.sql
@@ -1,0 +1,239 @@
+/* @bruin
+name: shopify.t2_customers
+type: clickhouse.sql
+description: "Conformed Shopify customer profiles with consent, geography, and completed-order lifecycle measures."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t1_customers
+  - shopify.t2_orders
+
+tags:
+  - t2
+  - conformed
+  - shopify
+  - customers
+  - restricted
+domains:
+  - commerce
+  - customer
+  - governance
+meta:
+  grain: one row per Shopify customer
+  source_system: shopify
+  currency_scope: customer and order values remain in their Shopify currency
+  pii_policy: direct identifiers and postal addresses remain in t1; this model retains identifiers and coarse geography only
+  revenue_policy: order measures include completed non-test non-cancelled orders
+  refresh_strategy: primary-key merge when either the customer or an associated order changes
+  data_classification: restricted
+
+custom_checks:
+  - name: customer catalog is preserved
+    description: "Ensures every raw Shopify customer appears in the conformed customer table."
+    query: |
+      SELECT
+        (SELECT count() FROM shopify.t2_customers)
+        =
+        (SELECT count() FROM shopify.t1_customers)
+    value: 1
+    blocking: true
+
+columns:
+  - name: customer_id
+    type: Int64
+    description: "Shopify numeric identifier for the customer."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: customer_created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify created the customer record."
+  - name: customer_updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the customer record."
+  - name: account_state
+    type: LowCardinality(String)
+    description: "Current Shopify customer-account state, or unknown when absent."
+  - name: locale
+    type: LowCardinality(String)
+    description: "Customer locale recorded by Shopify, or blank when absent."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO currency code associated with Shopify's customer spending total."
+  - name: country_code
+    type: LowCardinality(String)
+    description: "ISO country code from the customer's default Shopify address, or blank when absent."
+  - name: province_code
+    type: LowCardinality(String)
+    description: "Province or state code from the customer's default Shopify address, or blank when absent."
+  - name: accepts_marketing
+    type: Bool
+    description: "Whether the customer currently accepts marketing according to Shopify's legacy consent flag."
+  - name: marketing_opt_in_level
+    type: LowCardinality(String)
+    description: "Marketing opt-in level recorded by Shopify, or unspecified when absent."
+  - name: is_tax_exempt
+    type: Bool
+    description: "Whether Shopify marks the customer as exempt from tax."
+  - name: has_verified_email
+    type: Bool
+    description: "Whether Shopify considers the customer's email address verified; no email value is exposed here."
+  - name: shopify_orders_count
+    type: Int64
+    description: "Lifetime order count reported on the Shopify customer record."
+    checks:
+      - name: non_negative
+  - name: shopify_total_spent
+    type: Decimal(18, 2)
+    description: "Lifetime amount spent reported on the Shopify customer record."
+    checks:
+      - name: non_negative
+  - name: first_completed_order_date
+    type: Nullable(Date)
+    description: "UTC date of the customer's first completed, non-test, non-cancelled order."
+  - name: last_completed_order_date
+    type: Nullable(Date)
+    description: "UTC date of the customer's most recent completed, non-test, non-cancelled order."
+  - name: completed_order_count
+    type: UInt64
+    description: "Count of completed, non-test, non-cancelled orders in the conformed order table."
+  - name: refunded_order_count
+    type: UInt64
+    description: "Count of the customer's completed orders currently marked partially refunded or refunded."
+  - name: gross_sales_amount
+    type: Decimal(18, 2)
+    description: "Original gross line-item value across the customer's completed orders."
+  - name: original_order_amount
+    type: Decimal(18, 2)
+    description: "Original total value across the customer's completed orders."
+  - name: recognized_revenue_amount
+    type: Decimal(18, 2)
+    description: "Current recognized revenue across the customer's completed orders."
+  - name: average_order_value
+    type: Decimal(18, 2)
+    description: "Recognized revenue divided by completed order count."
+    checks:
+      - name: non_negative
+  - name: customer_status
+    type: LowCardinality(String)
+    description: "Lifecycle band derived from completed orders: prospect, one_time, or repeat."
+    checks:
+      - name: accepted_values
+        value: ["prospect", "one_time", "repeat"]
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest customer or associated order update timestamp contributing to the row."
+@bruin */
+
+WITH changed_customers AS (
+    SELECT id AS customer_id
+    FROM shopify.t1_customers
+    WHERE updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+    UNION DISTINCT
+    SELECT assumeNotNull(customer_id) AS customer_id
+    FROM shopify.t2_orders
+    WHERE customer_id IS NOT NULL
+      AND order_updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+),
+order_summary AS (
+    SELECT
+        assumeNotNull(o.customer_id) AS customer_id,
+        min(
+            toNullable(
+                if(o.is_completed_order = 1, o.order_date, NULL)
+            )
+        ) AS first_completed_order_date,
+        max(
+            toNullable(
+                if(o.is_completed_order = 1, o.order_date, NULL)
+            )
+        ) AS last_completed_order_date,
+        countIf(o.is_completed_order = 1) AS completed_order_count,
+        countIf(o.is_completed_order = 1 AND o.is_refunded_order = 1) AS refunded_order_count,
+        toDecimal64(
+            sumIf(o.gross_sales_amount, o.is_completed_order = 1),
+            2
+        ) AS gross_sales_amount,
+        toDecimal64(
+            sumIf(o.original_total_amount, o.is_completed_order = 1),
+            2
+        ) AS original_order_amount,
+        toDecimal64(sum(o.recognized_revenue_amount), 2) AS recognized_revenue_amount,
+        max(o.order_updated_at) AS orders_max_updated_at
+    FROM shopify.t2_orders AS o
+    INNER JOIN changed_customers AS changed
+        ON o.customer_id = changed.customer_id
+    WHERE o.customer_id IS NOT NULL
+    GROUP BY assumeNotNull(o.customer_id)
+)
+SELECT
+    c.id AS customer_id,
+    c.created_at AS customer_created_at,
+    c.updated_at AS customer_updated_at,
+    toLowCardinality(lower(ifNull(c.state, 'unknown'))) AS account_state,
+    toLowCardinality(ifNull(c.locale, '')) AS locale,
+    toLowCardinality(ifNull(c.currency, '')) AS currency,
+    toLowCardinality(
+        ifNull(JSONExtractString(c.default_address, 'country_code'), '')
+    ) AS country_code,
+    toLowCardinality(
+        ifNull(JSONExtractString(c.default_address, 'province_code'), '')
+    ) AS province_code,
+    toBool(ifNull(c.accepts_marketing, false)) AS accepts_marketing,
+    toLowCardinality(ifNull(c.marketing_opt_in_level, 'unspecified')) AS marketing_opt_in_level,
+    toBool(ifNull(c.tax_exempt, false)) AS is_tax_exempt,
+    toBool(ifNull(c.verified_email, false)) AS has_verified_email,
+    greatest(toInt64(ifNull(c.orders_count, 0)), toInt64(0)) AS shopify_orders_count,
+    greatest(
+        toDecimal64OrZero(ifNull(c.total_spent, ''), 2),
+        toDecimal64(0, 2)
+    ) AS shopify_total_spent,
+    orders.first_completed_order_date,
+    orders.last_completed_order_date,
+    toUInt64(ifNull(orders.completed_order_count, 0)) AS completed_order_count,
+    toUInt64(ifNull(orders.refunded_order_count, 0)) AS refunded_order_count,
+    toDecimal64(
+        ifNull(orders.gross_sales_amount, toDecimal64(0, 2)),
+        2
+    ) AS gross_sales_amount,
+    toDecimal64(
+        ifNull(orders.original_order_amount, toDecimal64(0, 2)),
+        2
+    ) AS original_order_amount,
+    toDecimal64(
+        ifNull(orders.recognized_revenue_amount, toDecimal64(0, 2)),
+        2
+    ) AS recognized_revenue_amount,
+    toDecimal64(
+        if(
+            ifNull(orders.completed_order_count, 0) = 0,
+            0,
+            ifNull(orders.recognized_revenue_amount, toDecimal64(0, 2))
+                / orders.completed_order_count
+        ),
+        2
+    ) AS average_order_value,
+    toLowCardinality(
+        multiIf(
+            ifNull(orders.completed_order_count, 0) = 0, 'prospect',
+            orders.completed_order_count = 1, 'one_time',
+            'repeat'
+        )
+    ) AS customer_status,
+    greatest(
+        ifNull(c.updated_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC')),
+        ifNull(orders.orders_max_updated_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC'))
+    ) AS source_max_updated_at
+FROM shopify.t1_customers AS c
+INNER JOIN changed_customers AS changed
+    ON c.id = changed.customer_id
+LEFT JOIN order_summary AS orders
+    ON c.id = orders.customer_id

--- a/templates/shopify-clickhouse/assets/t2/t2_inventory_items.sql
+++ b/templates/shopify-clickhouse/assets/t2/t2_inventory_items.sql
@@ -1,0 +1,120 @@
+/* @bruin
+name: shopify.t2_inventory_items
+type: clickhouse.sql
+description: "Conformed Shopify inventory items with product, variant, price, cost, and sellable quantity attributes."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t1_inventory_items
+
+tags:
+  - t2
+  - conformed
+  - shopify
+  - inventory
+domains:
+  - commerce
+  - merchandising
+  - fulfillment
+meta:
+  grain: one row per Shopify inventory item
+  source_system: shopify
+  refresh_strategy: primary-key merge for source records updated in the run interval
+  data_classification: internal
+
+columns:
+  - name: inventory_item_id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the inventory item."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: inventory_item_legacy_id
+    type: UInt64
+    description: "Legacy numeric Shopify identifier for the inventory item."
+  - name: product_id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the parent product."
+  - name: variant_id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the product variant."
+  - name: variant_legacy_id
+    type: UInt64
+    description: "Legacy numeric Shopify identifier for the product variant."
+  - name: sku
+    type: String
+    description: "Merchant-defined stock-keeping unit."
+  - name: variant_title
+    type: String
+    description: "Merchant-facing product variant title."
+  - name: variant_price
+    type: Decimal(18, 2)
+    description: "Current variant price in shop currency."
+    checks:
+      - name: non_negative
+  - name: unit_cost
+    type: Nullable(Decimal(18, 2))
+    description: "Unit cost recorded in Shopify, when available."
+  - name: inventory_quantity
+    type: Int64
+    description: "Current tracked inventory quantity across locations."
+  - name: sellable_online_quantity
+    type: Int64
+    description: "Quantity Shopify reports as sellable online."
+  - name: available_for_sale
+    type: Bool
+    description: "Whether Shopify reports the variant as available for sale."
+  - name: tracked
+    type: Bool
+    description: "Whether Shopify tracks inventory for the item."
+  - name: requires_shipping
+    type: Bool
+    description: "Whether the inventory item represents a physical item requiring shipping."
+  - name: location_count
+    type: UInt64
+    description: "Number of inventory locations returned for the item."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the inventory item was created in Shopify."
+  - name: updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the inventory item was last updated in Shopify."
+@bruin */
+
+SELECT
+    id AS inventory_item_id,
+    toUInt64OrZero(ifNull(legacy_resource_id, '')) AS inventory_item_legacy_id,
+    JSONExtractString(ifNull(variant, '{}'), 'product', 'id') AS product_id,
+    JSONExtractString(ifNull(variant, '{}'), 'id') AS variant_id,
+    toUInt64OrZero(
+        JSONExtractString(ifNull(variant, '{}'), 'legacyResourceId')
+    ) AS variant_legacy_id,
+    ifNull(sku, '') AS sku,
+    JSONExtractString(ifNull(variant, '{}'), 'title') AS variant_title,
+    toDecimal64OrZero(
+        JSONExtractString(ifNull(variant, '{}'), 'price'),
+        2
+    ) AS variant_price,
+    toDecimal64OrNull(toString(cost), 2) AS unit_cost,
+    toInt64(
+        JSONExtractInt(ifNull(variant, '{}'), 'inventoryQuantity')
+    ) AS inventory_quantity,
+    toInt64(
+        JSONExtractInt(ifNull(variant, '{}'), 'sellableOnlineQuantity')
+    ) AS sellable_online_quantity,
+    toBool(
+        JSONExtractBool(ifNull(variant, '{}'), 'availableForSale')
+    ) AS available_for_sale,
+    toBool(ifNull(tracked, false)) AS tracked,
+    toBool(ifNull(requires_shipping, false)) AS requires_shipping,
+    toUInt64(JSONLength(ifNull(inventory_levels, '[]'))) AS location_count,
+    created_at,
+    updated_at
+FROM shopify.t1_inventory_items
+WHERE updated_at BETWEEN
+    parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+    AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')

--- a/templates/shopify-clickhouse/assets/t2/t2_order_line_items.sql
+++ b/templates/shopify-clickhouse/assets/t2/t2_order_line_items.sql
@@ -1,0 +1,294 @@
+/* @bruin
+name: shopify.t2_order_line_items
+type: clickhouse.sql
+description: "Conformed Shopify order lines parsed from the nested order payload."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t1_orders
+  - shopify.t2_orders
+
+tags:
+  - t2
+  - conformed
+  - shopify
+  - order-lines
+domains:
+  - commerce
+  - finance
+  - merchandising
+meta:
+  grain: one row per Shopify order line item
+  source_system: shopify
+  currency_scope: monetary values remain in each order's shop currency
+  refund_policy: recognized line revenue allocates the order's current subtotal proportionally across original net line values
+  refresh_strategy: primary-key merge for lines belonging to orders updated in the run interval
+  data_classification: internal
+
+custom_checks:
+  - name: excluded orders have no recognized line revenue
+    description: "Ensures lines from cancelled, test, and incomplete orders do not contribute recognized merchandise revenue."
+    query: |
+      SELECT count()
+      FROM shopify.t2_order_line_items
+      WHERE is_completed_order = 0
+        AND recognized_line_revenue_amount != 0
+    value: 0
+    blocking: true
+  - name: line totals reconcile to order headers
+    description: "Ensures line gross sales and discounts reconcile to Shopify order-header totals."
+    query: |
+      WITH line_totals AS (
+          SELECT
+              order_id,
+              sum(gross_sales_amount) AS gross_sales_amount,
+              sum(discount_amount) AS discount_amount
+          FROM shopify.t2_order_line_items
+          GROUP BY order_id
+      )
+      SELECT count()
+      FROM shopify.t2_orders AS o
+      INNER JOIN line_totals AS l USING (order_id)
+      WHERE abs(o.gross_sales_amount - l.gross_sales_amount) > 0.01
+         OR abs(o.discount_amount - l.discount_amount) > 0.01
+    value: 0
+    blocking: true
+  - name: recognized line revenue reconciles to current merchandise subtotal
+    description: "Ensures proportional line allocations reconcile to completed orders' current subtotals within cent-rounding tolerance."
+    query: |
+      WITH line_totals AS (
+          SELECT
+              order_id,
+              sum(recognized_line_revenue_amount) AS recognized_line_revenue_amount,
+              count() AS line_count
+          FROM shopify.t2_order_line_items
+          GROUP BY order_id
+      )
+      SELECT count()
+      FROM shopify.t2_orders AS o
+      INNER JOIN line_totals AS l USING (order_id)
+      WHERE o.is_completed_order = 1
+        AND abs(o.current_subtotal_amount - l.recognized_line_revenue_amount)
+            > greatest(toDecimal64(0.01, 2), toDecimal64(l.line_count * 0.01, 2))
+    value: 0
+    blocking: true
+
+columns:
+  - name: line_item_key
+    type: String
+    description: "Date-prefixed stable key used as the ClickHouse primary and sorting key."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: line_item_id
+    type: Int64
+    description: "Shopify numeric identifier for the order line item."
+    checks:
+      - name: not_null
+      - name: unique
+  - name: order_id
+    type: Int64
+    description: "Shopify numeric identifier for the parent order."
+  - name: order_date
+    type: Date
+    description: "UTC calendar date when the parent order was created."
+  - name: order_month
+    type: Date
+    description: "First day of the UTC order month."
+  - name: order_updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the parent order."
+  - name: customer_id
+    type: Nullable(Int64)
+    description: "Shopify numeric customer identifier from the parent order."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code for monetary measures."
+  - name: source_name
+    type: LowCardinality(String)
+    description: "Shopify order source or sales channel."
+  - name: product_id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the product, or blank for deleted/custom products."
+  - name: product_legacy_id
+    type: UInt64
+    description: "Legacy numeric Shopify product identifier."
+  - name: variant_legacy_id
+    type: UInt64
+    description: "Legacy numeric Shopify product variant identifier."
+  - name: sku
+    type: String
+    description: "Stock-keeping unit recorded on the order line."
+  - name: product_title
+    type: String
+    description: "Product title recorded when the order was placed."
+  - name: variant_title
+    type: String
+    description: "Variant title recorded when the order was placed."
+  - name: vendor
+    type: LowCardinality(String)
+    description: "Product vendor recorded on the order line."
+  - name: quantity
+    type: Int64
+    description: "Original quantity ordered."
+    checks:
+      - name: positive
+  - name: current_quantity
+    type: Int64
+    description: "Current quantity after order edits and removals."
+  - name: unit_price
+    type: Decimal(18, 2)
+    description: "Unit price recorded on the line in shop currency."
+    checks:
+      - name: non_negative
+  - name: gross_sales_amount
+    type: Decimal(18, 2)
+    description: "Unit price multiplied by original quantity."
+    checks:
+      - name: non_negative
+  - name: discount_amount
+    type: Decimal(18, 2)
+    description: "Total discount allocated by Shopify to the line."
+    checks:
+      - name: non_negative
+  - name: net_line_amount
+    type: Decimal(18, 2)
+    description: "Gross line sales less Shopify line discounts."
+  - name: recognized_line_revenue_amount
+    type: Decimal(18, 2)
+    description: "Completed order's current subtotal allocated to the line in proportion to its original net line value."
+  - name: is_completed_order
+    type: UInt8
+    description: "One when the parent order qualifies as completed."
+  - name: is_refunded_order
+    type: UInt8
+    description: "One when Shopify reports the parent order as partially refunded or refunded."
+  - name: requires_shipping
+    type: Bool
+    description: "Whether the order line requires shipping."
+  - name: taxable
+    type: Bool
+    description: "Whether the order line is taxable."
+  - name: is_gift_card
+    type: Bool
+    description: "Whether the order line represents a gift card."
+@bruin */
+
+WITH raw_lines AS (
+    SELECT
+        o.id AS order_id,
+        o.updated_at AS order_updated_at,
+        item
+    FROM shopify.t1_orders AS o
+    ARRAY JOIN JSONExtractArrayRaw(ifNull(o.line_items, '[]')) AS item
+    WHERE o.updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+),
+parsed AS (
+    SELECT
+        r.order_id,
+        r.order_updated_at,
+        JSONExtractInt(r.item, 'id') AS line_item_id,
+        toUInt64(JSONExtractInt(r.item, 'product_id')) AS product_legacy_id,
+        toUInt64(JSONExtractInt(r.item, 'variant_id')) AS variant_legacy_id,
+        JSONExtractString(r.item, 'sku') AS sku,
+        JSONExtractString(r.item, 'title') AS product_title,
+        JSONExtractString(r.item, 'variant_title') AS variant_title,
+        toLowCardinality(JSONExtractString(r.item, 'vendor')) AS vendor,
+        toInt64(JSONExtractInt(r.item, 'quantity')) AS quantity,
+        toInt64(JSONExtractInt(r.item, 'current_quantity')) AS current_quantity,
+        toDecimal64OrZero(JSONExtractString(r.item, 'price'), 2) AS unit_price,
+        toDecimal64OrZero(JSONExtractString(r.item, 'total_discount'), 2) AS discount_amount,
+        toBool(JSONExtractBool(r.item, 'requires_shipping')) AS requires_shipping,
+        toBool(JSONExtractBool(r.item, 'taxable')) AS taxable,
+        toBool(JSONExtractBool(r.item, 'gift_card')) AS is_gift_card
+    FROM raw_lines AS r
+),
+line_base AS (
+    SELECT
+        concat(toString(o.order_date), '|', toString(p.line_item_id)) AS line_item_key,
+        p.line_item_id,
+        p.order_id,
+        o.order_date,
+        o.order_month,
+        p.order_updated_at,
+        o.customer_id,
+        o.currency,
+        o.source_name,
+        if(
+            p.product_legacy_id = 0,
+            '',
+            concat('gid://shopify/Product/', toString(p.product_legacy_id))
+        ) AS product_id,
+        p.product_legacy_id,
+        p.variant_legacy_id,
+        p.sku,
+        p.product_title,
+        p.variant_title,
+        p.vendor,
+        p.quantity,
+        p.current_quantity,
+        p.unit_price,
+        toDecimal64(p.unit_price * p.quantity, 2) AS gross_sales_amount,
+        p.discount_amount,
+        toDecimal64((p.unit_price * p.quantity) - p.discount_amount, 2) AS net_line_amount,
+        o.current_subtotal_amount,
+        o.is_completed_order,
+        o.is_refunded_order,
+        p.requires_shipping,
+        p.taxable,
+        p.is_gift_card
+    FROM parsed AS p
+    INNER JOIN shopify.t2_orders AS o
+        ON p.order_id = o.order_id
+),
+with_order_totals AS (
+    SELECT
+        lines.*,
+        sum(lines.net_line_amount) OVER (PARTITION BY lines.order_id) AS order_net_line_amount
+    FROM line_base AS lines
+)
+SELECT
+    lines.line_item_key,
+    lines.line_item_id,
+    lines.order_id,
+    lines.order_date,
+    lines.order_month,
+    lines.order_updated_at,
+    lines.customer_id,
+    lines.currency,
+    lines.source_name,
+    lines.product_id,
+    lines.product_legacy_id,
+    lines.variant_legacy_id,
+    lines.sku,
+    lines.product_title,
+    lines.variant_title,
+    lines.vendor,
+    lines.quantity,
+    lines.current_quantity,
+    lines.unit_price,
+    lines.gross_sales_amount,
+    lines.discount_amount,
+    lines.net_line_amount,
+    if(
+        lines.is_completed_order = 1 AND lines.order_net_line_amount != 0,
+        toDecimal64(
+            toFloat64(lines.current_subtotal_amount)
+                * toFloat64(lines.net_line_amount)
+                / toFloat64(lines.order_net_line_amount),
+            2
+        ),
+        toDecimal64(0, 2)
+    ) AS recognized_line_revenue_amount,
+    lines.is_completed_order,
+    lines.is_refunded_order,
+    lines.requires_shipping,
+    lines.taxable,
+    lines.is_gift_card
+FROM with_order_totals AS lines

--- a/templates/shopify-clickhouse/assets/t2/t2_orders.sql
+++ b/templates/shopify-clickhouse/assets/t2/t2_orders.sql
@@ -1,0 +1,291 @@
+/* @bruin
+name: shopify.t2_orders
+type: clickhouse.sql
+description: "Conformed Shopify order headers with customer, channel, lifecycle, and current financial measures."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t1_orders
+
+tags:
+  - t2
+  - conformed
+  - shopify
+  - orders
+domains:
+  - commerce
+  - finance
+  - fulfillment
+meta:
+  grain: one row per Shopify order
+  source_system: shopify
+  currency_scope: monetary values remain in each order's shop currency
+  revenue_policy: completed non-test non-cancelled orders use Shopify current totals
+  refresh_strategy: primary-key merge for source records updated in the run interval
+  data_classification: internal
+
+custom_checks:
+  - name: excluded orders have no recognized revenue
+    description: "Ensures cancelled, test, and incomplete orders do not contribute recognized revenue."
+    query: |
+      SELECT count()
+      FROM shopify.t2_orders
+      WHERE is_completed_order = 0
+        AND recognized_revenue_amount != 0
+    value: 0
+    blocking: true
+
+columns:
+  - name: order_key
+    type: String
+    description: "Date-prefixed stable key used as the ClickHouse primary and sorting key."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: order_id
+    type: Int64
+    description: "Shopify numeric identifier for the order."
+    checks:
+      - name: not_null
+      - name: unique
+  - name: order_name
+    type: String
+    description: "Merchant-facing Shopify order name."
+  - name: order_date
+    type: Date
+    description: "UTC calendar date when the order was created."
+  - name: order_month
+    type: Date
+    description: "First day of the UTC order month for grouping and retention analysis."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify created the order."
+  - name: processed_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify processed the order."
+  - name: order_updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the order."
+  - name: customer_id
+    type: Nullable(Int64)
+    description: "Shopify numeric customer identifier, null for guest orders without a customer object."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code for monetary measures."
+  - name: presentment_currency
+    type: LowCardinality(String)
+    description: "ISO currency code presented to the buyer."
+  - name: source_name
+    type: LowCardinality(String)
+    description: "Shopify order source or sales channel."
+  - name: financial_status
+    type: LowCardinality(String)
+    description: "Current Shopify financial status."
+  - name: fulfillment_status
+    type: LowCardinality(String)
+    description: "Current Shopify fulfillment status, or `unfulfilled` when absent."
+  - name: shipping_country_code
+    type: LowCardinality(String)
+    description: "ISO country code from the shipping address; blank when unavailable."
+  - name: shipping_province_code
+    type: LowCardinality(String)
+    description: "Province or state code from the shipping address; blank when unavailable."
+  - name: discount_code
+    type: String
+    description: "First discount code recorded on the order, or blank when none was used."
+  - name: is_test_order
+    type: UInt8
+    description: "One when Shopify marks the order as a test."
+  - name: is_cancelled_order
+    type: UInt8
+    description: "One when the order has a cancellation timestamp."
+  - name: is_completed_order
+    type: UInt8
+    description: "One for paid or refunded, non-test, non-cancelled orders."
+  - name: is_refunded_order
+    type: UInt8
+    description: "One when Shopify reports a partially refunded or refunded financial status."
+  - name: gross_sales_amount
+    type: Decimal(18, 2)
+    description: "Original line-item value before order-level discounts."
+  - name: discount_amount
+    type: Decimal(18, 2)
+    description: "Original total discounts applied to the order."
+  - name: subtotal_amount
+    type: Decimal(18, 2)
+    description: "Original line-item subtotal after discounts and before shipping."
+  - name: shipping_amount
+    type: Decimal(18, 2)
+    description: "Original shipping amount in shop currency."
+  - name: tax_amount
+    type: Decimal(18, 2)
+    description: "Original tax amount in shop currency."
+  - name: original_total_amount
+    type: Decimal(18, 2)
+    description: "Original Shopify order total."
+  - name: current_subtotal_amount
+    type: Decimal(18, 2)
+    description: "Current subtotal after returns, refunds, edits, and cancellations."
+  - name: current_discount_amount
+    type: Decimal(18, 2)
+    description: "Current discount total after returns and refunds."
+  - name: current_tax_amount
+    type: Decimal(18, 2)
+    description: "Current tax total after returns and refunds."
+  - name: current_total_amount
+    type: Decimal(18, 2)
+    description: "Current Shopify order total after returns, refunds, edits, and cancellations."
+  - name: refunded_amount
+    type: Decimal(18, 2)
+    description: "Non-negative difference between original and current order totals."
+  - name: outstanding_amount
+    type: Decimal(18, 2)
+    description: "Amount Shopify reports as still owed."
+  - name: recognized_revenue_amount
+    type: Decimal(18, 2)
+    description: "Current total recognized only for completed, non-test, non-cancelled orders."
+  - name: line_item_count
+    type: UInt64
+    description: "Number of serialized line items on the order."
+  - name: refund_record_count
+    type: UInt64
+    description: "Number of serialized Shopify refund records on the order."
+  - name: cancelled_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the order was cancelled."
+  - name: closed_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the order was closed."
+  - name: _ingestr_loaded_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when ingestr loaded the raw order used for this record."
+@bruin */
+
+WITH base AS (
+    SELECT
+        concat(
+            toString(toDate(ifNull(created_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC')))),
+            '|',
+            toString(id)
+        ) AS order_key,
+        id AS order_id,
+        ifNull(name, '') AS order_name,
+        toDate(ifNull(created_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC'))) AS order_date,
+        toStartOfMonth(
+            toDate(ifNull(created_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC')))
+        ) AS order_month,
+        created_at,
+        processed_at,
+        updated_at AS order_updated_at,
+        nullIf(JSONExtractInt(customer, 'id'), 0) AS customer_id,
+        toLowCardinality(ifNull(currency, '')) AS currency,
+        toLowCardinality(ifNull(presentment_currency, ifNull(currency, ''))) AS presentment_currency,
+        toLowCardinality(ifNull(source_name, 'unknown')) AS source_name,
+        toLowCardinality(ifNull(o.financial_status, 'unknown')) AS financial_status,
+        toLowCardinality(ifNull(o.fulfillment_status, 'unfulfilled')) AS fulfillment_status,
+        toLowCardinality(
+            JSONExtractString(ifNull(shipping_address, '{}'), 'country_code')
+        ) AS shipping_country_code,
+        toLowCardinality(
+            JSONExtractString(ifNull(shipping_address, '{}'), 'province_code')
+        ) AS shipping_province_code,
+        JSONExtractString(
+            arrayElement(JSONExtractArrayRaw(ifNull(discount_codes, '[]')), 1),
+            'code'
+        ) AS discount_code,
+        toUInt8(ifNull(o.test, false)) AS is_test_order,
+        toUInt8(o.cancelled_at IS NOT NULL) AS is_cancelled_order,
+        toUInt8(
+            materialize(ifNull(o.financial_status, ''))
+            IN ('paid', 'partially_refunded', 'refunded')
+        ) AS has_completed_financial_status,
+        toUInt8(
+            materialize(ifNull(o.financial_status, ''))
+            IN ('partially_refunded', 'refunded')
+        ) AS is_refunded_order,
+        toDecimal64OrZero(ifNull(total_line_items_price, ''), 2) AS gross_sales_amount,
+        toDecimal64OrZero(ifNull(total_discounts, ''), 2) AS discount_amount,
+        toDecimal64OrZero(ifNull(subtotal_price, ''), 2) AS subtotal_amount,
+        toDecimal64OrZero(
+            JSONExtractString(
+                ifNull(total_shipping_price_set, '{}'),
+                'shop_money',
+                'amount'
+            ),
+            2
+        ) AS shipping_amount,
+        toDecimal64OrZero(ifNull(total_tax, ''), 2) AS tax_amount,
+        toDecimal64OrZero(ifNull(total_price, ''), 2) AS original_total_amount,
+        toDecimal64OrZero(ifNull(current_subtotal_price, ''), 2) AS current_subtotal_amount,
+        toDecimal64OrZero(ifNull(current_total_discounts, ''), 2) AS current_discount_amount,
+        toDecimal64OrZero(ifNull(current_total_tax, ''), 2) AS current_tax_amount,
+        toDecimal64OrZero(ifNull(current_total_price, ''), 2) AS current_total_amount,
+        toDecimal64OrZero(ifNull(total_outstanding, ''), 2) AS outstanding_amount,
+        toUInt64(JSONLength(ifNull(line_items, '[]'))) AS line_item_count,
+        toUInt64(JSONLength(ifNull(refunds, '[]'))) AS refund_record_count,
+        cancelled_at,
+        closed_at,
+        _ingestr_loaded_at
+    FROM shopify.t1_orders AS o
+    WHERE updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+)
+SELECT
+    order_key,
+    order_id,
+    order_name,
+    order_date,
+    order_month,
+    created_at,
+    processed_at,
+    order_updated_at,
+    customer_id,
+    currency,
+    presentment_currency,
+    source_name,
+    financial_status,
+    fulfillment_status,
+    shipping_country_code,
+    shipping_province_code,
+    discount_code,
+    is_test_order,
+    is_cancelled_order,
+    toUInt8(
+        has_completed_financial_status = 1
+        AND is_test_order = 0
+        AND is_cancelled_order = 0
+    ) AS is_completed_order,
+    is_refunded_order,
+    gross_sales_amount,
+    discount_amount,
+    subtotal_amount,
+    shipping_amount,
+    tax_amount,
+    original_total_amount,
+    current_subtotal_amount,
+    current_discount_amount,
+    current_tax_amount,
+    current_total_amount,
+    greatest(
+        toDecimal64(0, 2),
+        toDecimal64(original_total_amount - current_total_amount, 2)
+    ) AS refunded_amount,
+    outstanding_amount,
+    if(
+        has_completed_financial_status = 1
+        AND is_test_order = 0
+        AND is_cancelled_order = 0,
+        current_total_amount,
+        toDecimal64(0, 2)
+    ) AS recognized_revenue_amount,
+    line_item_count,
+    refund_record_count,
+    cancelled_at,
+    closed_at,
+    _ingestr_loaded_at
+FROM base

--- a/templates/shopify-clickhouse/assets/t2/t2_products.sql
+++ b/templates/shopify-clickhouse/assets/t2/t2_products.sql
@@ -1,0 +1,222 @@
+/* @bruin
+name: shopify.t2_products
+type: clickhouse.sql
+description: "Conformed Shopify product catalog enriched with variant pricing and current inventory."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t1_products
+  - shopify.t2_inventory_items
+
+tags:
+  - t2
+  - conformed
+  - shopify
+  - products
+domains:
+  - commerce
+  - merchandising
+  - fulfillment
+meta:
+  grain: one row per Shopify product
+  source_system: shopify
+  currency_scope: catalog price and cost values use shop currency
+  cost_policy: average unit cost and inventory value include only inventory items with a Shopify cost
+  refresh_strategy: primary-key merge for changed products and products with changed inventory
+  data_classification: internal
+
+custom_checks:
+  - name: product catalog is preserved
+    description: "Ensures every raw Shopify product appears in the conformed catalog."
+    query: |
+      SELECT
+        (SELECT count() FROM shopify.t2_products)
+        =
+        (SELECT count() FROM shopify.t1_products)
+    value: 1
+    blocking: true
+
+columns:
+  - name: product_id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the product."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: product_legacy_id
+    type: UInt64
+    description: "Legacy numeric Shopify identifier parsed from the global identifier."
+  - name: product_title
+    type: String
+    description: "Merchant-facing product title."
+  - name: handle
+    type: String
+    description: "URL-safe Shopify product handle."
+  - name: product_type
+    type: LowCardinality(String)
+    description: "Merchant-defined product type."
+  - name: vendor
+    type: LowCardinality(String)
+    description: "Vendor assigned to the product."
+  - name: status
+    type: LowCardinality(String)
+    description: "Current Shopify product status."
+  - name: is_active
+    type: UInt8
+    description: "One when the Shopify product status is active."
+  - name: catalog_currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code attached to Shopify's product price range."
+  - name: minimum_variant_price
+    type: Decimal(18, 2)
+    description: "Minimum current variant price in shop currency."
+    checks:
+      - name: non_negative
+  - name: maximum_variant_price
+    type: Decimal(18, 2)
+    description: "Maximum current variant price in shop currency."
+    checks:
+      - name: non_negative
+  - name: variant_count
+    type: UInt64
+    description: "Number of variants reported by Shopify."
+  - name: inventory_item_count
+    type: UInt64
+    description: "Number of ingested inventory items associated with the product."
+  - name: tracked_inventory_item_count
+    type: UInt64
+    description: "Number of associated inventory items with tracking enabled."
+  - name: costed_inventory_item_count
+    type: UInt64
+    description: "Number of associated inventory items with a non-null Shopify unit cost."
+  - name: inventory_quantity
+    type: Int64
+    description: "Current tracked inventory quantity summed across product inventory items."
+  - name: sellable_online_quantity
+    type: Int64
+    description: "Current sellable-online quantity summed across product inventory items."
+  - name: average_unit_cost
+    type: Nullable(Float64)
+    description: "Average Shopify unit cost across inventory items where cost is available."
+  - name: known_cost_inventory_value
+    type: Decimal(18, 2)
+    description: "Inventory quantity multiplied by unit cost for costed inventory items only."
+  - name: inventory_status
+    type: LowCardinality(String)
+    description: "Derived stock band: out_of_stock, low_stock, or in_stock."
+    checks:
+      - name: accepted_values
+        value: ["out_of_stock", "low_stock", "in_stock"]
+  - name: tracks_inventory
+    type: Bool
+    description: "Whether Shopify reports inventory tracking for the product."
+  - name: created_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the product was created in Shopify."
+  - name: published_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when the product was first published."
+  - name: product_updated_at
+    type: Nullable(DateTime64(6, 'UTC'))
+    description: "Timestamp when Shopify last updated the product."
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest product or inventory update timestamp contributing to the row."
+@bruin */
+
+WITH changed_products AS (
+    SELECT id AS product_id
+    FROM shopify.t1_products
+    WHERE updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+    UNION DISTINCT
+    SELECT product_id
+    FROM shopify.t2_inventory_items
+    WHERE updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+),
+inventory_summary AS (
+    SELECT
+        inv.product_id,
+        count() AS inventory_item_count,
+        countIf(inv.tracked) AS tracked_inventory_item_count,
+        countIf(inv.unit_cost IS NOT NULL) AS costed_inventory_item_count,
+        sum(inv.inventory_quantity) AS inventory_quantity,
+        sum(inv.sellable_online_quantity) AS sellable_online_quantity,
+        avgOrNull(toFloat64(inv.unit_cost)) AS average_unit_cost,
+        toDecimal64(
+            sum(ifNull(toFloat64(inv.unit_cost), 0) * toFloat64(inv.inventory_quantity)),
+            2
+        ) AS known_cost_inventory_value,
+        max(inv.updated_at) AS inventory_updated_at
+    FROM shopify.t2_inventory_items AS inv
+    GROUP BY inv.product_id
+)
+SELECT
+    p.id AS product_id,
+    toUInt64OrZero(arrayElement(splitByChar('/', p.id), -1)) AS product_legacy_id,
+    ifNull(p.title, '') AS product_title,
+    ifNull(p.handle, '') AS handle,
+    toLowCardinality(ifNull(p.product_type, '')) AS product_type,
+    toLowCardinality(ifNull(p.vendor, '')) AS vendor,
+    toLowCardinality(lower(ifNull(p.status, 'unknown'))) AS status,
+    toUInt8(upper(ifNull(p.status, '')) = 'ACTIVE') AS is_active,
+    toLowCardinality(
+        JSONExtractString(
+            ifNull(p.price_range_v2, '{}'),
+            'minVariantPrice',
+            'currencyCode'
+        )
+    ) AS catalog_currency,
+    toDecimal64OrZero(
+        JSONExtractString(
+            ifNull(p.price_range_v2, '{}'),
+            'minVariantPrice',
+            'amount'
+        ),
+        2
+    ) AS minimum_variant_price,
+    toDecimal64OrZero(
+        JSONExtractString(
+            ifNull(p.price_range_v2, '{}'),
+            'maxVariantPrice',
+            'amount'
+        ),
+        2
+    ) AS maximum_variant_price,
+    toUInt64(
+        JSONExtractInt(ifNull(p.variants_count, '{}'), 'count')
+    ) AS variant_count,
+    toUInt64(ifNull(i.inventory_item_count, 0)) AS inventory_item_count,
+    toUInt64(ifNull(i.tracked_inventory_item_count, 0)) AS tracked_inventory_item_count,
+    toUInt64(ifNull(i.costed_inventory_item_count, 0)) AS costed_inventory_item_count,
+    toInt64(ifNull(i.inventory_quantity, 0)) AS inventory_quantity,
+    toInt64(ifNull(i.sellable_online_quantity, 0)) AS sellable_online_quantity,
+    i.average_unit_cost,
+    ifNull(i.known_cost_inventory_value, toDecimal64(0, 2)) AS known_cost_inventory_value,
+    toLowCardinality(
+        multiIf(
+            ifNull(i.sellable_online_quantity, 0) <= 0, 'out_of_stock',
+            ifNull(i.sellable_online_quantity, 0) <= 10, 'low_stock',
+            'in_stock'
+        )
+    ) AS inventory_status,
+    toBool(ifNull(p.tracks_inventory, false)) AS tracks_inventory,
+    p.created_at,
+    p.published_at,
+    p.updated_at AS product_updated_at,
+    greatest(
+        ifNull(p.updated_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC')),
+        ifNull(i.inventory_updated_at, toDateTime64('1970-01-01 00:00:00', 6, 'UTC'))
+    ) AS source_max_updated_at
+FROM shopify.t1_products AS p
+INNER JOIN changed_products AS c
+    ON p.id = c.product_id
+LEFT JOIN inventory_summary AS i
+    ON p.id = i.product_id

--- a/templates/shopify-clickhouse/assets/t3/t3_customer_cohorts.sql
+++ b/templates/shopify-clickhouse/assets/t3/t3_customer_cohorts.sql
@@ -1,0 +1,195 @@
+/* @bruin
+name: shopify.t3_customer_cohorts
+type: clickhouse.sql
+description: "Monthly Shopify customer retention and revenue cohorts by first completed-order month and currency."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+depends:
+  - shopify.t2_orders
+
+tags:
+  - t3
+  - mart
+  - shopify
+  - cohorts
+  - retention
+domains:
+  - commerce
+  - customer
+  - finance
+meta:
+  grain: one row per cohort month, activity month, and shop currency
+  source_system: shopify
+  currency_scope: customers are assigned to independent cohorts per shop currency; no currency conversion
+  customer_policy: guest orders without a Shopify customer identifier are excluded
+  revenue_policy: completed non-test non-cancelled orders use Shopify current totals
+  refresh_strategy: create-and-replace because cohort assignment depends on complete customer order history
+  physical_design: compact aggregate rebuilt atomically; partitioning would add overhead at current scale
+  data_classification: internal aggregated
+
+custom_checks:
+  - name: cohort chronology is valid
+    description: "Activity month cannot precede the customer's cohort month."
+    query: |
+      SELECT count()
+      FROM shopify.t3_customer_cohorts
+      WHERE activity_month < cohort_month
+    value: 0
+    blocking: true
+  - name: retained customers fit cohort
+    description: "Retained customers cannot exceed the original cohort size."
+    query: |
+      SELECT count()
+      FROM shopify.t3_customer_cohorts
+      WHERE retained_customers > cohort_size
+    value: 0
+    blocking: true
+
+columns:
+  - name: cohort_key
+    type: String
+    description: "Stable key composed of cohort month, activity month, and currency."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: cohort_month
+    type: Date
+    description: "First day of the month containing customers' first completed order."
+  - name: activity_month
+    type: Date
+    description: "First day of the month containing the represented follow-on order activity."
+  - name: months_since_first_order
+    type: UInt32
+    description: "Whole calendar months elapsed between cohort and activity month."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code for the cohort and every monetary value in the row."
+  - name: cohort_size
+    type: UInt64
+    description: "Distinct customers whose first completed order in the currency occurred in the cohort month."
+  - name: retained_customers
+    type: UInt64
+    description: "Distinct cohort customers with a completed order in the activity month."
+  - name: completed_orders
+    type: UInt64
+    description: "Completed orders placed by retained customers in the activity month."
+  - name: recognized_revenue_amount
+    type: Decimal(18, 2)
+    description: "Current recognized revenue from cohort customers in the activity month."
+    checks:
+      - name: non_negative
+  - name: revenue_per_retained_customer
+    type: Decimal(18, 2)
+    description: "Recognized revenue divided by retained customer count."
+    checks:
+      - name: non_negative
+  - name: retention_rate
+    type: Float64
+    description: "Retained customers divided by original cohort size."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest Shopify order update timestamp contributing to the activity row."
+@bruin */
+
+WITH completed_orders AS (
+    SELECT
+        assumeNotNull(o.customer_id) AS customer_id,
+        o.order_month,
+        o.currency,
+        o.recognized_revenue_amount,
+        ifNull(
+            o.order_updated_at,
+            toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+        ) AS order_updated_at
+    FROM shopify.t2_orders AS o
+    WHERE o.is_completed_order = 1
+      AND o.customer_id IS NOT NULL
+),
+first_orders AS (
+    SELECT
+        orders.customer_id,
+        orders.currency,
+        min(orders.order_month) AS cohort_month
+    FROM completed_orders AS orders
+    GROUP BY
+        orders.customer_id,
+        orders.currency
+),
+cohort_sizes AS (
+    SELECT
+        first.cohort_month,
+        first.currency,
+        uniqExact(first.customer_id) AS cohort_size
+    FROM first_orders AS first
+    GROUP BY
+        first.cohort_month,
+        first.currency
+),
+activity AS (
+    SELECT
+        first.cohort_month,
+        orders.order_month AS activity_month,
+        orders.currency,
+        uniqExact(orders.customer_id) AS retained_customers,
+        count() AS completed_orders,
+        toDecimal64(
+            sum(orders.recognized_revenue_amount),
+            2
+        ) AS recognized_revenue_amount,
+        max(orders.order_updated_at) AS source_max_updated_at
+    FROM completed_orders AS orders
+    INNER JOIN first_orders AS first
+        ON orders.customer_id = first.customer_id
+        AND orders.currency = first.currency
+    GROUP BY
+        first.cohort_month,
+        orders.order_month,
+        orders.currency
+)
+SELECT
+    concat(
+        toString(activity.cohort_month),
+        '|',
+        toString(activity.activity_month),
+        '|',
+        activity.currency
+    ) AS cohort_key,
+    activity.cohort_month,
+    activity.activity_month,
+    toUInt32(dateDiff('month', activity.cohort_month, activity.activity_month))
+        AS months_since_first_order,
+    activity.currency,
+    sizes.cohort_size,
+    activity.retained_customers,
+    activity.completed_orders,
+    activity.recognized_revenue_amount,
+    toDecimal64(
+        if(
+            activity.retained_customers = 0,
+            0,
+            activity.recognized_revenue_amount / activity.retained_customers
+        ),
+        2
+    ) AS revenue_per_retained_customer,
+    round(
+        if(
+            sizes.cohort_size = 0,
+            0,
+            toFloat64(activity.retained_customers) / toFloat64(sizes.cohort_size)
+        ),
+        4
+    ) AS retention_rate,
+    activity.source_max_updated_at
+FROM activity
+INNER JOIN cohort_sizes AS sizes
+    ON activity.cohort_month = sizes.cohort_month
+    AND activity.currency = sizes.currency

--- a/templates/shopify-clickhouse/assets/t3/t3_daily_kpis.sql
+++ b/templates/shopify-clickhouse/assets/t3/t3_daily_kpis.sql
@@ -1,0 +1,251 @@
+/* @bruin
+name: shopify.t3_daily_kpis
+type: clickhouse.sql
+description: "Shopify-only daily commerce scorecard with order, revenue, refund, and customer-mix KPIs."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t3_daily_revenue
+  - shopify.t2_orders
+  - shopify.t2_customers
+
+tags:
+  - t3
+  - mart
+  - shopify
+  - kpi
+domains:
+  - commerce
+  - finance
+  - customer
+meta:
+  grain: one row per UTC order date and shop currency
+  source_system: shopify
+  currency_scope: no currency conversion; every row contains exactly one shop currency
+  customer_policy: customer metrics exclude guest orders without a Shopify customer identifier
+  metric_scope: Shopify-native commerce KPIs only; no web-session, advertising, fee, COGS, or profit estimates
+  refresh_strategy: primary-key merge for date-currency groups touched by changed orders or customers
+  physical_design: unpartitioned at current scale; date-prefixed primary key supports ordered date access
+  data_classification: internal
+
+custom_checks:
+  - name: customer mix does not exceed identified customers
+    description: "New plus returning customers cannot exceed the distinct identified customers on a row."
+    query: |
+      SELECT count()
+      FROM shopify.t3_daily_kpis
+      WHERE new_customers + returning_customers > unique_customers
+    value: 0
+    blocking: true
+
+columns:
+  - name: metric_key
+    type: String
+    description: "Date-prefixed stable key composed of metric date and currency."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: metric_date
+    type: Date
+    description: "UTC calendar date represented by the scorecard row."
+  - name: metric_month
+    type: Date
+    description: "First day of the UTC metric month."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code for every monetary value in the row."
+  - name: order_attempts
+    type: UInt64
+    description: "Number of Shopify order records created on the date."
+  - name: completed_orders
+    type: UInt64
+    description: "Number of paid or refunded, non-test, non-cancelled orders."
+  - name: refunded_orders
+    type: UInt64
+    description: "Number of completed orders marked partially refunded or refunded."
+  - name: unique_customers
+    type: UInt64
+    description: "Distinct identified customers with completed orders."
+  - name: new_customers
+    type: UInt64
+    description: "Distinct customers whose first completed order was on the metric date."
+  - name: returning_customers
+    type: UInt64
+    description: "Distinct customers whose first completed order preceded the metric date."
+  - name: gross_sales_amount
+    type: Decimal(18, 2)
+    description: "Original line-item value before discounts across completed orders."
+    checks:
+      - name: non_negative
+  - name: discount_amount
+    type: Decimal(18, 2)
+    description: "Original discounts across completed orders."
+    checks:
+      - name: non_negative
+  - name: refunded_amount
+    type: Decimal(18, 2)
+    description: "Reduction from original to current totals across completed orders."
+    checks:
+      - name: non_negative
+  - name: recognized_revenue_amount
+    type: Decimal(18, 2)
+    description: "Current total recognized for completed, non-test, non-cancelled orders."
+    checks:
+      - name: non_negative
+  - name: average_order_value
+    type: Decimal(18, 2)
+    description: "Recognized revenue divided by completed order count."
+    checks:
+      - name: non_negative
+  - name: revenue_per_customer
+    type: Decimal(18, 2)
+    description: "Recognized revenue divided by distinct identified customers."
+    checks:
+      - name: non_negative
+  - name: orders_per_customer
+    type: Float64
+    description: "Completed order count divided by distinct identified customers."
+    checks:
+      - name: non_negative
+  - name: completion_rate
+    type: Float64
+    description: "Completed orders divided by all order attempts."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: refund_rate
+    type: Float64
+    description: "Refunded completed orders divided by completed orders."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: returning_customer_share
+    type: Float64
+    description: "Returning customers divided by distinct identified customers."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest Shopify order or customer update timestamp contributing to the row."
+@bruin */
+
+WITH changed_metric_keys AS (
+    SELECT DISTINCT
+        o.order_date AS metric_date,
+        o.currency AS currency
+    FROM shopify.t2_orders AS o
+    WHERE o.order_updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+    UNION DISTINCT
+    SELECT DISTINCT
+        c.first_completed_order_date AS metric_date,
+        o.currency AS currency
+    FROM shopify.t2_customers AS c
+    INNER JOIN shopify.t2_orders AS o
+        ON c.customer_id = o.customer_id
+        AND c.first_completed_order_date = o.order_date
+        AND o.is_completed_order = 1
+    WHERE c.first_completed_order_date IS NOT NULL
+      AND c.customer_updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+),
+customer_daily AS (
+    SELECT
+        o.order_date AS metric_date,
+        o.currency AS currency,
+        uniqExactIf(
+            o.customer_id,
+            c.first_completed_order_date = o.order_date
+        ) AS new_customers,
+        uniqExactIf(
+            o.customer_id,
+            c.first_completed_order_date < o.order_date
+        ) AS returning_customers,
+        max(
+            ifNull(
+                c.source_max_updated_at,
+                toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+            )
+        ) AS customer_max_updated_at
+    FROM shopify.t2_orders AS o
+    INNER JOIN changed_metric_keys AS changed
+        ON o.order_date = changed.metric_date
+        AND o.currency = changed.currency
+    LEFT JOIN shopify.t2_customers AS c
+        ON o.customer_id = c.customer_id
+    WHERE o.is_completed_order = 1
+      AND o.customer_id IS NOT NULL
+    GROUP BY
+        o.order_date,
+        o.currency
+)
+SELECT
+    concat(toString(r.revenue_date), '|', r.currency) AS metric_key,
+    r.revenue_date AS metric_date,
+    r.revenue_month AS metric_month,
+    r.currency AS currency,
+    r.order_attempts,
+    r.completed_orders,
+    r.refunded_orders,
+    r.unique_customers,
+    toUInt64(ifNull(customers.new_customers, 0)) AS new_customers,
+    toUInt64(ifNull(customers.returning_customers, 0)) AS returning_customers,
+    r.gross_sales_amount,
+    r.discount_amount,
+    r.refunded_amount,
+    r.recognized_revenue_amount,
+    r.average_order_value,
+    toDecimal64(
+        if(
+            r.unique_customers = 0,
+            0,
+            r.recognized_revenue_amount / r.unique_customers
+        ),
+        2
+    ) AS revenue_per_customer,
+    round(
+        if(
+            r.unique_customers = 0,
+            0,
+            toFloat64(r.completed_orders) / toFloat64(r.unique_customers)
+        ),
+        4
+    ) AS orders_per_customer,
+    r.completion_rate,
+    r.refund_rate,
+    round(
+        if(
+            r.unique_customers = 0,
+            0,
+            toFloat64(ifNull(customers.returning_customers, 0))
+                / toFloat64(r.unique_customers)
+        ),
+        4
+    ) AS returning_customer_share,
+    greatest(
+        r.source_max_updated_at,
+        ifNull(
+            customers.customer_max_updated_at,
+            toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+        )
+    ) AS source_max_updated_at
+FROM shopify.t3_daily_revenue AS r
+INNER JOIN changed_metric_keys AS changed
+    ON r.revenue_date = changed.metric_date
+    AND r.currency = changed.currency
+LEFT JOIN customer_daily AS customers
+    ON r.revenue_date = customers.metric_date
+    AND r.currency = customers.currency

--- a/templates/shopify-clickhouse/assets/t3/t3_daily_revenue.sql
+++ b/templates/shopify-clickhouse/assets/t3/t3_daily_revenue.sql
@@ -1,0 +1,277 @@
+/* @bruin
+name: shopify.t3_daily_revenue
+type: clickhouse.sql
+description: "Daily Shopify order and revenue mart at UTC date and shop-currency grain."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t2_orders
+
+tags:
+  - t3
+  - mart
+  - shopify
+  - revenue
+domains:
+  - commerce
+  - finance
+meta:
+  grain: one row per UTC order date and shop currency
+  source_system: shopify
+  currency_scope: no currency conversion; every row contains exactly one shop currency
+  revenue_policy: completed non-test non-cancelled orders use Shopify current totals
+  refresh_strategy: primary-key merge that recomputes complete date-currency groups touched by changed orders
+  physical_design: unpartitioned at current scale; date-prefixed primary key supports ordered date access
+  data_classification: internal
+
+custom_checks:
+  - name: recognized revenue reconciles
+    description: "Recognized revenue must equal current order value for the completed orders in each row."
+    query: |
+      SELECT count()
+      FROM shopify.t3_daily_revenue
+      WHERE recognized_revenue_amount != current_order_amount
+    value: 0
+    blocking: true
+
+columns:
+  - name: revenue_key
+    type: String
+    description: "Date-prefixed stable key composed of revenue date and currency."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: revenue_date
+    type: Date
+    description: "UTC calendar date when the represented orders were created."
+    checks:
+      - name: not_null
+  - name: revenue_month
+    type: Date
+    description: "First day of the UTC revenue month."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code for every monetary value in the row."
+    checks:
+      - name: not_null
+  - name: order_attempts
+    type: UInt64
+    description: "Number of Shopify orders created on the date, including incomplete, cancelled, and test orders."
+  - name: completed_orders
+    type: UInt64
+    description: "Number of paid or refunded, non-test, non-cancelled orders."
+  - name: cancelled_orders
+    type: UInt64
+    description: "Number of orders with a Shopify cancellation timestamp."
+  - name: test_orders
+    type: UInt64
+    description: "Number of orders Shopify marks as tests."
+  - name: refunded_orders
+    type: UInt64
+    description: "Number of completed orders currently marked partially refunded or refunded."
+  - name: unique_customers
+    type: UInt64
+    description: "Distinct identified customers with completed orders; guest orders are excluded."
+  - name: gross_sales_amount
+    type: Decimal(18, 2)
+    description: "Original line-item value before discounts across completed orders."
+    checks:
+      - name: non_negative
+  - name: discount_amount
+    type: Decimal(18, 2)
+    description: "Original discounts across completed orders."
+    checks:
+      - name: non_negative
+  - name: subtotal_amount
+    type: Decimal(18, 2)
+    description: "Original post-discount subtotal across completed orders."
+    checks:
+      - name: non_negative
+  - name: shipping_amount
+    type: Decimal(18, 2)
+    description: "Original shipping amount across completed orders."
+    checks:
+      - name: non_negative
+  - name: tax_amount
+    type: Decimal(18, 2)
+    description: "Original tax amount across completed orders."
+    checks:
+      - name: non_negative
+  - name: original_order_amount
+    type: Decimal(18, 2)
+    description: "Original total value across completed orders."
+    checks:
+      - name: non_negative
+  - name: current_order_amount
+    type: Decimal(18, 2)
+    description: "Current total value across completed orders after returns, refunds, and edits."
+    checks:
+      - name: non_negative
+  - name: refunded_amount
+    type: Decimal(18, 2)
+    description: "Non-negative reduction from original to current totals across completed orders."
+    checks:
+      - name: non_negative
+  - name: outstanding_amount
+    type: Decimal(18, 2)
+    description: "Amount Shopify reports as still owed across non-test, non-cancelled order attempts."
+    checks:
+      - name: non_negative
+  - name: recognized_revenue_amount
+    type: Decimal(18, 2)
+    description: "Current total recognized for completed, non-test, non-cancelled orders."
+    checks:
+      - name: non_negative
+  - name: average_order_value
+    type: Decimal(18, 2)
+    description: "Recognized revenue divided by completed order count."
+    checks:
+      - name: non_negative
+  - name: completion_rate
+    type: Float64
+    description: "Completed orders divided by all order attempts."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: refund_rate
+    type: Float64
+    description: "Refunded completed orders divided by completed orders."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest Shopify order update timestamp contributing to the row."
+@bruin */
+
+WITH changed_daily_keys AS (
+    SELECT DISTINCT
+        o.order_date,
+        o.currency
+    FROM shopify.t2_orders AS o
+    WHERE o.order_updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+),
+daily AS (
+    SELECT
+        o.order_date AS revenue_date,
+        o.currency AS currency,
+        count() AS order_attempts,
+        countIf(o.is_completed_order = 1) AS completed_orders,
+        countIf(o.is_cancelled_order = 1) AS cancelled_orders,
+        countIf(o.is_test_order = 1) AS test_orders,
+        countIf(o.is_completed_order = 1 AND o.is_refunded_order = 1) AS refunded_orders,
+        uniqExactIf(o.customer_id, o.is_completed_order = 1 AND o.customer_id IS NOT NULL) AS unique_customers,
+        toDecimal64(
+            sumIf(o.gross_sales_amount, o.is_completed_order = 1),
+            2
+        ) AS gross_sales_amount,
+        toDecimal64(
+            sumIf(o.discount_amount, o.is_completed_order = 1),
+            2
+        ) AS discount_amount,
+        toDecimal64(
+            sumIf(o.subtotal_amount, o.is_completed_order = 1),
+            2
+        ) AS subtotal_amount,
+        toDecimal64(
+            sumIf(o.shipping_amount, o.is_completed_order = 1),
+            2
+        ) AS shipping_amount,
+        toDecimal64(
+            sumIf(o.tax_amount, o.is_completed_order = 1),
+            2
+        ) AS tax_amount,
+        toDecimal64(
+            sumIf(o.original_total_amount, o.is_completed_order = 1),
+            2
+        ) AS original_order_amount,
+        toDecimal64(
+            sumIf(o.current_total_amount, o.is_completed_order = 1),
+            2
+        ) AS current_order_amount,
+        toDecimal64(
+            sumIf(o.refunded_amount, o.is_completed_order = 1),
+            2
+        ) AS refunded_amount,
+        toDecimal64(
+            sumIf(
+                o.outstanding_amount,
+                o.is_test_order = 0 AND o.is_cancelled_order = 0
+            ),
+            2
+        ) AS outstanding_amount,
+        toDecimal64(
+            sum(o.recognized_revenue_amount),
+            2
+        ) AS recognized_revenue_amount,
+        max(
+            ifNull(
+                o.order_updated_at,
+                toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+            )
+        ) AS source_max_updated_at
+    FROM shopify.t2_orders AS o
+    INNER JOIN changed_daily_keys AS changed
+        ON o.order_date = changed.order_date
+        AND o.currency = changed.currency
+    GROUP BY
+        o.order_date,
+        o.currency
+)
+SELECT
+    concat(toString(d.revenue_date), '|', d.currency) AS revenue_key,
+    d.revenue_date,
+    toStartOfMonth(d.revenue_date) AS revenue_month,
+    d.currency,
+    d.order_attempts,
+    d.completed_orders,
+    d.cancelled_orders,
+    d.test_orders,
+    d.refunded_orders,
+    d.unique_customers,
+    d.gross_sales_amount,
+    d.discount_amount,
+    d.subtotal_amount,
+    d.shipping_amount,
+    d.tax_amount,
+    d.original_order_amount,
+    d.current_order_amount,
+    d.refunded_amount,
+    d.outstanding_amount,
+    d.recognized_revenue_amount,
+    toDecimal64(
+        if(
+            d.completed_orders = 0,
+            0,
+            d.recognized_revenue_amount / d.completed_orders
+        ),
+        2
+    ) AS average_order_value,
+    round(
+        if(
+            d.order_attempts = 0,
+            0,
+            toFloat64(d.completed_orders) / toFloat64(d.order_attempts)
+        ),
+        4
+    ) AS completion_rate,
+    round(
+        if(
+            d.completed_orders = 0,
+            0,
+            toFloat64(d.refunded_orders) / toFloat64(d.completed_orders)
+        ),
+        4
+    ) AS refund_rate,
+    d.source_max_updated_at
+FROM daily AS d

--- a/templates/shopify-clickhouse/assets/t3/t3_payment_reconciliation.sql
+++ b/templates/shopify-clickhouse/assets/t3/t3_payment_reconciliation.sql
@@ -1,0 +1,211 @@
+/* @bruin
+name: shopify.t3_payment_reconciliation
+type: clickhouse.sql
+description: "Daily Shopify order financial-status and amount reconciliation at UTC date and currency grain."
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - shopify.t2_orders
+
+tags:
+  - t3
+  - mart
+  - shopify
+  - payments
+  - reconciliation
+domains:
+  - commerce
+  - finance
+meta:
+  grain: one row per UTC order date and shop currency
+  source_system: shopify orders
+  currency_scope: no currency conversion; every row contains exactly one shop currency
+  reconciliation_scope: Shopify order financial statuses and order-header amounts
+  transaction_scope: does not include a gateway settlement or balance transaction ledger
+  refresh_strategy: primary-key merge that recomputes complete date-currency groups touched by changed orders
+  physical_design: unpartitioned at current scale; date-prefixed primary key supports ordered date access
+  data_classification: internal
+
+custom_checks:
+  - name: financial status buckets reconcile
+    description: "Every order must fall into exactly one declared financial-status bucket."
+    query: |
+      SELECT count()
+      FROM shopify.t3_payment_reconciliation
+      WHERE order_attempts !=
+        pending_orders
+        + authorized_orders
+        + partially_paid_orders
+        + paid_orders
+        + partially_refunded_orders
+        + refunded_orders
+        + voided_orders
+        + other_status_orders
+    value: 0
+    blocking: true
+  - name: recognized amount reconciles
+    description: "Recognized revenue must equal current totals for completed non-test non-cancelled orders."
+    query: |
+      SELECT count()
+      FROM shopify.t3_payment_reconciliation
+      WHERE recognized_revenue_amount != completed_current_amount
+    value: 0
+    blocking: true
+
+columns:
+  - name: reconciliation_key
+    type: String
+    description: "Date-prefixed stable key composed of reconciliation date and currency."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: reconciliation_date
+    type: Date
+    description: "UTC calendar date when the represented orders were created."
+  - name: reconciliation_month
+    type: Date
+    description: "First day of the UTC reconciliation month."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO shop-currency code for every monetary value in the row."
+  - name: order_attempts
+    type: UInt64
+    description: "Number of Shopify order records created on the date."
+  - name: pending_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is pending."
+  - name: authorized_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is authorized."
+  - name: partially_paid_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is partially paid."
+  - name: paid_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is paid."
+  - name: partially_refunded_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is partially refunded."
+  - name: refunded_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is refunded."
+  - name: voided_orders
+    type: UInt64
+    description: "Orders whose current Shopify financial status is voided."
+  - name: other_status_orders
+    type: UInt64
+    description: "Orders with a missing or non-standard Shopify financial status."
+  - name: test_orders
+    type: UInt64
+    description: "Orders Shopify marks as tests, independently of financial status."
+  - name: cancelled_orders
+    type: UInt64
+    description: "Orders with a Shopify cancellation timestamp, independently of financial status."
+  - name: original_order_amount
+    type: Decimal(18, 2)
+    description: "Original total value across all represented order attempts."
+    checks:
+      - name: non_negative
+  - name: current_order_amount
+    type: Decimal(18, 2)
+    description: "Current total value across all represented order attempts."
+    checks:
+      - name: non_negative
+  - name: completed_current_amount
+    type: Decimal(18, 2)
+    description: "Current total value across completed, non-test, non-cancelled orders."
+    checks:
+      - name: non_negative
+  - name: refunded_amount
+    type: Decimal(18, 2)
+    description: "Non-negative reduction from original to current totals across completed orders."
+    checks:
+      - name: non_negative
+  - name: outstanding_amount
+    type: Decimal(18, 2)
+    description: "Amount Shopify reports as still owed across non-test, non-cancelled orders."
+    checks:
+      - name: non_negative
+  - name: recognized_revenue_amount
+    type: Decimal(18, 2)
+    description: "Current total recognized for completed, non-test, non-cancelled orders."
+    checks:
+      - name: non_negative
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest Shopify order update timestamp contributing to the row."
+@bruin */
+
+WITH changed_reconciliation_keys AS (
+    SELECT DISTINCT
+        o.order_date,
+        o.currency
+    FROM shopify.t2_orders AS o
+    WHERE o.order_updated_at BETWEEN
+        parseDateTime64BestEffort('{{ start_timestamp }}', 6, 'UTC')
+        AND parseDateTime64BestEffort('{{ end_timestamp }}', 6, 'UTC')
+)
+SELECT
+    concat(toString(o.order_date), '|', o.currency) AS reconciliation_key,
+    o.order_date AS reconciliation_date,
+    toStartOfMonth(o.order_date) AS reconciliation_month,
+    o.currency,
+    count() AS order_attempts,
+    countIf(o.financial_status = 'pending') AS pending_orders,
+    countIf(o.financial_status = 'authorized') AS authorized_orders,
+    countIf(o.financial_status = 'partially_paid') AS partially_paid_orders,
+    countIf(o.financial_status = 'paid') AS paid_orders,
+    countIf(o.financial_status = 'partially_refunded') AS partially_refunded_orders,
+    countIf(o.financial_status = 'refunded') AS refunded_orders,
+    countIf(o.financial_status = 'voided') AS voided_orders,
+    countIf(
+        o.financial_status NOT IN (
+            'pending',
+            'authorized',
+            'partially_paid',
+            'paid',
+            'partially_refunded',
+            'refunded',
+            'voided'
+        )
+    ) AS other_status_orders,
+    countIf(o.is_test_order = 1) AS test_orders,
+    countIf(o.is_cancelled_order = 1) AS cancelled_orders,
+    toDecimal64(sum(o.original_total_amount), 2) AS original_order_amount,
+    toDecimal64(sum(o.current_total_amount), 2) AS current_order_amount,
+    toDecimal64(
+        sumIf(o.current_total_amount, o.is_completed_order = 1),
+        2
+    ) AS completed_current_amount,
+    toDecimal64(
+        sumIf(o.refunded_amount, o.is_completed_order = 1),
+        2
+    ) AS refunded_amount,
+    toDecimal64(
+        sumIf(
+            o.outstanding_amount,
+            o.is_test_order = 0 AND o.is_cancelled_order = 0
+        ),
+        2
+    ) AS outstanding_amount,
+    toDecimal64(
+        sum(o.recognized_revenue_amount),
+        2
+    ) AS recognized_revenue_amount,
+    max(
+        ifNull(
+            o.order_updated_at,
+            toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+        )
+    ) AS source_max_updated_at
+FROM shopify.t2_orders AS o
+INNER JOIN changed_reconciliation_keys AS changed
+    ON o.order_date = changed.order_date
+    AND o.currency = changed.currency
+GROUP BY
+    o.order_date,
+    o.currency

--- a/templates/shopify-clickhouse/assets/t3/t3_product_performance.sql
+++ b/templates/shopify-clickhouse/assets/t3/t3_product_performance.sql
@@ -1,0 +1,268 @@
+/* @bruin
+name: shopify.t3_product_performance
+type: clickhouse.sql
+description: "Current Shopify product catalog enriched with lifetime completed-order demand and refund-adjusted merchandise revenue."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+depends:
+  - shopify.t2_products
+  - shopify.t2_order_line_items
+
+tags:
+  - t3
+  - mart
+  - shopify
+  - products
+  - merchandising
+domains:
+  - commerce
+  - merchandising
+  - fulfillment
+  - finance
+meta:
+  grain: one row per current Shopify product
+  source_system: shopify
+  currency_scope: catalog and order-line amounts use the Shopify shop currency; mismatches are blocked
+  revenue_policy: current order merchandise subtotals are allocated proportionally to completed order lines
+  cost_policy: no historical margin is estimated because Shopify provides current inventory cost, not order-time COGS
+  refresh_strategy: create-and-replace because this compact mart combines the full current catalog with lifetime sales history
+  physical_design: product identifier is the lookup key; partitioning would add overhead at current scale
+  data_classification: internal
+
+custom_checks:
+  - name: product catalog is preserved
+    description: "Ensures every conformed Shopify product appears exactly once in the performance mart."
+    query: |
+      SELECT
+        (SELECT count() FROM shopify.t3_product_performance)
+        =
+        (SELECT count() FROM shopify.t2_products)
+    value: 1
+    blocking: true
+  - name: catalog and order currency agree
+    description: "Prevents product sales from being aggregated into a catalog currency without conversion."
+    query: |
+      SELECT count()
+      FROM shopify.t2_order_line_items AS lines
+      INNER JOIN shopify.t2_products AS products
+        ON lines.product_id = products.product_id
+      WHERE lines.is_completed_order = 1
+        AND lines.currency != products.catalog_currency
+    value: 0
+    blocking: true
+
+columns:
+  - name: product_id
+    type: String
+    description: "Shopify Admin GraphQL global identifier for the product."
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: product_legacy_id
+    type: UInt64
+    description: "Legacy numeric Shopify identifier for the product."
+  - name: product_title
+    type: String
+    description: "Current merchant-facing Shopify product title."
+  - name: product_type
+    type: LowCardinality(String)
+    description: "Current merchant-defined product type."
+  - name: vendor
+    type: LowCardinality(String)
+    description: "Current product vendor."
+  - name: status
+    type: LowCardinality(String)
+    description: "Current Shopify product status."
+  - name: is_active
+    type: UInt8
+    description: "One when the current Shopify product status is active."
+  - name: currency
+    type: LowCardinality(String)
+    description: "ISO Shopify shop-currency code for catalog and sales amounts."
+  - name: minimum_variant_price
+    type: Decimal(18, 2)
+    description: "Minimum current variant price."
+    checks:
+      - name: non_negative
+  - name: maximum_variant_price
+    type: Decimal(18, 2)
+    description: "Maximum current variant price."
+    checks:
+      - name: non_negative
+  - name: inventory_quantity
+    type: Int64
+    description: "Current tracked inventory quantity across associated inventory items."
+  - name: sellable_online_quantity
+    type: Int64
+    description: "Current sellable-online quantity across associated inventory items."
+  - name: inventory_status
+    type: LowCardinality(String)
+    description: "Current stock band derived in the product model."
+  - name: has_completed_sales
+    type: Bool
+    description: "Whether the product appears on at least one completed Shopify order."
+  - name: first_completed_order_date
+    type: Nullable(Date)
+    description: "UTC date of the product's earliest completed order in the ingested history."
+  - name: last_completed_order_date
+    type: Nullable(Date)
+    description: "UTC date of the product's most recent completed order in the ingested history."
+  - name: completed_order_count
+    type: UInt64
+    description: "Distinct completed orders containing the product."
+  - name: refunded_order_count
+    type: UInt64
+    description: "Distinct completed orders containing the product that are currently partially refunded or refunded."
+  - name: unique_customer_count
+    type: UInt64
+    description: "Distinct identified customers who completed an order containing the product."
+  - name: units_ordered
+    type: UInt64
+    description: "Original product units on completed orders."
+  - name: gross_sales_amount
+    type: Decimal(18, 2)
+    description: "Original line value before discounts on completed orders."
+    checks:
+      - name: non_negative
+  - name: discount_amount
+    type: Decimal(18, 2)
+    description: "Shopify line discounts on completed orders."
+    checks:
+      - name: non_negative
+  - name: recognized_product_revenue_amount
+    type: Decimal(18, 2)
+    description: "Refund-adjusted current merchandise subtotal allocated to the product's completed order lines."
+    checks:
+      - name: non_negative
+  - name: realized_revenue_per_unit
+    type: Decimal(18, 2)
+    description: "Recognized product revenue divided by original units ordered."
+    checks:
+      - name: non_negative
+  - name: discount_rate
+    type: Float64
+    description: "Line discounts divided by original gross line value on completed orders."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: revenue_share
+    type: Float64
+    description: "Product recognized revenue divided by recognized revenue across catalog-matched products."
+    checks:
+      - name: min
+        value: 0
+      - name: max
+        value: 1
+  - name: source_max_updated_at
+    type: DateTime64(6, 'UTC')
+    description: "Latest Shopify catalog, inventory, or completed-order update timestamp contributing to the row."
+@bruin */
+
+WITH product_sales AS (
+    SELECT
+        lines.product_id,
+        min(lines.order_date) AS first_completed_order_date,
+        max(lines.order_date) AS last_completed_order_date,
+        uniqExact(lines.order_id) AS completed_order_count,
+        uniqExactIf(lines.order_id, lines.is_refunded_order = 1) AS refunded_order_count,
+        uniqExactIf(lines.customer_id, lines.customer_id IS NOT NULL) AS unique_customer_count,
+        toUInt64(sum(lines.quantity)) AS units_ordered,
+        toDecimal64(sum(lines.gross_sales_amount), 2) AS gross_sales_amount,
+        toDecimal64(sum(lines.discount_amount), 2) AS discount_amount,
+        toDecimal64(
+            sum(lines.recognized_line_revenue_amount),
+            2
+        ) AS recognized_product_revenue_amount,
+        max(
+            ifNull(
+                lines.order_updated_at,
+                toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+            )
+        ) AS sales_max_updated_at
+    FROM shopify.t2_order_line_items AS lines
+    WHERE lines.is_completed_order = 1
+      AND lines.product_id != ''
+    GROUP BY lines.product_id
+),
+sales_total AS (
+    SELECT
+        sum(sales.recognized_product_revenue_amount) AS recognized_product_revenue_amount
+    FROM product_sales AS sales
+)
+SELECT
+    products.product_id AS product_id,
+    products.product_legacy_id,
+    products.product_title,
+    products.product_type,
+    products.vendor,
+    products.status,
+    products.is_active,
+    products.catalog_currency AS currency,
+    products.minimum_variant_price,
+    products.maximum_variant_price,
+    products.inventory_quantity,
+    products.sellable_online_quantity,
+    products.inventory_status,
+    toBool(ifNull(sales.completed_order_count, 0) > 0) AS has_completed_sales,
+    if(
+        ifNull(sales.completed_order_count, 0) = 0,
+        CAST(NULL, 'Nullable(Date)'),
+        toNullable(sales.first_completed_order_date)
+    ) AS first_completed_order_date,
+    if(
+        ifNull(sales.completed_order_count, 0) = 0,
+        CAST(NULL, 'Nullable(Date)'),
+        toNullable(sales.last_completed_order_date)
+    ) AS last_completed_order_date,
+    toUInt64(ifNull(sales.completed_order_count, 0)) AS completed_order_count,
+    toUInt64(ifNull(sales.refunded_order_count, 0)) AS refunded_order_count,
+    toUInt64(ifNull(sales.unique_customer_count, 0)) AS unique_customer_count,
+    toUInt64(ifNull(sales.units_ordered, 0)) AS units_ordered,
+    ifNull(sales.gross_sales_amount, toDecimal64(0, 2)) AS gross_sales_amount,
+    ifNull(sales.discount_amount, toDecimal64(0, 2)) AS discount_amount,
+    ifNull(
+        sales.recognized_product_revenue_amount,
+        toDecimal64(0, 2)
+    ) AS recognized_product_revenue_amount,
+    toDecimal64(
+        if(
+            ifNull(sales.units_ordered, 0) = 0,
+            0,
+            sales.recognized_product_revenue_amount / sales.units_ordered
+        ),
+        2
+    ) AS realized_revenue_per_unit,
+    round(
+        if(
+            ifNull(sales.gross_sales_amount, toDecimal64(0, 2)) = 0,
+            0,
+            toFloat64(sales.discount_amount) / toFloat64(sales.gross_sales_amount)
+        ),
+        4
+    ) AS discount_rate,
+    round(
+        if(
+            ifNull(total.recognized_product_revenue_amount, toDecimal64(0, 2)) = 0,
+            0,
+            toFloat64(ifNull(sales.recognized_product_revenue_amount, toDecimal64(0, 2)))
+                / toFloat64(total.recognized_product_revenue_amount)
+        ),
+        6
+    ) AS revenue_share,
+    greatest(
+        products.source_max_updated_at,
+        ifNull(
+            sales.sales_max_updated_at,
+            toDateTime64('1970-01-01 00:00:00', 6, 'UTC')
+        )
+    ) AS source_max_updated_at
+FROM shopify.t2_products AS products
+LEFT JOIN product_sales AS sales
+    ON products.product_id = sales.product_id
+CROSS JOIN sales_total AS total

--- a/templates/shopify-clickhouse/pipeline.yml
+++ b/templates/shopify-clickhouse/pipeline.yml
@@ -1,0 +1,29 @@
+name: shopify-clickhouse
+schedule: "@daily"
+start_date: "2020-01-01"
+catchup: false
+
+default_connections:
+    clickhouse: "clickhouse-default"
+    shopify: "shopify-default"
+
+tags:
+    - clickhouse
+    - ecommerce
+    - shopify
+    - ingestr
+
+domains:
+    - commerce
+    - finance
+    - customer
+    - merchandising
+    - fulfillment
+
+meta:
+    description: "Shopify analytics warehouse ingested with ingestr and modeled in ClickHouse."
+    data_classification: mixed
+    source_mode: live-shopify
+    source_connection: shopify-default
+    reporting_timezone: UTC
+    currency_policy: no conversion; monetary aggregates remain at shop-currency grain


### PR DESCRIPTION
## Summary

- add a generic Shopify-to-ClickHouse template with raw ingestion, conformed commerce models, and reporting marts
- document setup, connection conventions, project structure, and customization guidance
- add the template to the documentation catalog and cover `bruin init shopify-clickhouse` with a regression test

## Validation

- `make format`
- `make test`
- validated all 16 template assets with Bruin using a temporary clean connection config
- `npm run docs:build`