### PR TITLE
Fix Shopify order line refreshes

### DIFF
--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -88,6 +88,11 @@ func TestInitShopifyClickHouseCopiesPipelineTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(ordersAsset), "name: shopify.t1_orders")
 	require.Contains(t, string(ordersAsset), "source_connection: shopify-default")
+
+	orderLinesAsset, err := os.ReadFile(filepath.Join(pipelineRoot, "assets", "t2", "t2_order_line_items.sql"))
+	require.NoError(t, err)
+	require.Contains(t, string(orderLinesAsset), "strategy: delete+insert")
+	require.Contains(t, string(orderLinesAsset), "incremental_key: order_id")
 }
 
 func TestSelfHealDemoTemplateContainsDataProblemScenarios(t *testing.T) {

--- a/docs/getting-started/templates-docs/shopify-clickhouse-README.md
+++ b/docs/getting-started/templates-docs/shopify-clickhouse-README.md
@@ -115,7 +115,7 @@ The T1 assets preserve Shopify structures that are useful as a starting point, i
 
 In particular, the payment reconciliation mart summarizes Shopify order financial statuses; it is not a payout or gateway-settlement ledger. Add Shopify Payments or another payment-source integration if you need settlement-level reporting.
 
-The template uses `merge` materializations for incrementally updated entities and daily marts. The customer-cohort and product-performance marts use `create+replace`, because they summarize the full available history.
+The template uses `merge` materializations for incrementally updated entities and daily marts. Order lines use `delete+insert` keyed by order so removed lines do not remain after an order edit. The customer-cohort and product-performance marts use `create+replace`, because they summarize the full available history.
 
 ## Explore the marts
 

--- a/templates/shopify-clickhouse/README.md
+++ b/templates/shopify-clickhouse/README.md
@@ -115,7 +115,7 @@ The T1 assets preserve Shopify structures that are useful as a starting point, i
 
 In particular, the payment reconciliation mart summarizes Shopify order financial statuses; it is not a payout or gateway-settlement ledger. Add Shopify Payments or another payment-source integration if you need settlement-level reporting.
 
-The template uses `merge` materializations for incrementally updated entities and daily marts. The customer-cohort and product-performance marts use `create+replace`, because they summarize the full available history.
+The template uses `merge` materializations for incrementally updated entities and daily marts. Order lines use `delete+insert` keyed by order so removed lines do not remain after an order edit. The customer-cohort and product-performance marts use `create+replace`, because they summarize the full available history.
 
 ## Explore the marts
 

--- a/templates/shopify-clickhouse/assets/t2/t2_order_line_items.sql
+++ b/templates/shopify-clickhouse/assets/t2/t2_order_line_items.sql
@@ -5,7 +5,8 @@ description: "Conformed Shopify order lines parsed from the nested order payload
 
 materialization:
   type: table
-  strategy: merge
+  strategy: delete+insert
+  incremental_key: order_id
 
 depends:
   - shopify.t1_orders
@@ -25,7 +26,7 @@ meta:
   source_system: shopify
   currency_scope: monetary values remain in each order's shop currency
   refund_policy: recognized line revenue allocates the order's current subtotal proportionally across original net line values
-  refresh_strategy: primary-key merge for lines belonging to orders updated in the run interval
+  refresh_strategy: replace complete line sets for orders updated in the run interval
   data_classification: internal
 
 custom_checks:


### PR DESCRIPTION
## Summary

- replace the Shopify order-line `merge` materialization with `delete+insert` keyed by `order_id`
- ensure an edited order replaces its complete line set, removing lines deleted in Shopify
- document the behavior and add regression coverage for the generated template

## Why

The prior primary-key merge only deleted line keys present in the staged query result. A line removed from an edited Shopify order was absent from that result and remained stale in ClickHouse.

## Validation

- `make format`
- `make test`
- validated all 16 template assets with Bruin using a temporary clean connection config
- `npm run docs:build`