### PR TITLE
fix(lint): don't corrupt validate JSON output when hook parser unavailable

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -197,12 +197,13 @@ func Lint(isDebug *bool) *cli.Command {
 			}
 
 			// Hook declare-hoisting is optional (Rust FFI, darwin/linux+CGO only).
-			// Log failures at debug level; printing them would corrupt JSON output.
+			// Warn on stderr when unavailable so DECLARE-related validation errors
+			// are explainable, without corrupting structured stdout output.
 			var hookHoister pipeline.DeclareHoister
 			if p, err := sqlparser.NewRustSQLParser(false); err != nil {
-				logger.Debugf("could not initialize hook SQL parser, skipping declare hoisting: %v", err)
+				fmt.Fprintf(os.Stderr, "warning: hook SQL parser unavailable, DECLARE hoisting disabled: %v\n", err)
 			} else if err := p.Start(); err != nil {
-				logger.Debugf("could not start hook SQL parser, skipping declare hoisting: %v", err)
+				fmt.Fprintf(os.Stderr, "warning: hook SQL parser unavailable, DECLARE hoisting disabled: %v\n", err)
 			} else {
 				hookHoister = p
 				defer p.Close()

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -196,11 +196,13 @@ func Lint(isDebug *bool) *cli.Command {
 				defer p.Close()
 			}
 
+			// Hook declare-hoisting is optional (Rust FFI, darwin/linux+CGO only).
+			// Log failures at debug level; printing them would corrupt JSON output.
 			var hookHoister pipeline.DeclareHoister
 			if p, err := sqlparser.NewRustSQLParser(false); err != nil {
-				printError(err, c.String("output"), "Could not initialize hook SQL parser")
+				logger.Debugf("could not initialize hook SQL parser, skipping declare hoisting: %v", err)
 			} else if err := p.Start(); err != nil {
-				printError(err, c.String("output"), "Could not start hook SQL parser")
+				logger.Debugf("could not start hook SQL parser, skipping declare hoisting: %v", err)
 			} else {
 				hookHoister = p
 				defer p.Close()


### PR DESCRIPTION
## Problem

The `validate-missing-upstream` integration test fails on Windows CI. `validate -o json` emits a stray `{"error":"rust sql parser ffi requires cgo on darwin or linux"}` line before the results array, breaking the test's JSON parser (`invalid character '[' after top-level value`).

## Root cause

The Rust FFI SQL parser powers optional hook *declare-hoisting* and is only compiled with CGO on darwin/linux. On Windows the build uses a stub whose `Start()` always returns that error. In `cmd/lint.go`, that failure was passed to `printError(..., "json", ...)`, which writes the error as JSON straight to **stdout**, corrupting the output. Execution then continued (the hoister is optional and degrades to `nil`), so the valid array printed right after — yielding two top-level JSON values.