### PR TITLE
fix(iceberg): resolve local catalog and storage paths against the config

### DIFF
--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -364,6 +364,14 @@ func (c *Config) SelectEnvironment(name string) error {
 	return nil
 }
 
+// hasURIScheme reports whether a path carries a scheme like s3://, gs:// or
+// file://, in which case it is a location rather than a path on this machine.
+func hasURIScheme(path string) bool {
+	i := strings.Index(path, "://")
+
+	return i > 0
+}
+
 func isAnchoredLocalPath(path string) bool {
 	return hasAnchoredLocalPathPrefix(path) || filepath.IsAbs(path)
 }
@@ -489,6 +497,21 @@ func LoadFromFileOrEnv(fs afero.Fs, path string) (*Config, error) {
 
 			if conn.SslKeyPath != "" && !isAnchoredLocalPath(conn.SslKeyPath) {
 				env.Connections.Vitess[i].SslKeyPath = filepath.Join(configLocation, conn.SslKeyPath)
+			}
+		}
+
+		// Make Iceberg local file paths absolute: a sqlite catalog is a file, a
+		// hadoop catalog without a scheme is a directory, and both are read by the
+		// ingestr subprocess, which does not run from the config's directory.
+		for i, conn := range env.Connections.Iceberg {
+			if conn.Catalog.Path != "" && !isAnchoredLocalPath(conn.Catalog.Path) && !hasURIScheme(conn.Catalog.Path) {
+				env.Connections.Iceberg[i].Catalog.Path = filepath.Join(configLocation, conn.Catalog.Path)
+			}
+			if conn.Storage.Path != "" && !isAnchoredLocalPath(conn.Storage.Path) && !hasURIScheme(conn.Storage.Path) {
+				env.Connections.Iceberg[i].Storage.Path = filepath.Join(configLocation, conn.Storage.Path)
+			}
+			if conn.Storage.KeyFile != "" && !isAnchoredLocalPath(conn.Storage.KeyFile) {
+				env.Connections.Iceberg[i].Storage.KeyFile = filepath.Join(configLocation, conn.Storage.KeyFile)
 			}
 		}
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -3745,3 +3745,50 @@ func mustMarshalConnectionJSON(t *testing.T, conn interface{}) map[string]interf
 	require.NoError(t, json.Unmarshal(data, &payload))
 	return payload
 }
+
+func TestLoadFromFile_MakesIcebergLocalPathsAbsolute(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	configPath := filepath.Join("repo", ".bruin.yml")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, afero.WriteFile(fs, configPath, []byte(`default_environment: default
+environments:
+  default:
+    connections:
+      iceberg:
+        - name: local
+          catalog:
+            type: sqlite
+            path: catalog.db
+          storage:
+            type: local
+            path: warehouse
+        - name: remote
+          catalog:
+            type: hadoop
+            path: "s3://bucket/warehouse"
+          storage:
+            type: gcs
+            path: "gs://bucket/warehouse"
+            key_file: creds/sa.json
+`), 0o644))
+
+	cfg, err := LoadFromFileOrEnv(fs, configPath)
+	require.NoError(t, err)
+
+	configLocation, err := filepath.Abs("repo")
+	require.NoError(t, err)
+
+	// A sqlite catalog and a local warehouse are files on this machine, and the
+	// ingestr subprocess does not run from the config's directory.
+	local := cfg.Environments["default"].Connections.Iceberg[0]
+	require.Equal(t, filepath.Join(configLocation, "catalog.db"), local.Catalog.Path)
+	require.Equal(t, filepath.Join(configLocation, "warehouse"), local.Storage.Path)
+
+	// Anything carrying a scheme is a location, not a path here.
+	remote := cfg.Environments["default"].Connections.Iceberg[1]
+	require.Equal(t, "s3://bucket/warehouse", remote.Catalog.Path)
+	require.Equal(t, "gs://bucket/warehouse", remote.Storage.Path)
+	require.Equal(t, filepath.Join(configLocation, "creds/sa.json"), remote.Storage.KeyFile)
+}


### PR DESCRIPTION
A local Iceberg path written relative to `.bruin.yml` does not work. A sqlite catalog fails with

```
iceberg: failed to load catalog: unable to open database file (14)
```

because the ingestr subprocess does not run from the config's directory, so `path: "catalog.db"` is resolved against whatever the working directory happens to be. Making it absolute is the only way to use one.

That is inconsistent with everything around it: duckdb ships `path: "duckdb.db"` relative in its own template and works, because `LoadFromFileOrEnv` already absolutises duckdb paths, GCP and Google Sheets service-account files, and the MySQL, Doris and Vitess SSL paths. Iceberg was simply never added to that list.

Adds the three Iceberg fields that name something on this machine — `catalog.path` (a sqlite file, or a hadoop warehouse directory), `storage.path` (a local warehouse) and `storage.key_file` (a service-account key) — resolved the same way against the config's directory.

Anything carrying a scheme is left alone. `s3://bucket/warehouse`, `gs://…` and `file://…` are locations, not paths here, and joining them to a directory would corrupt them.