### PR TITLE
fix(iceberg): keep Glue catalog credentials separate from storage

### DIFF
--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -5,6 +5,7 @@ package iceberg
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -57,7 +58,14 @@ func (c Config) GetIngestrURI() (string, error) {
 
 	// Storage settings take precedence; catalog settings fill any gaps (ingestr
 	// aliases region/credentials into both the s3.* and glue.* namespaces).
+	// The shared credential keys are filled as a group: storage that brings its
+	// own key pair must not inherit the catalog's session token, which belongs
+	// to a different account and would be rejected.
+	storageHasOwnCredentials := hasAnySharedCredential(q)
 	for key, values := range catalogParams {
+		if storageHasOwnCredentials && isSharedCredentialParam(key) {
+			continue
+		}
 		if _, exists := q[key]; !exists {
 			q[key] = values
 		}
@@ -93,7 +101,11 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 	q := url.Values{}
 	switch cat.Type {
 	case config.IcebergCatalogGlue:
+		// The shared keys keep serving storage that has no credentials of its own;
+		// glue.* pins the catalog's account so S3-compatible storage (GCS interop,
+		// MinIO, R2) with different credentials cannot overwrite it.
 		setAWSCredentials(q, cat.Region, cat.Auth.AccessKey, cat.Auth.SecretKey, cat.Auth.SessionToken)
+		setGlueCredentials(q, cat.Region, cat.Auth.AccessKey, cat.Auth.SecretKey, cat.Auth.SessionToken)
 		if cat.CatalogID != "" {
 			q.Set("glue.id", cat.CatalogID)
 		}
@@ -219,6 +231,41 @@ func setAWSCredentials(q url.Values, region, accessKey, secretKey, sessionToken 
 	}
 	if sessionToken != "" {
 		q.Set("session_token", sessionToken)
+	}
+}
+
+// sharedCredentialParams are the credential keys ingestr aliases into both the
+// s3.* and glue.* namespaces; they always come from a single account.
+var sharedCredentialParams = []string{"access_key_id", "secret_access_key", "session_token"}
+
+func isSharedCredentialParam(key string) bool {
+	return slices.Contains(sharedCredentialParams, key)
+}
+
+func hasAnySharedCredential(q url.Values) bool {
+	for _, key := range sharedCredentialParams {
+		if q.Get(key) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// setGlueCredentials sets the glue.*-namespaced region and credential parameters
+// so the catalog keeps its own AWS account regardless of what storage sets.
+func setGlueCredentials(q url.Values, region, accessKey, secretKey, sessionToken string) {
+	if region != "" {
+		q.Set("glue.region", region)
+	}
+	if accessKey != "" {
+		q.Set("glue.access-key-id", accessKey)
+	}
+	if secretKey != "" {
+		q.Set("glue.secret-access-key", secretKey)
+	}
+	if sessionToken != "" {
+		q.Set("glue.session-token", sessionToken)
 	}
 }
 

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -55,6 +55,87 @@ func TestConfig_GetIngestrURI_GlueS3(t *testing.T) {
 	assert.Equal(t, "analytics", q.Get("catalog_name"))
 }
 
+func TestConfig_GetIngestrURI_GlueOnS3CompatibleStorage(t *testing.T) {
+	t.Parallel()
+
+	// Glue on S3-compatible storage: the two use different accounts, so the
+	// catalog's AWS settings must survive the storage block.
+	useSSL := true
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:   config.IcebergCatalogGlue,
+			Region: "eu-north-1",
+			Auth:   config.IcebergAuth{AccessKey: "ASIAKID", SecretKey: "AWSSECRET", SessionToken: "AWSTOKEN"},
+		},
+		Storage: config.IcebergStorage{
+			Type:     config.IcebergStorageS3,
+			Path:     testS3LakeWh,
+			Endpoint: "storage.googleapis.com",
+			UseSSL:   &useSSL,
+			Region:   "auto",
+			Auth:     config.IcebergAuth{AccessKey: "GOOGKID", SecretKey: "GOOGSECRET"},
+		},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "eu-north-1", q.Get("glue.region"))
+	assert.Equal(t, "ASIAKID", q.Get("glue.access-key-id"))
+	assert.Equal(t, "AWSSECRET", q.Get("glue.secret-access-key"))
+	assert.Equal(t, "AWSTOKEN", q.Get("glue.session-token"))
+
+	// Storage still owns the shared keys ingestr aliases into s3.*.
+	assert.Equal(t, "auto", q.Get("region"))
+	assert.Equal(t, "GOOGKID", q.Get("access_key_id"))
+	assert.Equal(t, "GOOGSECRET", q.Get("secret_access_key"))
+}
+
+func TestConfig_GetIngestrURI_StorageKeepsOwnCredentials(t *testing.T) {
+	t.Parallel()
+
+	// Storage with its own key pair and no session token must not inherit the
+	// catalog's; MinIO and other S3-compatible stores reject an AWS STS token.
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:   config.IcebergCatalogGlue,
+			Region: "eu-north-1",
+			Auth:   config.IcebergAuth{AccessKey: "ASIAKID", SecretKey: "AWSSECRET", SessionToken: "AWSTOKEN"},
+		},
+		Storage: config.IcebergStorage{
+			Type:     config.IcebergStorageS3,
+			Path:     "s3://warehouse/wh",
+			Endpoint: "localhost:9000",
+			Auth:     config.IcebergAuth{AccessKey: "minioadmin", SecretKey: "minioadmin"},
+		},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "minioadmin", q.Get("access_key_id"))
+	assert.Equal(t, "minioadmin", q.Get("secret_access_key"))
+	assert.Empty(t, q.Get("session_token"), "catalog session token must not leak into S3-compatible storage")
+	assert.Equal(t, "AWSTOKEN", q.Get("glue.session-token"))
+}
+
+func TestConfig_GetIngestrURI_CredentialsSharedWhenStorageHasNone(t *testing.T) {
+	t.Parallel()
+
+	// Storage without credentials still inherits the catalog's, the common
+	// Glue + real-S3 setup where both sides are the same AWS account.
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:   config.IcebergCatalogGlue,
+			Region: testAWSRegion,
+			Auth:   config.IcebergAuth{AccessKey: "AKID", SecretKey: "SECRET", SessionToken: "TOKEN"},
+		},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "AKID", q.Get("access_key_id"))
+	assert.Equal(t, "SECRET", q.Get("secret_access_key"))
+	assert.Equal(t, "TOKEN", q.Get("session_token"))
+	assert.Equal(t, testAWSRegion, q.Get("region"))
+}
+
 func TestConfig_GetIngestrURI_SQLiteS3MinIO(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A Glue catalog paired with S3-compatible (non-AWS) storage cannot work: the catalog receives the *storage* account's region and credentials.

`icebergCatalogURI` and `icebergStorageParams` both write the same generic keys — `region`, `access_key_id`, `secret_access_key`, `session_token` — and the merge in `GetIngestrURI` gives storage precedence ("Storage settings take precedence; catalog settings fill any gaps"). ingestr then aliases those keys into the `glue.*` namespace, and iceberg-go builds the Glue client from `glue.region` / `glue.access-key-id` / … (`catalog/glue/glue.go`, `toAwsConfig`). The catalog's own values never arrive.

Reproduced against real backends with a Glue catalog on GCS S3-interop storage and on MinIO:

```
# storage region "auto" reaches Glue
Glue: GetDatabase, request send failed, Post "https://glue.auto.amazonaws.com/": no such host

# MinIO credentials reach Glue
Glue: GetDatabase, https response error StatusCode: 400
```

There is a mirror case in the same merge. Storage that brings its own key pair but no session token inherits the catalog's AWS STS token, and S3-compatible stores reject it:

```
GetObject … api error InvalidTokenId: The security token included in the request is invalid
```

The keys are only correct when catalog and storage are the same AWS account, which stops being true the moment storage is GCS interop, MinIO, or R2.