### PR TITLE
bigquery: run truncate+insert materialization in a transaction

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -301,6 +301,9 @@ select
 from users
 ```
 
+> [!NOTE]
+> On platforms where `TRUNCATE` participates in transactions (such as BigQuery), Bruin wraps the truncate and insert in a single transaction. A failed insert rolls back the truncate, and readers never observe the table in its intermediate empty state. On engines where `TRUNCATE` implicitly commits, the truncate and insert run as separate statements, so a failure between them can leave the table empty.
+
 ### `append`
 
 `append` strategy is useful when you want to add new rows to the table without overwriting the existing rows. This is useful when you have a table that is constantly being updated and you want to keep the history of the data.

--- a/pkg/bigquery/materialization.go
+++ b/pkg/bigquery/materialization.go
@@ -47,12 +47,16 @@ func viewMaterializer(asset *pipeline.Asset, query string) (string, error) {
 }
 
 func buildTruncateInsertQuery(task *pipeline.Asset, query string) (string, error) {
-	// BigQuery doesn't support transactions, so we execute as separate statements
+	// BigQuery treats TRUNCATE TABLE as a DML statement, so the truncate and insert can
+	// run inside a single transaction. This makes the full refresh atomic: readers never
+	// observe the intermediate empty table, and a failed insert rolls back the truncate.
 	queries := []string{
+		"BEGIN TRANSACTION",
 		"TRUNCATE TABLE " + task.Name,
 		fmt.Sprintf("INSERT INTO %s %s", task.Name, strings.TrimSuffix(query, ";")),
+		"COMMIT TRANSACTION",
 	}
-	return strings.Join(queries, ";\n"), nil
+	return strings.Join(queries, ";\n") + ";", nil
 }
 
 func mergeMaterializer(asset *pipeline.Asset, query string) (string, error) {

--- a/pkg/bigquery/materialization_test.go
+++ b/pkg/bigquery/materialization_test.go
@@ -115,7 +115,7 @@ func TestMaterializer_Render(t *testing.T) {
 			want:  "INSERT INTO my.asset SELECT 1",
 		},
 		{
-			name: "truncate+insert builds proper queries without transactions",
+			name: "truncate+insert wraps truncate and insert in a transaction",
 			task: &pipeline.Asset{
 				Name: "my.asset",
 				Materialization: pipeline.Materialization{
@@ -124,8 +124,11 @@ func TestMaterializer_Render(t *testing.T) {
 				},
 			},
 			query: "SELECT 1 as id, 'test' as name",
-			want: `TRUNCATE TABLE my.asset;
-INSERT INTO my.asset SELECT 1 as id, 'test' as name`,
+			want: `BEGIN TRANSACTION;
+TRUNCATE TABLE my.asset;
+INSERT INTO my.asset SELECT 1 as id, 'test' as name;
+COMMIT TRANSACTION;`,
+			exactMatch: true,
 		},
 		{
 			name: "incremental strategies require the incremental_key to be set",


### PR DESCRIPTION
## What

`bq.sql` assets using the `truncate+insert` materialization strategy now run `TRUNCATE` and `INSERT` inside a single `BEGIN TRANSACTION` / `COMMIT TRANSACTION` block instead of as two separate autocommit statements.

## Why

Previously the strategy emitted `TRUNCATE TABLE` and `INSERT INTO` as independent statements. Because each committed on its own, a failed insert left the target table empty with the truncate already applied — a data-loss window on every full refresh.

BigQuery classifies `TRUNCATE TABLE` as a DML statement, so it can participate in a multi-statement transaction. Wrapping both statements makes the full refresh atomic:

- A failed insert rolls back the truncate; the table keeps its previous contents.
- Concurrent readers only ever see the old or the new full table, never the intermediate empty state.

This brings `truncate+insert` in line with the `delete+insert` and `time_interval` strategies, which are already transactional in the same file.

## Changes

- `pkg/bigquery/materialization.go`: wrap truncate + insert in `BEGIN`/`COMMIT TRANSACTION`.
- `pkg/bigquery/materialization_test.go`: update expectation to the transactional output.
- `docs/assets/materialization.md`: document the atomicity behavior (scoped to platforms where `TRUNCATE` is transactional).