### PR TITLE
fix(iceberg): keep S3-compatible storage credentials out of the catalog

### DIFF
--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -4,8 +4,8 @@ package iceberg
 
 import (
 	"fmt"
+	"net"
 	"net/url"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -56,18 +56,32 @@ func (c Config) GetIngestrURI() (string, error) {
 		return "", err
 	}
 
-	// Storage settings take precedence; catalog settings fill any gaps (ingestr
-	// aliases region/credentials into both the s3.* and glue.* namespaces).
-	// The shared credential keys are filled as a group: storage that brings its
-	// own key pair must not inherit the catalog's session token, which belongs
-	// to a different account and would be rejected.
-	storageHasOwnCredentials := hasAnySharedCredential(q)
+	// Storage settings take precedence; catalog settings fill any gaps.
 	for key, values := range catalogParams {
-		if storageHasOwnCredentials && isSharedCredentialParam(key) {
-			continue
-		}
 		if _, exists := q[key]; !exists {
 			q[key] = values
+		}
+	}
+
+	// Each block's credentials go under its own namespace (glue.* and s3.*) rather
+	// than the shared keys ingestr aliases into both: with one flat namespace it
+	// cannot tell a storage key pair from a catalog one, and would hand MinIO's to
+	// AWS Glue. Sharing is then explicit, and only between two AWS endpoints --
+	// when just one side is configured, the operator gave a single AWS account and
+	// means it for both.
+	if c.Catalog.Type == config.IcebergCatalogGlue && isAWSStorage(c.Storage) {
+		if !hasAWSCredentials(c.Storage.Auth) {
+			region := c.Storage.Region
+			if region == "" {
+				region = c.Catalog.Region
+			}
+			setS3Credentials(q, region, c.Catalog.Auth.AccessKey, c.Catalog.Auth.SecretKey, c.Catalog.Auth.SessionToken)
+		} else if !hasAWSCredentials(c.Catalog.Auth) {
+			region := c.Catalog.Region
+			if region == "" {
+				region = c.Storage.Region
+			}
+			setGlueCredentials(q, region, c.Storage.Auth.AccessKey, c.Storage.Auth.SecretKey, c.Storage.Auth.SessionToken)
 		}
 	}
 
@@ -101,10 +115,6 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 	q := url.Values{}
 	switch cat.Type {
 	case config.IcebergCatalogGlue:
-		// The shared keys keep serving storage that has no credentials of its own;
-		// glue.* pins the catalog's account so S3-compatible storage (GCS interop,
-		// MinIO, R2) with different credentials cannot overwrite it.
-		setAWSCredentials(q, cat.Region, cat.Auth.AccessKey, cat.Auth.SecretKey, cat.Auth.SessionToken)
 		setGlueCredentials(q, cat.Region, cat.Auth.AccessKey, cat.Auth.SecretKey, cat.Auth.SessionToken)
 		if cat.CatalogID != "" {
 			q.Set("glue.id", cat.CatalogID)
@@ -215,17 +225,7 @@ func icebergStorageParams(st config.IcebergStorage) (url.Values, error) {
 	if st.UseSSL != nil {
 		q.Set("use_ssl", strconv.FormatBool(*st.UseSSL))
 	}
-	// A custom endpoint means the storage is S3-compatible but not AWS (MinIO, R2,
-	// GCS interop), so its credentials are pinned to s3.*: left in the shared keys,
-	// ingestr would alias them into glue.* whenever the catalog has none of its own
-	// -- a Glue catalog relying on the ambient AWS credentials would then try to
-	// authenticate with, say, minioadmin. Real S3 keeps using the shared keys so a
-	// Glue catalog in the same account still inherits them.
-	if st.Endpoint != "" {
-		setS3Credentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
-	} else {
-		setAWSCredentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
-	}
+	setS3Credentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
 	if st.KeyFile != "" {
 		q.Set("gcs.keypath", st.KeyFile)
 	}
@@ -235,43 +235,35 @@ func icebergStorageParams(st config.IcebergStorage) (url.Values, error) {
 	return q, nil
 }
 
-// setAWSCredentials sets the shared S3/Glue region and credential parameters that
-// ingestr aliases into both the s3.* and glue.* namespaces.
-func setAWSCredentials(q url.Values, region, accessKey, secretKey, sessionToken string) {
-	if region != "" {
-		q.Set("region", region)
+// isAWSStorage reports whether the storage is AWS S3 itself rather than an
+// S3-compatible service. Regional, VPC, FIPS and dualstack endpoints all live
+// under amazonaws.com; MinIO, R2 and GCS interop do not.
+func isAWSStorage(st config.IcebergStorage) bool {
+	if st.Type == config.IcebergStorageGCS || st.Type == config.IcebergStorageLocal {
+		return false
 	}
-	if accessKey != "" {
-		q.Set("access_key_id", accessKey)
+	if st.Endpoint == "" {
+		return true
 	}
-	if secretKey != "" {
-		q.Set("secret_access_key", secretKey)
+
+	host := st.Endpoint
+	if idx := strings.Index(host, "://"); idx >= 0 {
+		host = host[idx+3:]
 	}
-	if sessionToken != "" {
-		q.Set("session_token", sessionToken)
+	host, _, _ = strings.Cut(host, "/")
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
 	}
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+
+	return host == "amazonaws.com" ||
+		strings.HasSuffix(host, ".amazonaws.com") ||
+		strings.HasSuffix(host, ".amazonaws.com.cn")
 }
 
-// sharedCredentialParams are the credential keys ingestr aliases into both the
-// s3.* and glue.* namespaces; they always come from a single account.
-var sharedCredentialParams = []string{"access_key_id", "secret_access_key", "session_token"}
-
-func isSharedCredentialParam(key string) bool {
-	return slices.Contains(sharedCredentialParams, key)
-}
-
-// storageCredentialParams are the s3.*-namespaced equivalents, set when the
-// storage is S3-compatible but not AWS.
-var storageCredentialParams = []string{"s3.access-key-id", "s3.secret-access-key", "s3.session-token"}
-
-func hasAnySharedCredential(q url.Values) bool {
-	for _, key := range append(append([]string{}, sharedCredentialParams...), storageCredentialParams...) {
-		if q.Get(key) != "" {
-			return true
-		}
-	}
-
-	return false
+// hasAWSCredentials reports whether an auth block carries an AWS key pair.
+func hasAWSCredentials(auth config.IcebergAuth) bool {
+	return auth.AccessKey != "" || auth.SecretKey != "" || auth.SessionToken != ""
 }
 
 // setS3Credentials sets the s3.*-namespaced region and credential parameters, so

--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -215,7 +215,17 @@ func icebergStorageParams(st config.IcebergStorage) (url.Values, error) {
 	if st.UseSSL != nil {
 		q.Set("use_ssl", strconv.FormatBool(*st.UseSSL))
 	}
-	setAWSCredentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
+	// A custom endpoint means the storage is S3-compatible but not AWS (MinIO, R2,
+	// GCS interop), so its credentials are pinned to s3.*: left in the shared keys,
+	// ingestr would alias them into glue.* whenever the catalog has none of its own
+	// -- a Glue catalog relying on the ambient AWS credentials would then try to
+	// authenticate with, say, minioadmin. Real S3 keeps using the shared keys so a
+	// Glue catalog in the same account still inherits them.
+	if st.Endpoint != "" {
+		setS3Credentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
+	} else {
+		setAWSCredentials(q, st.Region, st.Auth.AccessKey, st.Auth.SecretKey, st.Auth.SessionToken)
+	}
 	if st.KeyFile != "" {
 		q.Set("gcs.keypath", st.KeyFile)
 	}
@@ -250,14 +260,35 @@ func isSharedCredentialParam(key string) bool {
 	return slices.Contains(sharedCredentialParams, key)
 }
 
+// storageCredentialParams are the s3.*-namespaced equivalents, set when the
+// storage is S3-compatible but not AWS.
+var storageCredentialParams = []string{"s3.access-key-id", "s3.secret-access-key", "s3.session-token"}
+
 func hasAnySharedCredential(q url.Values) bool {
-	for _, key := range sharedCredentialParams {
+	for _, key := range append(append([]string{}, sharedCredentialParams...), storageCredentialParams...) {
 		if q.Get(key) != "" {
 			return true
 		}
 	}
 
 	return false
+}
+
+// setS3Credentials sets the s3.*-namespaced region and credential parameters, so
+// they configure the storage client and nothing else.
+func setS3Credentials(q url.Values, region, accessKey, secretKey, sessionToken string) {
+	if region != "" {
+		q.Set("s3.region", region)
+	}
+	if accessKey != "" {
+		q.Set("s3.access-key-id", accessKey)
+	}
+	if secretKey != "" {
+		q.Set("s3.secret-access-key", secretKey)
+	}
+	if sessionToken != "" {
+		q.Set("s3.session-token", sessionToken)
+	}
 }
 
 // setGlueCredentials sets the glue.*-namespaced region and credential parameters

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -83,10 +83,11 @@ func TestConfig_GetIngestrURI_GlueOnS3CompatibleStorage(t *testing.T) {
 	assert.Equal(t, "AWSSECRET", q.Get("glue.secret-access-key"))
 	assert.Equal(t, "AWSTOKEN", q.Get("glue.session-token"))
 
-	// Storage still owns the shared keys ingestr aliases into s3.*.
-	assert.Equal(t, "auto", q.Get("region"))
-	assert.Equal(t, "GOOGKID", q.Get("access_key_id"))
-	assert.Equal(t, "GOOGSECRET", q.Get("secret_access_key"))
+	// The storage has an endpoint, so its credentials are pinned to s3.*.
+	assert.Equal(t, "auto", q.Get("s3.region"))
+	assert.Equal(t, "GOOGKID", q.Get("s3.access-key-id"))
+	assert.Equal(t, "GOOGSECRET", q.Get("s3.secret-access-key"))
+	assert.Empty(t, q.Get("access_key_id"), "GCS interop keys must never reach the shared params")
 }
 
 func TestConfig_GetIngestrURI_StorageKeepsOwnCredentials(t *testing.T) {
@@ -109,9 +110,10 @@ func TestConfig_GetIngestrURI_StorageKeepsOwnCredentials(t *testing.T) {
 	}
 
 	_, q := parseQuery(t, mustURI(t, c))
-	assert.Equal(t, "minioadmin", q.Get("access_key_id"))
-	assert.Equal(t, "minioadmin", q.Get("secret_access_key"))
-	assert.Empty(t, q.Get("session_token"), "catalog session token must not leak into S3-compatible storage")
+	assert.Equal(t, "minioadmin", q.Get("s3.access-key-id"))
+	assert.Equal(t, "minioadmin", q.Get("s3.secret-access-key"))
+	assert.Empty(t, q.Get("s3.session-token"), "catalog session token must not leak into S3-compatible storage")
+	assert.Empty(t, q.Get("session_token"), "nor through the shared params, which ingestr aliases into s3.*")
 	assert.Equal(t, "AWSTOKEN", q.Get("glue.session-token"))
 }
 
@@ -164,7 +166,7 @@ func TestConfig_GetIngestrURI_SQLiteS3MinIO(t *testing.T) {
 	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "localhost:9000", q.Get("endpoint"))
 	assert.Equal(t, "false", q.Get("use_ssl"))
-	assert.Equal(t, "minioadmin", q.Get("access_key_id"))
+	assert.Equal(t, "minioadmin", q.Get("s3.access-key-id"))
 }
 
 func TestConfig_GetIngestrURI_BucketPrefixStorage(t *testing.T) {
@@ -298,6 +300,55 @@ func TestConfig_GetIngestrURI_HadoopStorageWarehouseWins(t *testing.T) {
 
 	_, q := parseQuery(t, mustURI(t, c))
 	assert.Equal(t, "s3://from-storage/wh", q.Get("warehouse"))
+}
+
+func TestConfig_GetIngestrURI_S3CompatibleStorageKeepsCredentialsToItself(t *testing.T) {
+	t.Parallel()
+
+	// The catalog has no credentials of its own: it authenticates with whatever
+	// the AWS default chain provides (env, SSO, instance role). MinIO's key pair
+	// must not reach glue.* through ingestr's aliasing, or Glue is called with it.
+	useSSL := false
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: "eu-north-1"},
+		Storage: config.IcebergStorage{
+			Type:     config.IcebergStorageS3,
+			Path:     "s3://warehouse/wh",
+			Endpoint: "localhost:9000",
+			UseSSL:   &useSSL,
+			Region:   testAWSRegion,
+			Auth:     config.IcebergAuth{AccessKey: "minioadmin", SecretKey: "minioadmin"},
+		},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "minioadmin", q.Get("s3.access-key-id"))
+	assert.Equal(t, "minioadmin", q.Get("s3.secret-access-key"))
+	assert.Equal(t, testAWSRegion, q.Get("s3.region"))
+	assert.Empty(t, q.Get("access_key_id"), "storage keys must not sit in the shared params, which ingestr aliases into glue.*")
+	assert.Empty(t, q.Get("secret_access_key"))
+	assert.Equal(t, "eu-north-1", q.Get("glue.region"))
+	assert.Empty(t, q.Get("glue.access-key-id"), "the catalog brought no credentials, so it must fall through to the default chain")
+}
+
+func TestConfig_GetIngestrURI_RealS3StillSharesCredentials(t *testing.T) {
+	t.Parallel()
+
+	// No endpoint means real AWS S3, where catalog and storage are normally the
+	// same account, so the shared keys stay put and Glue keeps inheriting them.
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
+		Storage: config.IcebergStorage{
+			Type: config.IcebergStorageS3,
+			Path: testS3LakeWh,
+			Auth: config.IcebergAuth{AccessKey: "AKID", SecretKey: "SECRET"},
+		},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "AKID", q.Get("access_key_id"))
+	assert.Equal(t, "SECRET", q.Get("secret_access_key"))
+	assert.Empty(t, q.Get("s3.access-key-id"), "real S3 keeps using the shared keys")
 }
 
 func TestConfig_GetIngestrURI_RESTUseSSL(t *testing.T) {

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -48,9 +48,11 @@ func TestConfig_GetIngestrURI_GlueS3(t *testing.T) {
 	assert.Equal(t, "iceberg+glue", scheme)
 	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
 	assert.Equal(t, "s3://company-lake/warehouse", q.Get("warehouse"))
-	assert.Equal(t, testAWSRegion, q.Get("region"))
-	assert.Equal(t, "AKID", q.Get("access_key_id"))
-	assert.Equal(t, "SECRET", q.Get("secret_access_key"))
+	assert.Equal(t, testAWSRegion, q.Get("glue.region"))
+	assert.Equal(t, "AKID", q.Get("glue.access-key-id"))
+	assert.Equal(t, "SECRET", q.Get("glue.secret-access-key"))
+	// real S3 and only the catalog configured, so the storage inherits it
+	assert.Equal(t, "AKID", q.Get("s3.access-key-id"))
 	assert.Equal(t, "123456789012", q.Get("glue.id"))
 	assert.Equal(t, "analytics", q.Get("catalog_name"))
 }
@@ -132,10 +134,10 @@ func TestConfig_GetIngestrURI_CredentialsSharedWhenStorageHasNone(t *testing.T) 
 	}
 
 	_, q := parseQuery(t, mustURI(t, c))
-	assert.Equal(t, "AKID", q.Get("access_key_id"))
-	assert.Equal(t, "SECRET", q.Get("secret_access_key"))
-	assert.Equal(t, "TOKEN", q.Get("session_token"))
-	assert.Equal(t, testAWSRegion, q.Get("region"))
+	assert.Equal(t, "AKID", q.Get("s3.access-key-id"))
+	assert.Equal(t, "SECRET", q.Get("s3.secret-access-key"))
+	assert.Equal(t, "TOKEN", q.Get("s3.session-token"))
+	assert.Equal(t, testAWSRegion, q.Get("s3.region"))
 }
 
 func TestConfig_GetIngestrURI_SQLiteS3MinIO(t *testing.T) {
@@ -214,7 +216,7 @@ func TestConfig_GetIngestrURI_PostgresS3(t *testing.T) {
 
 	_, q := parseQuery(t, got)
 	assert.Empty(t, q.Get("storage"), "storage flag is no longer emitted; the warehouse scheme carries the backend")
-	assert.Equal(t, "eu-west-1", q.Get("region"))
+	assert.Equal(t, "eu-west-1", q.Get("s3.region"))
 }
 
 func TestConfig_GetIngestrURI_RESTCatalog(t *testing.T) {
@@ -331,11 +333,38 @@ func TestConfig_GetIngestrURI_S3CompatibleStorageKeepsCredentialsToItself(t *tes
 	assert.Empty(t, q.Get("glue.access-key-id"), "the catalog brought no credentials, so it must fall through to the default chain")
 }
 
+func TestConfig_GetIngestrURI_AWSEndpointStillSharesCredentials(t *testing.T) {
+	t.Parallel()
+
+	// Regional, VPC and FIPS endpoints are still AWS, so the credentials stay in
+	// the shared keys and a Glue catalog without its own auth keeps inheriting them.
+	for _, endpoint := range []string{
+		"s3.eu-north-1.amazonaws.com",
+		"https://s3.eu-north-1.amazonaws.com",
+		"bucket.vpce-0123-abcd.s3.eu-north-1.vpce.amazonaws.com",
+		"s3-fips.us-east-1.amazonaws.com:443",
+	} {
+		c := Config{
+			Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
+			Storage: config.IcebergStorage{
+				Type:     config.IcebergStorageS3,
+				Path:     testS3LakeWh,
+				Endpoint: endpoint,
+				Auth:     config.IcebergAuth{AccessKey: "AKID", SecretKey: "SECRET"},
+			},
+		}
+
+		_, q := parseQuery(t, mustURI(t, c))
+		assert.Equalf(t, "AKID", q.Get("glue.access-key-id"), "endpoint %q is AWS, so Glue must still inherit the credentials", endpoint)
+		assert.Equalf(t, "AKID", q.Get("s3.access-key-id"), "the storage keeps its own credentials for endpoint %q", endpoint)
+	}
+}
+
 func TestConfig_GetIngestrURI_RealS3StillSharesCredentials(t *testing.T) {
 	t.Parallel()
 
 	// No endpoint means real AWS S3, where catalog and storage are normally the
-	// same account, so the shared keys stay put and Glue keeps inheriting them.
+	// same account, so credentials given on one side serve both.
 	c := Config{
 		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogGlue, Region: testAWSRegion},
 		Storage: config.IcebergStorage{
@@ -346,9 +375,10 @@ func TestConfig_GetIngestrURI_RealS3StillSharesCredentials(t *testing.T) {
 	}
 
 	_, q := parseQuery(t, mustURI(t, c))
-	assert.Equal(t, "AKID", q.Get("access_key_id"))
-	assert.Equal(t, "SECRET", q.Get("secret_access_key"))
-	assert.Empty(t, q.Get("s3.access-key-id"), "real S3 keeps using the shared keys")
+	assert.Equal(t, "AKID", q.Get("s3.access-key-id"))
+	assert.Equal(t, "SECRET", q.Get("s3.secret-access-key"))
+	assert.Equal(t, "AKID", q.Get("glue.access-key-id"), "only the storage is configured, so Glue inherits it")
+	assert.Equal(t, testAWSRegion, q.Get("glue.region"))
 }
 
 func TestConfig_GetIngestrURI_RESTUseSSL(t *testing.T) {
@@ -483,7 +513,7 @@ func TestConfig_GetIngestrURI_NoStorage(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, "iceberg+glue://?"), "got: %s", got)
 	_, q := parseQuery(t, got)
 	assert.Empty(t, q.Get("storage"))
-	assert.Equal(t, testAWSRegion, q.Get("region"))
+	assert.Equal(t, testAWSRegion, q.Get("glue.region"))
 }
 
 func TestConfig_GetIngestrURI_SQLCatalogViaProperties(t *testing.T) {
@@ -564,7 +594,7 @@ func TestConfig_GetIngestrURI_InferStorageFromScheme(t *testing.T) {
 	}
 	_, q = parseQuery(t, mustURI(t, s3))
 	assert.Equal(t, testS3LakeWh, q.Get("warehouse"))
-	assert.Equal(t, "AKID", q.Get("access_key_id"))
+	assert.Equal(t, "AKID", q.Get("s3.access-key-id"))
 
 	// file:// warehouse, no type → inferred local.
 	local := Config{


### PR DESCRIPTION
## Problem

A Glue catalog that authenticates through the AWS default chain — env vars, `aws sso`, an instance role/IRSA — calls Glue with the **storage's** credentials whenever that storage is S3-compatible but not AWS:

```
Glue: GetDatabase, api error UnrecognizedClientException:
The security token included in the request is invalid.
```

Catalog and storage credentials were both written to the same shared parameters — `region`, `access_key_id`, `secret_access_key`, `session_token` — and ingestr's `aliasIfMissing` copies those into *both* the `s3.*` and `glue.*` namespaces. With no `catalog.auth` there is nothing in `glue.*` to stop it, so MinIO's `minioadmin`, or a GCS HMAC pair, is presented to AWS Glue.

ingestr cannot resolve this on its own: its URI has one flat credential namespace, so `access_key_id=…` may legitimately mean the catalog, the storage, or both — and for a Glue catalog on real S3, aliasing it into `glue.*` is the feature that lets you write the credentials once. Only bruin knows which block a value came from, because only bruin has `catalog.auth` and `storage.auth` as separate structures.

This is the case #2478 did not cover. That one fixed a catalog **with** credentials being overwritten by storage; here the catalog has none on purpose, which is how a hosted worker or anyone running after `aws sso login` is configured.

Deterministic, and limited to Glue paired with non-AWS storage:

| catalog auth | storage auth | v0.11.705 |
|---|---|---|
| none (default chain) | none (`gs://` + keyfile) | pass |
| none (default chain) | none (real S3) | pass |
| none (default chain) | MinIO key pair | **fail** |
| none (default chain) | GCS HMAC pair | **fail** |

## Changes

Each block now emits its credentials under the namespace that names its owner, and neither writes the shared keys:

- `catalog.auth` → `glue.region`, `glue.access-key-id`, `glue.secret-access-key`, `glue.session-token`
- `storage.auth` → `s3.region`, `s3.access-key-id`, `s3.secret-access-key`, `s3.session-token`

Nothing has to be inferred to keep MinIO's key pair away from Glue: it is simply never in a parameter Glue reads.

Sharing one credential set across both is still what an operator means when only one side is filled in, so it is now copied across **explicitly**, in both directions, and only when both sides are AWS:

- catalog configured, storage not → the storage inherits it
- storage configured, catalog not → Glue inherits it, **provided the storage is AWS**

`isAWSStorage` answers only that last question. Storage with no endpoint is AWS; an endpoint is AWS when it sits under `amazonaws.com`, which covers the regional, VPC, FIPS and dualstack forms; GCS and local storage never qualify. An earlier revision of this PR used the endpoint to decide *where credentials live*, which put real S3 behind a VPC or FIPS endpoint into the S3-compatible branch and broke inheritance — thanks @greptile-apps for catching it. The check now only decides whether sharing is safe.

Since the shared keys are no longer written, the group-fill logic added in #2478 is gone with them: there is nothing left to leak between the two namespaces.