### PR TITLE
pipeline: accept "replace" as materialization strategy alias

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -184,6 +184,8 @@ Bruin forwards these write strategies to ingestr:
 | `materialization.strategy: truncate+insert` | `truncate+insert` |
 | `parameters.incremental_strategy` | Passed through as-is |
 
+For convenience, `materialization.strategy: replace` is accepted as an alias for `create+replace`, so assets that reference ingestr's own `replace` strategy name keep working. Both map to ingestr's `replace`; `create+replace` remains the canonical Bruin name.
+
 Use `materialization.incremental_key` or `parameters.incremental_key` only with `append`, `merge`, and `delete+insert`. `merge` requires primary keys, supplied either by ingestr source metadata/schema or by asset columns marked `primary_key: true`; CDC assets determine keys from the source. `truncate+insert` is accepted by Bruin, but ingestr will fail the run if the selected destination cannot truncate tables. Ingestr's `scd2` strategy is not a supported Bruin ingestr asset materialization strategy.
 
 Destination support depends on ingestr's destination implementation:

--- a/pkg/pipeline/comment.go
+++ b/pkg/pipeline/comment.go
@@ -380,7 +380,7 @@ func commentRowsToTask(commentRows []string) (*Asset, error) {
 				task.Materialization.Type = MaterializationType(strings.ToLower(value))
 				continue
 			case "strategy":
-				task.Materialization.Strategy = MaterializationStrategy(strings.ToLower(value))
+				task.Materialization.Strategy = NormalizeMaterializationStrategy(value)
 				continue
 			case "partition_by":
 				task.Materialization.PartitionBy = value

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -635,6 +635,25 @@ var AllAvailableMaterializationStrategies = []MaterializationStrategy{
 	MaterializationStrategyDataVaultSatellite,
 }
 
+// materializationStrategyAliases maps alternative strategy names to their
+// canonical Bruin equivalent. ingestr users often reference ingestr's
+// incremental-strategy names, and ingestr calls a full-table replace "replace"
+// whereas Bruin exposes the same behavior as "create+replace". Accepting the
+// alias keeps those pipelines working instead of failing validation.
+var materializationStrategyAliases = map[MaterializationStrategy]MaterializationStrategy{
+	"replace": MaterializationStrategyCreateReplace,
+}
+
+// NormalizeMaterializationStrategy lowercases the given strategy and resolves
+// any known alias to its canonical Bruin strategy.
+func NormalizeMaterializationStrategy(strategy string) MaterializationStrategy {
+	normalized := MaterializationStrategy(strings.ToLower(strings.TrimSpace(strategy)))
+	if canonical, ok := materializationStrategyAliases[normalized]; ok {
+		return canonical
+	}
+	return normalized
+}
+
 type Materialization struct {
 	Type                 MaterializationType            `json:"type" yaml:"type,omitempty" mapstructure:"type"`
 	Strategy             MaterializationStrategy        `json:"strategy" yaml:"strategy,omitempty" mapstructure:"strategy"`

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1013,6 +1013,50 @@ func TestMaterialization_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestNormalizeMaterializationStrategy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  pipeline.MaterializationStrategy
+	}{
+		{
+			name:  "replace is aliased to create+replace",
+			input: "replace",
+			want:  pipeline.MaterializationStrategyCreateReplace,
+		},
+		{
+			name:  "replace alias is case-insensitive and trimmed",
+			input: "  REPLACE ",
+			want:  pipeline.MaterializationStrategyCreateReplace,
+		},
+		{
+			name:  "create+replace is kept as-is",
+			input: "create+replace",
+			want:  pipeline.MaterializationStrategyCreateReplace,
+		},
+		{
+			name:  "other strategies pass through lowercased",
+			input: "Delete+Insert",
+			want:  pipeline.MaterializationStrategyDeleteInsert,
+		},
+		{
+			name:  "empty stays empty",
+			input: "",
+			want:  pipeline.MaterializationStrategyNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, pipeline.NormalizeMaterializationStrategy(tt.input))
+		})
+	}
+}
+
 func TestColumnCheckValue_MarshalJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -515,7 +515,7 @@ func ConvertYamlToTask(content []byte) (*Asset, error) {
 func taskDefinitionToAsset(definition taskDefinition) (*Asset, error) {
 	mat := Materialization{
 		Type:                 MaterializationType(strings.ToLower(definition.Materialization.Type)),
-		Strategy:             MaterializationStrategy(strings.ToLower(definition.Materialization.Strategy)),
+		Strategy:             NormalizeMaterializationStrategy(definition.Materialization.Strategy),
 		ClusterBy:            definition.Materialization.ClusterBy,
 		PartitionBy:          definition.Materialization.PartitionBy,
 		IncrementalKey:       definition.Materialization.IncrementalKey,

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -411,6 +411,22 @@ routing:
 	require.Equal(t, &pipeline.RoutingConfig{EgressGateway: "wg-shared-ams3"}, task.Routing)
 }
 
+func TestConvertYamlToTask_MaterializationStrategyAlias(t *testing.T) {
+	t.Parallel()
+
+	// ingestr users often reference ingestr's "replace" incremental strategy,
+	// which Bruin exposes as "create+replace". The parser should accept it.
+	task, err := pipeline.ConvertYamlToTask([]byte(strings.TrimSpace(`
+name: dataset.asset
+type: ingestr
+materialization:
+  type: table
+  strategy: replace
+`)))
+	require.NoError(t, err)
+	require.Equal(t, pipeline.MaterializationStrategyCreateReplace, task.Materialization.Strategy)
+}
+
 func TestConvertYamlToTask_Timeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Accept `replace` as an alias for the `create+replace` materialization strategy.

## Why

ingestr names its full-table replace strategy `replace` (it is also ingestr's default). Bruin exposes the same behavior as `create+replace` and rejected a bare `replace` with a `valid-ingestr` lint error:

```
Materialization strategy 'replace' is not supported for ingestr assets.
Supported strategies are: create+replace, append, merge, delete+insert, truncate+insert (valid-ingestr)
```

Users who model their assets after ingestr's own incremental-strategy names hit this, and their pipelines fail to parse.

## How

Normalize the materialization strategy at parse time (`NormalizeMaterializationStrategy`) so `replace` resolves to `create+replace`. Applying the alias in the parser keeps a single canonical value flowing into lint, the ingestr operator, and the SQL materializers, so the alias works for every asset type without special-casing any downstream code. `create+replace` remains the canonical name.

## Changes

- `pkg/pipeline`: add the alias map + `NormalizeMaterializationStrategy`, and call it from the YAML and comment parsers.
- Tests: unit coverage for the normalizer and an end-to-end parse test for `strategy: replace`.
- Docs: note the alias in the ingestr asset strategy-mapping table.