### PR TITLE
feat(templates): five Apache Iceberg templates

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -525,6 +525,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         ],
                     },
                     {
+                        text: "Apache Iceberg",
+                        collapsed: false,
+                        items: [
+                            {text: "iceberg-sqlite-local", link: "/getting-started/templates-docs/iceberg-sqlite-local-README"},
+                            {text: "iceberg-rest-minio", link: "/getting-started/templates-docs/iceberg-rest-minio-README"},
+                            {text: "iceberg-glue-s3", link: "/getting-started/templates-docs/iceberg-glue-s3-README"},
+                            {text: "iceberg-postgres-gcs", link: "/getting-started/templates-docs/iceberg-postgres-gcs-README"},
+                            {text: "iceberg-hadoop-gcsinterop", link: "/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README"},
+                        ],
+                    },
+                    {
                         text: "Source Ingestion",
                         collapsed: false,
                         items: [

--- a/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
+++ b/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
@@ -12,7 +12,8 @@ An IAM user or role that can reach both halves:
 - **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
 - **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
-Then set these before running:
+Then supply the values, either by exporting them or by replacing the `${...}`
+placeholders in `.bruin.yml` directly:
 
 ```bash
 export AWS_REGION=eu-north-1

--- a/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
+++ b/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
@@ -12,8 +12,29 @@ An IAM user or role that can reach both halves:
 - **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
 - **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
-Then supply the values, either by exporting them or by replacing the `${...}`
-placeholders in `.bruin.yml` directly:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only
+the marked values are missing:
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: glue
+            region: "${AWS_REGION}"                     # <- e.g. eu-north-1
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"        # <-
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"    # <-
+          storage:
+            type: s3
+            path: "s3://${S3_BUCKET}/warehouse"         # <- your bucket
+            region: "${AWS_REGION}"
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"
+```
+
+Replace each `${...}` with the value, or export them as environment variables
+and leave the file alone — Bruin expands both:
 
 ```bash
 export AWS_REGION=eu-north-1

--- a/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
+++ b/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
@@ -47,6 +47,8 @@ Use a long-lived access key, not SSO or STS credentials — those expire within
 hours and a scheduled pipeline would start failing overnight. If you must use
 them, add `session_token` to both `auth` blocks.
 
+## Run it
+
 ```bash
 bruin run iceberg-glue-s3
 ```

--- a/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
+++ b/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
@@ -1,0 +1,43 @@
+# Bruin — Iceberg with AWS Glue and S3
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** tables catalogued in AWS Glue with the
+data in S3. This is the shape most AWS deployments use: a managed catalog, so
+there is no metastore to run.
+
+## Setup
+
+An IAM user or role that can reach both halves:
+
+- **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
+- **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
+
+Then set these before running:
+
+```bash
+export AWS_REGION=eu-north-1
+export AWS_ACCESS_KEY_ID=AKIA…
+export AWS_SECRET_ACCESS_KEY=…
+export S3_BUCKET=my-company-lake
+```
+
+Use a long-lived access key, not SSO or STS credentials — those expire within
+hours and a scheduled pipeline would start failing overnight. If you must use
+them, add `session_token` to both `auth` blocks.
+
+```bash
+bruin run iceberg-glue-s3
+```
+
+The tables appear in Glue under the `raw` database, with data at
+`s3://$S3_BUCKET/warehouse/raw.db/`.
+
+## Notes
+
+The catalog and the storage have **separate** `auth` blocks. They are the same
+credentials here, but they do not have to be — Glue is an AWS API and the bucket
+is storage, and Bruin sends each set to the right place.
+
+`region` is required for both: Glue needs to know which regional endpoint to
+call, and S3 uses it to route the request. A wrong one gives you
+`PermanentRedirect`; an empty one gives you `Invalid region`.

--- a/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
+++ b/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
@@ -1,0 +1,40 @@
+# Bruin — Iceberg with no catalog service, on GCS
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** tables that need no catalog service at
+all. The `hadoop` catalog keeps its metadata in the warehouse itself, so the
+bucket is the only thing to provision.
+
+Storage is Google Cloud Storage reached through its **S3 interoperability API**,
+the alternative to a service-account key.
+
+## Setup
+
+An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
+*Create a key*. It looks like an AWS key pair and is used as one.
+
+```bash
+export GCS_BUCKET=my-company-lake
+export GCS_HMAC_KEY=GOOG1E…
+export GCS_HMAC_SECRET=…
+```
+
+```bash
+bruin run iceberg-hadoop-gcsinterop
+```
+
+## Notes
+
+> **The hadoop catalog does not commit atomically to object storage.** It needs
+> `allow-unsafe-commits: "true"`, already set here. Two writers to one table can
+> lose a commit, so this is for getting started and for single-writer pipelines —
+> not for concurrent production writes. Move to Glue, REST or Postgres when that
+> matters.
+
+The storage block says `type: s3` with an `s3://` warehouse even though the
+bucket is Google's, because the S3 interop endpoint really is an S3 API — only
+`endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://`
+warehouse and a service-account key, as in `iceberg-postgres-gcs`.
+
+`region: auto` is a placeholder: Google ignores it, but the AWS SDK will not sign
+a request without one.

--- a/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
+++ b/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
@@ -41,6 +41,8 @@ export GCS_HMAC_KEY=GOOG1E…
 export GCS_HMAC_SECRET=…
 ```
 
+## Run it
+
 ```bash
 bruin run iceberg-hadoop-gcsinterop
 ```

--- a/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
+++ b/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
@@ -25,7 +25,6 @@ the marked values are missing:
             type: s3
             path: "s3://${GCS_BUCKET}/warehouse"        # <- your GCS bucket
             endpoint: "storage.googleapis.com"
-            region: "auto"
             auth:
               access_key: "${GCS_HMAC_KEY}"             # <-
               secret_key: "${GCS_HMAC_SECRET}"          # <-
@@ -59,5 +58,5 @@ bucket is Google's, because the S3 interop endpoint really is an S3 API — only
 `endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://`
 warehouse and a service-account key, as in `iceberg-postgres-gcs`.
 
-`region: auto` is a placeholder: Google ignores it, but the AWS SDK will not sign
-a request without one.
+No `region` here: Google ignores it, and ingestr supplies the placeholder the
+AWS SDK insists on. AWS S3 still needs a real one.

--- a/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
+++ b/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
@@ -13,8 +13,28 @@ the alternative to a service-account key.
 An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
 *Create a key*. It looks like an AWS key pair and is used as one.
 
-Then supply the values, either by exporting them or by replacing the `${...}`
-placeholders in `.bruin.yml` directly:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only
+the marked values are missing:
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: hadoop
+          storage:
+            type: s3
+            path: "s3://${GCS_BUCKET}/warehouse"        # <- your GCS bucket
+            endpoint: "storage.googleapis.com"
+            region: "auto"
+            auth:
+              access_key: "${GCS_HMAC_KEY}"             # <-
+              secret_key: "${GCS_HMAC_SECRET}"          # <-
+          properties:
+            allow-unsafe-commits: "true"
+```
+
+Replace each `${...}` with the value, or export them as environment variables
+and leave the file alone — Bruin expands both:
 
 ```bash
 export GCS_BUCKET=my-company-lake

--- a/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
+++ b/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
@@ -13,6 +13,9 @@ the alternative to a service-account key.
 An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
 *Create a key*. It looks like an AWS key pair and is used as one.
 
+Then supply the values, either by exporting them or by replacing the `${...}`
+placeholders in `.bruin.yml` directly:
+
 ```bash
 export GCS_BUCKET=my-company-lake
 export GCS_HMAC_KEY=GOOG1E…

--- a/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
+++ b/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
@@ -13,6 +13,9 @@ RDS, or one you run.
 2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
    Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
 
+Then supply the values, either by exporting them or by replacing the `${...}`
+placeholders in `.bruin.yml` directly:
+
 ```bash
 export PG_HOST=my-catalog.example.com
 export PG_DATABASE=iceberg_catalog

--- a/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
+++ b/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
@@ -38,6 +38,8 @@ the marked values are missing:
 Replace each `${...}` with the value, or export them as environment variables
 and leave the file alone — Bruin expands both.
 
+## Run it
+
 ```bash
 bruin run iceberg-postgres-gcs
 ```

--- a/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
+++ b/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
@@ -13,16 +13,30 @@ RDS, or one you run.
 2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
    Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
 
-Then supply the values, either by exporting them or by replacing the `${...}`
-placeholders in `.bruin.yml` directly:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only
+the marked values are missing:
 
-```bash
-export PG_HOST=my-catalog.example.com
-export PG_DATABASE=iceberg_catalog
-export PG_USERNAME=iceberg_user
-export PG_PASSWORD=…
-export GCS_BUCKET=my-company-lake
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: postgres
+            host: "${PG_HOST}"              # <- your Postgres host
+            port: 5432
+            database: "${PG_DATABASE}"      # <-
+            auth:
+              username: "${PG_USERNAME}"    # <-
+              password: "${PG_PASSWORD}"    # <-
+          storage:
+            type: gcs
+            path: "gs://${GCS_BUCKET}/warehouse"   # <- your bucket
+            key_file: "sa.json"
+          properties:
+            sslmode: "require"
 ```
+
+Replace each `${...}` with the value, or export them as environment variables
+and leave the file alone — Bruin expands both.
 
 ```bash
 bruin run iceberg-postgres-gcs

--- a/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
+++ b/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
@@ -1,0 +1,40 @@
+# Bruin — Iceberg with a Postgres catalog and Google Cloud Storage
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** tables catalogued in Postgres with the
+data in Google Cloud Storage. Useful on GCP, or anywhere you would rather own the
+catalog than depend on a cloud service: any Postgres will do — Cloud SQL, Neon,
+RDS, or one you run.
+
+## Setup
+
+1. **A Postgres database** for the catalog. It needs no schema; Iceberg creates
+   its own tables on first run.
+2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
+   Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
+
+```bash
+export PG_HOST=my-catalog.example.com
+export PG_DATABASE=iceberg_catalog
+export PG_USERNAME=iceberg_user
+export PG_PASSWORD=…
+export GCS_BUCKET=my-company-lake
+```
+
+```bash
+bruin run iceberg-postgres-gcs
+```
+
+Data lands at `gs://$GCS_BUCKET/warehouse/raw.db/`.
+
+## Notes
+
+`sslmode: require` is in `properties` because managed Postgres — Neon, RDS,
+Cloud SQL — refuses plaintext connections. Drop it for a local database that
+does not speak TLS.
+
+Storage authenticates with a service-account key, given as `key_file` (a path)
+or `key_json` (the key inline). A path is fine here, where the pipeline runs on
+your machine; use `key_json` anywhere the run happens elsewhere, such as Bruin
+Cloud, since the file will not be on that machine. Leave both out to use
+Application Default Credentials.

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -55,6 +55,3 @@ than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
 reaches storage **itself** to write metadata, which is why the same MinIO
 credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
 
-`raw.exchange_rates` depends on `raw.currencies` so the two do not race to create
-the `raw` namespace on the first run — the catalog registers it once and the
-loser fails. Ordinary concurrent writes to existing tables are fine.

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -55,5 +55,6 @@ than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
 reaches storage **itself** to write metadata, which is why the same MinIO
 credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
 
-Unlike the SQLite catalog in `iceberg-sqlite-local`, a catalog server handles
-concurrent writers, so these two assets load in parallel.
+`raw.exchange_rates` depends on `raw.currencies` so the two do not race to create
+the `raw` namespace on the first run — the catalog registers it once and the
+loser fails. Ordinary concurrent writes to existing tables are fine.

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -24,7 +24,7 @@ raw/currencies/metadata/00001-….metadata.json
 
 Tear it down with `docker compose down -v`.
 
-## What this shows
+## Notes
 
 An Iceberg connection is a **catalog** (where table metadata lives) and
 **storage** (where the data files go). Here the catalog is a server you talk to

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -14,7 +14,7 @@ docker compose up -d          # MinIO + the bucket + the REST catalog
 bruin run iceberg-rest-minio
 ```
 
-Browse what landed at [localhost:9001](http://localhost:9001) (`minioadmin` /
+Browse what landed in the MinIO console at `localhost:9001` (`minioadmin` /
 `minioadmin`), under `warehouse/raw/`:
 
 ```

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -1,0 +1,59 @@
+# Bruin — Iceberg with a REST catalog and MinIO
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** — with a real catalog server in front
+of real object storage, both running locally in Docker. Still no cloud account.
+
+- `raw/currencies.asset.yml` — the list of currency codes and names.
+- `raw/exchange_rates.asset.yml` — the latest rates.
+
+## Run it
+
+```bash
+docker compose up -d          # MinIO + the bucket + the REST catalog
+bruin run iceberg-rest-minio
+```
+
+Browse what landed at [localhost:9001](http://localhost:9001) (`minioadmin` /
+`minioadmin`), under `warehouse/raw/`:
+
+```
+raw/currencies/data/00000-0-….parquet
+raw/currencies/metadata/00001-….metadata.json
+```
+
+Tear it down with `docker compose down -v`.
+
+## What this shows
+
+An Iceberg connection is a **catalog** (where table metadata lives) and
+**storage** (where the data files go). Here the catalog is a server you talk to
+over HTTP and storage is S3-compatible, which is the shape most production
+setups have — swap in Glue or Postgres and a real S3 bucket and nothing about
+the assets changes.
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: rest
+            host: "localhost"
+            port: 8181
+          storage:
+            type: s3
+            path: "s3://warehouse"
+            endpoint: "localhost:9000"        # MinIO, not AWS
+            use_ssl: false                    # it is plain HTTP locally
+            region: "us-east-1"
+            auth:
+              access_key: "minioadmin"
+              secret_key: "minioadmin"
+```
+
+Two things about that `endpoint`. It is what makes this S3-*compatible* rather
+than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
+reaches storage **itself** to write metadata, which is why the same MinIO
+credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
+
+Unlike the SQLite catalog in `iceberg-sqlite-local`, a catalog server handles
+concurrent writers, so these two assets load in parallel.

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -50,8 +50,9 @@ the assets changes.
               secret_key: "minioadmin"
 ```
 
-Two things about that `endpoint`. It is what makes this S3-*compatible* rather
-than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
-reaches storage **itself** to write metadata, which is why the same MinIO
-credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
+Two things about that `endpoint`. It marks the store as S3-*compatible* rather
+than S3, which ingestr turns into `s3.compat-mode` — MinIO does not need it, but
+GCS over its S3 endpoint does. And the REST catalog reaches storage **itself** to
+write metadata, which is why the same MinIO credentials appear in
+`docker-compose.yml`; the ones above configure only Bruin.
 

--- a/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
+++ b/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
@@ -48,10 +48,10 @@ a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
 Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
 assets never change.
 
-A SQLite catalog is a single-writer file, which is why `raw.exchange_rates`
-depends on `raw.currencies`: without an order the two assets create the catalog
-at the same time and one fails with `SQLITE_BUSY`. Catalogs backed by a server
-have no such limit.
+`raw.exchange_rates` depends on `raw.currencies` so the two do not start
+together: a SQLite catalog is a single-writer file, and both creating it at once
+fails with `SQLITE_BUSY`. Every catalog needs the ordering for the first run
+anyway, since the namespace is created once and the second asset loses.
 
 Not for production — the point is to see Iceberg work before committing to
 infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)

--- a/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
+++ b/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
@@ -48,11 +48,6 @@ a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
 Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
 assets never change.
 
-`raw.exchange_rates` depends on `raw.currencies` so the two do not start
-together: a SQLite catalog is a single-writer file, and both creating it at once
-fails with `SQLITE_BUSY`. Every catalog needs the ordering for the first run
-anyway, since the namespace is created once and the second asset loses.
-
 Not for production — the point is to see Iceberg work before committing to
 infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)
 for the real backends.

--- a/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
+++ b/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
@@ -40,7 +40,7 @@ SET unsafe_enable_version_guessing = true;
 SELECT * FROM iceberg_scan('warehouse/raw.db/currencies');
 ```
 
-## What this shows
+## Notes
 
 An Iceberg connection is a **catalog** (where table metadata lives) and
 **storage** (where the data files go). This template picks the simplest of each:

--- a/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
+++ b/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
@@ -1,0 +1,58 @@
+# Bruin — Iceberg on your laptop
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate
+API, into **Apache Iceberg** tables on your own disk. No cloud account, no
+credentials, no services to start.
+
+- `raw/currencies.asset.yml` — the list of currency codes and names.
+- `raw/exchange_rates.asset.yml` — the latest rates.
+
+## Run it
+
+```bash
+bruin run iceberg-sqlite-local
+```
+
+That is the whole setup. The connection in `.bruin.yml` needs nothing filled in:
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: sqlite
+            path: "catalog.db"          # relative to .bruin.yml
+          storage:
+            type: local
+            path: "warehouse"           # relative to .bruin.yml
+```
+
+Afterwards, `catalog.db` holds the table metadata and `warehouse/` the data:
+
+```
+warehouse/raw.db/currencies/data/00000-0-….parquet
+warehouse/raw.db/currencies/metadata/00001-….metadata.json
+```
+
+Read them back with DuckDB:
+
+```sql
+SET unsafe_enable_version_guessing = true;
+SELECT * FROM iceberg_scan('warehouse/raw.db/currencies');
+```
+
+## What this shows
+
+An Iceberg connection is a **catalog** (where table metadata lives) and
+**storage** (where the data files go). This template picks the simplest of each:
+a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
+Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
+assets never change.
+
+A SQLite catalog is a single-writer file, which is why `raw.exchange_rates`
+depends on `raw.currencies`: without an order the two assets create the catalog
+at the same time and one fails with `SQLITE_BUSY`. Catalogs backed by a server
+have no such limit.
+
+Not for production — the point is to see Iceberg work before committing to
+infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)
+for the real backends.

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -118,6 +118,43 @@ AI agent skills are installed separately with `bruin ai skills`; see [AI Skills]
   </a>
 </div>
 
+### Apache Iceberg
+
+An Iceberg connection is a **catalog** (where table metadata lives) plus **storage** (where the data files go). These five differ only in those two blocks; the assets are identical, so they double as a reference for wiring up a catalog and storage pair.
+
+<div class="template-grid">
+  <a class="template-card" href="./templates-docs/iceberg-sqlite-local-README.html">
+    <span class="template-card__category">Credential-free</span>
+    <strong>iceberg-sqlite-local</strong>
+    <span>Iceberg tables on your own disk with a SQLite catalog. No accounts, no services &mdash; run it as soon as it is generated.</span>
+    <span class="template-card__tags"><code>Iceberg</code><code>SQLite</code><code>local</code></span>
+  </a>
+  <a class="template-card" href="./templates-docs/iceberg-rest-minio-README.html">
+    <span class="template-card__category">Local stack</span>
+    <strong>iceberg-rest-minio</strong>
+    <span>A REST catalog server in front of MinIO, both from the bundled docker-compose file.</span>
+    <span class="template-card__tags"><code>Iceberg</code><code>REST</code><code>MinIO</code></span>
+  </a>
+  <a class="template-card" href="./templates-docs/iceberg-glue-s3-README.html">
+    <span class="template-card__category">AWS</span>
+    <strong>iceberg-glue-s3</strong>
+    <span>AWS Glue as the catalog with data in S3 &mdash; a managed catalog, so there is no metastore to run.</span>
+    <span class="template-card__tags"><code>Iceberg</code><code>Glue</code><code>S3</code></span>
+  </a>
+  <a class="template-card" href="./templates-docs/iceberg-postgres-gcs-README.html">
+    <span class="template-card__category">GCP</span>
+    <strong>iceberg-postgres-gcs</strong>
+    <span>A Postgres catalog you own, with data in Google Cloud Storage via a service-account key.</span>
+    <span class="template-card__tags"><code>Iceberg</code><code>Postgres</code><code>GCS</code></span>
+  </a>
+  <a class="template-card" href="./templates-docs/iceberg-hadoop-gcsinterop-README.html">
+    <span class="template-card__category">No catalog service</span>
+    <strong>iceberg-hadoop-gcsinterop</strong>
+    <span>Metadata kept in the warehouse itself, on GCS through its S3 interoperability API.</span>
+    <span class="template-card__tags"><code>Iceberg</code><code>hadoop</code><code>GCS interop</code></span>
+  </a>
+</div>
+
 ### Source-to-warehouse ingestion
 
 <div class="template-grid">
@@ -208,7 +245,8 @@ bruin init nyc-taxi my-taxi-pipeline
 
 | Goal | Start with |
 | --- | --- |
-| Learn Bruin locally without cloud credentials | `duckdb`, `python`, `frankfurter`, or `chess` |
+| Learn Bruin locally without cloud credentials | `duckdb`, `python`, `frankfurter`, `chess`, or `iceberg-sqlite-local` |
+| Load into an Iceberg lakehouse | `iceberg-sqlite-local` to try it, then `iceberg-glue-s3`, `iceberg-postgres-gcs`, `iceberg-rest-minio`, or `iceberg-hadoop-gcsinterop` |
 | Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `shopify-clickhouse`, `gsheet-bigquery`, `notion`, or `gorgias` |
 | Explore a complete demo with generated data | `demo-snowflake-sales-analytics` or `demo-snowflake-salesforce` |
 | Scaffold ecommerce reporting | `ecommerce` |

--- a/templates/iceberg-glue-s3/.bruin.yml
+++ b/templates/iceberg-glue-s3/.bruin.yml
@@ -1,0 +1,21 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: glue
+            region: "${AWS_REGION}"
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"
+          storage:
+            type: s3
+            path: "s3://${S3_BUCKET}/warehouse"
+            region: "${AWS_REGION}"
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"

--- a/templates/iceberg-glue-s3/README.md
+++ b/templates/iceberg-glue-s3/README.md
@@ -12,7 +12,8 @@ An IAM user or role that can reach both halves:
 - **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
 - **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
-Then set these before running:
+Then supply the values, either by exporting them or by replacing the `${...}`
+placeholders in `.bruin.yml` directly:
 
 ```bash
 export AWS_REGION=eu-north-1

--- a/templates/iceberg-glue-s3/README.md
+++ b/templates/iceberg-glue-s3/README.md
@@ -12,8 +12,29 @@ An IAM user or role that can reach both halves:
 - **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
 - **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
-Then supply the values, either by exporting them or by replacing the `${...}`
-placeholders in `.bruin.yml` directly:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only
+the marked values are missing:
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: glue
+            region: "${AWS_REGION}"                     # <- e.g. eu-north-1
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"        # <-
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"    # <-
+          storage:
+            type: s3
+            path: "s3://${S3_BUCKET}/warehouse"         # <- your bucket
+            region: "${AWS_REGION}"
+            auth:
+              access_key: "${AWS_ACCESS_KEY_ID}"
+              secret_key: "${AWS_SECRET_ACCESS_KEY}"
+```
+
+Replace each `${...}` with the value, or export them as environment variables
+and leave the file alone — Bruin expands both:
 
 ```bash
 export AWS_REGION=eu-north-1

--- a/templates/iceberg-glue-s3/README.md
+++ b/templates/iceberg-glue-s3/README.md
@@ -47,6 +47,8 @@ Use a long-lived access key, not SSO or STS credentials — those expire within
 hours and a scheduled pipeline would start failing overnight. If you must use
 them, add `session_token` to both `auth` blocks.
 
+## Run it
+
 ```bash
 bruin run iceberg-glue-s3
 ```

--- a/templates/iceberg-glue-s3/README.md
+++ b/templates/iceberg-glue-s3/README.md
@@ -1,0 +1,43 @@
+# Bruin — Iceberg with AWS Glue and S3
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** tables catalogued in AWS Glue with the
+data in S3. This is the shape most AWS deployments use: a managed catalog, so
+there is no metastore to run.
+
+## Setup
+
+An IAM user or role that can reach both halves:
+
+- **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
+- **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
+
+Then set these before running:
+
+```bash
+export AWS_REGION=eu-north-1
+export AWS_ACCESS_KEY_ID=AKIA…
+export AWS_SECRET_ACCESS_KEY=…
+export S3_BUCKET=my-company-lake
+```
+
+Use a long-lived access key, not SSO or STS credentials — those expire within
+hours and a scheduled pipeline would start failing overnight. If you must use
+them, add `session_token` to both `auth` blocks.
+
+```bash
+bruin run iceberg-glue-s3
+```
+
+The tables appear in Glue under the `raw` database, with data at
+`s3://$S3_BUCKET/warehouse/raw.db/`.
+
+## Notes
+
+The catalog and the storage have **separate** `auth` blocks. They are the same
+credentials here, but they do not have to be — Glue is an AWS API and the bucket
+is storage, and Bruin sends each set to the right place.
+
+`region` is required for both: Glue needs to know which regional endpoint to
+call, and S3 uses it to route the request. A wrong one gives you
+`PermanentRedirect`; an empty one gives you `Invalid region`.

--- a/templates/iceberg-glue-s3/assets/raw/currencies.asset.yml
+++ b/templates/iceberg-glue-s3/assets/raw/currencies.asset.yml
@@ -1,0 +1,8 @@
+name: raw.currencies
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: currencies
+  destination: iceberg

--- a/templates/iceberg-glue-s3/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-glue-s3/assets/raw/exchange_rates.asset.yml
@@ -1,0 +1,8 @@
+name: raw.exchange_rates
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: exchange_rates
+  destination: iceberg

--- a/templates/iceberg-glue-s3/pipeline.yml
+++ b/templates/iceberg-glue-s3/pipeline.yml
@@ -1,0 +1,2 @@
+name: iceberg-glue-s3
+catchup: false

--- a/templates/iceberg-hadoop-gcsinterop/.bruin.yml
+++ b/templates/iceberg-hadoop-gcsinterop/.bruin.yml
@@ -12,7 +12,6 @@ environments:
             type: s3
             path: "s3://${GCS_BUCKET}/warehouse"
             endpoint: "storage.googleapis.com"
-            region: "auto"
             auth:
               access_key: "${GCS_HMAC_KEY}"
               secret_key: "${GCS_HMAC_SECRET}"

--- a/templates/iceberg-hadoop-gcsinterop/.bruin.yml
+++ b/templates/iceberg-hadoop-gcsinterop/.bruin.yml
@@ -1,0 +1,20 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: hadoop
+          storage:
+            type: s3
+            path: "s3://${GCS_BUCKET}/warehouse"
+            endpoint: "storage.googleapis.com"
+            region: "auto"
+            auth:
+              access_key: "${GCS_HMAC_KEY}"
+              secret_key: "${GCS_HMAC_SECRET}"
+          properties:
+            allow-unsafe-commits: "true"  # hadoop does not commit atomically to object storage

--- a/templates/iceberg-hadoop-gcsinterop/README.md
+++ b/templates/iceberg-hadoop-gcsinterop/README.md
@@ -1,0 +1,40 @@
+# Bruin — Iceberg with no catalog service, on GCS
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** tables that need no catalog service at
+all. The `hadoop` catalog keeps its metadata in the warehouse itself, so the
+bucket is the only thing to provision.
+
+Storage is Google Cloud Storage reached through its **S3 interoperability API**,
+the alternative to a service-account key.
+
+## Setup
+
+An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
+*Create a key*. It looks like an AWS key pair and is used as one.
+
+```bash
+export GCS_BUCKET=my-company-lake
+export GCS_HMAC_KEY=GOOG1E…
+export GCS_HMAC_SECRET=…
+```
+
+```bash
+bruin run iceberg-hadoop-gcsinterop
+```
+
+## Notes
+
+> **The hadoop catalog does not commit atomically to object storage.** It needs
+> `allow-unsafe-commits: "true"`, already set here. Two writers to one table can
+> lose a commit, so this is for getting started and for single-writer pipelines —
+> not for concurrent production writes. Move to Glue, REST or Postgres when that
+> matters.
+
+The storage block says `type: s3` with an `s3://` warehouse even though the
+bucket is Google's, because the S3 interop endpoint really is an S3 API — only
+`endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://`
+warehouse and a service-account key, as in `iceberg-postgres-gcs`.
+
+`region: auto` is a placeholder: Google ignores it, but the AWS SDK will not sign
+a request without one.

--- a/templates/iceberg-hadoop-gcsinterop/README.md
+++ b/templates/iceberg-hadoop-gcsinterop/README.md
@@ -41,6 +41,8 @@ export GCS_HMAC_KEY=GOOG1E…
 export GCS_HMAC_SECRET=…
 ```
 
+## Run it
+
 ```bash
 bruin run iceberg-hadoop-gcsinterop
 ```

--- a/templates/iceberg-hadoop-gcsinterop/README.md
+++ b/templates/iceberg-hadoop-gcsinterop/README.md
@@ -25,7 +25,6 @@ the marked values are missing:
             type: s3
             path: "s3://${GCS_BUCKET}/warehouse"        # <- your GCS bucket
             endpoint: "storage.googleapis.com"
-            region: "auto"
             auth:
               access_key: "${GCS_HMAC_KEY}"             # <-
               secret_key: "${GCS_HMAC_SECRET}"          # <-
@@ -59,5 +58,5 @@ bucket is Google's, because the S3 interop endpoint really is an S3 API — only
 `endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://`
 warehouse and a service-account key, as in `iceberg-postgres-gcs`.
 
-`region: auto` is a placeholder: Google ignores it, but the AWS SDK will not sign
-a request without one.
+No `region` here: Google ignores it, and ingestr supplies the placeholder the
+AWS SDK insists on. AWS S3 still needs a real one.

--- a/templates/iceberg-hadoop-gcsinterop/README.md
+++ b/templates/iceberg-hadoop-gcsinterop/README.md
@@ -13,8 +13,28 @@ the alternative to a service-account key.
 An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
 *Create a key*. It looks like an AWS key pair and is used as one.
 
-Then supply the values, either by exporting them or by replacing the `${...}`
-placeholders in `.bruin.yml` directly:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only
+the marked values are missing:
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: hadoop
+          storage:
+            type: s3
+            path: "s3://${GCS_BUCKET}/warehouse"        # <- your GCS bucket
+            endpoint: "storage.googleapis.com"
+            region: "auto"
+            auth:
+              access_key: "${GCS_HMAC_KEY}"             # <-
+              secret_key: "${GCS_HMAC_SECRET}"          # <-
+          properties:
+            allow-unsafe-commits: "true"
+```
+
+Replace each `${...}` with the value, or export them as environment variables
+and leave the file alone — Bruin expands both:
 
 ```bash
 export GCS_BUCKET=my-company-lake

--- a/templates/iceberg-hadoop-gcsinterop/README.md
+++ b/templates/iceberg-hadoop-gcsinterop/README.md
@@ -13,6 +13,9 @@ the alternative to a service-account key.
 An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
 *Create a key*. It looks like an AWS key pair and is used as one.
 
+Then supply the values, either by exporting them or by replacing the `${...}`
+placeholders in `.bruin.yml` directly:
+
 ```bash
 export GCS_BUCKET=my-company-lake
 export GCS_HMAC_KEY=GOOG1E…

--- a/templates/iceberg-hadoop-gcsinterop/assets/raw/currencies.asset.yml
+++ b/templates/iceberg-hadoop-gcsinterop/assets/raw/currencies.asset.yml
@@ -1,0 +1,8 @@
+name: raw.currencies
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: currencies
+  destination: iceberg

--- a/templates/iceberg-hadoop-gcsinterop/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-hadoop-gcsinterop/assets/raw/exchange_rates.asset.yml
@@ -1,0 +1,8 @@
+name: raw.exchange_rates
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: exchange_rates
+  destination: iceberg

--- a/templates/iceberg-hadoop-gcsinterop/pipeline.yml
+++ b/templates/iceberg-hadoop-gcsinterop/pipeline.yml
@@ -1,0 +1,2 @@
+name: iceberg-hadoop-gcsinterop
+catchup: false

--- a/templates/iceberg-postgres-gcs/.bruin.yml
+++ b/templates/iceberg-postgres-gcs/.bruin.yml
@@ -1,0 +1,22 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: postgres
+            host: "${PG_HOST}"
+            port: 5432
+            database: "${PG_DATABASE}"
+            auth:
+              username: "${PG_USERNAME}"
+              password: "${PG_PASSWORD}"
+          storage:
+            type: gcs
+            path: "gs://${GCS_BUCKET}/warehouse"
+            key_file: "sa.json"           # relative to this file
+          properties:
+            sslmode: "require"            # managed Postgres refuses plaintext

--- a/templates/iceberg-postgres-gcs/README.md
+++ b/templates/iceberg-postgres-gcs/README.md
@@ -13,6 +13,9 @@ RDS, or one you run.
 2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
    Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
 
+Then supply the values, either by exporting them or by replacing the `${...}`
+placeholders in `.bruin.yml` directly:
+
 ```bash
 export PG_HOST=my-catalog.example.com
 export PG_DATABASE=iceberg_catalog

--- a/templates/iceberg-postgres-gcs/README.md
+++ b/templates/iceberg-postgres-gcs/README.md
@@ -38,6 +38,8 @@ the marked values are missing:
 Replace each `${...}` with the value, or export them as environment variables
 and leave the file alone — Bruin expands both.
 
+## Run it
+
 ```bash
 bruin run iceberg-postgres-gcs
 ```

--- a/templates/iceberg-postgres-gcs/README.md
+++ b/templates/iceberg-postgres-gcs/README.md
@@ -13,16 +13,30 @@ RDS, or one you run.
 2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
    Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
 
-Then supply the values, either by exporting them or by replacing the `${...}`
-placeholders in `.bruin.yml` directly:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only
+the marked values are missing:
 
-```bash
-export PG_HOST=my-catalog.example.com
-export PG_DATABASE=iceberg_catalog
-export PG_USERNAME=iceberg_user
-export PG_PASSWORD=…
-export GCS_BUCKET=my-company-lake
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: postgres
+            host: "${PG_HOST}"              # <- your Postgres host
+            port: 5432
+            database: "${PG_DATABASE}"      # <-
+            auth:
+              username: "${PG_USERNAME}"    # <-
+              password: "${PG_PASSWORD}"    # <-
+          storage:
+            type: gcs
+            path: "gs://${GCS_BUCKET}/warehouse"   # <- your bucket
+            key_file: "sa.json"
+          properties:
+            sslmode: "require"
 ```
+
+Replace each `${...}` with the value, or export them as environment variables
+and leave the file alone — Bruin expands both.
 
 ```bash
 bruin run iceberg-postgres-gcs

--- a/templates/iceberg-postgres-gcs/README.md
+++ b/templates/iceberg-postgres-gcs/README.md
@@ -1,0 +1,40 @@
+# Bruin — Iceberg with a Postgres catalog and Google Cloud Storage
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** tables catalogued in Postgres with the
+data in Google Cloud Storage. Useful on GCP, or anywhere you would rather own the
+catalog than depend on a cloud service: any Postgres will do — Cloud SQL, Neon,
+RDS, or one you run.
+
+## Setup
+
+1. **A Postgres database** for the catalog. It needs no schema; Iceberg creates
+   its own tables on first run.
+2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
+   Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
+
+```bash
+export PG_HOST=my-catalog.example.com
+export PG_DATABASE=iceberg_catalog
+export PG_USERNAME=iceberg_user
+export PG_PASSWORD=…
+export GCS_BUCKET=my-company-lake
+```
+
+```bash
+bruin run iceberg-postgres-gcs
+```
+
+Data lands at `gs://$GCS_BUCKET/warehouse/raw.db/`.
+
+## Notes
+
+`sslmode: require` is in `properties` because managed Postgres — Neon, RDS,
+Cloud SQL — refuses plaintext connections. Drop it for a local database that
+does not speak TLS.
+
+Storage authenticates with a service-account key, given as `key_file` (a path)
+or `key_json` (the key inline). A path is fine here, where the pipeline runs on
+your machine; use `key_json` anywhere the run happens elsewhere, such as Bruin
+Cloud, since the file will not be on that machine. Leave both out to use
+Application Default Credentials.

--- a/templates/iceberg-postgres-gcs/assets/raw/currencies.asset.yml
+++ b/templates/iceberg-postgres-gcs/assets/raw/currencies.asset.yml
@@ -1,0 +1,8 @@
+name: raw.currencies
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: currencies
+  destination: iceberg

--- a/templates/iceberg-postgres-gcs/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-postgres-gcs/assets/raw/exchange_rates.asset.yml
@@ -1,0 +1,8 @@
+name: raw.exchange_rates
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: exchange_rates
+  destination: iceberg

--- a/templates/iceberg-postgres-gcs/pipeline.yml
+++ b/templates/iceberg-postgres-gcs/pipeline.yml
@@ -1,0 +1,2 @@
+name: iceberg-postgres-gcs
+catchup: false

--- a/templates/iceberg-rest-minio/.bruin.yml
+++ b/templates/iceberg-rest-minio/.bruin.yml
@@ -1,0 +1,21 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: rest
+            host: "localhost"
+            port: 8181
+          storage:
+            type: s3
+            path: "s3://warehouse"
+            endpoint: "localhost:9000"
+            use_ssl: false
+            region: "us-east-1"
+            auth:
+              access_key: "minioadmin"
+              secret_key: "minioadmin"

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -55,6 +55,3 @@ than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
 reaches storage **itself** to write metadata, which is why the same MinIO
 credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
 
-`raw.exchange_rates` depends on `raw.currencies` so the two do not race to create
-the `raw` namespace on the first run — the catalog registers it once and the
-loser fails. Ordinary concurrent writes to existing tables are fine.

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -55,5 +55,6 @@ than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
 reaches storage **itself** to write metadata, which is why the same MinIO
 credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
 
-Unlike the SQLite catalog in `iceberg-sqlite-local`, a catalog server handles
-concurrent writers, so these two assets load in parallel.
+`raw.exchange_rates` depends on `raw.currencies` so the two do not race to create
+the `raw` namespace on the first run — the catalog registers it once and the
+loser fails. Ordinary concurrent writes to existing tables are fine.

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -24,7 +24,7 @@ raw/currencies/metadata/00001-….metadata.json
 
 Tear it down with `docker compose down -v`.
 
-## What this shows
+## Notes
 
 An Iceberg connection is a **catalog** (where table metadata lives) and
 **storage** (where the data files go). Here the catalog is a server you talk to

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -14,7 +14,7 @@ docker compose up -d          # MinIO + the bucket + the REST catalog
 bruin run iceberg-rest-minio
 ```
 
-Browse what landed at [localhost:9001](http://localhost:9001) (`minioadmin` /
+Browse what landed in the MinIO console at `localhost:9001` (`minioadmin` /
 `minioadmin`), under `warehouse/raw/`:
 
 ```

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -1,0 +1,59 @@
+# Bruin — Iceberg with a REST catalog and MinIO
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public
+exchange-rate API, into **Apache Iceberg** — with a real catalog server in front
+of real object storage, both running locally in Docker. Still no cloud account.
+
+- `raw/currencies.asset.yml` — the list of currency codes and names.
+- `raw/exchange_rates.asset.yml` — the latest rates.
+
+## Run it
+
+```bash
+docker compose up -d          # MinIO + the bucket + the REST catalog
+bruin run iceberg-rest-minio
+```
+
+Browse what landed at [localhost:9001](http://localhost:9001) (`minioadmin` /
+`minioadmin`), under `warehouse/raw/`:
+
+```
+raw/currencies/data/00000-0-….parquet
+raw/currencies/metadata/00001-….metadata.json
+```
+
+Tear it down with `docker compose down -v`.
+
+## What this shows
+
+An Iceberg connection is a **catalog** (where table metadata lives) and
+**storage** (where the data files go). Here the catalog is a server you talk to
+over HTTP and storage is S3-compatible, which is the shape most production
+setups have — swap in Glue or Postgres and a real S3 bucket and nothing about
+the assets changes.
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: rest
+            host: "localhost"
+            port: 8181
+          storage:
+            type: s3
+            path: "s3://warehouse"
+            endpoint: "localhost:9000"        # MinIO, not AWS
+            use_ssl: false                    # it is plain HTTP locally
+            region: "us-east-1"
+            auth:
+              access_key: "minioadmin"
+              secret_key: "minioadmin"
+```
+
+Two things about that `endpoint`. It is what makes this S3-*compatible* rather
+than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
+reaches storage **itself** to write metadata, which is why the same MinIO
+credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
+
+Unlike the SQLite catalog in `iceberg-sqlite-local`, a catalog server handles
+concurrent writers, so these two assets load in parallel.

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -50,8 +50,9 @@ the assets changes.
               secret_key: "minioadmin"
 ```
 
-Two things about that `endpoint`. It is what makes this S3-*compatible* rather
-than S3, so Bruin turns on S3 compatibility mode for you. And the REST catalog
-reaches storage **itself** to write metadata, which is why the same MinIO
-credentials appear in `docker-compose.yml` — the ones above configure only Bruin.
+Two things about that `endpoint`. It marks the store as S3-*compatible* rather
+than S3, which ingestr turns into `s3.compat-mode` — MinIO does not need it, but
+GCS over its S3 endpoint does. And the REST catalog reaches storage **itself** to
+write metadata, which is why the same MinIO credentials appear in
+`docker-compose.yml`; the ones above configure only Bruin.
 

--- a/templates/iceberg-rest-minio/assets/raw/currencies.asset.yml
+++ b/templates/iceberg-rest-minio/assets/raw/currencies.asset.yml
@@ -1,0 +1,8 @@
+name: raw.currencies
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: currencies
+  destination: iceberg

--- a/templates/iceberg-rest-minio/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-rest-minio/assets/raw/exchange_rates.asset.yml
@@ -2,11 +2,6 @@ name: raw.exchange_rates
 type: ingestr
 connection: iceberg-default
 
-# Both assets create the raw namespace on the first run; the catalog registers it
-# once and the loser fails, so give them an order.
-depends:
-  - raw.currencies
-
 parameters:
   source_connection: frankfurter-default
   source_table: exchange_rates

--- a/templates/iceberg-rest-minio/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-rest-minio/assets/raw/exchange_rates.asset.yml
@@ -2,6 +2,11 @@ name: raw.exchange_rates
 type: ingestr
 connection: iceberg-default
 
+# Both assets create the raw namespace on the first run; the catalog registers it
+# once and the loser fails, so give them an order.
+depends:
+  - raw.currencies
+
 parameters:
   source_connection: frankfurter-default
   source_table: exchange_rates

--- a/templates/iceberg-rest-minio/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-rest-minio/assets/raw/exchange_rates.asset.yml
@@ -1,0 +1,8 @@
+name: raw.exchange_rates
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: exchange_rates
+  destination: iceberg

--- a/templates/iceberg-rest-minio/docker-compose.yml
+++ b/templates/iceberg-rest-minio/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-    ports:
-      - "9000:9000"     # S3 API
-      - "9001:9001"     # web console
+    ports:                          # localhost only: the credentials above are the defaults
+      - "127.0.0.1:9000:9000"       # S3 API
+      - "127.0.0.1:9001:9001"       # web console
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
@@ -41,4 +41,4 @@ services:
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_REGION: us-east-1
     ports:
-      - "8181:8181"
+      - "127.0.0.1:8181:8181"

--- a/templates/iceberg-rest-minio/docker-compose.yml
+++ b/templates/iceberg-rest-minio/docker-compose.yml
@@ -1,0 +1,44 @@
+# Local Iceberg stack: a REST catalog server in front of MinIO.
+#   docker compose up -d      then      bruin run iceberg-rest-minio
+services:
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"     # S3 API
+      - "9001:9001"     # web console
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      retries: 12
+
+  # The bucket has to exist before the catalog writes to it.
+  createbucket:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing local/warehouse
+      "
+
+  iceberg-rest:
+    image: apache/iceberg-rest-fixture
+    depends_on:
+      createbucket:
+        condition: service_completed_successfully
+    environment:
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+    ports:
+      - "8181:8181"

--- a/templates/iceberg-rest-minio/pipeline.yml
+++ b/templates/iceberg-rest-minio/pipeline.yml
@@ -1,0 +1,2 @@
+name: iceberg-rest-minio
+catchup: false

--- a/templates/iceberg-sqlite-local/.bruin.yml
+++ b/templates/iceberg-sqlite-local/.bruin.yml
@@ -1,0 +1,14 @@
+default_environment: default
+environments:
+  default:
+    connections:
+      frankfurter:
+        - name: "frankfurter-default"
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: sqlite
+            path: "catalog.db"          # relative to this file
+          storage:
+            type: local
+            path: "warehouse"           # relative to this file

--- a/templates/iceberg-sqlite-local/README.md
+++ b/templates/iceberg-sqlite-local/README.md
@@ -48,10 +48,10 @@ a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
 Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
 assets never change.
 
-A SQLite catalog is a single-writer file, which is why `raw.exchange_rates`
-depends on `raw.currencies`: without an order the two assets create the catalog
-at the same time and one fails with `SQLITE_BUSY`. Catalogs backed by a server
-have no such limit.
+`raw.exchange_rates` depends on `raw.currencies` so the two do not start
+together: a SQLite catalog is a single-writer file, and both creating it at once
+fails with `SQLITE_BUSY`. Every catalog needs the ordering for the first run
+anyway, since the namespace is created once and the second asset loses.
 
 Not for production — the point is to see Iceberg work before committing to
 infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)

--- a/templates/iceberg-sqlite-local/README.md
+++ b/templates/iceberg-sqlite-local/README.md
@@ -48,11 +48,6 @@ a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
 Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
 assets never change.
 
-`raw.exchange_rates` depends on `raw.currencies` so the two do not start
-together: a SQLite catalog is a single-writer file, and both creating it at once
-fails with `SQLITE_BUSY`. Every catalog needs the ordering for the first run
-anyway, since the namespace is created once and the second asset loses.
-
 Not for production — the point is to see Iceberg work before committing to
 infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)
 for the real backends.

--- a/templates/iceberg-sqlite-local/README.md
+++ b/templates/iceberg-sqlite-local/README.md
@@ -40,7 +40,7 @@ SET unsafe_enable_version_guessing = true;
 SELECT * FROM iceberg_scan('warehouse/raw.db/currencies');
 ```
 
-## What this shows
+## Notes
 
 An Iceberg connection is a **catalog** (where table metadata lives) and
 **storage** (where the data files go). This template picks the simplest of each:

--- a/templates/iceberg-sqlite-local/README.md
+++ b/templates/iceberg-sqlite-local/README.md
@@ -1,0 +1,58 @@
+# Bruin — Iceberg on your laptop
+
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate
+API, into **Apache Iceberg** tables on your own disk. No cloud account, no
+credentials, no services to start.
+
+- `raw/currencies.asset.yml` — the list of currency codes and names.
+- `raw/exchange_rates.asset.yml` — the latest rates.
+
+## Run it
+
+```bash
+bruin run iceberg-sqlite-local
+```
+
+That is the whole setup. The connection in `.bruin.yml` needs nothing filled in:
+
+```yaml
+      iceberg:
+        - name: "iceberg-default"
+          catalog:
+            type: sqlite
+            path: "catalog.db"          # relative to .bruin.yml
+          storage:
+            type: local
+            path: "warehouse"           # relative to .bruin.yml
+```
+
+Afterwards, `catalog.db` holds the table metadata and `warehouse/` the data:
+
+```
+warehouse/raw.db/currencies/data/00000-0-….parquet
+warehouse/raw.db/currencies/metadata/00001-….metadata.json
+```
+
+Read them back with DuckDB:
+
+```sql
+SET unsafe_enable_version_guessing = true;
+SELECT * FROM iceberg_scan('warehouse/raw.db/currencies');
+```
+
+## What this shows
+
+An Iceberg connection is a **catalog** (where table metadata lives) and
+**storage** (where the data files go). This template picks the simplest of each:
+a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
+Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
+assets never change.
+
+A SQLite catalog is a single-writer file, which is why `raw.exchange_rates`
+depends on `raw.currencies`: without an order the two assets create the catalog
+at the same time and one fails with `SQLITE_BUSY`. Catalogs backed by a server
+have no such limit.
+
+Not for production — the point is to see Iceberg work before committing to
+infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)
+for the real backends.

--- a/templates/iceberg-sqlite-local/assets/raw/currencies.asset.yml
+++ b/templates/iceberg-sqlite-local/assets/raw/currencies.asset.yml
@@ -1,0 +1,8 @@
+name: raw.currencies
+type: ingestr
+connection: iceberg-default
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: currencies
+  destination: iceberg

--- a/templates/iceberg-sqlite-local/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-sqlite-local/assets/raw/exchange_rates.asset.yml
@@ -1,0 +1,13 @@
+name: raw.exchange_rates
+type: ingestr
+connection: iceberg-default
+
+# A sqlite catalog is a single-writer file: without an order, both assets create
+# the catalog at once and one of them loses with SQLITE_BUSY.
+depends:
+  - raw.currencies
+
+parameters:
+  source_connection: frankfurter-default
+  source_table: exchange_rates
+  destination: iceberg

--- a/templates/iceberg-sqlite-local/assets/raw/exchange_rates.asset.yml
+++ b/templates/iceberg-sqlite-local/assets/raw/exchange_rates.asset.yml
@@ -2,11 +2,6 @@ name: raw.exchange_rates
 type: ingestr
 connection: iceberg-default
 
-# A sqlite catalog is a single-writer file: without an order, both assets create
-# the catalog at once and one of them loses with SQLITE_BUSY.
-depends:
-  - raw.currencies
-
 parameters:
   source_connection: frankfurter-default
   source_table: exchange_rates

--- a/templates/iceberg-sqlite-local/pipeline.yml
+++ b/templates/iceberg-sqlite-local/pipeline.yml
@@ -1,0 +1,2 @@
+name: iceberg-sqlite-local
+catchup: false


### PR DESCRIPTION
Iceberg is the one destination whose setup is genuinely a choice — a connection is a **catalog** plus **storage**, and which pair you want depends on where you run. There was no template for any of them, so the only way in was reading the docs and assembling a connection by hand.

Five templates, each a different catalog *and* a different storage:

| template | catalog | storage | needs |
|---|---|---|---|
| `iceberg-sqlite-local` | sqlite | local disk | **nothing** |
| `iceberg-rest-minio` | REST server | MinIO | Docker (compose file included) |
| `iceberg-glue-s3` | Glue | S3 | AWS credentials |
| `iceberg-postgres-gcs` | Postgres | native `gs://` | a Postgres + a service-account key |
| `iceberg-hadoop-gcsinterop` | hadoop (none) | GCS over S3 interop | HMAC keys |

The assets are identical in all five — two ingestr assets pulling from `frankfurter`, which needs no credentials — so what differs is only the connection, which is the thing being demonstrated. Swapping catalogs is then visibly a `.bruin.yml` change and nothing else.