### PR TITLE
docs(iceberg): document the defaults a non-AWS endpoint fills in

### DIFF
--- a/docs/ingestion/iceberg.md
+++ b/docs/ingestion/iceberg.md
@@ -183,7 +183,7 @@ Recognized connection parameters: `sslmode`, `sslcert`, `sslkey`, `sslrootcert`,
 ```
 
 > [!TIP]
-> For non-AWS S3-compatible stores (MinIO, Cloudflare R2, GCS interop), S3 compatibility mode is enabled automatically when `endpoint` is set — without it GCS interop rejects the headers the AWS SDK signs and fails with `SignatureDoesNotMatch`. To disable it, add `s3.compat-mode: "false"` to the top-level [`properties`](#table-options) block.
+> An `endpoint` that isn't AWS (MinIO, Cloudflare R2, GCS interop) defaults `s3.compat-mode` on — GCS interop fails with `SignatureDoesNotMatch` without it — and `region` to `auto`, which those stores ignore but the AWS SDK insists on. Override either in [`properties`](#table-options). AWS endpoints, including VPC and FIPS, get neither.
 
 **Google Cloud Storage (native)** — `type: gcs` with a `gs://` warehouse and a service-account key (`bucket` + `prefix` works too):
 
@@ -203,7 +203,7 @@ Leave `key_file`/`key_json` empty to use Application Default Credentials.
             type: s3
             path: "s3://my-gcs-bucket/warehouse"
             endpoint: "storage.googleapis.com"
-            region: "auto"                              # required, but unused once endpoint is set
+            region: "auto"                              # optional — the default for a non-AWS endpoint
             auth:
               access_key: "${GCS_HMAC_KEY}"
               secret_key: "${GCS_HMAC_SECRET}"


### PR DESCRIPTION
Pointing `endpoint` at something that is not AWS makes ingestr supply two things those stores need:

- **`s3.compat-mode`** — already documented.
- **`region: auto`** — not documented. Those stores ignore the region, but the AWS SDK will not sign a request without one, so leaving it empty fails with `Invalid region: region was not a valid DNS name`, an error that names a host the store has nothing to do with.

They are stated together now, since they come from one condition, along with the exclusion that applies to both: regional, VPC, FIPS and dualstack endpoints **are** AWS, where the region routes the request and compatibility mode is unwanted.

Also fixes the GCS interop example, which annotated `region` as though it always had to be supplied.