### PR TITLE
feat(fabric): support database browsing in the Databases panel

### DIFF
--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -338,6 +338,57 @@ func fromFabricValue(value any) (string, bool) {
 	}
 }
 
+// GetDatabases returns the databases available to the connection. A Fabric
+// connection is scoped to a single warehouse (there is no cross-warehouse USE),
+// so the only database we can enumerate is the configured one.
+func (db *DB) GetDatabases(ctx context.Context) ([]string, error) {
+	if db.config.Database == "" {
+		return nil, errors.New("database name not configured")
+	}
+	return []string{db.config.Database}, nil
+}
+
+// GetTablesWithSchemas returns the tables of the warehouse grouped by schema,
+// which lets the extension render a schema level in the connections tree.
+func (db *DB) GetTablesWithSchemas(ctx context.Context, databaseName string) (map[string][]string, error) {
+	if databaseName == "" {
+		databaseName = db.config.Database
+	}
+	if databaseName == "" {
+		return nil, errors.New("database name not configured")
+	}
+
+	const schemaQuery = `
+SELECT TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.tables
+WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
+ORDER BY TABLE_SCHEMA, TABLE_NAME
+`
+
+	rows, err := db.Select(ctx, &query.Query{Query: schemaQuery})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query information_schema.tables: %w", err)
+	}
+
+	schemas := make(map[string][]string)
+	for _, row := range rows {
+		if len(row) < 2 {
+			continue
+		}
+		schemaName, ok := fromFabricValue(row[0])
+		if !ok {
+			continue
+		}
+		tableName, ok := fromFabricValue(row[1])
+		if !ok {
+			continue
+		}
+		schemas[schemaName] = append(schemas[schemaName], tableName)
+	}
+
+	return schemas, nil
+}
+
 func (db *DB) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error) {
 	currentDB := db.config.Database
 	if currentDB == "" {

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -353,6 +353,8 @@ func (db *DB) GetDatabases(ctx context.Context) ([]string, error) {
 func (db *DB) GetTablesWithSchemas(ctx context.Context, databaseName string) (map[string][]string, error) {
 	if databaseName == "" {
 		databaseName = db.config.Database
+	} else if databaseName != db.config.Database {
+		return nil, fmt.Errorf("database %q does not match configured database %q", databaseName, db.config.Database)
 	}
 	if databaseName == "" {
 		return nil, errors.New("database name not configured")

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -532,3 +532,11 @@ func TestDB_GetTablesWithSchemas(t *testing.T) {
 	}, got)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestDB_GetTablesWithSchemas_MismatchedDatabase(t *testing.T) {
+	t.Parallel()
+
+	db := &DB{config: &Config{Database: "warehouse"}}
+	_, err := db.GetTablesWithSchemas(t.Context(), "other")
+	require.Error(t, err)
+}

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -485,3 +485,50 @@ func TestDB_FetchDateTimeStats(t *testing.T) {
 	assert.Equal(t, time.Date(2024, 1, 2, 11, 30, 0, 123456700, time.UTC), *got.LatestDate)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+const expectedTablesWithSchemasQuery = `
+SELECT TABLE_SCHEMA, TABLE_NAME
+FROM information_schema.tables
+WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
+ORDER BY TABLE_SCHEMA, TABLE_NAME
+`
+
+func TestDB_GetDatabases(t *testing.T) {
+	t.Parallel()
+
+	db := &DB{config: &Config{Database: "warehouse"}}
+	got, err := db.GetDatabases(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"warehouse"}, got)
+
+	dbNoName := &DB{config: &Config{}}
+	_, err = dbNoName.GetDatabases(t.Context())
+	require.Error(t, err)
+}
+
+func TestDB_GetTablesWithSchemas(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	mock.ExpectQuery(expectedTablesWithSchemasQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_SCHEMA", "TABLE_NAME"}).
+			AddRow("dbo", "customers").
+			AddRow("dbo", "orders").
+			AddRow("sales", "regions"))
+
+	db := &DB{
+		conn:   sqlx.NewDb(mockDB, "sqlmock"),
+		config: &Config{Database: "warehouse"},
+	}
+
+	got, err := db.GetTablesWithSchemas(t.Context(), "warehouse")
+	require.NoError(t, err)
+	assert.Equal(t, map[string][]string{
+		"dbo":   {"customers", "orders"},
+		"sales": {"regions"},
+	}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Fabric connections showed up in the VS Code extension's Databases panel but failed on expand with `connection type '...' does not support database fetching`. The tree drill-down needs `GetDatabases` and a table lister, which Fabric didn't implement (it only had `GetColumns` and `GetDatabaseSummary`, unlike MSSQL/Synapse which work).

This adds `GetDatabases` (returns the single configured warehouse, since Fabric has no cross-warehouse `USE`) and `GetTablesWithSchemas` (tables grouped by schema), both using Fabric-compatible `information_schema` queries rather than MSSQL's `sys.databases`/`USE`. With this the tree browses end-to-end: connection → warehouse → schema → table → columns.