### PR TITLE
Read snake_case keys from token-API asset-instance and backfill responses

### DIFF
--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -830,7 +830,7 @@ func TestListBackfills(t *testing.T) {
 		assert.Equal(t, "pipe", r.URL.Query().Get("pipeline"))
 		assert.Equal(t, "5", r.URL.Query().Get("limit"))
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"id":"m1","project":"proj","pipeline":"pipe","interval_start":"2026-01-01T00:00:00.000Z","interval_end":"2026-01-03T00:00:00.000Z","created_at":"2026-01-01T00:00:00.000Z","runs":[{"runId":"m1__a"},{"runId":"m1__b"}]}]`))
+		_, _ = w.Write([]byte(`[{"id":"m1","project":"proj","pipeline":"pipe","interval_start":"2026-01-01T00:00:00.000Z","interval_end":"2026-01-03T00:00:00.000Z","created_at":"2026-01-01T00:00:00.000Z","runs":[{"run_id":"m1__a"},{"run_id":"m1__b"}]}]`))
 	})
 
 	backfills, err := client.ListBackfills(t.Context(), "proj", "pipe", 5)
@@ -847,7 +847,7 @@ func TestGetBackfillRuns(t *testing.T) {
 		assert.Equal(t, "/backfills/m1/runs", r.URL.Path)
 		assert.Equal(t, "30", r.URL.Query().Get("limit"))
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"project":"proj","pipeline":"pipe","runId":"m1__a","interval_start":"2026-01-01T00:00:00.000Z","interval_end":"2026-01-02T00:00:00.000Z","created_at":"2026-01-01T00:00:00.000Z","note":null}]`))
+		_, _ = w.Write([]byte(`[{"project":"proj","pipeline":"pipe","run_id":"m1__a","interval_start":"2026-01-01T00:00:00.000Z","interval_end":"2026-01-02T00:00:00.000Z","created_at":"2026-01-01T00:00:00.000Z","note":null}]`))
 	})
 
 	runs, err := client.GetBackfillRuns(t.Context(), "m1", 30, 0)

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -68,7 +68,7 @@ type Backfill struct {
 type BackfillRun struct {
 	Project       string  `json:"project"`
 	Pipeline      string  `json:"pipeline"`
-	RunID         string  `json:"runId"`
+	RunID         string  `json:"run_id"`
 	IntervalStart string  `json:"interval_start"`
 	IntervalEnd   string  `json:"interval_end"`
 	CreatedAt     string  `json:"created_at"`
@@ -197,14 +197,14 @@ type AssetInstanceResponse struct {
 type AssetInstanceInfo struct {
 	Asset                  string             `json:"asset"`
 	Type                   string             `json:"type"`
-	StartDate              string             `json:"startDate"`
-	EndDate                string             `json:"endDate"`
-	WallTimeDuration       float64            `json:"wallTimeDuration"`
-	TotalExecutionDuration float64            `json:"totalExecutionDuration"`
+	StartDate              string             `json:"start_date"`
+	EndDate                string             `json:"end_date"`
+	WallTimeDuration       float64            `json:"wall_time_duration"`
+	TotalExecutionDuration float64            `json:"total_execution_duration"`
 	Status                 string             `json:"status"`
-	IsFinished             bool               `json:"isFinished"`
+	IsFinished             bool               `json:"is_finished"`
 	Steps                  AssetInstanceSteps `json:"steps"`
-	StepIDs                []string           `json:"stepIds"`
+	StepIDs                []string           `json:"step_ids"`
 }
 
 // AssetInstanceSteps represents the steps of an asset instance.


### PR DESCRIPTION
## What

Paired with cloud PR bruin-data/cloud#2829, which makes the token API emit **snake_case** on the endpoints that previously leaked camelCase from raw domain objects. This updates the CLI decode structs to match:

- `BackfillRun.RunID`: `json:"runId"` → `json:"run_id"` — consumed by `/backfills` and `/backfills/{id}/runs`.
- `AssetInstanceInfo`: `startDate`, `endDate`, `wallTimeDuration`, `totalExecutionDuration`, `isFinished`, `stepIds` → snake_case — consumed by `/asset-instances-for-run`.

Nested `steps` (`StepInstance`) stay camelCase — the cloud side keeps them camelCase (shared with the web UI), so no change here.

## Must ship with the cloud PR

These are decode tags, so this and cloud#2829 must land together — otherwise the affected fields decode empty.

Side effect: the instances command's `--output json` field names change camel → snake, matching the rest of the CLI output.