### PR TITLE
Add Fabric Lakehouse Spark SQL support

### DIFF
--- a/cmd/fabric_spark.go
+++ b/cmd/fabric_spark.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/fabric"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+)
+
+// assetConnectionResolver resolves the connection an asset executes against,
+// including the asset types whose client is derived from another connection
+// type. Derived clients are built once and shared, so a command that walks many
+// assets reuses a single Fabric Spark session per connection instead of opening
+// one per asset.
+type assetConnectionResolver struct {
+	connections config.ConnectionAndDetailsGetter
+
+	fabricSparkOnce sync.Once
+	fabricSpark     *fabric.SparkConnectionGetter
+}
+
+func newAssetConnectionResolver(connections config.ConnectionAndDetailsGetter) *assetConnectionResolver {
+	return &assetConnectionResolver{connections: connections}
+}
+
+func (r *assetConnectionResolver) Resolve(
+	ctx context.Context,
+	assetType pipeline.AssetType,
+	connectionName string,
+) (any, error) {
+	if assetType == pipeline.AssetTypeFabricSparkQuery {
+		r.fabricSparkOnce.Do(func() {
+			r.fabricSpark = fabric.NewSparkConnectionGetter(r.connections)
+		})
+		return r.fabricSpark.ResolveSparkClient(ctx, connectionName)
+	}
+	connection := r.connections.GetConnection(connectionName)
+	if connection == nil {
+		return nil, config.NewConnectionNotFoundError(ctx, "", connectionName)
+	}
+	return connection, nil
+}
+
+// resolveConnectionForAsset resolves a single asset's connection. Callers that
+// resolve connections for more than one asset should build an
+// assetConnectionResolver once and reuse it instead.
+func resolveConnectionForAsset(
+	ctx context.Context,
+	connections config.ConnectionAndDetailsGetter,
+	assetType pipeline.AssetType,
+	connectionName string,
+) (any, error) {
+	return newAssetConnectionResolver(connections).Resolve(ctx, assetType, connectionName)
+}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -969,9 +969,9 @@ func getConnectionFromPipelineInfoWithContext(ctx context.Context, pipelineInfo 
 		return "", nil, errors.Wrap(err, "failed to get connection")
 	}
 
-	conn := manager.GetConnection(connName)
-	if conn == nil {
-		return "", nil, config.NewConnectionNotFoundError(ctx, "", connName)
+	conn, err := resolveConnectionForAsset(ctx, manager, pipelineInfo.Asset.Type, connName)
+	if err != nil {
+		return "", nil, err
 	}
 
 	return connName, conn, nil

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -300,6 +300,7 @@ func Render() *cli.Command {
 					pipeline.AssetTypeSailQuery:               sail.NewMaterializer(fullRefresh),
 					pipeline.AssetTypeSailQuerySensor:         sail.NewMaterializer(fullRefresh),
 					pipeline.AssetTypeSparkQuery:              spark.NewRenderer(fullRefresh),
+					pipeline.AssetTypeFabricSparkQuery:        spark.NewRenderer(fullRefresh),
 					pipeline.AssetTypeSparkQuerySensor:        spark.NewRenderer(fullRefresh),
 					pipeline.AssetTypeOracleQuery:             oracle.NewMaterializer(fullRefresh),
 					pipeline.AssetTypeMsSQLQuery:              mssql.NewMaterializer(fullRefresh),

--- a/cmd/render_ddl.go
+++ b/cmd/render_ddl.go
@@ -240,6 +240,7 @@ func RenderDDL() *cli.Command {
 					pipeline.AssetTypeSailQuery:               sail.NewMaterializer(false),
 					pipeline.AssetTypeSailQuerySensor:         sail.NewMaterializer(false),
 					pipeline.AssetTypeSparkQuery:              spark.NewRenderer(false),
+					pipeline.AssetTypeFabricSparkQuery:        spark.NewRenderer(false),
 					pipeline.AssetTypeSparkQuerySensor:        spark.NewRenderer(false),
 					pipeline.AssetTypeOracleQuery:             oracle.NewMaterializer(false),
 					pipeline.AssetTypeMsSQLQuery:              mssql.NewMaterializer(false),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2195,6 +2195,27 @@ func SetupExecutors(
 			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = customCheckRunner
 		}
 	}
+	if s.WillRunTaskOfType(pipeline.AssetTypeFabricSparkQuery) || estimateCustomCheckType == pipeline.AssetTypeFabricSparkQuery {
+		fabricSparkConnections := fabric.NewSparkConnectionGetter(conn)
+		fabricSparkFileExtractor := &query.FileQuerySplitterExtractor{
+			Fs:                        fs,
+			Renderer:                  renderer,
+			PreserveSessionStatements: true,
+			BackslashEscapes:          true,
+		}
+		fabricSparkOperator := spark.NewBasicOperator(fabricSparkConnections, fabricSparkFileExtractor, fullRefresh, hoister, parser)
+		fabricSparkCheckRunner := spark.NewColumnCheckOperator(fabricSparkConnections)
+		fabricSparkCustomCheckRunner := ansisql.NewCustomCheckOperator(fabricSparkConnections, renderer)
+
+		mainExecutors[pipeline.AssetTypeFabricSparkQuery][scheduler.TaskInstanceTypeMain] = fabricSparkOperator
+		mainExecutors[pipeline.AssetTypeFabricSparkQuery][scheduler.TaskInstanceTypeColumnCheck] = fabricSparkCheckRunner
+		mainExecutors[pipeline.AssetTypeFabricSparkQuery][scheduler.TaskInstanceTypeCustomCheck] = fabricSparkCustomCheckRunner
+
+		if estimateCustomCheckType == pipeline.AssetTypeFabricSparkQuery {
+			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeColumnCheck] = fabricSparkCheckRunner
+			mainExecutors[pipeline.AssetTypePython][scheduler.TaskInstanceTypeCustomCheck] = fabricSparkCustomCheckRunner
+		}
+	}
 	if s.WillRunTaskOfType(pipeline.AssetTypeOracleQuery) || s.WillRunTaskOfType(pipeline.AssetTypeOracleSource) || estimateCustomCheckType == pipeline.AssetTypeOracleQuery {
 		oracleFileExtractor := &query.OracleScriptExtractor{
 			Fs:       fs,

--- a/cmd/unittest.go
+++ b/cmd/unittest.go
@@ -96,6 +96,10 @@ func UnitTest() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
+			// Built once so that assets sharing a connection also share the
+			// clients derived from it.
+			connectionResolver := newAssetConnectionResolver(manager)
+
 			passed, failed := 0, 0
 			for _, target := range targets {
 				// Macros are per-pipeline, so load them for each pipeline tested.
@@ -106,7 +110,7 @@ func UnitTest() *cli.Command {
 				}
 				schemas := assetColumnSchemas(target.pipeline)
 				for _, asset := range target.assets {
-					p, f := runAssetUnitTests(ctx, parser, manager, target.pipeline, asset, startDate, endDate, macroContent, schemas)
+					p, f := runAssetUnitTests(ctx, parser, connectionResolver, target.pipeline, asset, startDate, endDate, macroContent, schemas)
 					passed += p
 					failed += f
 				}
@@ -223,7 +227,7 @@ func resolveConnectionManager(ctx context.Context, pipelinePath, env string) (co
 // Each test is compiled to a single read-only CTE-injected query (no DDL, no
 // artifacts on the target), run via the connection, and compared. Returns
 // pass/fail counts.
-func runAssetUnitTests(ctx context.Context, parser unittest.Rewriter, manager config.ConnectionAndDetailsGetter, pl *pipeline.Pipeline, asset *pipeline.Asset, startDate, endDate time.Time, macroContent string, schemas map[string][]pipeline.Column) (passed, failed int) {
+func runAssetUnitTests(ctx context.Context, parser unittest.Rewriter, connections *assetConnectionResolver, pl *pipeline.Pipeline, asset *pipeline.Asset, startDate, endDate time.Time, macroContent string, schemas map[string][]pipeline.Column) (passed, failed int) {
 	if len(asset.UnitTests) == 0 {
 		return 0, 0
 	}
@@ -239,7 +243,12 @@ func runAssetUnitTests(ctx context.Context, parser unittest.Rewriter, manager co
 		errorPrinter.Printf("ERROR  %s — failed to resolve the connection: %v\n", asset.Name, err)
 		return 0, len(asset.UnitTests)
 	}
-	querier, ok := manager.GetConnection(connName).(schemaQuerier)
+	connection, err := connections.Resolve(ctx, asset.Type, connName)
+	if err != nil {
+		errorPrinter.Printf("ERROR  %s — failed to resolve connection %q: %v\n", asset.Name, connName, err)
+		return 0, len(asset.UnitTests)
+	}
+	querier, ok := connection.(schemaQuerier)
 	if !ok {
 		errorPrinter.Printf("ERROR  %s — connection %q is missing or cannot run queries\n", asset.Name, connName)
 		return 0, len(asset.UnitTests)

--- a/docs/platforms/fabric.md
+++ b/docs/platforms/fabric.md
@@ -33,7 +33,7 @@ https://app.fabric.microsoft.com/groups/<workspace_id>/lakehouses/<lakehouse_id>
 
 If `use_azure_default_credential: true` is set, the connector uses Azure's DefaultAzureCredential chain. You can authenticate locally with Azure CLI (`az login`).
 
-If a connection sets `use_azure_default_credential: true` *and* the service principal fields, the default credential wins on every execution path — Warehouse, Spark, and ingestr — so one connection always authenticates as a single identity.
+Configure only one Microsoft Entra authentication method per connection. For backward compatibility, Warehouse and Spark use the default credential when both methods are configured, while ingestr continues to use the service principal.
 
 ### Service principal (client secret)
 
@@ -122,7 +122,7 @@ FROM raw.events
 GROUP BY event_date
 ```
 
-Fabric Spark SQL authenticates with Microsoft Entra ID using the parent connection's credentials, following the same [precedence](#azure-ad-defaultazurecredential) as the rest of the platform. When using a service principal, all three of `client_id`, `client_secret`, and `tenant_id` must be set. The authenticated identity must have permission to execute jobs on the Lakehouse.
+Fabric Spark SQL authenticates with Microsoft Entra ID using the parent connection's credentials. When using a service principal, all three of `client_id`, `client_secret`, and `tenant_id` must be set. The authenticated identity must have permission to execute jobs on the Lakehouse.
 
 ## Using Fabric with Ingestr
 

--- a/docs/platforms/fabric.md
+++ b/docs/platforms/fabric.md
@@ -1,10 +1,10 @@
-# Microsoft Fabric Warehouse
+# Microsoft Fabric
 
-Bruin supports Microsoft Fabric Warehouse through the SQL endpoint (TDS protocol) using the `go-mssqldb` driver. Fabric is case-sensitive for identifiers, so use quoted identifiers or consistent casing in asset names.
+Bruin supports Microsoft Fabric Warehouse through the SQL endpoint (TDS protocol) and Fabric Lakehouses through the Fabric Livy API and Spark SQL. Both execution engines can share one Fabric connection and its Microsoft Entra credentials.
 
 ## Connection configuration
 
-Add a Fabric Warehouse connection under `fabric`:
+Add a Fabric connection under `fabric`. The optional `lakehouse` block enables Spark SQL assets without requiring a second `spark` connection:
 
 ```yaml
 # .bruin.yml
@@ -17,12 +17,23 @@ environments:
           port: 1433
           database: your_warehouse
           use_azure_default_credential: true
+          lakehouse:
+            workspace_id: "<workspace GUID>"
+            lakehouse_id: "<lakehouse GUID>"
           # options: "encrypt=true&TrustServerCertificate=false" # optional
+```
+
+`host`, `port`, and `database` configure the Warehouse SQL endpoint. They are required on every Fabric connection, even one used only for `fabric.spark_sql` assets, so point them at your workspace's SQL analytics endpoint. `lakehouse.workspace_id` and `lakehouse.lakehouse_id` identify the Lakehouse used by `fabric.spark_sql`; authentication is inherited from the parent Fabric connection. The IDs are visible in the Fabric Lakehouse URL:
+
+```text
+https://app.fabric.microsoft.com/groups/<workspace_id>/lakehouses/<lakehouse_id>
 ```
 
 ### Azure AD (DefaultAzureCredential)
 
 If `use_azure_default_credential: true` is set, the connector uses Azure's DefaultAzureCredential chain. You can authenticate locally with Azure CLI (`az login`).
+
+If a connection sets `use_azure_default_credential: true` *and* the service principal fields, the default credential wins on every execution path — Warehouse, Spark, and ingestr — so one connection always authenticates as a single identity.
 
 ### Service principal (client secret)
 
@@ -56,11 +67,12 @@ environments:
 ```
 
 > [!NOTE]
-> SQL authentication is only available for native Fabric assets (`fabric.sql`, `fabric.seed`, sensors). Using Fabric as an [ingestr](#using-fabric-with-ingestr) source or destination requires Microsoft Entra ID authentication — username/password connections are rejected.
+> SQL authentication is only available for Warehouse assets (`fabric.sql`, `fabric.seed`, sensors). Using `fabric.spark_sql` or Fabric as an [ingestr](#using-fabric-with-ingestr) source or destination requires Microsoft Entra ID authentication — username/password connections are rejected.
 
 ## Asset types
 
 - `fabric.sql`
+- `fabric.spark_sql`
 - `fabric.seed`
 - `fabric.sensor.query`
 - `fabric.sensor.table`
@@ -91,6 +103,26 @@ SELECT
 FROM source_table
 WHERE modified_date > '{{ start_date }}'
 ```
+
+## Spark SQL on a Lakehouse
+
+Use `fabric.spark_sql` to execute Spark SQL through the [Fabric Livy API](https://learn.microsoft.com/fabric/data-engineering/api-livy-overview). It uses the same Spark SQL execution, checks, Jinja functions, and materialization machinery as `spark.sql`, while resolving the named connection from the `fabric` section.
+
+```sql
+/* @bruin
+name: analytics.daily_events
+type: fabric.spark_sql
+connection: fabric-default
+materialization:
+  type: table
+@bruin */
+
+SELECT event_date, COUNT(*) AS event_count
+FROM raw.events
+GROUP BY event_date
+```
+
+Fabric Spark SQL authenticates with Microsoft Entra ID using the parent connection's credentials, following the same [precedence](#azure-ad-defaultazurecredential) as the rest of the platform. When using a service principal, all three of `client_id`, `client_secret`, and `tenant_id` must be set. The authenticated identity must have permission to execute jobs on the Lakehouse.
 
 ## Using Fabric with Ingestr
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -2244,6 +2244,9 @@
         },
         "tenant_id": {
           "type": "string"
+        },
+        "lakehouse": {
+          "$ref": "#/$defs/FabricLakehouseConfig"
         }
       },
       "additionalProperties": false,
@@ -2253,6 +2256,22 @@
         "host",
         "port",
         "database"
+      ]
+    },
+    "FabricLakehouseConfig": {
+      "properties": {
+        "workspace_id": {
+          "type": "string"
+        },
+        "lakehouse_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "workspace_id",
+        "lakehouse_id"
       ]
     },
     "FacebookAdsConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -268,16 +268,24 @@ func (c SynapseConnection) GetName() string {
 
 type FabricConnection struct {
 	ConnectionMetadata        `yaml:",inline" mapstructure:",squash"`
-	Host                      string `yaml:"host,omitempty"     json:"host" mapstructure:"host"`
-	Port                      int    `yaml:"port,omitempty"     json:"port" mapstructure:"port" jsonschema:"default=1433"`
-	Database                  string `yaml:"database,omitempty" json:"database" mapstructure:"database"`
-	Username                  string `yaml:"username,omitempty" json:"username,omitempty" mapstructure:"username"`
-	Password                  string `yaml:"password,omitempty" json:"password,omitempty" mapstructure:"password" sensitive:"true"`
-	Options                   string `yaml:"options,omitempty"  json:"options,omitempty" mapstructure:"options"`
-	UseAzureDefaultCredential bool   `yaml:"use_azure_default_credential,omitempty" json:"use_azure_default_credential,omitempty" mapstructure:"use_azure_default_credential"`
-	ClientID                  string `yaml:"client_id,omitempty" json:"client_id,omitempty" mapstructure:"client_id"`
-	ClientSecret              string `yaml:"client_secret,omitempty" json:"client_secret,omitempty" mapstructure:"client_secret" sensitive:"true"`
-	TenantID                  string `yaml:"tenant_id,omitempty" json:"tenant_id,omitempty" mapstructure:"tenant_id"`
+	Host                      string                 `yaml:"host,omitempty"     json:"host" mapstructure:"host"`
+	Port                      int                    `yaml:"port,omitempty"     json:"port" mapstructure:"port" jsonschema:"default=1433"`
+	Database                  string                 `yaml:"database,omitempty" json:"database" mapstructure:"database"`
+	Username                  string                 `yaml:"username,omitempty" json:"username,omitempty" mapstructure:"username"`
+	Password                  string                 `yaml:"password,omitempty" json:"password,omitempty" mapstructure:"password" sensitive:"true"`
+	Options                   string                 `yaml:"options,omitempty"  json:"options,omitempty" mapstructure:"options"`
+	UseAzureDefaultCredential bool                   `yaml:"use_azure_default_credential,omitempty" json:"use_azure_default_credential,omitempty" mapstructure:"use_azure_default_credential"`
+	ClientID                  string                 `yaml:"client_id,omitempty" json:"client_id,omitempty" mapstructure:"client_id"`
+	ClientSecret              string                 `yaml:"client_secret,omitempty" json:"client_secret,omitempty" mapstructure:"client_secret" sensitive:"true"`
+	TenantID                  string                 `yaml:"tenant_id,omitempty" json:"tenant_id,omitempty" mapstructure:"tenant_id"`
+	Lakehouse                 *FabricLakehouseConfig `yaml:"lakehouse,omitempty" json:"lakehouse,omitempty" mapstructure:"lakehouse"`
+}
+
+// FabricLakehouseConfig identifies the Lakehouse used by Fabric Spark assets.
+// Authentication is inherited from the parent Fabric connection.
+type FabricLakehouseConfig struct {
+	WorkspaceID string `yaml:"workspace_id,omitempty" json:"workspace_id" mapstructure:"workspace_id"`
+	LakehouseID string `yaml:"lakehouse_id,omitempty" json:"lakehouse_id" mapstructure:"lakehouse_id"`
 }
 
 func (c FabricConnection) GetName() string {

--- a/pkg/executor/defaults.go
+++ b/pkg/executor/defaults.go
@@ -627,6 +627,12 @@ var DefaultExecutorsV2 = map[pipeline.AssetType]Config{
 		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},
 		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
 	},
+	pipeline.AssetTypeFabricSparkQuery: {
+		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
+		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},
+		scheduler.TaskInstanceTypeColumnCheck:  NoOpOperator{},
+		scheduler.TaskInstanceTypeCustomCheck:  NoOpOperator{},
+	},
 	pipeline.AssetTypeSparkSeed: {
 		scheduler.TaskInstanceTypeMain:         NoOpOperator{},
 		scheduler.TaskInstanceTypeMetadataPush: NoOpOperator{},

--- a/pkg/fabric/config.go
+++ b/pkg/fabric/config.go
@@ -84,11 +84,9 @@ func (c *Config) ToDBConnectionURI() string {
 }
 
 // GetIngestrURI builds the URI ingestr expects for a Microsoft Fabric Warehouse
-// source/destination. Fabric only supports Microsoft Entra ID authentication, so
-// use_azure_default_credential produces an ActiveDirectoryDefault URI and the client
-// credentials produce a service-principal one. Default credential takes precedence when
-// both are set, matching ToDBConnectionURI and fabricSparkConfig, so that one Fabric
-// connection authenticates as the same identity on every execution path. SQL
+// source/destination. Fabric only supports Microsoft Entra ID authentication, so a
+// service-principal URI is produced when client credentials are set, falling back to
+// ActiveDirectoryDefault when use_azure_default_credential is enabled. SQL
 // username/password auth is rejected because Fabric Warehouse has no such login.
 //
 //	fabric://<client_id>:<client_secret>@<host>:<port>/<database>?tenant_id=<tenant_id>
@@ -104,10 +102,7 @@ func (c *Config) GetIngestrURI() (string, error) {
 	}
 
 	query := url.Values{}
-	switch {
-	case c.UseAzureDefaultCredential:
-		query.Set("fedauth", "ActiveDirectoryDefault")
-	case c.ClientID != "":
+	if c.ClientID != "" {
 		if c.ClientSecret != "" {
 			u.User = url.UserPassword(c.ClientID, c.ClientSecret)
 		} else {
@@ -116,6 +111,8 @@ func (c *Config) GetIngestrURI() (string, error) {
 		if c.TenantID != "" {
 			query.Set("tenant_id", c.TenantID)
 		}
+	} else {
+		query.Set("fedauth", "ActiveDirectoryDefault")
 	}
 
 	u.RawQuery = query.Encode()

--- a/pkg/fabric/config.go
+++ b/pkg/fabric/config.go
@@ -84,9 +84,11 @@ func (c *Config) ToDBConnectionURI() string {
 }
 
 // GetIngestrURI builds the URI ingestr expects for a Microsoft Fabric Warehouse
-// source/destination. Fabric only supports Microsoft Entra ID authentication, so a
-// service-principal URI is produced when client credentials are set, falling back to
-// ActiveDirectoryDefault when use_azure_default_credential is enabled. SQL
+// source/destination. Fabric only supports Microsoft Entra ID authentication, so
+// use_azure_default_credential produces an ActiveDirectoryDefault URI and the client
+// credentials produce a service-principal one. Default credential takes precedence when
+// both are set, matching ToDBConnectionURI and fabricSparkConfig, so that one Fabric
+// connection authenticates as the same identity on every execution path. SQL
 // username/password auth is rejected because Fabric Warehouse has no such login.
 //
 //	fabric://<client_id>:<client_secret>@<host>:<port>/<database>?tenant_id=<tenant_id>
@@ -102,7 +104,10 @@ func (c *Config) GetIngestrURI() (string, error) {
 	}
 
 	query := url.Values{}
-	if c.ClientID != "" {
+	switch {
+	case c.UseAzureDefaultCredential:
+		query.Set("fedauth", "ActiveDirectoryDefault")
+	case c.ClientID != "":
 		if c.ClientSecret != "" {
 			u.User = url.UserPassword(c.ClientID, c.ClientSecret)
 		} else {
@@ -111,8 +116,6 @@ func (c *Config) GetIngestrURI() (string, error) {
 		if c.TenantID != "" {
 			query.Set("tenant_id", c.TenantID)
 		}
-	} else {
-		query.Set("fedauth", "ActiveDirectoryDefault")
 	}
 
 	u.RawQuery = query.Encode()

--- a/pkg/fabric/config_test.go
+++ b/pkg/fabric/config_test.go
@@ -60,8 +60,7 @@ func TestConfig_ToDBConnectionURI(t *testing.T) {
 		assert.Equal(t, azuread.DriverName, c.DriverName())
 	})
 
-	// fabricSparkConfig mirrors this precedence so that one Fabric connection
-	// authenticates as the same identity on the Warehouse and Spark engines.
+	// fabricSparkConfig mirrors the Warehouse path's existing precedence.
 	t.Run("azure default credential wins over service principal", func(t *testing.T) {
 		t.Parallel()
 		c := Config{
@@ -125,9 +124,9 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 		assert.Equal(t, "fabric://fabric.example:1433/warehouse?fedauth=ActiveDirectoryDefault", uri)
 	})
 
-	// Matches ToDBConnectionURI and fabricSparkConfig, so a connection that sets
-	// both authenticates as one identity on every execution path.
-	t.Run("azure default credential wins over service principal", func(t *testing.T) {
+	// Keep the existing ingestr precedence for connections that already set both
+	// modes: explicit service-principal credentials win over ambient credentials.
+	t.Run("service principal wins over azure default credential", func(t *testing.T) {
 		t.Parallel()
 		c := Config{
 			Host:                      "fabric.example",
@@ -140,7 +139,7 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 
 		uri, err := c.GetIngestrURI()
 		require.NoError(t, err)
-		assert.Equal(t, "fabric://fabric.example:1433/warehouse?fedauth=ActiveDirectoryDefault", uri)
+		assert.Equal(t, "fabric://client-id:secret@fabric.example:1433/warehouse?tenant_id=tenant-id", uri)
 	})
 
 	t.Run("sql auth is rejected", func(t *testing.T) {

--- a/pkg/fabric/config_test.go
+++ b/pkg/fabric/config_test.go
@@ -59,6 +59,24 @@ func TestConfig_ToDBConnectionURI(t *testing.T) {
 		assert.Contains(t, uri, "fedauth=ActiveDirectoryServicePrincipal")
 		assert.Equal(t, azuread.DriverName, c.DriverName())
 	})
+
+	// fabricSparkConfig mirrors this precedence so that one Fabric connection
+	// authenticates as the same identity on the Warehouse and Spark engines.
+	t.Run("azure default credential wins over service principal", func(t *testing.T) {
+		t.Parallel()
+		c := Config{
+			Host:                      "fabric.example",
+			Database:                  "warehouse",
+			UseAzureDefaultCredential: true,
+			ClientID:                  "client-id",
+			ClientSecret:              "secret",
+			TenantID:                  "tenant-id",
+		}
+
+		uri := c.ToDBConnectionURI()
+		assert.Contains(t, uri, "fedauth=ActiveDirectoryDefault")
+		assert.NotContains(t, uri, "fedauth=ActiveDirectoryServicePrincipal")
+	})
 }
 
 func TestConfig_GetIngestrURI(t *testing.T) {
@@ -100,6 +118,24 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 			Host:                      "fabric.example",
 			Database:                  "warehouse",
 			UseAzureDefaultCredential: true,
+		}
+
+		uri, err := c.GetIngestrURI()
+		require.NoError(t, err)
+		assert.Equal(t, "fabric://fabric.example:1433/warehouse?fedauth=ActiveDirectoryDefault", uri)
+	})
+
+	// Matches ToDBConnectionURI and fabricSparkConfig, so a connection that sets
+	// both authenticates as one identity on every execution path.
+	t.Run("azure default credential wins over service principal", func(t *testing.T) {
+		t.Parallel()
+		c := Config{
+			Host:                      "fabric.example",
+			Database:                  "warehouse",
+			UseAzureDefaultCredential: true,
+			ClientID:                  "client-id",
+			ClientSecret:              "secret",
+			TenantID:                  "tenant-id",
 		}
 
 		uri, err := c.GetIngestrURI()

--- a/pkg/fabric/spark.go
+++ b/pkg/fabric/spark.go
@@ -1,0 +1,138 @@
+package fabric
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/spark"
+	"github.com/pkg/errors"
+)
+
+const (
+	fabricSparkHost = "api.fabric.microsoft.com:443"
+	fabricLivyAPI   = "2023-12-01"
+)
+
+// SparkConnectionGetter resolves a Fabric connection as a Spark client while
+// leaving the connection manager's regular Fabric/TDS client untouched.
+type SparkConnectionGetter struct {
+	connections config.ConnectionDetailsGetter
+
+	mu      sync.Mutex
+	clients map[string]*spark.Client
+}
+
+func NewSparkConnectionGetter(connections config.ConnectionDetailsGetter) *SparkConnectionGetter {
+	return &SparkConnectionGetter{
+		connections: connections,
+		clients:     make(map[string]*spark.Client),
+	}
+}
+
+// GetConnection implements config.ConnectionGetter. Callers that support
+// spark.ClientResolver use ResolveSparkClient directly and retain configuration
+// errors; generic check runners receive nil when the Fabric Spark configuration
+// is invalid.
+func (g *SparkConnectionGetter) GetConnection(name string) any {
+	client, err := g.ResolveSparkClient(context.Background(), name)
+	if err != nil {
+		return nil
+	}
+	return client
+}
+
+// ResolveSparkClient builds and caches the Spark client derived from a Fabric
+// connection's shared Entra credentials and Lakehouse coordinates.
+func (g *SparkConnectionGetter) ResolveSparkClient(ctx context.Context, name string) (*spark.Client, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if client, ok := g.clients[name]; ok {
+		return client, nil
+	}
+	if connectionType := g.connections.GetConnectionType(name); connectionType != "fabric" {
+		if connectionType == "" {
+			return nil, errors.Errorf("connection %q does not exist", name)
+		}
+		return nil, errors.Errorf("connection %q is a %s connection, not a Fabric connection", name, connectionType)
+	}
+
+	details, ok := g.connections.GetConnectionDetails(name).(*config.FabricConnection)
+	if !ok || details == nil {
+		return nil, errors.Errorf("connection %q does not contain Fabric connection details", name)
+	}
+	sparkConfig, err := fabricSparkConfig(details)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid Fabric Spark configuration for connection %q", name)
+	}
+	client, err := spark.NewClient(ctx, sparkConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create Fabric Spark client for connection %q", name)
+	}
+	g.clients[name] = client
+	return client, nil
+}
+
+func fabricSparkConfig(connection *config.FabricConnection) (spark.Config, error) {
+	if connection.Lakehouse == nil {
+		return spark.Config{}, errors.New("lakehouse configuration is required; set lakehouse.workspace_id and lakehouse.lakehouse_id")
+	}
+	workspaceID := strings.TrimSpace(connection.Lakehouse.WorkspaceID)
+	lakehouseID := strings.TrimSpace(connection.Lakehouse.LakehouseID)
+	if workspaceID == "" || lakehouseID == "" {
+		return spark.Config{}, errors.New("both lakehouse.workspace_id and lakehouse.lakehouse_id are required")
+	}
+
+	endpoint := &url.URL{Scheme: "spark", Host: fabricSparkHost}
+	var credential string
+	switch {
+	// use_azure_default_credential takes precedence over the service principal
+	// fields, matching ToDBConnectionURI, so that one Fabric connection
+	// authenticates as the same identity on both execution engines.
+	case connection.UseAzureDefaultCredential:
+		credential = "ActiveDirectoryDefault"
+	case connection.ClientID != "" || connection.ClientSecret != "" || connection.TenantID != "":
+		missing := make([]string, 0, 3)
+		if connection.ClientID == "" {
+			missing = append(missing, "client_id")
+		}
+		if connection.ClientSecret == "" {
+			missing = append(missing, "client_secret")
+		}
+		if connection.TenantID == "" {
+			missing = append(missing, "tenant_id")
+		}
+		if len(missing) > 0 {
+			return spark.Config{}, fmt.Errorf("service principal authentication requires %s", strings.Join(missing, ", "))
+		}
+		endpoint.User = url.UserPassword(connection.ClientID+"@"+connection.TenantID, connection.ClientSecret)
+		credential = "ActiveDirectoryServicePrincipal"
+	default:
+		return spark.Config{}, errors.New("Microsoft Entra authentication is required; set client_id/client_secret/tenant_id or use_azure_default_credential")
+	}
+
+	baseURL := fmt.Sprintf(
+		"/v1/workspaces/%s/lakehouses/%s/livyapi/versions/%s",
+		url.PathEscape(workspaceID),
+		url.PathEscape(lakehouseID),
+		fabricLivyAPI,
+	)
+	// net/url leaves semicolons unescaped in userinfo, while the ADBC
+	// database/sql bridge uses them as DSN option delimiters.
+	uri := strings.ReplaceAll(endpoint.String(), ";", "%3B")
+	return spark.Config{
+		URI: uri,
+		Options: map[string]string{
+			"spark.api":                   "livy",
+			"spark.auth_type":             "azure_token",
+			"spark.livy.azure.credential": credential,
+			"spark.livy.base_url":         baseURL,
+			"spark.livy.session_kind":     "sql",
+			"spark.tls":                   "true",
+		},
+	}, nil
+}

--- a/pkg/fabric/spark_test.go
+++ b/pkg/fabric/spark_test.go
@@ -1,0 +1,194 @@
+package fabric
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type fabricSparkConnectionDetails struct {
+	connectionType string
+	details        any
+}
+
+func (f fabricSparkConnectionDetails) GetConnectionDetails(string) any {
+	return f.details
+}
+
+func (f fabricSparkConnectionDetails) GetConnectionType(string) string {
+	return f.connectionType
+}
+
+func TestFabricSparkConfigWithDefaultCredential(t *testing.T) {
+	t.Parallel()
+
+	got, err := fabricSparkConfig(&config.FabricConnection{
+		UseAzureDefaultCredential: true,
+		Lakehouse: &config.FabricLakehouseConfig{
+			WorkspaceID: "workspace-id",
+			LakehouseID: "lakehouse-id",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "spark://api.fabric.microsoft.com:443", got.URI)
+	require.Equal(t, map[string]string{
+		"spark.api":                   "livy",
+		"spark.auth_type":             "azure_token",
+		"spark.livy.azure.credential": "ActiveDirectoryDefault",
+		"spark.livy.base_url":         "/v1/workspaces/workspace-id/lakehouses/lakehouse-id/livyapi/versions/2023-12-01",
+		"spark.livy.session_kind":     "sql",
+		"spark.tls":                   "true",
+	}, got.Options)
+}
+
+func TestFabricLakehouseConfigParsesFromYAML(t *testing.T) {
+	t.Parallel()
+
+	var connection config.FabricConnection
+	err := yaml.Unmarshal([]byte(`
+name: fabric-default
+use_azure_default_credential: true
+lakehouse:
+  workspace_id: workspace-id
+  lakehouse_id: lakehouse-id
+`), &connection)
+	require.NoError(t, err)
+	require.NotNil(t, connection.Lakehouse)
+	require.Equal(t, "workspace-id", connection.Lakehouse.WorkspaceID)
+	require.Equal(t, "lakehouse-id", connection.Lakehouse.LakehouseID)
+}
+
+func TestFabricSparkConfigWithServicePrincipal(t *testing.T) {
+	t.Parallel()
+
+	got, err := fabricSparkConfig(&config.FabricConnection{
+		ClientID:     "client-id",
+		ClientSecret: "secret:/?#[]@!$&'()*+,;=",
+		TenantID:     "tenant-id",
+		Lakehouse: &config.FabricLakehouseConfig{
+			WorkspaceID: "workspace-id",
+			LakehouseID: "lakehouse-id",
+		},
+	})
+	require.NoError(t, err)
+	parsed, err := url.Parse(got.URI)
+	require.NoError(t, err)
+	require.Equal(t, "client-id@tenant-id", parsed.User.Username())
+	password, present := parsed.User.Password()
+	require.True(t, present)
+	require.Equal(t, "secret:/?#[]@!$&'()*+,;=", password)
+	require.Equal(t, "ActiveDirectoryServicePrincipal", got.Options["spark.livy.azure.credential"])
+	_, err = got.ToDSN()
+	require.NoError(t, err)
+}
+
+// The Warehouse path (ToDBConnectionURI) lets use_azure_default_credential win
+// over the service principal fields, so Spark has to agree — otherwise one
+// connection authenticates as two different identities.
+func TestFabricSparkConfigPrefersDefaultCredentialOverServicePrincipal(t *testing.T) {
+	t.Parallel()
+
+	got, err := fabricSparkConfig(&config.FabricConnection{
+		UseAzureDefaultCredential: true,
+		ClientID:                  "client-id",
+		ClientSecret:              "client-secret",
+		TenantID:                  "tenant-id",
+		Lakehouse: &config.FabricLakehouseConfig{
+			WorkspaceID: "workspace-id",
+			LakehouseID: "lakehouse-id",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ActiveDirectoryDefault", got.Options["spark.livy.azure.credential"])
+	require.Equal(t, "spark://api.fabric.microsoft.com:443", got.URI)
+
+	// The unused service principal secret must not reach the Livy DSN.
+	parsed, err := url.Parse(got.URI)
+	require.NoError(t, err)
+	require.Nil(t, parsed.User)
+	require.NotContains(t, got.URI, "client-secret")
+}
+
+func TestFabricSparkConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		connection *config.FabricConnection
+		want       string
+	}{
+		{
+			name:       "missing Lakehouse",
+			connection: &config.FabricConnection{UseAzureDefaultCredential: true},
+			want:       "lakehouse configuration is required",
+		},
+		{
+			name: "missing Lakehouse ID",
+			connection: &config.FabricConnection{
+				UseAzureDefaultCredential: true,
+				Lakehouse:                 &config.FabricLakehouseConfig{WorkspaceID: "workspace-id"},
+			},
+			want: "both lakehouse.workspace_id and lakehouse.lakehouse_id are required",
+		},
+		{
+			name: "missing service principal fields",
+			connection: &config.FabricConnection{
+				ClientID:  "client-id",
+				Lakehouse: &config.FabricLakehouseConfig{WorkspaceID: "workspace-id", LakehouseID: "lakehouse-id"},
+			},
+			want: "service principal authentication requires client_secret, tenant_id",
+		},
+		{
+			name: "SQL authentication",
+			connection: &config.FabricConnection{
+				Username:  "user",
+				Password:  "password",
+				Lakehouse: &config.FabricLakehouseConfig{WorkspaceID: "workspace-id", LakehouseID: "lakehouse-id"},
+			},
+			want: "Microsoft Entra authentication is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := fabricSparkConfig(tt.connection)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestSparkConnectionGetterResolvesAndCachesClient(t *testing.T) {
+	t.Parallel()
+
+	connection := &config.FabricConnection{
+		UseAzureDefaultCredential: true,
+		Lakehouse: &config.FabricLakehouseConfig{
+			WorkspaceID: "workspace-id",
+			LakehouseID: "lakehouse-id",
+		},
+	}
+	getter := NewSparkConnectionGetter(fabricSparkConnectionDetails{
+		connectionType: "fabric",
+		details:        connection,
+	})
+
+	first, err := getter.ResolveSparkClient(context.Background(), "fabric-default")
+	require.NoError(t, err)
+	second, err := getter.ResolveSparkClient(context.Background(), "fabric-default")
+	require.NoError(t, err)
+	require.Same(t, first, second)
+	require.Same(t, first, getter.GetConnection("fabric-default"))
+}
+
+func TestSparkConnectionGetterRejectsNonFabricConnection(t *testing.T) {
+	t.Parallel()
+
+	getter := NewSparkConnectionGetter(fabricSparkConnectionDetails{connectionType: "spark"})
+	_, err := getter.ResolveSparkClient(context.Background(), "spark-default")
+	require.ErrorContains(t, err, "not a Fabric connection")
+}

--- a/pkg/fabric/spark_test.go
+++ b/pkg/fabric/spark_test.go
@@ -86,9 +86,8 @@ func TestFabricSparkConfigWithServicePrincipal(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// The Warehouse path (ToDBConnectionURI) lets use_azure_default_credential win
-// over the service principal fields, so Spark has to agree — otherwise one
-// connection authenticates as two different identities.
+// Match the Warehouse path's existing precedence when both modes are present.
+// Ingestr separately preserves its historical service-principal precedence.
 func TestFabricSparkConfigPrefersDefaultCredentialOverServicePrincipal(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/jinja/bruin_funcs_test.go
+++ b/pkg/jinja/bruin_funcs_test.go
@@ -735,6 +735,7 @@ func TestPlatformForAssetType(t *testing.T) {
 		{pipeline.AssetTypeMotherduckQuery, PlatformDuckDB},
 		{pipeline.AssetTypeDatabricksQuery, PlatformDatabricks},
 		{pipeline.AssetTypeSparkQuery, PlatformSpark},
+		{pipeline.AssetTypeFabricSparkQuery, PlatformSpark},
 		{pipeline.AssetTypeAthenaQuery, PlatformAthena},
 		{pipeline.AssetTypeTrinoQuery, PlatformTrino},
 		{pipeline.AssetTypeSynapseQuery, PlatformSynapse},

--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -392,6 +392,7 @@ var assetTypePlatform = map[pipeline.AssetType]Platform{
 	pipeline.AssetTypeDatabricksTableSensor: PlatformDatabricks,
 
 	pipeline.AssetTypeSparkQuery:       PlatformSpark,
+	pipeline.AssetTypeFabricSparkQuery: PlatformSpark,
 	pipeline.AssetTypeSparkSeed:        PlatformSpark,
 	pipeline.AssetTypeSparkQuerySensor: PlatformSpark,
 	pipeline.AssetTypeSparkSource:      PlatformSpark,

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -86,6 +86,7 @@ const (
 	AssetTypeMsSQLSource               = AssetType("ms.source")
 	AssetTypeMsSQLTableSensor          = AssetType("ms.sensor.table")
 	AssetTypeFabricQuery               = AssetType("fabric.sql")
+	AssetTypeFabricSparkQuery          = AssetType("fabric.spark_sql")
 	AssetTypeFabricQuerySensor         = AssetType("fabric.sensor.query")
 	AssetTypeFabricSeed                = AssetType("fabric.seed")
 	AssetTypeFabricTableSensor         = AssetType("fabric.sensor.table")
@@ -934,6 +935,7 @@ var AssetTypeConnectionMapping = map[AssetType]string{
 	AssetTypeMsSQLTableSensor:          "mssql",
 	AssetTypeMsSQLSource:               "mssql",
 	AssetTypeFabricQuery:               "fabric",
+	AssetTypeFabricSparkQuery:          "fabric",
 	AssetTypeFabricSeed:                "fabric",
 	AssetTypeFabricQuerySensor:         "fabric",
 	AssetTypeFabricTableSensor:         "fabric",
@@ -2529,6 +2531,7 @@ func (p *Pipeline) GetMajorityAssetTypesFromSQLAssets(defaultIfNone AssetType) A
 		AssetTypeRedshiftQuery:     0,
 		AssetTypeSynapseQuery:      0,
 		AssetTypeFabricQuery:       0,
+		AssetTypeFabricSparkQuery:  0,
 		AssetTypeFabricQueryLegacy: 0,
 		AssetTypeAthenaQuery:       0,
 		AssetTypeDuckDBQuery:       0,
@@ -4007,6 +4010,7 @@ func IsSQLAssetType(t AssetType) bool {
 		AssetTypeDatabricksQuery,
 		AssetTypeSynapseQuery,
 		AssetTypeFabricQuery,
+		AssetTypeFabricSparkQuery,
 		AssetTypeFabricQueryLegacy,
 		AssetTypeAthenaQuery,
 		AssetTypeDuckDBQuery,

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -54,6 +54,7 @@ func sqlQueryAssetTypes() []pipeline.AssetType {
 		pipeline.AssetTypeDremioQuery,
 		pipeline.AssetTypeDuckDBQuery,
 		pipeline.AssetTypeFabricQuery,
+		pipeline.AssetTypeFabricSparkQuery,
 		pipeline.AssetTypeFabricQueryLegacy,
 		pipeline.AssetTypeMotherduckQuery,
 		pipeline.AssetTypeMsSQLQuery,
@@ -824,6 +825,19 @@ func TestPipeline_GetConnectionNameForAsset(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "postgres-default", found)
+	})
+
+	t.Run("Fabric Spark assets reuse the Fabric default connection", func(t *testing.T) {
+		t.Parallel()
+		fabricPipeline := &pipeline.Pipeline{
+			Name:               "fabric-pipeline",
+			DefaultConnections: map[string]string{"fabric": "shared-fabric"},
+		}
+		found, err := fabricPipeline.GetConnectionNameForAsset(&pipeline.Asset{
+			Type: pipeline.AssetTypeFabricSparkQuery,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "shared-fabric", found)
 	})
 
 	t.Run("motherduck SQL assets resolve motherduck default connections", func(t *testing.T) {

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -803,6 +803,9 @@ type SQLFileInfo struct {
 // DetectDialectFromAssetType extracts the dialect from an asset's type field
 // by splitting on the first dot and mapping the prefix.
 func DetectDialectFromAssetType(assetType string) string {
+	if assetType == string(pipeline.AssetTypeFabricSparkQuery) {
+		return "sparksql"
+	}
 	parts := strings.Split(assetType, ".")
 	if len(parts) == 0 {
 		return "ansi" // fallback to ANSI SQL

--- a/pkg/python/uv_pyproject_test.go
+++ b/pkg/python/uv_pyproject_test.go
@@ -29,6 +29,11 @@ func TestDetectDialectFromAssetType(t *testing.T) {
 			want:      "tsql",
 		},
 		{
+			name:      "fabric Spark assets use Spark SQL",
+			assetType: string(pipeline.AssetTypeFabricSparkQuery),
+			want:      "sparksql",
+		},
+		{
 			name:      "mssql uses tsql",
 			assetType: string(pipeline.AssetTypeMsSQLQuery),
 			want:      "tsql",

--- a/pkg/spark/operator.go
+++ b/pkg/spark/operator.go
@@ -31,6 +31,12 @@ type devEnv interface {
 	RegisterAssetForSchemaCache(ctx context.Context, p *pipeline.Pipeline, a *pipeline.Asset, q *query.Query) error
 }
 
+// ClientResolver allows execution backends such as Microsoft Fabric to derive
+// a Spark client from another Bruin connection type.
+type ClientResolver interface {
+	ResolveSparkClient(ctx context.Context, name string) (*Client, error)
+}
+
 type BasicOperator struct {
 	connection   config.ConnectionGetter
 	extractor    query.QueryExtractor
@@ -77,13 +83,9 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, asset 
 	if err != nil {
 		return err
 	}
-	rawConnection := o.connection.GetConnection(connectionName)
-	if rawConnection == nil {
-		return config.NewConnectionNotFoundError(ctx, "", connectionName)
-	}
-	connection, ok := rawConnection.(*Client)
-	if !ok {
-		return errors.Errorf("connection '%s' is not a Spark connection", connectionName)
+	connection, err := resolveClient(ctx, o.connection, connectionName)
+	if err != nil {
+		return err
 	}
 	materialized, err := o.renderQueries(asset, queries)
 	if err != nil {
@@ -145,6 +147,21 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, asset 
 		return errors.Wrap(err, "cannot register asset for schema cache")
 	}
 	return nil
+}
+
+func resolveClient(ctx context.Context, connections config.ConnectionGetter, name string) (*Client, error) {
+	if resolver, ok := connections.(ClientResolver); ok {
+		return resolver.ResolveSparkClient(ctx, name)
+	}
+	rawConnection := connections.GetConnection(name)
+	if rawConnection == nil {
+		return nil, config.NewConnectionNotFoundError(ctx, "", name)
+	}
+	connection, ok := rawConnection.(*Client)
+	if !ok {
+		return nil, errors.Errorf("connection '%s' is not a Spark connection", name)
+	}
+	return connection, nil
 }
 
 func (o BasicOperator) renderQueries(asset *pipeline.Asset, queries []*query.Query) (string, error) {

--- a/pkg/spark/operator_test.go
+++ b/pkg/spark/operator_test.go
@@ -37,6 +37,20 @@ func (g sparkConnectionGetter) GetConnection(string) any {
 	return g.connection
 }
 
+type resolvingSparkConnectionGetter struct {
+	client       *Client
+	resolvedName string
+}
+
+func (g *resolvingSparkConnectionGetter) GetConnection(string) any {
+	return nil
+}
+
+func (g *resolvingSparkConnectionGetter) ResolveSparkClient(_ context.Context, name string) (*Client, error) {
+	g.resolvedName = name
+	return g.client, nil
+}
+
 type sparkOperatorExtractor struct {
 	extractCount int
 }
@@ -257,6 +271,31 @@ func TestBasicOperatorQueryAnnotations(t *testing.T) {
 	}
 	require.Contains(t, connection.queries[0], "SET spark.sql.shuffle.partitions = 8")
 	require.Contains(t, connection.queries[1], "SELECT 1")
+}
+
+func TestBasicOperatorUsesSparkClientResolver(t *testing.T) {
+	t.Parallel()
+
+	connection := &recordingConnection{}
+	resolver := &resolvingSparkConnectionGetter{client: &Client{connection: connection}}
+	operator := BasicOperator{
+		connection:   resolver,
+		extractor:    &sparkOperatorExtractor{},
+		materializer: sparkOperatorMaterializer{},
+		devEnv:       nil,
+	}
+	asset := &pipeline.Asset{
+		Name:       "analytics.asset",
+		Type:       pipeline.AssetTypeFabricSparkQuery,
+		Connection: "shared-fabric",
+		ExecutableFile: pipeline.ExecutableFile{
+			Content: "SELECT 1",
+		},
+	}
+
+	require.NoError(t, operator.RunTask(t.Context(), &pipeline.Pipeline{Name: "pipeline"}, asset))
+	require.Equal(t, "shared-fabric", resolver.resolvedName)
+	require.NotEmpty(t, connection.queries)
 }
 
 func TestBasicOperatorQueryAnnotationsDisabled(t *testing.T) {

--- a/pkg/sqlparser/parser.go
+++ b/pkg/sqlparser/parser.go
@@ -353,6 +353,7 @@ var assetTypeDialectMap = map[pipeline.AssetType]string{
 	pipeline.AssetTypeDremioQuery:       "trino",
 	pipeline.AssetTypeSailQuery:         "trino",
 	pipeline.AssetTypeSparkQuery:        "spark",
+	pipeline.AssetTypeFabricSparkQuery:  "spark",
 	pipeline.AssetTypeClickHouse:        "clickhouse",
 	pipeline.AssetTypeDatabricksQuery:   "databricks",
 	pipeline.AssetTypeMsSQLQuery:        "tsql",

--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -1428,6 +1428,7 @@ func TestAssetTypeToDialect(t *testing.T) {
 		pipeline.AssetTypeDremioQuery:       "trino",
 		pipeline.AssetTypeDuckDBQuery:       "duckdb",
 		pipeline.AssetTypeFabricQuery:       "fabric",
+		pipeline.AssetTypeFabricSparkQuery:  "spark",
 		pipeline.AssetTypeFabricQueryLegacy: "fabric",
 		pipeline.AssetTypeMotherduckQuery:   "duckdb",
 		pipeline.AssetTypeMsSQLQuery:        "tsql",


### PR DESCRIPTION
## What
Adds `fabric.spark_sql` so Fabric Lakehouse jobs reuse an existing Fabric connection and its Microsoft Entra credentials.

## Changes
- Add the Fabric Livy adapter and route Spark SQL execution, checks, rendering, fetch, and unit tests through it.
- Add Lakehouse configuration, consistent auth precedence, tests, schema expectations, and docs.

## How to test
1. `make format`
2. `make test`
3. `make build`
4. `(cd integration-tests && env SILENT=1 SF_DISABLE_MINICORE=true go test -tags=no_duckdb_arrow -count=1 -run '^TestIndividualTasks$/^internal-connections$' .)`

## Risk & rollback
- **Risk:** Medium; live execution requires a published Spark ADBC release containing the merged Fabric Livy support.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
N/A
