### PR TITLE
fabric: fix Query Preview 'Invalid column name' on subquery aliases

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1005,6 +1005,16 @@ type Limiter interface {
 }
 
 func addLimitToQuery(query string, limit int64, conn interface{}, parser *sqlparser.SQLParser, dialect string) string {
+	// Fabric Warehouses use a case-sensitive collation, and the SQL parser's
+	// add-limit round-trip lowercases derived-table column aliases (e.g. a
+	// subquery's `Account` is re-emitted as `account`), which then fails to
+	// resolve in the case-sensitive outer query. Wrap the query verbatim so the
+	// original identifiers are preserved.
+	if dialect == "fabric" {
+		if l, ok := conn.(Limiter); ok {
+			return l.Limit(query, limit)
+		}
+	}
 	// Check if the query is a single SELECT statement before applying limit
 	if parser != nil {
 		isSingleSelect, err := parser.IsSingleSelectQuery(query, dialect)

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1005,16 +1005,6 @@ type Limiter interface {
 }
 
 func addLimitToQuery(query string, limit int64, conn interface{}, parser *sqlparser.SQLParser, dialect string) string {
-	// Fabric Warehouses use a case-sensitive collation, and the SQL parser's
-	// add-limit round-trip lowercases derived-table column aliases (e.g. a
-	// subquery's `Account` is re-emitted as `account`), which then fails to
-	// resolve in the case-sensitive outer query. Wrap the query verbatim so the
-	// original identifiers are preserved.
-	if dialect == "fabric" {
-		if l, ok := conn.(Limiter); ok {
-			return l.Limit(query, limit)
-		}
-	}
 	// Check if the query is a single SELECT statement before applying limit
 	if parser != nil {
 		isSingleSelect, err := parser.IsSingleSelectQuery(query, dialect)
@@ -1023,6 +1013,18 @@ func addLimitToQuery(query string, limit int64, conn interface{}, parser *sqlpar
 			return query
 		}
 		// If there's an error checking or it is a single SELECT, proceed with adding limit
+	}
+
+	// Fabric Warehouses use a case-sensitive collation, and the SQL parser's
+	// add-limit round-trip lowercases derived-table column aliases (e.g. a
+	// subquery's `Account` is re-emitted as `account`), which then fails to
+	// resolve in the case-sensitive outer query. Wrap the query verbatim so the
+	// original identifiers are preserved. This runs after the single-select
+	// guard so multi-statement / non-SELECT input is left untouched.
+	if dialect == "fabric" {
+		if l, ok := conn.(Limiter); ok {
+			return l.Limit(query, limit)
+		}
 	}
 
 	var err error

--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -83,6 +83,15 @@ func (db *DB) RunQueryWithoutResult(ctx context.Context, q *query.Query) error {
 	return err
 }
 
+// Limit wraps the query so it returns at most `limit` rows. It preserves the
+// original query verbatim inside a derived table rather than rewriting it,
+// which matters on Fabric's case-sensitive collation where a parser round-trip
+// would otherwise lowercase column aliases and break the outer references.
+func (db *DB) Limit(query string, limit int64) string {
+	query = strings.TrimRight(query, "; \n\t")
+	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, query)
+}
+
 func (db *DB) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {
 	queryString := q.String()
 	rows, err := db.conn.QueryContext(ctx, queryString)

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -540,3 +540,13 @@ func TestDB_GetTablesWithSchemas_MismatchedDatabase(t *testing.T) {
 	_, err := db.GetTablesWithSchemas(t.Context(), "other")
 	require.Error(t, err)
 }
+
+func TestDB_Limit(t *testing.T) {
+	t.Parallel()
+
+	db := &DB{}
+	// The query is preserved verbatim inside the derived table (no rewrite),
+	// so case-sensitive column aliases survive.
+	got := db.Limit("SELECT src.Account FROM (SELECT x AS Account FROM t) src;", 100)
+	assert.Equal(t, "SELECT TOP 100 * FROM (\nSELECT src.Account FROM (SELECT x AS Account FROM t) src\n) as t", got)
+}


### PR DESCRIPTION
Query Preview against a Fabric asset failed with `mssql: Invalid column name 'Account'` when a subquery aliased a column (e.g. `AccountNumber AS Account`) and the outer query referenced that alias. The query runs fine on full-refresh/incremental — only the `--limit` path (preview) broke it.

**Root cause:** the parser's add-limit round-trip (via the `polyglot-sql` crate) re-emits derived-table `SELECT DISTINCT` projections with lowercased aliases (`Account` → `account`). On Fabric's **case-sensitive** collation, the outer `src.Account` then can't resolve. Reproduced exactly against a case-sensitive SQL Server DB.

**Fix:** give Fabric a `Limit()` that wraps the query verbatim (`SELECT TOP N * FROM (<query>) as t`) and prefer it over the parser for the `fabric` dialect, preserving the original identifiers. Verified the client's query now returns rows with `--limit`; simpler shapes still work.

Note: the deeper cause is the third-party parser lowercasing identifiers; this wraps around it for Fabric rather than patching that crate.