### PR TITLE
feat(iceberg): add ssl_mode to the postgres catalog

### DIFF
--- a/docs/ingestion/iceberg.md
+++ b/docs/ingestion/iceberg.md
@@ -96,7 +96,7 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
 
 A managed database (Neon, RDS, Cloud SQL) refuses plaintext connections, so `ssl_mode` is usually required there. It takes libpq's values — `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full` — and is sent to the catalog database as `sslmode`.
 
-The remaining PostgreSQL connection parameters have no dedicated field; set them through the top-level [`properties`](#table-options) block, which ingestr forwards to the catalog database connection:
+`ssl_mode` is the only PostgreSQL connection parameter with a dedicated field. To set any of the others — certificate paths, timeouts, and so on — use the top-level [`properties`](#table-options) block, which ingestr forwards to the catalog database connection:
 
 ```yaml
           catalog:

--- a/docs/ingestion/iceberg.md
+++ b/docs/ingestion/iceberg.md
@@ -88,27 +88,31 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
             host: "metadata-db.internal"      # required
             port: 5432                        # optional
             database: "iceberg_catalog"       # optional
+            ssl_mode: "require"               # optional — TLS mode
             auth:                             # optional
               username: "iceberg_user"
               password: "${PG_PASSWORD}"
 ```
 
-For the `postgres` catalog, ingestr forwards standard PostgreSQL connection parameters to the catalog database connection, so you can secure or tune it via the top-level [`properties`](#table-options) block — a managed database (Neon, RDS, Cloud SQL) usually needs TLS:
+A managed database (Neon, RDS, Cloud SQL) refuses plaintext connections, so `ssl_mode` is usually required there. It takes libpq's values — `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full` — and is sent to the catalog database as `sslmode`.
+
+The remaining PostgreSQL connection parameters have no dedicated field; set them through the top-level [`properties`](#table-options) block, which ingestr forwards to the catalog database connection:
 
 ```yaml
           catalog:
             type: postgres
             host: "metadata-db.internal"
             database: "iceberg_catalog"
+            ssl_mode: "verify-full"
             auth:
               username: "iceberg_user"
               password: "${PG_PASSWORD}"
           properties:
-            sslmode: "require"                # e.g. require, verify-full
-            sslrootcert: "/path/to/ca.pem"    # optional
+            sslrootcert: "/path/to/ca.pem"
+            connect_timeout: "10"
 ```
 
-Recognized connection parameters: `sslmode`, `sslcert`, `sslkey`, `sslrootcert`, `sslpassword`, `sslcrl`, `sslcrldir`, `sslsni`, `sslcompression`, `requiressl`, `connect_timeout`, `application_name`, `fallback_application_name`, `target_session_attrs`, `tcp_user_timeout`, `options`, `service`, `servicefile`, `passfile`, `krbsrvname`, and `replication`. Any other property is treated as an Iceberg/storage option, not a database connection setting. This forwarding applies only to `type: postgres`; for the generic `sql` catalog, embed these inside the `uri` connection string instead (e.g. `postgresql://…?sslmode=require`).
+Recognized connection parameters: `sslmode`, `sslcert`, `sslkey`, `sslrootcert`, `sslpassword`, `sslcrl`, `sslcrldir`, `sslsni`, `sslcompression`, `requiressl`, `connect_timeout`, `application_name`, `fallback_application_name`, `target_session_attrs`, `tcp_user_timeout`, `options`, `service`, `servicefile`, `passfile`, `krbsrvname`, and `replication`. Any other property is treated as an Iceberg/storage option, not a database connection setting. This forwarding applies only to `type: postgres`; for the generic `sql` catalog, embed these inside the `uri` connection string instead (e.g. `postgresql://…?sslmode=require`). A `sslmode` set in `properties` takes precedence over the `ssl_mode` field.
 
 **SQLite**
 ```yaml

--- a/pkg/config/connection_fields.go
+++ b/pkg/config/connection_fields.go
@@ -162,7 +162,7 @@ func extractFields(t reflect.Type) []ConnectionFieldDef {
 
 func kindToTypeString(t reflect.Type) string {
 	k := t.Kind()
-	if k == reflect.Ptr {
+	if k == reflect.Pointer {
 		k = t.Elem().Kind()
 	}
 

--- a/pkg/config/iceberg.go
+++ b/pkg/config/iceberg.go
@@ -51,11 +51,8 @@ type IcebergCatalog struct {
 	// set true for managed catalogs like Polaris, Unity, or Tabular.
 	RestUseSSL *bool `yaml:"rest_use_ssl,omitempty" json:"rest_use_ssl,omitempty" mapstructure:"rest_use_ssl"`
 
-	// SSLMode is the postgres catalog's TLS mode (disable, require, verify-full,
-	// ...), spelled ssl_mode like every other connection and sent to the catalog as
-	// libpq's sslmode. Managed Postgres -- Neon, RDS, Cloud SQL -- generally refuses
-	// plaintext, so it is needed more often than not; the sql catalog carries TLS in
-	// its own uri instead.
+	// SSLMode sets the postgres catalog's libpq TLS mode (e.g. require); spelled
+	// ssl_mode to match every other connection, emitted to the catalog as sslmode.
 	SSLMode string `yaml:"ssl_mode,omitempty" json:"ssl_mode,omitempty" mapstructure:"ssl_mode"`
 
 	// Driver and Dialect configure the generic sql catalog (both required, e.g.

--- a/pkg/config/iceberg.go
+++ b/pkg/config/iceberg.go
@@ -51,6 +51,13 @@ type IcebergCatalog struct {
 	// set true for managed catalogs like Polaris, Unity, or Tabular.
 	RestUseSSL *bool `yaml:"rest_use_ssl,omitempty" json:"rest_use_ssl,omitempty" mapstructure:"rest_use_ssl"`
 
+	// SSLMode is the postgres catalog's TLS mode (disable, require, verify-full,
+	// ...), spelled ssl_mode like every other connection and sent to the catalog as
+	// libpq's sslmode. Managed Postgres -- Neon, RDS, Cloud SQL -- generally refuses
+	// plaintext, so it is needed more often than not; the sql catalog carries TLS in
+	// its own uri instead.
+	SSLMode string `yaml:"ssl_mode,omitempty" json:"ssl_mode,omitempty" mapstructure:"ssl_mode"`
+
 	// Driver and Dialect configure the generic sql catalog (both required, e.g.
 	// driver=pgx, dialect=postgres); the sqlite/postgres types set them for you.
 	Driver  string `yaml:"driver,omitempty" json:"driver,omitempty" mapstructure:"driver"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -579,7 +579,7 @@ func expandEnvVarsInYAMLValues(node *yaml.Node, targetType reflect.Type) error {
 }
 
 func dereferenceType(targetType reflect.Type) reflect.Type {
-	for targetType != nil && targetType.Kind() == reflect.Ptr {
+	for targetType != nil && targetType.Kind() == reflect.Pointer {
 		targetType = targetType.Elem()
 	}
 

--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -129,6 +129,12 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 		if cat.Host == "" {
 			return "", nil, fmt.Errorf("iceberg: postgres catalog requires %q", "host")
 		}
+		// ingestr copies the libpq DSN parameters it recognises into the catalog
+		// connection string, sslmode among them.
+		if cat.SSLMode != "" {
+			q.Set("sslmode", cat.SSLMode)
+		}
+
 		return "iceberg+postgres://" + postgresAuthority(cat), q, nil
 	case config.IcebergCatalogREST:
 		if cat.Host == "" {

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -381,6 +381,40 @@ func TestConfig_GetIngestrURI_RealS3StillSharesCredentials(t *testing.T) {
 	assert.Equal(t, testAWSRegion, q.Get("glue.region"))
 }
 
+func TestConfig_GetIngestrURI_PostgresCatalogSSLMode(t *testing.T) {
+	t.Parallel()
+
+	// Managed Postgres refuses plaintext, and ingestr copies the libpq DSN
+	// parameters it recognises into the catalog connection string.
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:     config.IcebergCatalogPostgres,
+			Host:     "ep-abc.eu-central-1.aws.neon.tech",
+			Port:     5432,
+			Database: "neondb",
+			SSLMode:  "require",
+			Auth:     config.IcebergAuth{Username: "u", Password: "p"},
+		},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Equal(t, "require", q.Get("sslmode"), "the field is ssl_mode but libpq calls it sslmode")
+}
+
+func TestConfig_GetIngestrURI_SSLModeOnlyForPostgres(t *testing.T) {
+	t.Parallel()
+
+	// Other catalogs carry TLS elsewhere: rest via rest_use_ssl, sql inside its uri.
+	c := Config{
+		Catalog: config.IcebergCatalog{Type: config.IcebergCatalogHive, Host: "metastore", Port: 9083, SSLMode: "require"},
+		Storage: config.IcebergStorage{Type: config.IcebergStorageS3, Path: testS3LakeWh},
+	}
+
+	_, q := parseQuery(t, mustURI(t, c))
+	assert.Empty(t, q.Get("sslmode"))
+}
+
 func TestConfig_GetIngestrURI_RESTUseSSL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Managed Postgres refuses plaintext connections, so an Iceberg **postgres catalog** on Neon, RDS or Cloud SQL needs `sslmode` set. Today the only way to say so is the free-form passthrough:

```yaml
catalog:
  type: postgres
  host: ep-….neon.tech
properties:
  sslmode: "require"
```

Two problems with that:

- **Every other connection has it as a field.** `postgres`, `redshift` and `mysql` all expose `ssl_mode`, so a user configuring an Iceberg postgres catalog reasonably looks for one, finds nothing, and gets a connection error that says nothing about TLS.
- **It cannot travel any other way.** The `sql` catalog can put `?sslmode=require` in its uri; the postgres catalog is configured by host and port, so the passthrough is the only route.

It also can't be surfaced in Bruin Cloud's connection form, since the form is generated from these fields — the user has to know to type a magic key into a properties box.

## Changes

`IcebergCatalog.SSLMode`, spelled **`ssl_mode`** to match the other connections, emitted as libpq's **`sslmode`**, which ingestr copies into the catalog connection string along with the other DSN parameters it recognises (`isPostgresDSNParam`).

```yaml
catalog:
  type: postgres
  host: ep-….neon.tech
  ssl_mode: require        # was: properties.sslmode
```

`properties` still wins on conflict, so existing configs are unaffected.

**Only the postgres catalog needs this.** The `sql` catalog carries TLS inside its uri, `rest` already has `rest_use_ssl`, `hive` speaks thrift, and sqlite/glue/hadoop have no connection to secure. The remaining libpq TLS parameters — `sslcert`, `sslkey`, `sslrootcert` — are file paths, which cannot exist on a hosted worker anyway, so they stay in `properties`.