### PR TITLE
Add `bruin cloud agents connections`

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2043,6 +2043,59 @@ func CloudAgents() *cli.Command {
 			cloudAgentsMessages(),
 			cloudAgentsGetPrompt(),
 			cloudAgentsSetPrompt(),
+			cloudAgentsConnections(),
+		},
+	}
+}
+
+func cloudAgentsConnections() *cli.Command {
+	return &cli.Command{
+		Name:  "connections",
+		Usage: "List the connections available to an agent (names and types)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			connections, err := client.ListAgentConnections(ctx, c.Int("agent-id"))
+			if err != nil {
+				printError(err, output, "Failed to list agent connections")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(connections, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(connections) == 0 {
+				infoPrinter.Println("No connections available to this agent.")
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Name", "Type"})
+			for _, conn := range connections {
+				t.AppendRow(table.Row{conn.Name, conn.Type})
+			}
+			t.Render()
+			return nil
 		},
 	}
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2065,6 +2065,13 @@ func cloudAgentsConnections() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
+			// Fail fast on an invalid id rather than sending a bad request and
+			// surfacing a generic remote error.
+			if c.Int("agent-id") <= 0 {
+				printError(fmt.Errorf("--agent-id must be a positive integer, got %d", c.Int("agent-id")), output, "Invalid --agent-id")
+				return cli.Exit("", 1)
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
@@ -2075,6 +2082,11 @@ func cloudAgentsConnections() *cli.Command {
 			if err != nil {
 				printError(err, output, "Failed to list agent connections")
 				return cli.Exit("", 1)
+			}
+			// Normalize a nil slice so JSON output is an empty list, not null —
+			// scripting consumers then handle one shape.
+			if connections == nil {
+				connections = []bruincloud.AgentConnection{}
 			}
 
 			if output == "json" {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -268,6 +268,24 @@ func TestCloudDashboardsCreate_RejectsNonPositiveAgentID(t *testing.T) {
 	}
 }
 
+func TestCloudAgentsConnections_RejectsNonPositiveAgentID(t *testing.T) {
+	t.Parallel()
+	// An explicit non-positive --agent-id must fail locally, not become a bad
+	// API request with a generic remote error.
+	for _, v := range []string{"0", "-3"} {
+		cmd := cloudAgentsConnections()
+		exitCode := 0
+		cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, err error) {
+			var ec cli.ExitCoder
+			if errors.As(err, &ec) {
+				exitCode = ec.ExitCode()
+			}
+		}
+		_ = cmd.Run(t.Context(), []string{"connections", "--api-key", "k", "--agent-id", v})
+		assert.Equalf(t, 1, exitCode, "agent-id %q should be rejected", v)
+	}
+}
+
 func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	t.Parallel()
 	cmd := CloudScheduledAgents()

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -222,7 +222,13 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 10)
+	require.Len(t, cmd.Commands, 11)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "connections")
 }
 
 func TestCloudDashboardsCommand_Help(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -491,6 +491,17 @@ List available agents:
 bruin cloud agents list
 ```
 
+#### `connections`
+
+List the connections available to an agent — names and types only (never
+credential values). Use it to pick a connection the agent can actually query,
+e.g. for a dashboard's `connection`:
+
+```bash
+bruin cloud agents connections --agent-id 7
+bruin cloud agents connections --agent-id 7 --output json
+```
+
 #### `send`
 
 Send a message to an agent:

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -419,6 +419,17 @@ func (c *APIClient) ListAgents(ctx context.Context) ([]Agent, error) {
 	return resp.Agents, err
 }
 
+// ListAgentConnections returns the connection names and types available to the
+// agent (from its dev-env secret) — names/types only, never credentials. Use it
+// to pick a connection the agent can actually query.
+func (c *APIClient) ListAgentConnections(ctx context.Context, agentID int) ([]AgentConnection, error) {
+	var resp struct {
+		Connections []AgentConnection `json:"connections"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%d/connections", agentID), nil, &resp)
+	return resp.Connections, err
+}
+
 // CreateAgent creates a new agent. Optional fields are omitted when empty so the
 // server applies its defaults (null description/prompt, "team" visibility).
 func (c *APIClient) CreateAgent(ctx context.Context, name, description, systemPrompt, visibility string) (*Agent, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -488,6 +488,27 @@ func TestListAgents(t *testing.T) {
 	assert.Equal(t, "test-agent", agents[0].Name)
 }
 
+func TestListAgentConnections(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/agents/7/connections", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"connections": []AgentConnection{
+				{Name: "warehouse_prod", Type: "snowflake"},
+				{Name: "djamila-dev", Type: "google_cloud_platform"},
+			},
+		})
+	})
+
+	connections, err := client.ListAgentConnections(t.Context(), 7)
+	require.NoError(t, err)
+	require.Len(t, connections, 2)
+	assert.Equal(t, "warehouse_prod", connections[0].Name)
+	assert.Equal(t, "google_cloud_platform", connections[1].Type)
+}
+
 func TestCreateAgent(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -105,6 +105,13 @@ type Agent struct {
 	Visibility  string  `json:"visibility"`
 }
 
+// AgentConnection is one connection available to an agent — name and type only
+// (no credential values).
+type AgentConnection struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
 // AgentThread represents a thread for an agent.
 type AgentThread struct {
 	ID        int    `json:"id"`


### PR DESCRIPTION
`bruin cloud agents connections --agent-id <id>` lists the connections in an agent's connection set — **names and types only**, never credential values — so a caller (human or agent) can pick a connection the agent can actually query (e.g. for a dashboard's `connection`) instead of guessing or using local `.bruin.yml` names.

Calls `GET /api/v1/agents/{id}/connections` (bruin-data/cloud#2764). `--output json` for scripting.