### PR TITLE
feat(cloud): surface backfill tracking URL + add `backfills` list/runs

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -32,6 +32,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudProjects(),
 			CloudPipelines(),
 			CloudRuns(),
+			CloudBackfills(),
 			CloudAssets(),
 			CloudInstances(),
 			CloudGlossary(),
@@ -885,15 +886,25 @@ func cloudRunsTrigger() *cli.Command {
 			}
 
 			startDate, endDate := c.String("start-date"), c.String("end-date")
-			if err := client.TriggerRun(ctx, project, pipeline, startDate, endDate, opts); err != nil {
+			result, err := client.TriggerRun(ctx, project, pipeline, startDate, endDate, opts)
+			if err != nil {
 				printError(err, output, "Failed to trigger run")
 				return cli.Exit("", 1)
 			}
 
+			if output == "json" {
+				data, _ := json.MarshalIndent(result, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
 			if split == "" {
-				printSuccessForOutput(output, fmt.Sprintf("Successfully triggered run for pipeline '%s' in project '%s'", pipeline, project))
+				successPrinter.Printf("Successfully triggered run for pipeline '%s' in project '%s'\n", pipeline, project)
 			} else {
-				printSuccessForOutput(output, fmt.Sprintf("Successfully triggered backfill (split by %s, chunk size %d) for pipeline '%s' in project '%s'", split, chunkSize, pipeline, project))
+				successPrinter.Printf("Successfully triggered backfill (split by %s, chunk size %d) for pipeline '%s' in project '%s'\n", split, chunkSize, pipeline, project)
+				if result.URL != "" {
+					fmt.Printf("Track this backfill at: %s\n", result.URL)
+				}
 			}
 			return nil
 		},
@@ -1248,6 +1259,117 @@ func cloudRunsDiagnose() *cli.Command {
 				}
 			}
 
+			return nil
+		},
+	}
+}
+
+// --- Backfills ---
+
+func CloudBackfills() *cli.Command {
+	return &cli.Command{
+		Name:  "backfills",
+		Usage: "Inspect backfills (grouped runs created by 'runs trigger --split')",
+		Commands: []*cli.Command{
+			cloudBackfillsList(),
+			cloudBackfillsRuns(),
+		},
+	}
+}
+
+func cloudBackfillsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List recent backfills",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			projectFlag(),
+			pipelineFlag(),
+			limitFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			backfills, err := client.ListBackfills(ctx, c.String("project-id"), c.String("pipeline"), c.Int("limit"))
+			if err != nil {
+				printError(err, output, "Failed to list backfills")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(backfills, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Backfill ID", "Project", "Pipeline", "Interval Start", "Interval End", "Runs", "Created"})
+			for _, b := range backfills {
+				t.AppendRow(table.Row{b.ID, b.Project, b.Pipeline, b.IntervalStart, b.IntervalEnd, len(b.Runs), b.CreatedAt})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudBackfillsRuns() *cli.Command {
+	return &cli.Command{
+		Name:  "runs",
+		Usage: "List the individual runs of a backfill",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.StringFlag{
+				Name:     "id",
+				Usage:    "backfill ID (the 'Backfill ID' from 'backfills list')",
+				Required: true,
+			},
+			limitFlag(),
+			offsetFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			runs, err := client.GetBackfillRuns(ctx, c.String("id"), c.Int("limit"), c.Int("offset"))
+			if err != nil {
+				printError(err, output, "Failed to get backfill runs")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(runs, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Run ID", "Interval Start", "Interval End", "Created", "Note"})
+			for _, r := range runs {
+				note := ""
+				if r.Note != nil {
+					note = *r.Note
+				}
+				t.AppendRow(table.Row{r.RunID, r.IntervalStart, r.IntervalEnd, r.CreatedAt, note})
+			}
+			t.Render()
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -143,7 +143,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 11)
+	assert.Len(t, cmd.Commands, 12)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -153,6 +153,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "projects")
 	assert.Contains(t, subNames, "pipelines")
 	assert.Contains(t, subNames, "runs")
+	assert.Contains(t, subNames, "backfills")
 	assert.Contains(t, subNames, "assets")
 	assert.Contains(t, subNames, "instances")
 	assert.Contains(t, subNames, "glossary")

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -401,7 +401,7 @@ bruin cloud backfills list --project-id <project-id> --pipeline <pipeline-name>
 
 Each row shows the backfill ID (the `multiple_action_id`), its overall interval,
 and how many runs it fanned out into. Use `--limit` to control how many backfills
-are returned (default 10).
+are returned (default 20).
 
 #### `runs`
 

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -308,6 +308,16 @@ bruin cloud runs trigger \
 > include a final period, pass the date one period past it — e.g. `--end-date 2024-01-04`
 > to cover `2024-01-03` with `--split day`.
 
+When a `--split` trigger succeeds, the command prints a link to track the backfill
+in the dashboard:
+
+```text
+Successfully triggered backfill (split by day, chunk size 1) for pipeline 'my-pipeline' in project 'my-project'
+Track this backfill at: https://cloud.getbruin.com/<company>/projects/my-project/pipelines/my-pipeline/backfills/<backfill-id>
+```
+
+Use `bruin cloud backfills` (below) to inspect the backfill and its runs from the CLI.
+
 #### `rerun`
 
 Re-run a previous pipeline run. Useful when a transient issue caused a failure:
@@ -374,6 +384,35 @@ bruin cloud runs diagnose --project-id <project-id> --run-id <run-id>
 
 > [!TIP]
 > The `diagnose` command is especially handy when used with `--latest` — you don't even need to know the run ID. Just point it at a pipeline and it tells you what went wrong.
+
+---
+
+### `backfills`
+
+Inspect backfills — the grouped runs created by `runs trigger --split`.
+
+#### `list`
+
+List recent backfills, optionally filtered by project and pipeline:
+
+```bash
+bruin cloud backfills list --project-id <project-id> --pipeline <pipeline-name>
+```
+
+Each row shows the backfill ID (the `multiple_action_id`), its overall interval,
+and how many runs it fanned out into. Use `--limit` to control how many backfills
+are returned (default 10).
+
+#### `runs`
+
+List the individual runs that make up a single backfill, using the backfill ID
+from `backfills list`:
+
+```bash
+bruin cloud backfills runs --id <backfill-id>
+```
+
+Use `--limit` / `--offset` to page through the runs.
 
 ---
 

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -242,8 +242,22 @@ func encodeRunNote(note string, tags []string) string {
 	return string(b)
 }
 
+// TriggerRunResult holds the response from the trigger endpoint. A normal run
+// returns RunID; a backfill (triggered with a split) returns MultipleActionID
+// and a URL to track the backfill in the dashboard.
+type TriggerRunResult struct {
+	Message          string `json:"message"`
+	Project          string `json:"project"`
+	Pipeline         string `json:"pipeline"`
+	RunID            string `json:"run_id"`
+	MultipleActionID string `json:"multiple_action_id"`
+	Split            string `json:"split"`
+	ChunkSize        int    `json:"chunk_size"`
+	URL              string `json:"url"`
+}
+
 // TriggerRun triggers a pipeline run for the given date range.
-func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline, startDate, endDate string, opts TriggerRunOptions) error {
+func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline, startDate, endDate string, opts TriggerRunOptions) (*TriggerRunResult, error) {
 	body := map[string]any{
 		"project":    project,
 		"pipeline":   pipeline,
@@ -273,7 +287,11 @@ func (c *APIClient) TriggerRun(ctx context.Context, project, pipeline, startDate
 	if note := encodeRunNote(opts.Note, opts.Tags); note != "" {
 		body["note"] = note
 	}
-	return c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-run", body, nil)
+	var result TriggerRunResult
+	if err := c.doRequest(ctx, http.MethodPost, "/trigger-pipeline-run", body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 func (c *APIClient) RerunRun(ctx context.Context, project, pipeline, runID string, onlyFailed bool) error {
@@ -313,6 +331,47 @@ func (c *APIClient) GetLatestRun(ctx context.Context, project, pipeline string) 
 		return nil, fmt.Errorf("no runs found for pipeline '%s' in project '%s'", pipeline, project)
 	}
 	return &runs[0], nil
+}
+
+// --- Backfills ---
+
+// ListBackfills returns the most recent backfills, optionally filtered by project and pipeline.
+func (c *APIClient) ListBackfills(ctx context.Context, project, pipeline string, limit int) ([]Backfill, error) {
+	params := url.Values{}
+	if project != "" {
+		params.Set("project", project)
+	}
+	if pipeline != "" {
+		params.Set("pipeline", pipeline)
+	}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/backfills"
+	if enc := params.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	var backfills []Backfill
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &backfills)
+	return backfills, err
+}
+
+// GetBackfillRuns returns the individual runs that make up a single backfill.
+func (c *APIClient) GetBackfillRuns(ctx context.Context, multipleActionID string, limit, offset int) ([]BackfillRun, error) {
+	params := url.Values{}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	if offset > 0 {
+		params.Set("offset", strconv.Itoa(offset))
+	}
+	path := "/backfills/" + url.PathEscape(multipleActionID) + "/runs"
+	if enc := params.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	var runs []BackfillRun
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &runs)
+	return runs, err
 }
 
 // --- Assets ---

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -310,11 +310,11 @@ func TestTriggerRun(t *testing.T) {
 		assert.NotContains(t, body, "split")
 		assert.NotContains(t, body, "assets")
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`200`))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"run_id":"run-1"}`))
 	})
 
-	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-02", TriggerRunOptions{})
+	_, err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-02", TriggerRunOptions{})
 	require.NoError(t, err)
 }
 
@@ -332,11 +332,11 @@ func TestTriggerRunWithSplit(t *testing.T) {
 		assert.Equal(t, "month", body["split"])
 		assert.EqualValues(t, 2, body["chunk_size"])
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`200`))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"multiple_action_id":"m1"}`))
 	})
 
-	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-04-01", TriggerRunOptions{Split: "month", ChunkSize: 2})
+	_, err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-04-01", TriggerRunOptions{Split: "month", ChunkSize: 2})
 	require.NoError(t, err)
 }
 
@@ -348,11 +348,11 @@ func TestTriggerRunSplitDefaultsChunkSize(t *testing.T) {
 		// Split set with the zero-value ChunkSize must still send a valid chunk size.
 		assert.EqualValues(t, 1, body["chunk_size"])
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`200`))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"multiple_action_id":"m1"}`))
 	})
 
-	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-04-01", TriggerRunOptions{Split: "month"})
+	_, err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-04-01", TriggerRunOptions{Split: "month"})
 	require.NoError(t, err)
 }
 
@@ -368,8 +368,8 @@ func TestTriggerRunWithOptions(t *testing.T) {
 		vars := body["variables"].(map[string]any)
 		assert.Equal(t, "bar", vars["foo"])
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`200`))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"run_id":"run-1"}`))
 	})
 
 	opts := TriggerRunOptions{
@@ -377,7 +377,7 @@ func TestTriggerRunWithOptions(t *testing.T) {
 		FullRefresh: true,
 		Variables:   map[string]any{"foo": "bar"},
 	}
-	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-31", opts)
+	_, err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-31", opts)
 	require.NoError(t, err)
 }
 
@@ -391,15 +391,15 @@ func TestTriggerRunWithDownstream(t *testing.T) {
 		assert.Equal(t, []any{"raw_events"}, body["assets"])
 		assert.Equal(t, true, body["downstream"])
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`200`))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"run_id":"run-1"}`))
 	})
 
 	opts := TriggerRunOptions{
 		Assets:     []string{"raw_events"},
 		Downstream: true,
 	}
-	err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-31", opts)
+	_, err := client.TriggerRun(t.Context(), "proj", "pipe", "2026-01-01", "2026-01-31", opts)
 	require.NoError(t, err)
 }
 
@@ -728,13 +728,65 @@ func TestTriggerRunWithTags(t *testing.T) {
 		body := readJSON(t, r)
 		// Note + tags are carried together inside the note field as JSON (the Cloud RunNote format).
 		assert.JSONEq(t, `{"note":"Q1 backfill","tags":["nightly","manual"]}`, body["note"].(string))
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`200`))
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"message":"Run triggered successfully","run_id":"run-123"}`))
 	})
 
-	err := client.TriggerRun(t.Context(), "p", "pipe", "2026-01-01", "2026-01-02",
+	result, err := client.TriggerRun(t.Context(), "p", "pipe", "2026-01-01", "2026-01-02",
 		TriggerRunOptions{Note: "Q1 backfill", Tags: []string{"nightly", "manual"}})
 	require.NoError(t, err)
+	assert.Equal(t, "run-123", result.RunID)
+}
+
+func TestTriggerRunBackfillReturnsURL(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body := readJSON(t, r)
+		assert.Equal(t, "day", body["split"])
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"message":"Backfill triggered successfully","multiple_action_id":"abc","split":"day","chunk_size":1,"url":"https://cloud.getbruin.com/acme/projects/p/pipelines/pipe/backfills/abc"}`))
+	})
+
+	result, err := client.TriggerRun(t.Context(), "p", "pipe", "2026-01-01", "2026-01-03",
+		TriggerRunOptions{Split: "day", ChunkSize: 1})
+	require.NoError(t, err)
+	assert.Equal(t, "https://cloud.getbruin.com/acme/projects/p/pipelines/pipe/backfills/abc", result.URL)
+	assert.Equal(t, "abc", result.MultipleActionID)
+}
+
+func TestListBackfills(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/backfills", r.URL.Path)
+		assert.Equal(t, "proj", r.URL.Query().Get("project"))
+		assert.Equal(t, "pipe", r.URL.Query().Get("pipeline"))
+		assert.Equal(t, "5", r.URL.Query().Get("limit"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"m1","project":"proj","pipeline":"pipe","interval_start":"2026-01-01T00:00:00.000Z","interval_end":"2026-01-03T00:00:00.000Z","created_at":"2026-01-01T00:00:00.000Z","runs":[{"runId":"m1__a"},{"runId":"m1__b"}]}]`))
+	})
+
+	backfills, err := client.ListBackfills(t.Context(), "proj", "pipe", 5)
+	require.NoError(t, err)
+	require.Len(t, backfills, 1)
+	assert.Equal(t, "m1", backfills[0].ID)
+	assert.Len(t, backfills[0].Runs, 2)
+}
+
+func TestGetBackfillRuns(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/backfills/m1/runs", r.URL.Path)
+		assert.Equal(t, "30", r.URL.Query().Get("limit"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"project":"proj","pipeline":"pipe","runId":"m1__a","interval_start":"2026-01-01T00:00:00.000Z","interval_end":"2026-01-02T00:00:00.000Z","created_at":"2026-01-01T00:00:00.000Z","note":null}]`))
+	})
+
+	runs, err := client.GetBackfillRuns(t.Context(), "m1", 30, 0)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, "m1__a", runs[0].RunID)
 }
 
 func TestListDashboards(t *testing.T) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -52,6 +52,29 @@ type PipelineRun struct {
 	Note                      *string         `json:"note"`
 }
 
+// Backfill represents a group of runs created by a single split trigger,
+// identified by its multiple_action_id.
+type Backfill struct {
+	ID            string        `json:"id"`
+	Project       string        `json:"project"`
+	Pipeline      string        `json:"pipeline"`
+	IntervalStart string        `json:"interval_start"`
+	IntervalEnd   string        `json:"interval_end"`
+	CreatedAt     string        `json:"created_at"`
+	Runs          []BackfillRun `json:"runs"`
+}
+
+// BackfillRun represents a single run within a backfill.
+type BackfillRun struct {
+	Project       string  `json:"project"`
+	Pipeline      string  `json:"pipeline"`
+	RunID         string  `json:"runId"`
+	IntervalStart string  `json:"interval_start"`
+	IntervalEnd   string  `json:"interval_end"`
+	CreatedAt     string  `json:"created_at"`
+	Note          *string `json:"note"`
+}
+
 // Asset represents a pipeline asset.
 type Asset struct {
 	Project                 string          `json:"project"`


### PR DESCRIPTION
## What

Part of [BRU-5351](https://linear.app/bruin/issue/BRU-5351). Improves backfill support in the `bruin cloud` command family.

Creating a backfill already worked via `bruin cloud runs trigger --split`, but the CLI discarded the API response and there was no way to inspect backfills. This PR:

1. **Surfaces the backfill tracking URL.** `runs trigger --split` now captures the trigger response and prints a dashboard link:
   ```
   Successfully triggered backfill (split by day, chunk size 1) for pipeline 'p' in project 'proj'
   Track this backfill at: https://cloud.getbruin.com/<company>/projects/proj/pipelines/p/backfills/<id>
   ```
   (`--output json` now passes through the full trigger response.)

2. **Adds `bruin cloud backfills list` and `bruin cloud backfills runs --id <id>`** to inspect backfills, consuming two new public endpoints (`GET /api/v1/backfills`, `GET /api/v1/backfills/{id}/runs`).

> [!NOTE]
> The CLI commands in (2) depend on the companion cloud-side PR that adds the public `/api/v1/backfills` endpoints. Merge that first.

## Testing

- `make format` + `golangci-lint` on changed packages: clean.
- `make test`: passing.
- Added client tests: `TestTriggerRunBackfillReturnsURL`, `TestListBackfills`, `TestGetBackfillRuns`; updated the cloud subcommand-count test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)