### PR TITLE
Add cloud --team flag to target a team via X-Bruin-Team

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -49,14 +49,18 @@ func Cloud(isDebug *bool) *cli.Command {
 }
 
 // addTeamFlag adds --team to every runnable cloud command, so any of them can
-// target a team other than the token owner's current one.
+// target a team other than the token owner's current one. A command is runnable
+// when it has an action of its own (leaves always, but also parents like
+// "agents connections" that both list and hold subcommands); recurse into any
+// parent so its children get the flag too.
 func addTeamFlag(cmd *cli.Command) {
 	for _, sub := range cmd.Commands {
+		if sub.Action != nil || len(sub.Commands) == 0 {
+			sub.Flags = append(sub.Flags, teamFlag())
+		}
 		if len(sub.Commands) > 0 {
 			addTeamFlag(sub)
-			continue
 		}
-		sub.Flags = append(sub.Flags, teamFlag())
 	}
 }
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -25,7 +25,7 @@ import (
 var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 func Cloud(isDebug *bool) *cli.Command {
-	return &cli.Command{
+	cmd := &cli.Command{
 		Name:  "cloud",
 		Usage: "Interact with Bruin Cloud API",
 		Commands: []*cli.Command{
@@ -43,6 +43,28 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudAuditLogs(),
 			CloudCost(),
 		},
+	}
+	addTeamFlag(cmd)
+	return cmd
+}
+
+// addTeamFlag adds --team to every runnable cloud command, so any of them can
+// target a team other than the token owner's current one.
+func addTeamFlag(cmd *cli.Command) {
+	for _, sub := range cmd.Commands {
+		if len(sub.Commands) > 0 {
+			addTeamFlag(sub)
+			continue
+		}
+		sub.Flags = append(sub.Flags, teamFlag())
+	}
+}
+
+func teamFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:    "team",
+		Usage:   "act on this team (company prefix) instead of your current team",
+		Sources: cli.EnvVars("BRUIN_CLOUD_TEAM"),
 	}
 }
 
@@ -143,7 +165,11 @@ func newCloudClient(c *cli.Command) (*bruincloud.APIClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return bruincloud.NewAPIClient(key), nil
+	client := bruincloud.NewAPIClient(key)
+	if team := c.String("team"); team != "" {
+		client.SetTeam(team)
+	}
+	return client, nil
 }
 
 func resolveRunID(ctx context.Context, c *cli.Command, client *bruincloud.APIClient, project, pipeline string) (string, error) {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -170,6 +170,35 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "audit-logs")
 }
 
+func TestCloudLeafCommandsHaveTeamFlag(t *testing.T) {
+	t.Parallel()
+	isDebug := false
+
+	checked := 0
+	var walk func(*cli.Command)
+	walk = func(c *cli.Command) {
+		for _, sub := range c.Commands {
+			if len(sub.Commands) > 0 {
+				walk(sub)
+				continue
+			}
+			has := false
+			for _, f := range sub.Flags {
+				for _, n := range f.Names() {
+					if n == "team" {
+						has = true
+					}
+				}
+			}
+			assert.Truef(t, has, "cloud command %q should have --team", sub.Name)
+			checked++
+		}
+	}
+	walk(Cloud(&isDebug))
+
+	assert.Positive(t, checked)
+}
+
 func TestCloudProjectsCommand_Help(t *testing.T) {
 	t.Parallel()
 	cmd := CloudProjects()

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -178,20 +178,23 @@ func TestCloudLeafCommandsHaveTeamFlag(t *testing.T) {
 	var walk func(*cli.Command)
 	walk = func(c *cli.Command) {
 		for _, sub := range c.Commands {
-			if len(sub.Commands) > 0 {
-				walk(sub)
-				continue
-			}
-			has := false
-			for _, f := range sub.Flags {
-				for _, n := range f.Names() {
-					if n == "team" {
-						has = true
+			// Every runnable command (a leaf, or a parent like "agents
+			// connections" that has its own action) must carry --team.
+			if sub.Action != nil || len(sub.Commands) == 0 {
+				has := false
+				for _, f := range sub.Flags {
+					for _, n := range f.Names() {
+						if n == "team" {
+							has = true
+						}
 					}
 				}
+				assert.Truef(t, has, "cloud command %q should have --team", sub.Name)
+				checked++
 			}
-			assert.Truef(t, has, "cloud command %q should have --team", sub.Name)
-			checked++
+			if len(sub.Commands) > 0 {
+				walk(sub)
+			}
 		}
 	}
 	walk(Cloud(&isDebug))

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -40,6 +40,7 @@ These flags are available on all `cloud` subcommands:
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--api-key` | str | - | Bruin Cloud API key. Also reads from `BRUIN_CLOUD_API_KEY` env var or `.bruin.yml`. |
+| `--team` | str | - | Act on this team (company prefix) instead of your current team. Also reads from `BRUIN_CLOUD_TEAM`. Only applies to personal API keys, and only for teams you belong to. |
 | `--output`, `-o` | str | `plain` | Output format: `plain` or `json`. Use `json` for scripting. |
 
 ## Subcommands

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -26,7 +26,14 @@ const (
 type APIClient struct {
 	baseURL    string
 	apiKey     string
+	team       string
 	httpClient *http.Client
+}
+
+// SetTeam makes requests act on the given team (company prefix) via the
+// X-Bruin-Team header, instead of the token owner's current team.
+func (c *APIClient) SetTeam(team string) {
+	c.team = team
 }
 
 // NewAPIClient creates a new API client with the given API key.
@@ -84,6 +91,9 @@ func (c *APIClient) doRequest(ctx context.Context, method, path string, body any
 
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Accept", "application/json")
+	if c.team != "" {
+		req.Header.Set("X-Bruin-Team", c.team)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -52,6 +52,39 @@ func TestDoRequest_AuthHeader(t *testing.T) {
 	assert.Equal(t, "Bearer test-api-key", gotAuth)
 }
 
+func TestDoRequest_TeamHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends X-Bruin-Team when set", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Get("X-Bruin-Team")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		})
+		client.SetTeam("acme")
+
+		_, err := client.ListProjects(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "acme", got)
+	})
+
+	t.Run("omits the header when unset", func(t *testing.T) {
+		t.Parallel()
+		var present bool
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, present = r.Header["X-Bruin-Team"]
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		})
+
+		_, err := client.ListProjects(t.Context())
+		require.NoError(t, err)
+		assert.False(t, present)
+	})
+}
+
 func TestDoRequest_ErrorParsing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
CLI half of the multi-team selector (pairs with the cloud `X-Bruin-Team` header). A personal API key only acted on the owner's current team; `--team <company-prefix>` now points any `bruin cloud ...` command at another team you belong to — no UI team-switch.

- `--team` (also `BRUIN_CLOUD_TEAM`) injected into every `cloud` subcommand.
- `newCloudClient` sets it on the API client, which sends the `X-Bruin-Team` header.
- No header sent when unset → current-team behavior unchanged.

Tests: client sends/omits the header; every cloud leaf command exposes `--team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)