### PR TITLE
Harden Vault secrets client

### DIFF
--- a/cmd/secrets_backend.go
+++ b/cmd/secrets_backend.go
@@ -54,7 +54,7 @@ func connectionManagerFromConfig(ctx context.Context, cm *config.Config, log log
 	case "":
 		return connection.NewManagerFromConfigWithContext(ctx, cm)
 	case "vault":
-		manager, err := secrets.NewVaultClientFromEnv(log) //nolint:contextcheck
+		manager, err := secrets.NewVaultClientFromEnvContext(ctx, log)
 		if err != nil {
 			return nil, []error{fmt.Errorf("failed to initialize vault client: %w", err)}
 		}

--- a/docs/secrets/vault.md
+++ b/docs/secrets/vault.md
@@ -26,6 +26,19 @@ Bruin connects to Vault using environment variables. The following are required:
 - either `BRUIN_VAULT_TOKEN` or `BRUIN_VAULT_ROLE`: The authentication token for Vault access, or if you are running Bruin inside a Kubernetes cluster, you can use a Kubernetes role for authentication with Vault by setting the `BRUIN_VAULT_ROLE` environment variable in your pod or deployment.
 - `BRUIN_VAULT_K8S_AUTH_MOUNT` (optional): The Kubernetes auth mount path in Vault. Defaults to `"kubernetes"` if not set.
 
+Bruin automatically retries transient network errors and Vault responses such as HTTP 429, 412, and most 5xx errors. Retries use exponential backoff with jitter and honor `Retry-After` responses. Authentication and secret reads share one overall timeout per operation, so retry waits cannot make a request hang indefinitely.
+
+The retry and timeout settings can be tuned with these optional environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BRUIN_VAULT_TIMEOUT` | `30s` | Overall timeout for one Vault authentication or secret-read operation, including retries. Uses Go duration syntax such as `500ms`, `10s`, or `1m`. |
+| `BRUIN_VAULT_MAX_RETRIES` | `3` | Maximum retries after the initial request. Set to `0` to disable retries. |
+| `BRUIN_VAULT_RETRY_WAIT_MIN` | `200ms` | Minimum backoff used to calculate retry delays. |
+| `BRUIN_VAULT_RETRY_WAIT_MAX` | `2s` | Maximum backoff used to calculate retry delays. Must be at least the minimum. |
+
+Use an `https://` Vault address for remote clusters so Vault tokens and secret data are encrypted in transit. Plain HTTP remains available for local Vault agents and development servers.
+
 ## Storing Secrets in Vault
 
 Bruin expects connection credentials to be stored in Vault using a path convention based on the connection name. By default, secrets are stored at `{BRUIN_VAULT_MOUNT_PATH}/data/{BRUIN_VAULT_PATH}/{secret/connection name}`.

--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -4,19 +4,53 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/connection"
 	"github.com/bruin-data/bruin/pkg/logger"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/vault-client-go"
 	"github.com/hashicorp/vault-client-go/schema"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 )
 
+const (
+	defaultVaultRequestTimeout = 30 * time.Second
+	defaultVaultRetryWaitMin   = 200 * time.Millisecond
+	defaultVaultRetryWaitMax   = 2 * time.Second
+	defaultVaultRetryMax       = 3
+)
+
+type vaultClientConfig struct {
+	requestTimeout time.Duration
+	retryWaitMin   time.Duration
+	retryWaitMax   time.Duration
+	retryMax       int
+}
+
+func defaultVaultClientConfig() vaultClientConfig {
+	return vaultClientConfig{
+		requestTimeout: defaultVaultRequestTimeout,
+		retryWaitMin:   defaultVaultRetryWaitMin,
+		retryWaitMax:   defaultVaultRetryWaitMax,
+		retryMax:       defaultVaultRetryMax,
+	}
+}
+
 func NewVaultClientFromEnv(logger logger.Logger) (*Client, error) {
+	return NewVaultClientFromEnvContext(context.Background(), logger)
+}
+
+func NewVaultClientFromEnvContext(ctx context.Context, logger logger.Logger) (*Client, error) {
 	host := os.Getenv("BRUIN_VAULT_HOST")
 	if host == "" {
 		return nil, errors.New("BRUIN_VAULT_HOST env variable not set")
@@ -39,12 +73,27 @@ func NewVaultClientFromEnv(logger logger.Logger) (*Client, error) {
 		kubernetesAuthMountPath = "kubernetes"
 	}
 
-	return NewVaultClient(logger, host, token, role, path, mountPath, kubernetesAuthMountPath)
+	clientConfig, err := vaultClientConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	return newVaultClient(ctx, logger, host, token, role, path, mountPath, kubernetesAuthMountPath, clientConfig)
 }
 
 func NewVaultClient(logger logger.Logger, host, token, role, path string, mountPath string, kubernetesAuthMountPath string) (*Client, error) {
+	return newVaultClient(context.Background(), logger, host, token, role, path, mountPath, kubernetesAuthMountPath, defaultVaultClientConfig())
+}
+
+func newVaultClient(ctx context.Context, logger logger.Logger, host, token, role, path string, mountPath string, kubernetesAuthMountPath string, clientConfig vaultClientConfig) (*Client, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context provided")
+	}
 	if host == "" {
 		return nil, errors.New("empty vault host provided")
+	}
+	if err := validateVaultAddress(host); err != nil {
+		return nil, err
 	}
 	if path == "" {
 		return nil, errors.New("empty vault path provided")
@@ -53,13 +102,86 @@ func NewVaultClient(logger logger.Logger, host, token, role, path string, mountP
 		return nil, errors.New("empty vault mountpath provided")
 	}
 	if token != "" {
-		return newVaultClientWithToken(host, token, mountPath, logger, path)
+		return newVaultClientWithToken(ctx, host, token, mountPath, logger, path, clientConfig)
 	}
 	if role != "" {
-		return newVaultClientWithKubernetesAuth(host, role, mountPath, kubernetesAuthMountPath, logger, path)
+		return newVaultClientWithKubernetesAuth(ctx, host, role, mountPath, kubernetesAuthMountPath, logger, path, clientConfig)
 	}
 
 	return nil, errors.New("no vault credentials provided")
+}
+
+func vaultClientConfigFromEnv() (vaultClientConfig, error) {
+	clientConfig := defaultVaultClientConfig()
+
+	var err error
+	clientConfig.requestTimeout, err = durationFromEnv("BRUIN_VAULT_TIMEOUT", clientConfig.requestTimeout)
+	if err != nil {
+		return vaultClientConfig{}, err
+	}
+	clientConfig.retryWaitMin, err = durationFromEnv("BRUIN_VAULT_RETRY_WAIT_MIN", clientConfig.retryWaitMin)
+	if err != nil {
+		return vaultClientConfig{}, err
+	}
+	clientConfig.retryWaitMax, err = durationFromEnv("BRUIN_VAULT_RETRY_WAIT_MAX", clientConfig.retryWaitMax)
+	if err != nil {
+		return vaultClientConfig{}, err
+	}
+
+	if value := os.Getenv("BRUIN_VAULT_MAX_RETRIES"); value != "" {
+		clientConfig.retryMax, err = strconv.Atoi(value)
+		if err != nil || clientConfig.retryMax < 0 {
+			return vaultClientConfig{}, errors.New("BRUIN_VAULT_MAX_RETRIES must be a non-negative integer")
+		}
+	}
+
+	if clientConfig.retryWaitMax < clientConfig.retryWaitMin {
+		return vaultClientConfig{}, errors.New("BRUIN_VAULT_RETRY_WAIT_MAX must be greater than or equal to BRUIN_VAULT_RETRY_WAIT_MIN")
+	}
+
+	return clientConfig, nil
+}
+
+func durationFromEnv(name string, defaultValue time.Duration) (time.Duration, error) {
+	value := os.Getenv(name)
+	if value == "" {
+		return defaultValue, nil
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return 0, errors.Errorf("%s must be a positive duration", name)
+	}
+
+	return duration, nil
+}
+
+func validateVaultAddress(address string) error {
+	parsed, err := url.Parse(address)
+	if err != nil {
+		return errors.Wrap(err, "invalid Vault host")
+	}
+	if parsed.User != nil {
+		return errors.New("invalid Vault host: URL credentials are not allowed")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("invalid Vault host: query parameters and fragments are not allowed")
+	}
+
+	switch parsed.Scheme {
+	case "http", "https":
+		if parsed.Host == "" {
+			return errors.New("invalid Vault host: HTTP(S) URL must include a host")
+		}
+	case "unix":
+		if strings.TrimPrefix(address, "unix://") == "" {
+			return errors.New("invalid Vault host: unix URL must include a socket path")
+		}
+	default:
+		return errors.New("invalid Vault host: URL scheme must be http, https, or unix")
+	}
+
+	return nil
 }
 
 type kvV2Reader interface {
@@ -71,15 +193,55 @@ type Client struct {
 	mountPath               string
 	path                    string
 	logger                  logger.Logger
+	ctx                     context.Context
+	requestTimeout          time.Duration
+	cacheMu                 sync.RWMutex
+	managerRequests         singleflight.Group
+	cacheManagers           map[string]config.ConnectionAndDetailsGetter
 	cacheConnections        map[string]any
 	cacheConnectionsDetails map[string]any
 }
 
-func newVaultClientWithToken(host, token, mountPath string, logger logger.Logger, path string) (*Client, error) {
+func newVaultAPIClient(host string, clientConfig vaultClientConfig) (*vault.Client, error) {
 	client, err := vault.New(
 		vault.WithAddress(host),
-		vault.WithRequestTimeout(30*time.Second),
+		vault.WithRequestTimeout(clientConfig.requestTimeout),
+		vault.WithRetryConfiguration(vault.RetryConfiguration{
+			RetryWaitMin: clientConfig.retryWaitMin,
+			RetryWaitMax: clientConfig.retryWaitMax,
+			RetryMax:     clientConfig.retryMax,
+			Backoff:      vaultRetryBackoff,
+		}),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func vaultRetryBackoff(minimum, maximum time.Duration, attempt int, response *http.Response) time.Duration {
+	delay := retryablehttp.DefaultBackoff(minimum, maximum, attempt, response)
+	if delay <= 1 || responseHasRetryAfter(response) {
+		return delay
+	}
+
+	// Equal jitter prevents clients from retrying in lockstep while retaining a
+	// useful minimum delay. The request context still caps the total wait.
+	half := delay / 2
+	return half + time.Duration(rand.Int64N(int64(delay-half)+1))
+}
+
+func responseHasRetryAfter(response *http.Response) bool {
+	if response == nil || (response.StatusCode != http.StatusTooManyRequests && response.StatusCode != http.StatusServiceUnavailable) {
+		return false
+	}
+
+	return response.Header.Get("Retry-After") != ""
+}
+
+func newVaultClientWithToken(ctx context.Context, host, token, mountPath string, logger logger.Logger, path string, clientConfig vaultClientConfig) (*Client, error) {
+	client, err := newVaultAPIClient(host, clientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -88,21 +250,11 @@ func newVaultClientWithToken(host, token, mountPath string, logger logger.Logger
 		return nil, errors.Wrap(err, "failed to set token on Vault client")
 	}
 
-	return &Client{
-		client:                  &client.Secrets,
-		mountPath:               mountPath,
-		path:                    path,
-		logger:                  logger,
-		cacheConnections:        make(map[string]any),
-		cacheConnectionsDetails: make(map[string]any),
-	}, nil
+	return newClient(ctx, &client.Secrets, mountPath, logger, path, clientConfig.requestTimeout), nil
 }
 
-func newVaultClientWithKubernetesAuth(host, role, mountPath, kubernetesAuthMountPath string, logger logger.Logger, path string) (*Client, error) {
-	client, err := vault.New(
-		vault.WithAddress(host),
-		vault.WithRequestTimeout(30*time.Second),
-	)
+func newVaultClientWithKubernetesAuth(ctx context.Context, host, role, mountPath, kubernetesAuthMountPath string, logger logger.Logger, path string, clientConfig vaultClientConfig) (*Client, error) {
+	client, err := newVaultAPIClient(host, clientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -112,24 +264,50 @@ func newVaultClientWithKubernetesAuth(host, role, mountPath, kubernetesAuthMount
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read service account token")
 	}
-
-	resp, err := client.Auth.KubernetesLogin(context.Background(), schema.KubernetesLoginRequest{Jwt: string(token), Role: role}, vault.WithMountPath(kubernetesAuthMountPath))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to login to the secrets backend")
+	serviceAccountToken := strings.TrimSpace(string(token))
+	if serviceAccountToken == "" {
+		return nil, errors.New("service account token is empty")
 	}
 
-	if err := client.SetToken(resp.Auth.ClientToken); err != nil {
+	authContext, cancel := context.WithTimeout(ctx, clientConfig.requestTimeout)
+	defer cancel()
+
+	clientToken, err := loginToVaultWithKubernetes(authContext, client, serviceAccountToken, role, kubernetesAuthMountPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.SetToken(clientToken); err != nil {
 		return nil, errors.Wrap(err, "failed to set token on secrets client")
 	}
 
+	return newClient(ctx, &client.Secrets, mountPath, logger, path, clientConfig.requestTimeout), nil
+}
+
+func loginToVaultWithKubernetes(ctx context.Context, client *vault.Client, serviceAccountToken, role, kubernetesAuthMountPath string) (string, error) {
+	resp, err := client.Auth.KubernetesLogin(ctx, schema.KubernetesLoginRequest{Jwt: serviceAccountToken, Role: role}, vault.WithMountPath(kubernetesAuthMountPath))
+	if err != nil {
+		return "", sanitizedVaultError(err, "failed to login to the secrets backend")
+	}
+	if resp == nil || resp.Auth == nil || strings.TrimSpace(resp.Auth.ClientToken) == "" {
+		return "", errors.New("failed to login to the secrets backend: Vault returned no client token")
+	}
+
+	return resp.Auth.ClientToken, nil
+}
+
+func newClient(ctx context.Context, client kvV2Reader, mountPath string, logger logger.Logger, path string, requestTimeout time.Duration) *Client {
 	return &Client{
-		client:                  &client.Secrets,
+		client:                  client,
 		mountPath:               mountPath,
 		path:                    path,
 		logger:                  logger,
+		ctx:                     ctx,
+		requestTimeout:          requestTimeout,
+		cacheManagers:           make(map[string]config.ConnectionAndDetailsGetter),
 		cacheConnections:        make(map[string]any),
 		cacheConnectionsDetails: make(map[string]any),
-	}, nil
+	}
 }
 
 func (c *Client) GetConnection(name string) any {
@@ -144,9 +322,12 @@ func (c *Client) GetConnection(name string) any {
 
 // ResolveConnection implements config.ConnectionResolver.
 func (c *Client) ResolveConnection(name string) (any, error) {
+	c.cacheMu.RLock()
 	if conn, ok := c.cacheConnections[name]; ok {
+		c.cacheMu.RUnlock()
 		return conn, nil
 	}
+	c.cacheMu.RUnlock()
 
 	manager, err := c.getVaultManager(name)
 	if err != nil {
@@ -154,15 +335,23 @@ func (c *Client) ResolveConnection(name string) (any, error) {
 	}
 
 	conn := manager.GetConnection(name)
+	c.cacheMu.Lock()
+	if c.cacheConnections == nil {
+		c.cacheConnections = make(map[string]any)
+	}
 	c.cacheConnections[name] = conn
+	c.cacheMu.Unlock()
 
 	return conn, nil
 }
 
 func (c *Client) GetConnectionDetails(name string) any {
+	c.cacheMu.RLock()
 	if deets, ok := c.cacheConnectionsDetails[name]; ok {
+		c.cacheMu.RUnlock()
 		return deets
 	}
+	c.cacheMu.RUnlock()
 
 	manager, err := c.getVaultManager(name)
 	if err != nil {
@@ -171,7 +360,12 @@ func (c *Client) GetConnectionDetails(name string) any {
 	}
 
 	deets := manager.GetConnectionDetails(name)
+	c.cacheMu.Lock()
+	if c.cacheConnectionsDetails == nil {
+		c.cacheConnectionsDetails = make(map[string]any)
+	}
 	c.cacheConnectionsDetails[name] = deets
+	c.cacheMu.Unlock()
 
 	return deets
 }
@@ -185,7 +379,61 @@ func (c *Client) GetConnectionType(name string) string {
 }
 
 func (c *Client) getVaultManager(name string) (config.ConnectionAndDetailsGetter, error) {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 30*time.Second)
+	if strings.TrimSpace(name) == "" {
+		return nil, errors.New("cannot read a Vault secret with an empty name")
+	}
+
+	c.cacheMu.RLock()
+	manager, ok := c.cacheManagers[name]
+	c.cacheMu.RUnlock()
+	if ok {
+		return manager, nil
+	}
+
+	result, err, _ := c.managerRequests.Do(name, func() (any, error) {
+		c.cacheMu.RLock()
+		manager, ok := c.cacheManagers[name]
+		c.cacheMu.RUnlock()
+		if ok {
+			return manager, nil
+		}
+
+		manager, err := c.fetchVaultManager(name)
+		if err != nil {
+			return nil, err
+		}
+
+		c.cacheMu.Lock()
+		if c.cacheManagers == nil {
+			c.cacheManagers = make(map[string]config.ConnectionAndDetailsGetter)
+		}
+		c.cacheManagers[name] = manager
+		c.cacheMu.Unlock()
+
+		return manager, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	manager, ok = result.(config.ConnectionAndDetailsGetter)
+	if !ok {
+		return nil, errors.New("failed to process Vault secret manager")
+	}
+
+	return manager, nil
+}
+
+func (c *Client) fetchVaultManager(name string) (config.ConnectionAndDetailsGetter, error) {
+	requestTimeout := c.requestTimeout
+	if requestTimeout <= 0 {
+		requestTimeout = defaultVaultRequestTimeout
+	}
+	baseContext := c.ctx
+	if baseContext == nil {
+		baseContext = context.Background()
+	}
+	ctx, cancelFunc := context.WithTimeout(baseContext, requestTimeout)
 	defer cancelFunc()
 
 	secretPath := fmt.Sprintf("%s/%s", c.path, name)
@@ -195,18 +443,17 @@ func (c *Client) getVaultManager(name string) (config.ConnectionAndDetailsGetter
 		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
 			return nil, errors.Errorf("secret '%s' not found in Vault", name)
 		}
-		return nil, errors.Wrapf(err, "failed to read secret '%s' from Vault", name)
+		return nil, sanitizedVaultError(err, fmt.Sprintf("failed to read secret '%s' from Vault", name))
+	}
+	if res == nil {
+		return nil, errors.Errorf("failed to read secret '%s' from Vault: Vault returned an empty response", name)
 	}
 
 	detailsRaw, okDetails := res.Data.Data["details"]
 	secretType, okType := res.Data.Data["type"].(string)
-	if !okDetails && !okType {
-		return nil, errors.Errorf("secret '%s' is missing required 'details' or 'type' fields", name)
-	}
-
 	details, ok := detailsRaw.(map[string]any)
-	if !ok {
-		return nil, errors.Errorf("secret '%s' has invalid 'details' field: expected a map", name)
+	if !okDetails || !ok || !okType || strings.TrimSpace(secretType) == "" {
+		return nil, errors.Errorf("secret '%s' must contain both 'type' (non-empty string) and 'details' (object)", name)
 	}
 
 	details["name"] = name
@@ -249,4 +496,17 @@ func (c *Client) getVaultManager(name string) (config.ConnectionAndDetailsGetter
 	}
 
 	return manager, nil
+}
+
+func sanitizedVaultError(err error, message string) error {
+	var responseError *vault.ResponseError
+	if errors.As(err, &responseError) {
+		statusText := http.StatusText(responseError.StatusCode)
+		if statusText == "" {
+			return errors.Errorf("%s: Vault returned HTTP status %d", message, responseError.StatusCode)
+		}
+		return errors.Errorf("%s: Vault returned HTTP status %d (%s)", message, responseError.StatusCode, statusText)
+	}
+
+	return errors.Wrap(err, message)
 }

--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -2,9 +2,10 @@ package secrets
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand/v2"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -193,7 +194,7 @@ type Client struct {
 	mountPath               string
 	path                    string
 	logger                  logger.Logger
-	ctx                     context.Context
+	contextProvider         func() context.Context
 	requestTimeout          time.Duration
 	cacheMu                 sync.RWMutex
 	managerRequests         singleflight.Group
@@ -229,7 +230,11 @@ func vaultRetryBackoff(minimum, maximum time.Duration, attempt int, response *ht
 	// Equal jitter prevents clients from retrying in lockstep while retaining a
 	// useful minimum delay. The request context still caps the total wait.
 	half := delay / 2
-	return half + time.Duration(rand.Int64N(int64(delay-half)+1))
+	jitter, err := crand.Int(crand.Reader, big.NewInt(int64(delay-half)+1))
+	if err != nil {
+		return delay
+	}
+	return half + time.Duration(jitter.Int64())
 }
 
 func responseHasRetryAfter(response *http.Response) bool {
@@ -302,7 +307,7 @@ func newClient(ctx context.Context, client kvV2Reader, mountPath string, logger 
 		mountPath:               mountPath,
 		path:                    path,
 		logger:                  logger,
-		ctx:                     ctx,
+		contextProvider:         func() context.Context { return ctx },
 		requestTimeout:          requestTimeout,
 		cacheManagers:           make(map[string]config.ConnectionAndDetailsGetter),
 		cacheConnections:        make(map[string]any),
@@ -429,9 +434,11 @@ func (c *Client) fetchVaultManager(name string) (config.ConnectionAndDetailsGett
 	if requestTimeout <= 0 {
 		requestTimeout = defaultVaultRequestTimeout
 	}
-	baseContext := c.ctx
-	if baseContext == nil {
-		baseContext = context.Background()
+	baseContext := context.Background()
+	if c.contextProvider != nil {
+		if providedContext := c.contextProvider(); providedContext != nil {
+			baseContext = providedContext
+		}
 	}
 	ctx, cancelFunc := context.WithTimeout(baseContext, requestTimeout)
 	defer cancelFunc()

--- a/pkg/secrets/vault_test.go
+++ b/pkg/secrets/vault_test.go
@@ -97,7 +97,7 @@ func TestValidateVaultAddress(t *testing.T) {
 	}
 }
 
-func TestVaultClientConfigFromEnv(t *testing.T) {
+func TestVaultClientConfigFromEnv(t *testing.T) { //nolint:paralleltest // mutates process environment via t.Setenv
 	environmentVariables := []string{
 		"BRUIN_VAULT_TIMEOUT",
 		"BRUIN_VAULT_RETRY_WAIT_MIN",
@@ -108,13 +108,13 @@ func TestVaultClientConfigFromEnv(t *testing.T) {
 		t.Setenv(name, "")
 	}
 
-	t.Run("uses defaults", func(t *testing.T) {
+	t.Run("uses defaults", func(t *testing.T) { //nolint:paralleltest
 		clientConfig, err := vaultClientConfigFromEnv()
 		require.NoError(t, err)
 		require.Equal(t, defaultVaultClientConfig(), clientConfig)
 	})
 
-	t.Run("reads overrides", func(t *testing.T) {
+	t.Run("reads overrides", func(t *testing.T) { //nolint:paralleltest
 		t.Setenv("BRUIN_VAULT_TIMEOUT", "12s")
 		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MIN", "50ms")
 		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MAX", "3s")
@@ -139,14 +139,14 @@ func TestVaultClientConfigFromEnv(t *testing.T) {
 		{name: "BRUIN_VAULT_RETRY_WAIT_MAX", value: "-1s"},
 		{name: "BRUIN_VAULT_MAX_RETRIES", value: "-1"},
 	} {
-		t.Run("rejects invalid "+tt.name, func(t *testing.T) {
+		t.Run("rejects invalid "+tt.name, func(t *testing.T) { //nolint:paralleltest
 			t.Setenv(tt.name, tt.value)
 			_, err := vaultClientConfigFromEnv()
 			require.ErrorContains(t, err, tt.name)
 		})
 	}
 
-	t.Run("rejects a maximum wait below the minimum", func(t *testing.T) {
+	t.Run("rejects a maximum wait below the minimum", func(t *testing.T) { //nolint:paralleltest
 		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MIN", "2s")
 		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MAX", "1s")
 		_, err := vaultClientConfigFromEnv()

--- a/pkg/secrets/vault_test.go
+++ b/pkg/secrets/vault_test.go
@@ -2,7 +2,13 @@ package secrets
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/logger"
@@ -37,23 +43,114 @@ func TestNewVaultClient(t *testing.T) {
 
 	t.Run("returns error if path is empty", func(t *testing.T) {
 		t.Parallel()
-		client, err := NewVaultClient(log, "host", "token", "role", "", "mount", "kubernetes")
+		client, err := NewVaultClient(log, "https://vault.example.com", "token", "role", "", "mount", "kubernetes")
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty vault path")
 		require.Nil(t, client)
 	})
 
 	t.Run("returns error if mountPath is empty", func(t *testing.T) {
 		t.Parallel()
-		client, err := NewVaultClient(log, "host", "token", "role", "path", "", "kubernetes")
+		client, err := NewVaultClient(log, "https://vault.example.com", "token", "role", "path", "", "kubernetes")
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty vault mountpath")
 		require.Nil(t, client)
 	})
 
 	t.Run("returns error if no credentials provided", func(t *testing.T) {
 		t.Parallel()
-		client, err := NewVaultClient(log, "host", "", "", "path", "mount", "kubernetes")
+		client, err := NewVaultClient(log, "https://vault.example.com", "", "", "path", "mount", "kubernetes")
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "no vault credentials")
 		require.Nil(t, client)
+	})
+}
+
+func TestValidateVaultAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		address string
+		wantErr string
+	}{
+		{name: "https", address: "https://vault.example.com:8200"},
+		{name: "http", address: "http://127.0.0.1:8200"},
+		{name: "unix socket", address: "unix:///var/run/vault.sock"},
+		{name: "missing scheme", address: "vault.example.com", wantErr: "URL scheme"},
+		{name: "missing host", address: "https:///vault", wantErr: "must include a host"},
+		{name: "URL credentials", address: "https://user:password@vault.example.com", wantErr: "URL credentials"},
+		{name: "query string", address: "https://vault.example.com?token=secret", wantErr: "query parameters"},
+		{name: "unsupported scheme", address: "ftp://vault.example.com", wantErr: "URL scheme"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateVaultAddress(tt.address)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestVaultClientConfigFromEnv(t *testing.T) {
+	environmentVariables := []string{
+		"BRUIN_VAULT_TIMEOUT",
+		"BRUIN_VAULT_RETRY_WAIT_MIN",
+		"BRUIN_VAULT_RETRY_WAIT_MAX",
+		"BRUIN_VAULT_MAX_RETRIES",
+	}
+	for _, name := range environmentVariables {
+		t.Setenv(name, "")
+	}
+
+	t.Run("uses defaults", func(t *testing.T) {
+		clientConfig, err := vaultClientConfigFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, defaultVaultClientConfig(), clientConfig)
+	})
+
+	t.Run("reads overrides", func(t *testing.T) {
+		t.Setenv("BRUIN_VAULT_TIMEOUT", "12s")
+		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MIN", "50ms")
+		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MAX", "3s")
+		t.Setenv("BRUIN_VAULT_MAX_RETRIES", "5")
+
+		clientConfig, err := vaultClientConfigFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, vaultClientConfig{
+			requestTimeout: 12 * time.Second,
+			retryWaitMin:   50 * time.Millisecond,
+			retryWaitMax:   3 * time.Second,
+			retryMax:       5,
+		}, clientConfig)
+	})
+
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{name: "BRUIN_VAULT_TIMEOUT", value: "invalid"},
+		{name: "BRUIN_VAULT_RETRY_WAIT_MIN", value: "0s"},
+		{name: "BRUIN_VAULT_RETRY_WAIT_MAX", value: "-1s"},
+		{name: "BRUIN_VAULT_MAX_RETRIES", value: "-1"},
+	} {
+		t.Run("rejects invalid "+tt.name, func(t *testing.T) {
+			t.Setenv(tt.name, tt.value)
+			_, err := vaultClientConfigFromEnv()
+			require.ErrorContains(t, err, tt.name)
+		})
+	}
+
+	t.Run("rejects a maximum wait below the minimum", func(t *testing.T) {
+		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MIN", "2s")
+		t.Setenv("BRUIN_VAULT_RETRY_WAIT_MAX", "1s")
+		_, err := vaultClientConfigFromEnv()
+		require.ErrorContains(t, err, "BRUIN_VAULT_RETRY_WAIT_MAX")
 	})
 }
 
@@ -62,9 +159,15 @@ func TestNewVaultClient(t *testing.T) {
 type mockVaultClient struct {
 	response *vault.Response[schema.KvV2ReadResponse]
 	err      error
+	handler  func(context.Context, string) (*vault.Response[schema.KvV2ReadResponse], error)
+	calls    atomic.Int32
 }
 
 func (m *mockVaultClient) KvV2Read(ctx context.Context, path string, opts ...vault.RequestOption) (*vault.Response[schema.KvV2ReadResponse], error) {
+	m.calls.Add(1)
+	if m.handler != nil {
+		return m.handler(ctx, path)
+	}
 	return m.response, m.err
 }
 
@@ -222,4 +325,258 @@ func TestClient_GetConnectionDetails_ReturnsDetails_FromCache(t *testing.T) {
 		},
 		deets,
 	)
+}
+
+func TestLoginToVaultWithKubernetesValidatesAuthResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		statusCode  int
+		body        string
+		wantToken   string
+		wantErr     string
+		redactedErr string
+	}{
+		{
+			name:       "returns client token",
+			statusCode: http.StatusOK,
+			body:       `{"data":null,"auth":{"client_token":"vault-client-token"}}`,
+			wantToken:  "vault-client-token",
+		},
+		{
+			name:       "rejects missing auth data",
+			statusCode: http.StatusOK,
+			body:       `{"data":null}`,
+			wantErr:    "Vault returned no client token",
+		},
+		{
+			name:        "redacts Vault error response",
+			statusCode:  http.StatusForbidden,
+			body:        `{"errors":["sensitive authentication diagnostic"]}`,
+			wantErr:     "HTTP status 403",
+			redactedErr: "sensitive authentication diagnostic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(tt.statusCode)
+				_, _ = writer.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			clientConfig := vaultClientConfig{
+				requestTimeout: time.Second,
+				retryWaitMin:   time.Millisecond,
+				retryWaitMax:   2 * time.Millisecond,
+				retryMax:       0,
+			}
+			client, err := newVaultAPIClient(server.URL, clientConfig)
+			require.NoError(t, err)
+
+			token, err := loginToVaultWithKubernetes(t.Context(), client, "service-account-token", "role", "kubernetes")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantToken, token)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+			if tt.redactedErr != "" {
+				require.NotContains(t, err.Error(), tt.redactedErr)
+			}
+		})
+	}
+}
+
+func TestClient_RetriesTransientVaultFailures(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		call := calls.Add(1)
+		if call <= 2 {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = writer.Write([]byte(`{"errors":["temporary failure"]}`))
+			return
+		}
+
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"data":{"data":{"details":{"value":"somevalue"},"type":"generic"}}}`))
+	}))
+	defer server.Close()
+
+	clientConfig := vaultClientConfig{
+		requestTimeout: time.Second,
+		retryWaitMin:   time.Millisecond,
+		retryWaitMax:   2 * time.Millisecond,
+		retryMax:       2,
+	}
+	client, err := newVaultClientWithToken(t.Context(), server.URL, "token", "mount", &mockLogger{}, "path", clientConfig)
+	require.NoError(t, err)
+
+	connection, err := client.ResolveConnection("test-connection")
+	require.NoError(t, err)
+	require.NotNil(t, connection)
+	require.EqualValues(t, 3, calls.Load())
+}
+
+func TestClient_DoesNotRetryPermanentVaultFailures(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		calls.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusNotFound)
+		_, _ = writer.Write([]byte(`{"errors":["not found"]}`))
+	}))
+	defer server.Close()
+
+	clientConfig := vaultClientConfig{
+		requestTimeout: time.Second,
+		retryWaitMin:   time.Millisecond,
+		retryWaitMax:   2 * time.Millisecond,
+		retryMax:       3,
+	}
+	client, err := newVaultClientWithToken(t.Context(), server.URL, "token", "mount", &mockLogger{}, "path", clientConfig)
+	require.NoError(t, err)
+
+	_, err = client.ResolveConnection("missing")
+	require.ErrorContains(t, err, "not found in Vault")
+	require.EqualValues(t, 1, calls.Load())
+}
+
+func TestClient_VaultReadHasAnOverallTimeout(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockVaultClient{
+		handler: func(ctx context.Context, _ string) (*vault.Response[schema.KvV2ReadResponse], error) {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.LessOrEqual(t, time.Until(deadline), 25*time.Millisecond)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	client := newClient(t.Context(), mockClient, "mount", &mockLogger{}, "path", 20*time.Millisecond)
+
+	started := time.Now()
+	_, err := client.ResolveConnection("test-connection")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(started), time.Second)
+}
+
+func TestClient_ConcurrentLookupsShareOneVaultRequest(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockVaultClient{
+		handler: func(_ context.Context, _ string) (*vault.Response[schema.KvV2ReadResponse], error) {
+			time.Sleep(20 * time.Millisecond)
+			return genericVaultResponse(), nil
+		},
+	}
+	client := newClient(t.Context(), mockClient, "mount", &mockLogger{}, "path", time.Second)
+
+	const goroutineCount = 10
+	connections := make([]any, goroutineCount)
+	var waitGroup sync.WaitGroup
+	for index := range goroutineCount {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			connections[index] = client.GetConnection("test-connection")
+		}()
+	}
+	waitGroup.Wait()
+
+	for index, connection := range connections {
+		require.NotNil(t, connection, "connection %d", index)
+	}
+	require.EqualValues(t, 1, mockClient.calls.Load())
+}
+
+func TestClient_RejectsMalformedVaultResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response *vault.Response[schema.KvV2ReadResponse]
+		wantErr  string
+	}{
+		{name: "empty response", response: nil, wantErr: "empty response"},
+		{
+			name: "missing type",
+			response: &vault.Response[schema.KvV2ReadResponse]{Data: schema.KvV2ReadResponse{Data: map[string]any{
+				"details": map[string]any{"value": "secret"},
+			}}},
+			wantErr: "must contain both 'type'",
+		},
+		{
+			name: "empty type",
+			response: &vault.Response[schema.KvV2ReadResponse]{Data: schema.KvV2ReadResponse{Data: map[string]any{
+				"type":    " ",
+				"details": map[string]any{"value": "secret"},
+			}}},
+			wantErr: "must contain both 'type'",
+		},
+		{
+			name: "invalid details",
+			response: &vault.Response[schema.KvV2ReadResponse]{Data: schema.KvV2ReadResponse{Data: map[string]any{
+				"type":    "generic",
+				"details": "secret",
+			}}},
+			wantErr: "must contain both 'type'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := newClient(t.Context(), &mockVaultClient{response: tt.response}, "mount", &mockLogger{}, "path", time.Second)
+			_, err := client.ResolveConnection("test-connection")
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestClient_RedactsVaultErrorResponseBodies(t *testing.T) {
+	t.Parallel()
+
+	client := newClient(t.Context(), &mockVaultClient{err: &vault.ResponseError{
+		StatusCode: http.StatusInternalServerError,
+		Errors:     []string{"sensitive backend diagnostic"},
+	}}, "mount", &mockLogger{}, "path", time.Second)
+
+	_, err := client.ResolveConnection("test-connection")
+	require.Error(t, err)
+	require.ErrorContains(t, err, fmt.Sprintf("HTTP status %d", http.StatusInternalServerError))
+	require.NotContains(t, err.Error(), "sensitive backend diagnostic")
+}
+
+func TestVaultRetryBackoffHonorsRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	response := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     http.Header{"Retry-After": []string{"3"}},
+	}
+	require.Equal(t, 3*time.Second, vaultRetryBackoff(time.Millisecond, time.Second, 0, response))
+}
+
+func genericVaultResponse() *vault.Response[schema.KvV2ReadResponse] {
+	return &vault.Response[schema.KvV2ReadResponse]{
+		Data: schema.KvV2ReadResponse{
+			Data: map[string]any{
+				"details": map[string]any{
+					"value": "somevalue",
+				},
+				"type": "generic",
+			},
+		},
+	}
 }


### PR DESCRIPTION
## What
Harden Vault secret access against transient failures, malformed responses, leaked diagnostics, and concurrent reads.

## Changes
- Add context-aware authentication, address validation, configurable timeouts/retries/backoff, sanitized errors, strict response validation, and request caching.
- Add coverage for the new behavior and document the settings.

## How to test
1. `make format`
2. `make test`

## Risk & rollback
- **Risk:** medium — changes Vault request, authentication, and caching behavior.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

