### PR TITLE
fabric: use uppercase INFORMATION_SCHEMA.TABLES for case-sensitive warehouses

### DIFF
--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -369,7 +369,7 @@ ORDER BY TABLE_SCHEMA, TABLE_NAME
 
 	rows, err := db.Select(ctx, &query.Query{Query: schemaQuery})
 	if err != nil {
-		return nil, fmt.Errorf("failed to query information_schema.tables: %w", err)
+		return nil, fmt.Errorf("failed to query INFORMATION_SCHEMA.TABLES: %w", err)
 	}
 
 	schemas := make(map[string][]string)
@@ -405,7 +405,7 @@ WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
 
 	tables, err := db.Select(ctx, &query.Query{Query: schemaQuery})
 	if err != nil {
-		return nil, fmt.Errorf("failed to query information_schema.tables: %w", err)
+		return nil, fmt.Errorf("failed to query INFORMATION_SCHEMA.TABLES: %w", err)
 	}
 
 	summary := &ansisql.DBDatabase{

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -362,7 +362,7 @@ func (db *DB) GetTablesWithSchemas(ctx context.Context, databaseName string) (ma
 
 	const schemaQuery = `
 SELECT TABLE_SCHEMA, TABLE_NAME
-FROM information_schema.tables
+FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
 ORDER BY TABLE_SCHEMA, TABLE_NAME
 `
@@ -399,7 +399,7 @@ func (db *DB) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, erro
 
 	const schemaQuery = `
 SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
-FROM information_schema.tables
+FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
 `
 

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -488,7 +488,7 @@ func TestDB_FetchDateTimeStats(t *testing.T) {
 
 const expectedTablesWithSchemasQuery = `
 SELECT TABLE_SCHEMA, TABLE_NAME
-FROM information_schema.tables
+FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
 ORDER BY TABLE_SCHEMA, TABLE_NAME
 `

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -540,3 +540,40 @@ func TestDB_GetTablesWithSchemas_MismatchedDatabase(t *testing.T) {
 	_, err := db.GetTablesWithSchemas(t.Context(), "other")
 	require.Error(t, err)
 }
+
+const expectedDatabaseSummaryQuery = `
+SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA NOT IN ('sys', 'INFORMATION_SCHEMA')
+`
+
+func TestDB_GetDatabaseSummary(t *testing.T) {
+	t.Parallel()
+
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	// Asserts the case-sensitive uppercase INFORMATION_SCHEMA.TABLES query.
+	mock.ExpectQuery(expectedDatabaseSummaryQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE"}).
+			AddRow("dbo", "customers", "BASE TABLE").
+			AddRow("dbo", "v_orders", "VIEW"))
+
+	db := &DB{
+		conn:   sqlx.NewDb(mockDB, "sqlmock"),
+		config: &Config{Database: "warehouse"},
+	}
+
+	got, err := db.GetDatabaseSummary(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "warehouse", got.Name)
+	require.Len(t, got.Schemas, 1)
+	assert.Equal(t, "dbo", got.Schemas[0].Name)
+	require.Len(t, got.Schemas[0].Tables, 2)
+	assert.Equal(t, "customers", got.Schemas[0].Tables[0].Name)
+	assert.Equal(t, ansisql.DBTableTypeTable, got.Schemas[0].Tables[0].Type)
+	assert.Equal(t, "v_orders", got.Schemas[0].Tables[1].Name)
+	assert.Equal(t, ansisql.DBTableTypeView, got.Schemas[0].Tables[1].Type)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Fabric database browsing (Databases panel → expand a connection) failed on real Fabric with `Invalid object name 'information_schema.tables'`. Fabric Warehouses default to a **case-sensitive** collation, so the lowercase `information_schema.tables` isn't resolved — it must be the canonical uppercase `INFORMATION_SCHEMA.TABLES`.

Fixes both `GetTablesWithSchemas` and `GetDatabaseSummary`. Reproduced against a case-sensitive SQL Server DB (`Latin1_General_100_CS_AS`): the old query throws the exact error, the uppercase query returns the schemas/tables correctly. The column query already used uppercase, which is why only table listing failed.