### PR TITLE
fix(connection): guard Kafka connection map writes with the mutex

### DIFF
--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/bruincloud"
@@ -301,6 +302,17 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "update")
 }
 
+// cliRunMu serializes cli.Command.Run: urfave/cli's ensureHelp resets the
+// package-level cli.HelpFlag on every run, so concurrent runs race on it.
+var cliRunMu sync.Mutex
+
+func runCLI(ctx context.Context, cmd *cli.Command, args []string) error {
+	cliRunMu.Lock()
+	defer cliRunMu.Unlock()
+
+	return cmd.Run(ctx, args)
+}
+
 func TestCloudDashboardsCreate_RejectsNonPositiveAgentID(t *testing.T) {
 	t.Parallel()
 	// An explicit non-positive --agent-id must fail fast (before any request)
@@ -316,7 +328,7 @@ func TestCloudDashboardsCreate_RejectsNonPositiveAgentID(t *testing.T) {
 				exitCode = ec.ExitCode()
 			}
 		}
-		_ = cmd.Run(t.Context(), []string{"create", "--title", "T", "--api-key", "k", "--agent-id", v})
+		_ = runCLI(t.Context(), cmd, []string{"create", "--title", "T", "--api-key", "k", "--agent-id", v})
 		assert.Equalf(t, 1, exitCode, "agent-id %q should be rejected", v)
 	}
 }
@@ -334,7 +346,7 @@ func TestCloudAgentsConnections_RejectsNonPositiveAgentID(t *testing.T) {
 				exitCode = ec.ExitCode()
 			}
 		}
-		_ = cmd.Run(t.Context(), []string{"connections", "--api-key", "k", "--agent-id", v})
+		_ = runCLI(t.Context(), cmd, []string{"connections", "--api-key", "k", "--agent-id", v})
 		assert.Equalf(t, 1, exitCode, "agent-id %q should be rejected", v)
 	}
 }

--- a/cmd/lineage_test.go
+++ b/cmd/lineage_test.go
@@ -39,8 +39,7 @@ func (m *mockPrinter) Print(a ...interface{}) (int, error) {
 }
 
 func TestLineageCommand_Run(t *testing.T) {
-	// Not parallel: cli.Command.Run mutates the package-level cli.HelpFlag, so two
-	// concurrent Run calls race inside the library.
+	t.Parallel()
 
 	type args struct {
 		assetPath string

--- a/cmd/lineage_test.go
+++ b/cmd/lineage_test.go
@@ -39,7 +39,8 @@ func (m *mockPrinter) Print(a ...interface{}) (int, error) {
 }
 
 func TestLineageCommand_Run(t *testing.T) {
-	t.Parallel()
+	// Not parallel: cli.Command.Run mutates the package-level cli.HelpFlag, so two
+	// concurrent Run calls race inside the library.
 
 	type args struct {
 		assetPath string

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -2060,6 +2060,9 @@ func (m *Manager) AddKafkaConnectionFromConfig(connection *config.KafkaConnectio
 		return err
 	}
 
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	m.Kafka[connection.Name] = client
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/adapty"
@@ -741,6 +743,44 @@ func TestManager_AddGenericConnectionFromConfig(t *testing.T) {
 	res, ok := m.GetConnection("test").(*config.GenericConnection)
 	assert.True(t, ok)
 	assert.NotNil(t, res)
+}
+
+func TestManager_AddKafkaConnectionFromConfigIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	m := Manager{
+		AllConnectionDetails: map[string]any{},
+		availableConnections: make(map[string]any),
+	}
+
+	// Connections are loaded in parallel, so every writer of the shared maps has
+	// to hold the mutex; a single unsynchronized writer takes the whole process
+	// down with "fatal error: concurrent map writes".
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, m.AddKafkaConnectionFromConfig(&config.KafkaConnection{
+				ConnectionMetadata: config.ConnectionMetadata{Name: fmt.Sprintf("kafka-%d", i)},
+				BootstrapServers:   "localhost:9092",
+				GroupID:            "g1",
+			}))
+		}()
+
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, m.AddGenericConnectionFromConfig(&config.GenericConnection{
+				ConnectionMetadata: config.ConnectionMetadata{Name: fmt.Sprintf("generic-%d", i)},
+				Value:              "somevalue",
+			}))
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, m.availableConnections, 100)
+	assert.Len(t, m.AllConnectionDetails, 100)
 }
 
 func TestManager_AddInfluxDBConnectionFromConfigStoresConnectionDetails(t *testing.T) {


### PR DESCRIPTION
## Problem

`bruin run` crashes intermittently — roughly 1 run in 20 on a config with ~90 connections — before any asset executes:

```
error: concurrent map writes
```

`processConnections` loads every connection in parallel, and each goroutine writes three shared maps: its per-type map, `m.availableConnections`, and `m.AllConnectionDetails`. 142 of the 143 `Add*FromConfig` functions hold `m.mutex` for those writes. `AddKafkaConnectionFromConfig` released it right after the nil-check and never took it again, so its three map writes were unsynchronized.

A mutex only protects a map if every writer takes it, so this one holdout made the shared maps unsafe for all 143 writers. Go raises an unrecoverable fatal error on the overlapping write, so the process dies. It reproduces only when a Kafka connection is present, and non-deterministically, because `kafka.NewClient` lands the unsynchronized write at a random point in the fan-out.

## Fix

Hold `m.mutex` across the map writes in `AddKafkaConnectionFromConfig`, matching the other 142. Confirmed with `-race`, which previously flagged the unlocked write at `connection.go:2064` against a correctly locked one.
