### PR TITLE
Add 'bruin cloud audit-logs list'

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3821,16 +3821,8 @@ func cloudAuditLogsList() *cli.Command {
 				Name:  "end-date",
 				Usage: "only entries at or before this time (ISO 8601)",
 			},
-			&cli.IntFlag{
-				Name:  "page",
-				Usage: "page number",
-				Value: 1,
-			},
-			&cli.IntFlag{
-				Name:  "limit",
-				Usage: "entries per page (max 100)",
-				Value: 25,
-			},
+			limitFlag(),
+			offsetFlag(),
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
@@ -3847,8 +3839,8 @@ func cloudAuditLogsList() *cli.Command {
 				UserIDs:   c.StringSlice("user-id"),
 				StartDate: c.String("start-date"),
 				EndDate:   c.String("end-date"),
-				Page:      c.Int("page"),
-				PerPage:   c.Int("limit"),
+				Limit:     c.Int("limit"),
+				Offset:    c.Int("offset"),
 			})
 			if err != nil {
 				printError(err, output, "Failed to list audit logs")

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -40,6 +40,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudConnections(),
 			CloudDashboards(),
 			CloudScheduledAgents(),
+			CloudAuditLogs(),
 			CloudCost(),
 		},
 	}
@@ -3785,6 +3786,91 @@ func derefString(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+func CloudAuditLogs() *cli.Command {
+	return &cli.Command{
+		Name:  "audit-logs",
+		Usage: "Read the Bruin Cloud team audit log",
+		Commands: []*cli.Command{
+			cloudAuditLogsList(),
+		},
+	}
+}
+
+func cloudAuditLogsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List audit log entries (requires a personal API token)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.StringSliceFlag{
+				Name:  "type",
+				Usage: "filter by event type (repeatable), e.g. --type login --type new_conn",
+			},
+			&cli.StringSliceFlag{
+				Name:  "user-id",
+				Usage: "filter by acting user ID (repeatable)",
+			},
+			&cli.StringFlag{
+				Name:  "start-date",
+				Usage: "only entries at or after this time (ISO 8601)",
+			},
+			&cli.StringFlag{
+				Name:  "end-date",
+				Usage: "only entries at or before this time (ISO 8601)",
+			},
+			&cli.IntFlag{
+				Name:  "page",
+				Usage: "page number",
+				Value: 1,
+			},
+			&cli.IntFlag{
+				Name:  "limit",
+				Usage: "entries per page (max 100)",
+				Value: 25,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			logs, err := client.ListAuditLogs(ctx, bruincloud.AuditLogListOptions{
+				Types:     c.StringSlice("type"),
+				UserIDs:   c.StringSlice("user-id"),
+				StartDate: c.String("start-date"),
+				EndDate:   c.String("end-date"),
+				Page:      c.Int("page"),
+				PerPage:   c.Int("limit"),
+			})
+			if err != nil {
+				printError(err, output, "Failed to list audit logs")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(logs, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Time", "Type", "User", "Source", "IP"})
+			for _, l := range logs {
+				t.AppendRow(table.Row{l.CreatedAt, l.Type, l.UserIdentifier, derefString(l.Source), derefString(l.IPAddress)})
+			}
+			t.Render()
+			return nil
+		},
+	}
 }
 
 func CloudCost() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -149,7 +149,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 12)
+	assert.Len(t, cmd.Commands, 13)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -167,6 +167,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "dashboards")
 	assert.Contains(t, subNames, "scheduled-agents")
+	assert.Contains(t, subNames, "audit-logs")
 }
 
 func TestCloudProjectsCommand_Help(t *testing.T) {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -747,11 +747,11 @@ func (c *APIClient) ListAuditLogs(ctx context.Context, opts AuditLogListOptions)
 	if opts.EndDate != "" {
 		params.Set("endDate", opts.EndDate)
 	}
-	if opts.Page > 0 {
-		params.Set("page", strconv.Itoa(opts.Page))
+	if opts.Limit > 0 {
+		params.Set("limit", strconv.Itoa(opts.Limit))
 	}
-	if opts.PerPage > 0 {
-		params.Set("perPage", strconv.Itoa(opts.PerPage))
+	if opts.Offset > 0 {
+		params.Set("offset", strconv.Itoa(opts.Offset))
 	}
 
 	path := "/audit-logs"

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -729,6 +729,43 @@ func (c *APIClient) UpdateScheduledAgent(ctx context.Context, scheduledAgentID i
 	return &result, nil
 }
 
+// --- Audit logs ---
+
+// ListAuditLogs returns a page of the team's audit trail, most recent first.
+// The endpoint is read-only and accepts only a personal (user-scoped) token.
+func (c *APIClient) ListAuditLogs(ctx context.Context, opts AuditLogListOptions) ([]AuditLog, error) {
+	params := url.Values{}
+	for _, t := range opts.Types {
+		params.Add("types[]", t)
+	}
+	for _, id := range opts.UserIDs {
+		params.Add("userIds[]", id)
+	}
+	if opts.StartDate != "" {
+		params.Set("startDate", opts.StartDate)
+	}
+	if opts.EndDate != "" {
+		params.Set("endDate", opts.EndDate)
+	}
+	if opts.Page > 0 {
+		params.Set("page", strconv.Itoa(opts.Page))
+	}
+	if opts.PerPage > 0 {
+		params.Set("perPage", strconv.Itoa(opts.PerPage))
+	}
+
+	path := "/audit-logs"
+	if encoded := params.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	var resp struct {
+		AuditLogs []AuditLog `json:"auditLogs"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &resp)
+	return resp.AuditLogs, err
+}
+
 // GetCostExplorerSchema lists the dimensions, filter fields, and time buckets the cost explorer supports.
 func (c *APIClient) GetCostExplorerSchema(ctx context.Context, platform string) (*CostExplorerSchema, error) {
 	params := url.Values{}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1102,8 +1102,8 @@ func TestListAuditLogs(t *testing.T) {
 		assert.Equal(t, []string{"login", "new_conn"}, q["types[]"])
 		assert.Equal(t, []string{"7"}, q["userIds[]"])
 		assert.Equal(t, "2026-07-01", q.Get("startDate"))
-		assert.Equal(t, "2", q.Get("page"))
-		assert.Equal(t, "50", q.Get("perPage"))
+		assert.Equal(t, "50", q.Get("limit"))
+		assert.Equal(t, "10", q.Get("offset"))
 		w.WriteHeader(http.StatusOK)
 		writeJSON(t, w, map[string]any{
 			"auditLogs": []AuditLog{
@@ -1117,8 +1117,8 @@ func TestListAuditLogs(t *testing.T) {
 		Types:     []string{"login", "new_conn"},
 		UserIDs:   []string{"7"},
 		StartDate: "2026-07-01",
-		Page:      2,
-		PerPage:   50,
+		Limit:     50,
+		Offset:    10,
 	})
 	require.NoError(t, err)
 	require.Len(t, logs, 1)

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1093,3 +1093,35 @@ func TestGetCostExplorer(t *testing.T) {
 	require.NotNil(t, resp.NextOffset)
 	assert.Equal(t, 2, *resp.NextOffset)
 }
+
+func TestListAuditLogs(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/audit-logs", r.URL.Path)
+		q := r.URL.Query()
+		assert.Equal(t, []string{"login", "new_conn"}, q["types[]"])
+		assert.Equal(t, []string{"7"}, q["userIds[]"])
+		assert.Equal(t, "2026-07-01", q.Get("startDate"))
+		assert.Equal(t, "2", q.Get("page"))
+		assert.Equal(t, "50", q.Get("perPage"))
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"auditLogs": []AuditLog{
+				{Type: "login", UserIdentifier: "alice@example.com"},
+			},
+			"total": 1,
+		})
+	})
+
+	logs, err := client.ListAuditLogs(t.Context(), AuditLogListOptions{
+		Types:     []string{"login", "new_conn"},
+		UserIDs:   []string{"7"},
+		StartDate: "2026-07-01",
+		Page:      2,
+		PerPage:   50,
+	})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, "login", logs[0].Type)
+	assert.Equal(t, "alice@example.com", logs[0].UserIdentifier)
+}

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -325,8 +325,8 @@ type AuditLogListOptions struct {
 	UserIDs   []string
 	StartDate string
 	EndDate   string
-	Page      int
-	PerPage   int
+	Limit     int
+	Offset    int
 }
 
 // CostDimension is a group-by dimension the cost explorer supports.

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -306,6 +306,29 @@ type ScheduledAgent struct {
 	RecentExecutions  json.RawMessage `json:"recent_executions,omitempty"`
 }
 
+// AuditLog is one entry in a team's audit trail as returned by GET /audit-logs.
+// Metadata is event-specific and left raw.
+type AuditLog struct {
+	Type           string          `json:"type"`
+	UserIdentifier string          `json:"user_identifier"`
+	IPAddress      *string         `json:"ip_address"`
+	CreatedAt      string          `json:"created_at"`
+	URL            *string         `json:"url"`
+	Source         *string         `json:"source"`
+	Metadata       json.RawMessage `json:"metadata"`
+}
+
+// AuditLogListOptions are the optional filters for ListAuditLogs. Zero values
+// are omitted from the request.
+type AuditLogListOptions struct {
+	Types     []string
+	UserIDs   []string
+	StartDate string
+	EndDate   string
+	Page      int
+	PerPage   int
+}
+
 // CostDimension is a group-by dimension the cost explorer supports.
 type CostDimension struct {
 	Key   string `json:"key"`


### PR DESCRIPTION
Reads the team audit log locally via the new `GET /api/v1/audit-logs` endpoint (bruin-data/cloud#2814).

`bruin cloud audit-logs list` with `--type`, `--user-id`, `--start-date`, `--end-date`, `--page`, `--limit`; table or `--output json`. Requires a personal (user-scoped) API token.