### PR TITLE
fix(iceberg): forward a hadoop warehouse URI instead of pathifying it

### DIFF
--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -130,9 +130,17 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 		}
 		return "iceberg+hive://" + hostPort(cat.Host, cat.Port), q, nil
 	case config.IcebergCatalogHadoop:
-		// Local warehouse goes in the URL path; for object storage (s3://, gs://)
-		// leave Path empty so the warehouse comes from the storage block.
+		// A local warehouse goes in the URL path. A warehouse URI cannot: it would
+		// produce iceberg+hadoop:///s3://bucket/wh, which reads back as the local
+		// path "/s3:" and fails with "mkdir /s3:". Forward it as the warehouse
+		// instead, where the storage block's own warehouse still takes precedence.
 		if cat.Path != "" {
+			if strings.Contains(cat.Path, "://") {
+				q.Set("warehouse", cat.Path)
+
+				return "iceberg+hadoop://", q, nil
+			}
+
 			return "iceberg+hadoop://" + ensureLeadingSlash(cat.Path), q, nil
 		}
 		return "iceberg+hadoop://", q, nil

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -187,6 +187,38 @@ func TestConfig_GetIngestrURI_HadoopAndHive(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, "iceberg+hive://metastore:9083?"), "got: %s", got)
 }
 
+func TestConfig_GetIngestrURI_HadoopWarehouseURIInCatalogPath(t *testing.T) {
+	t.Parallel()
+
+	// A warehouse URI in catalog.path is not a filesystem path: in the URL path it
+	// would come back as "/s3://bucket/wh" and the catalog would treat it as local.
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogHadoop, Path: "s3://bucket/wh"},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3},
+	}
+
+	got, err := c.GetIngestrURI()
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, "iceberg+hadoop://?"), "warehouse URI must not land in the URL path, got: %s", got)
+
+	_, q := parseQuery(t, got)
+	assert.Equal(t, "s3://bucket/wh", q.Get("warehouse"))
+}
+
+func TestConfig_GetIngestrURI_HadoopStorageWarehouseWins(t *testing.T) {
+	t.Parallel()
+
+	// storage.path is the documented place for the warehouse, so it takes
+	// precedence over a URI left in catalog.path.
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogHadoop, Path: "s3://from-catalog/wh"},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: "s3://from-storage/wh"},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "s3://from-storage/wh", q.Get("warehouse"))
+}
+
 func TestConfig_GetIngestrURI_RESTUseSSL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A hadoop catalog with an object-storage warehouse in `catalog.path` cannot run:

```
hadoop catalog: failed to create namespace: mkdir /s3:: read-only file system
```

`icebergCatalogURI` puts `catalog.path` into the URL path unconditionally:

```go
if cat.Path != "" {
    return "iceberg+hadoop://" + ensureLeadingSlash(cat.Path), q, nil
}
```

For `s3://bucket/wh` that produces `iceberg+hadoop:///s3://bucket/wh`. ingestr reads the hadoop warehouse from exactly that path (`applyCatalogShorthand`, `case "iceberg+hadoop"`), so the warehouse becomes the string `/s3://bucket/wh` — no scheme, so iceberg-go's hadoop catalog treats it as a local directory and tries to `mkdir /s3:`.

A URI is not a filesystem path. `file:///tmp/wh` is mangled the same way, into `/file:///tmp/wh`.

The existing comment tells the user to leave `Path` empty and use the storage block instead, but nothing enforces that and the failure gives no hint — the field is accepted and silently produces a broken warehouse.

## Changes

If `catalog.path` contains a scheme, emit it as the `warehouse` query param — where ingestr looks for it, and where the storage block's own warehouse still takes precedence (catalog params only fill gaps). A plain filesystem path keeps going into the URL path exactly as before.