### PR TITLE
Add Fivetran migration template

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -392,16 +392,16 @@ func Init() *cli.Command {
 				return nil
 			}
 
-			centralConfig, err := config.LoadOrCreateWithoutPathAbsolutization(afero.NewOsFs(), bruinYmlPath)
-			if err != nil {
-				errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)
-				return err
-			}
-
 			// Read template's .bruin.yml if it exists
 			templateBruinPath := templateName + "/.bruin.yml"
 			templateBruinContent, err := templates.Templates.ReadFile(templateBruinPath)
 			if err == nil { // Only process if file exists
+				centralConfig, err := config.LoadOrCreateWithoutPathAbsolutization(afero.NewOsFs(), bruinYmlPath)
+				if err != nil {
+					errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)
+					return err
+				}
+
 				if err := mergeTemplateConfig(centralConfig, templateBruinContent); err != nil {
 					errorPrinter.Printf("%v\n", err)
 					return err

--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -95,6 +95,48 @@ func TestInitShopifyClickHouseCopiesPipelineTemplate(t *testing.T) {
 	require.Contains(t, string(orderLinesAsset), "incremental_key: order_id")
 }
 
+func TestInitMigrationFivetranCopiesMigrationWorkspace(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+
+	gitInit := exec.CommandContext(t.Context(), "git", "init")
+	gitInit.Dir = targetRoot
+	out, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	err = os.WriteFile(filepath.Join(targetRoot, ".bruin.yml"), []byte("connections:\n  duckdb: []\n  duckdb: []\n"), 0o600)
+	require.NoError(t, err)
+
+	err = Init().Run(t.Context(), []string{"init", "migration-fivetran", "my-fivetran-migration"})
+	require.NoError(t, err)
+
+	migrationRoot := filepath.Join(targetRoot, "my-fivetran-migration")
+	require.FileExists(t, filepath.Join(migrationRoot, ".gitignore"))
+	require.FileExists(t, filepath.Join(migrationRoot, "fivetran-bruin-prompt.md"))
+	require.FileExists(t, filepath.Join(migrationRoot, "plan.md"))
+	require.FileExists(t, filepath.Join(migrationRoot, "bruin", "pipeline.yml"))
+	require.FileExists(t, filepath.Join(migrationRoot, "bruin", "assets", "placeholder"))
+	require.FileExists(t, filepath.Join(migrationRoot, ".agents", "skills", "bruin-fivetran-migrator", "SKILL.md"))
+	require.FileExists(t, filepath.Join(migrationRoot, ".agents", "skills", "bruin-fivetran-migrator", "import_fivetran.py"))
+
+	pipeline, err := os.ReadFile(filepath.Join(migrationRoot, "bruin", "pipeline.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(pipeline), "name: bruin")
+
+	prompt, err := os.ReadFile(filepath.Join(migrationRoot, "fivetran-bruin-prompt.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(prompt), "review-gated workflow")
+
+	skill, err := os.ReadFile(filepath.Join(migrationRoot, ".agents", "skills", "bruin-fivetran-migrator", "SKILL.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(skill), "Capture exactly one connection selected by the user.")
+
+	gitCheckIgnore := exec.CommandContext(t.Context(), "git", "check-ignore", ".bruin.yml", ".artifacts/fivetran/capture")
+	gitCheckIgnore.Dir = migrationRoot
+	out, err = gitCheckIgnore.CombinedOutput()
+	require.NoError(t, err, string(out))
+}
+
 func TestSelfHealDemoTemplateContainsDataProblemScenarios(t *testing.T) {
 	t.Parallel()
 

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -177,6 +177,15 @@ AI agent skills are installed separately with `bruin ai skills`; see [AI Skills]
   </a>
 </div>
 
+## Migration templates
+
+Migration templates provide a review-gated starting point for moving existing
+data integrations to Bruin.
+
+| Template | Use when you want to start with |
+| --- | --- |
+| `migration-fivetran` | A review-gated Fivetran migration workspace with a blank `bruin/` pipeline, migration prompt, plan, and agent skill. |
+
 ## Other bundled templates
 
 Bruin also ships smaller starter templates and specialized examples that may not have full walkthrough pages yet.
@@ -210,6 +219,7 @@ bruin init nyc-taxi my-taxi-pipeline
 | --- | --- |
 | Learn Bruin locally without cloud credentials | `duckdb`, `python`, `frankfurter`, or `chess` |
 | Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `shopify-clickhouse`, `gsheet-bigquery`, `notion`, or `gorgias` |
+| Migrate one Fivetran connection to a review-gated Bruin project | `migration-fivetran` |
 | Explore a complete demo with generated data | `demo-snowflake-sales-analytics` or `demo-snowflake-salesforce` |
 | Scaffold ecommerce reporting | `ecommerce` |
 | Work with a specific database | `athena`, `clickhouse`, `bronze-silver-postgres`, `bigquery`, `databricks`, or `redshift` |

--- a/templates/migration-fivetran/.agents/skills/bruin-fivetran-migrator/SKILL.md
+++ b/templates/migration-fivetran/.agents/skills/bruin-fivetran-migrator/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: bruin-fivetran-migrator
+description: Stage a review-gated migration from one Fivetran connection to a new Bruin ingestr project.
+---
+
+# Fivetran to Bruin migrator
+
+Use this skill when a user wants to migrate one Fivetran connection to Bruin.
+Read the repository-root `fivetran-bruin-prompt.md` and `plan.md` before
+acting. Follow the prompt's stages in order.
+
+Use the sibling `import_fivetran.py` for Fivetran access. It makes GET requests
+only and writes redacted captures to `.artifacts/` at the repository root.
+
+Rules:
+
+- Capture exactly one connection selected by the user.
+- Prefer an approved connector ID, which fetches that connection directly; a
+  connector name must match the Fivetran connection name exactly.
+- Never expose or store credentials, source data, endpoints, or Fivetran state.
+- Treat `.bruin.yml` and `.artifacts/` as sensitive even when they are
+  Git-ignored: do not print them, pass them to AI subprocesses, or copy them
+  into generated documentation.
+- Create the new `bruin/` project yourself; do not expect generated assets.
+- Pause after connection placeholders, before any destination write, and after
+  each approved v0 run.
+- Keep repository-root `plan.md` current with facts, decisions, TODOs, run
+  history, source-consistency boundaries, unsupported behavior, and cutover
+  work.
+- Before a historical ingestr run, obtain explicit start/end bounds and a
+  source-consistency boundary; `--full-refresh` does not by itself make the
+  ingestr source interval unbounded.
+- Run approved aggregate parity and quality checks after every v0 load. Use
+  cross-platform data diff as a pass/fail gate only when its representation is
+  explicitly reviewed as comparable.
+- Never use the importer `--replace` flag during a migration; preserve a new,
+  timestamped capture instead.
+- Do not enable schedules, run destructive refreshes, or disable Fivetran
+  without explicit user approval.

--- a/templates/migration-fivetran/.agents/skills/bruin-fivetran-migrator/import_fivetran.py
+++ b/templates/migration-fivetran/.agents/skills/bruin-fivetran-migrator/import_fivetran.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Capture one redacted Fivetran connection and its schema configuration.
+
+The script performs GET requests only. It reads Fivetran credentials from an
+untracked Bruin config, then writes safe JSON files under `.artifacts/`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib import error, parse, request
+
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - environment setup error
+    raise SystemExit("PyYAML is required: python3 -m pip install PyYAML") from exc
+
+
+API_BASE = "https://api.fivetran.com/v1"
+MIGRATION_ROOT = Path(__file__).resolve().parents[3]
+ARTIFACT_ROOT = MIGRATION_ROOT / ".artifacts"
+SECRET_FIELD = re.compile(
+    r"api[_-]?key|secret|password|token|authorization|private[_-]?key|"
+    r"client[_-]?secret|connection[_-]?string|credential",
+    re.IGNORECASE,
+)
+NETWORK_FIELD = re.compile(
+    r"(?:^|[_-])(?:host(?:name)?|endpoint|url|uri|address|port)(?:[_-]|$)",
+    re.IGNORECASE,
+)
+ENV_TOKEN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+BRUIN_ENV = re.compile(
+    r"^\{\{\s*env_var\(\s*['\"]([A-Za-z_][A-Za-z0-9_]*)['\"]\s*\)\s*\}\}$"
+)
+
+
+class ImportError(RuntimeError):
+    """An error safe to show to the user."""
+
+
+def fail(message: str) -> None:
+    raise ImportError(message)
+
+
+def artifact_roots() -> tuple[Path, ...]:
+    return (ARTIFACT_ROOT.resolve(),)
+
+
+def require_artifact_path(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    for root in artifact_roots():
+        try:
+            relative = resolved.relative_to(root)
+            if len(relative.parts) < 2:
+                fail("output must name one capture directory at least two levels below an artifact root")
+            return resolved
+        except ValueError:
+            pass
+    fail(f"output must be below {ARTIFACT_ROOT}")
+
+
+def load_config(path: Path, environment_name: str | None) -> dict[str, Any]:
+    try:
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"Bruin config not found: {path}")
+    except yaml.YAMLError as exc:
+        fail(f"Bruin config is not valid YAML: {exc}")
+    if not isinstance(config, dict):
+        fail("Bruin config must be a YAML mapping")
+    environment_name = environment_name or str(config.get("default_environment", "default"))
+    environments = config.get("environments")
+    if isinstance(environments, dict) and isinstance(environments.get(environment_name), dict):
+        return environments[environment_name]
+    if environment_name == "default" and isinstance(config.get("connections"), dict):
+        return config
+    fail(f"environment {environment_name!r} was not found")
+
+
+def expand(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{label} must be a non-empty string")
+    match = BRUIN_ENV.fullmatch(value)
+    if match:
+        name = match.group(1)
+        if name not in os.environ:
+            fail(f"environment variable {name!r} is required for {label}")
+        return os.environ[name]
+
+    def replace(token: re.Match[str]) -> str:
+        name = token.group(1) or token.group(2)
+        if name not in os.environ:
+            fail(f"environment variable {name!r} is required for {label}")
+        return os.environ[name]
+
+    return ENV_TOKEN.sub(replace, value)
+
+
+def fivetran_authorization(config_path: Path, environment_name: str | None) -> str:
+    connections = load_config(config_path, environment_name).get("connections", {})
+    generic = connections.get("generic", []) if isinstance(connections, dict) else []
+    values: dict[str, Any] = {}
+    if isinstance(generic, list):
+        for entry in generic:
+            if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                values[entry["name"]] = entry.get("value")
+    elif isinstance(generic, dict):
+        for name, entry in generic.items():
+            values[str(name)] = entry.get("value") if isinstance(entry, dict) else entry
+    key = expand(values.get("fivetran_api_key"), "fivetran_api_key")
+    secret = expand(values.get("fivetran_api_secret"), "fivetran_api_secret")
+    token = base64.b64encode(f"{key}:{secret}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def get_json(authorization: str, endpoint: str, label: str, timeout: float, query: dict[str, str] | None = None) -> dict[str, Any]:
+    """Fetch one Fivetran resource without placing identifiers in errors."""
+
+    url = f"{API_BASE.rstrip('/')}/{endpoint.lstrip('/')}"
+    if query:
+        url = f"{url}?{parse.urlencode(query)}"
+    for attempt in range(3):
+        try:
+            with request.urlopen(
+                request.Request(
+                    url,
+                    headers={"Authorization": authorization, "Accept": "application/json;version=2"},
+                    method="GET",
+                ),
+                timeout=timeout,
+            ) as response:
+                result = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            if exc.code in {429, 500, 502, 503, 504} and attempt < 2:
+                retry_after = exc.headers.get("Retry-After") if exc.headers else None
+                delay = min(float(retry_after), 10.0) if retry_after and retry_after.isdigit() else attempt + 1
+                time.sleep(delay)
+                continue
+            fail(f"Fivetran GET {label} failed with HTTP {exc.code}")
+        except (error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            fail(f"Fivetran GET {label} failed: {type(exc).__name__}")
+        if not isinstance(result, dict):
+            fail(f"Fivetran GET {label} returned invalid JSON")
+        return result
+    fail(f"Fivetran GET {label} exhausted retry attempts")
+
+
+def data_object(payload: dict[str, Any], endpoint: str) -> dict[str, Any]:
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        fail(f"Fivetran GET {endpoint} did not return an object")
+    return data
+
+
+def list_connections(authorization: str, timeout: float) -> list[dict[str, Any]]:
+    connections: list[dict[str, Any]] = []
+    cursor: str | None = None
+    for _ in range(100):
+        query = {"limit": "1000"}
+        if cursor:
+            query["cursor"] = cursor
+        data = get_json(authorization, "connections", "connections list", timeout, query).get("data")
+        if isinstance(data, dict):
+            items, cursor = data.get("items", []), data.get("next_cursor")
+        elif isinstance(data, list):
+            items, cursor = data, None
+        else:
+            fail("Fivetran connections response did not contain a list")
+        if not isinstance(items, list):
+            fail("Fivetran connections response did not contain items")
+        connections.extend(item for item in items if isinstance(item, dict))
+        if not cursor:
+            return connections
+        if not isinstance(cursor, str):
+            fail("Fivetran returned an invalid pagination cursor")
+    fail("Fivetran pagination exceeded 100 pages")
+
+
+def select_connection_by_name(connections: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    matches = [item for item in connections if item.get("name") == name]
+    ids = {str(item.get("id")) for item in matches}
+    if len(ids) != 1:
+        fail(f"expected exactly one Fivetran connection name match, found {len(ids)}")
+    return matches[0]
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, list):
+        return [redact(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    result: dict[str, Any] = {}
+    for key, nested in value.items():
+        key = str(key)
+        normalized_key = re.sub(r"(?<!^)(?=[A-Z])", "_", key)
+        if SECRET_FIELD.search(key) or NETWORK_FIELD.search(normalized_key):
+            result[key] = "[REDACTED]"
+        elif key == "config" and isinstance(nested, dict):
+            result[key] = {"redacted": True, "field_names": sorted(map(str, nested))}
+        else:
+            result[key] = redact(nested)
+    return result
+
+
+def capture_directory(args: argparse.Namespace, connection: dict[str, Any]) -> Path:
+    if args.output_dir:
+        return require_artifact_path(Path(args.output_dir))
+    name = str(connection.get("name") or connection.get("id") or "connection")
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", name).strip(".-").lower() or "connection"
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return require_artifact_path(ARTIFACT_ROOT / "fivetran" / f"{slug}-{stamp}")
+
+
+def write_capture(destination: Path, connection: dict[str, Any], schemas: dict[str, Any], replace: bool) -> None:
+    if destination.exists():
+        if not replace:
+            fail(f"capture directory exists: {destination}; use --replace to replace it")
+        shutil.rmtree(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}.", dir=destination.parent))
+    try:
+        for name, value in (("connection.json", redact(connection)), ("schemas.json", redact(schemas))):
+            (temporary / name).write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def run(args: argparse.Namespace) -> None:
+    authorization = fivetran_authorization(Path(args.config_file), args.environment)
+    if args.replace and not args.output_dir:
+        fail("--replace requires an explicit capture directory")
+    if args.connector_id:
+        connection_id = args.connector_id
+        selected: dict[str, Any] = {"id": connection_id}
+    else:
+        if not args.connector_name:
+            fail("a Fivetran connector name or ID is required")
+        selected = select_connection_by_name(list_connections(authorization, args.timeout), args.connector_name)
+        connection_id = selected.get("id")
+    if not isinstance(connection_id, str) or not connection_id:
+        fail("selected connection has no ID")
+    connection_path = parse.quote(connection_id, safe="")
+    detail = data_object(get_json(authorization, f"connections/{connection_path}", "connection details", args.timeout), "connection details")
+    schemas = data_object(get_json(authorization, f"connections/{connection_path}/schemas", "connection schemas", args.timeout), "connection schemas")
+    connection = {**selected, **detail}
+    destination = capture_directory(args, connection)
+    write_capture(destination, connection, schemas, args.replace)
+    print(f"Captured redacted Fivetran configuration to {destination}")
+
+
+def parser() -> argparse.ArgumentParser:
+    parsed = argparse.ArgumentParser(description=__doc__)
+    parsed.add_argument("--config-file", required=True)
+    parsed.add_argument("--environment")
+    selected = parsed.add_mutually_exclusive_group(required=True)
+    selected.add_argument("--connector-name", help="exact Fivetran connection name")
+    selected.add_argument("--connector-id", help="exact Fivetran connection ID")
+    parsed.add_argument("--timeout", type=float, default=20.0)
+    parsed.add_argument("--output-dir", help="artifact directory for this capture")
+    parsed.add_argument("--replace", action="store_true")
+    return parsed
+
+
+def main() -> int:
+    try:
+        run(parser().parse_args())
+    except ImportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/migration-fivetran/.gitignore
+++ b/templates/migration-fivetran/.gitignore
@@ -1,0 +1,3 @@
+.bruin.yml
+.artifacts/
+__pycache__/

--- a/templates/migration-fivetran/bruin/pipeline.yml
+++ b/templates/migration-fivetran/bruin/pipeline.yml
@@ -1,0 +1,9 @@
+name: bruin
+
+# schedule: daily
+# start_date: "2024-01-01"
+# catchup: false
+
+# default_connections:
+#   postgresql: "postgres-default"
+#   google_cloud_platform: "bigquery-default"

--- a/templates/migration-fivetran/fivetran-bruin-prompt.md
+++ b/templates/migration-fivetran/fivetran-bruin-prompt.md
@@ -1,0 +1,153 @@
+# Fivetran to Bruin migration prompt
+
+Use this prompt from the repository root to migrate one Fivetran connection
+into a new Bruin ingestr project. This is a staged, review-gated workflow, not
+an automatic cutover. Keep customer captures and generated evidence under
+`.artifacts/`; never put credentials or source data in Git. The installed
+importer writes captures under the repository-root `.artifacts/` directory;
+do not pass a nested artifact directory unless the installed importer confirms
+that it supports one.
+
+You are a data-migration agent. Use the Bruin MCP and official Bruin
+documentation for all Bruin configuration and commands; do not guess syntax.
+Migrate exactly one Fivetran connection at a time. Ask the user whenever a
+connection, mapping, or migration decision is unclear.
+
+Read the repository-root `plan.md` first and update it after every stage. Keep
+automated findings, human decisions, unsupported behavior, and open TODOs
+separate.
+
+## Stage 0 — bootstrap the migration workspace
+
+Before importing anything:
+
+1. Verify that the Bruin CLI is installed and compatible. Do not update it
+   unless the user approves the update or a documented compatibility issue
+   requires it.
+2. Ask the user to confirm the Fivetran connection name or ID to migrate, the
+   source PostgreSQL connection name, the destination BigQuery connection name,
+   and the pipeline name if it should differ from `bruin`.
+3. Create or review the repository-root, Git-ignored `.bruin.yml`. It may
+   already contain user-supplied connection values or environment-variable
+   references. Confirm only its non-secret structure and the named source and
+   destination connections; never print, copy, commit, or modify credential
+   values. Keep generic Fivetran values named `fivetran_api_key` and
+   `fivetran_api_secret`.
+4. Create an empty Bruin pipeline in `bruin/`, including `pipeline.yml` and
+   `assets/`.
+5. Verify `.bruin.yml` and `.artifacts/` are ignored by Git before any capture.
+
+When the destination is BigQuery, set the pipeline default under
+`default_connections.google_cloud_platform`; `default_connections.bigquery`
+does not resolve a BigQuery destination in the current Bruin CLI.
+
+Do not import Fivetran configuration until this setup is complete. Do not write
+destination data, enable schedules, disable Fivetran, or perform cutover work
+without the user's explicit approval.
+
+Start with this implementation instruction:
+
+> Read the imported Fivetran configuration, connection details, optional
+> database and table mappings, and source table/asset schemas and definitions.
+> Read the relevant Bruin documentation and Fivetran-to-Bruin configuration
+> mapping, including frequency, materialization, incremental strategy, and
+> related execution settings.
+>
+> Use the Bruin MCP and documentation to build an MVP/draft ingestion pipeline.
+> Create `plan.md` alongside the migration prompt. Initially, it must record
+> configuration mismatches; ingestion-specific column mappings (including
+> casts, defaults, renames, omissions, and generated fields); and every TODO or
+> question requiring clarification, such as materialization and incremental
+> strategy.
+>
+> Validate the MVP, then run it to an isolated temporary destination to create
+> v0 tables and demonstrate the ingestion outcome. Verify the resulting data
+> and make the validation fail on a mismatch. Update `plan.md` after that run
+> with next steps and a production-migration plan, including decisions still
+> needed for incremental strategy, metadata columns, downstream refactors,
+> validation, and switchover.
+
+## Stage 1 — import Fivetran configuration
+
+Ask the user to identify one connection by name or ID. Then capture exactly
+that connection using only GET requests:
+
+```bash
+python3 .agents/skills/bruin-fivetran-migrator/import_fivetran.py \
+  --config-file .bruin.yml \
+  --connector-name <approved-connection-name> \
+  --output-dir .artifacts/fivetran/<capture-id>
+```
+
+Prefer `--connector-id` when it is available: the importer then fetches only
+that connection rather than listing connections to resolve a name. A name must
+be an exact connection-name match. Never use `--replace` during a migration;
+create a new, timestamped capture directory instead.
+
+Read the redacted `connection.json` and `schemas.json`. Update `plan.md` with the source/destination inventory, schedule/state,
+selected tables, missing metadata, compatibility gaps, and next user actions.
+
+## Stage 2 — review Bruin connections, then pause
+
+Review the bootstrapped `.bruin.yml` and the empty `bruin/` project. Confirm
+the non-secret connection names and platform settings; do not add, print, or
+copy real connection values. Explain only the missing non-secret configuration,
+update the plan, and stop. Resume only when the user explicitly says the
+connections are ready; then test both named connections and record the result.
+After one failed connection test, perform at most one bounded, credential-free
+reachability diagnosis and pause for a user-directed configuration change. If
+PostgreSQL is reachable but rejects the connection through `pg_hba.conf`,
+correct an approved TLS mode to a valid Bruin value such as `require` (not
+`required`) and retest; never print connection values while diagnosing.
+
+## Stage 3 — draft the MVP
+
+Read the imported capture, source definitions, Bruin documentation, and Bruin
+MCP. Build the Bruin ingestr pipeline and assets from scratch. For every table,
+record in `plan.md` the mapping, casts, renames, omissions, generated fields,
+materialization, keys, incremental strategy, schema ownership, schedule choice,
+and unsupported Fivetran behavior. Do not run ingestion yet.
+
+## Stage 4 — resolve TODOs
+
+Walk through every open TODO with the user before any destination write. Obtain
+explicit answers for initial-run scope, isolated target names, date bounds,
+primary and incremental keys, materialization, delete/history behavior, schema
+handling, validation boundary, rollback, and operational ownership. Update the
+pipeline and plan after each answer. Stay paused if any required decision is
+missing.
+
+Also define a source-consistency boundary: record an approved source watermark
+or snapshot boundary before the run, apply it consistently to extraction and
+reconciliation, and state how concurrent source writes are handled.
+
+## Stage 5 — approved v0 run
+
+After explicit approval, validate and run only the approved scope to isolated
+v0 tables. A `--full-refresh` still uses Bruin's run interval for ingestr
+filtering: profile the source `incremental_key` range first, then obtain
+explicit approval for inclusive/exclusive `--start-date` and `--end-date`
+bounds that cover the intended history. Use `bruin query` to compare source and
+target row counts, null and duplicate keys, and incremental ranges; normalize
+timestamps to the same timezone before comparing them. Run the reviewed
+quality checks after the load, not just `bruin validate`. Run `bruin data-diff
+--full --tolerance 0 --fail-if-diff` when a reviewed common representation
+exists. Treat every mismatch as a failure, except documented, user-approved
+destination metadata or cross-platform type representation differences that
+make `data-diff` diagnostic-only; in that case the exact aggregate parity
+profile is the required pass/fail gate. Ingestr may add
+`_ingestr_loaded_at`; document and exclude that generated field from common
+column parity if approved. Preserve evidence in `.artifacts/`, update the
+plan's Run history, summarize the result, and pause.
+
+## Stage 6 — final review only on request
+
+Ask whether the user wants a final review and metadata update. Only if they say
+yes, review the assets, manually add or review metadata, validate the result,
+create `bruin/README.md`, and complete the migration/cutover checklist in
+`plan.md`. Do not run `bruin ai enhance --codex` in the migration workspace:
+its subprocesses may inspect `.bruin.yml` or `.artifacts/`. If the user
+explicitly wants AI assistance, use an isolated temporary copy containing only
+sanitized asset definitions, then review its diff, validate the copied changes,
+and run the resulting quality checks. Do not disable Fivetran or enable a Bruin
+schedule without separate, explicit approval.

--- a/templates/migration-fivetran/plan.md
+++ b/templates/migration-fivetran/plan.md
@@ -1,0 +1,107 @@
+# Fivetran to Bruin migration plan
+
+This is a reusable, reviewed plan template. During a runtime migration, replace
+only the placeholder values after reviewing the redacted files in
+`.artifacts/fivetran/<capture-id>/`. Do not put credentials, raw Fivetran
+exports, source data, or Fivetran cursor state in this file.
+
+## Status and provenance
+
+- Migration name: `TODO`
+- Fivetran connection name / ID: `TODO`
+- Capture location: `.artifacts/fivetran/TODO/`
+- Capture importer/version/API version: `TODO`
+- Capture time and operator: `TODO`
+- Current phase: `imported | waiting_for_connections | drafting | waiting_for_run_approval | validating | MVP_complete`
+
+## Source and target inventory
+
+| Fivetran source object | Fivetran destination name | Sync mode / state | Source connection | Proposed Bruin asset | Isolated target | Dependencies |
+| --- | --- | --- | --- | --- | --- | --- |
+| `TODO.schema.table` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
+
+## Automated findings from import
+
+- `TODO`: record source service, selected objects, schedule/status, destination
+  renames, Fivetran schema policy, configured column overrides, and missing
+  metadata from the redacted `connection.json` and `schemas.json` capture.
+- `TODO`: list any source-to-Bruin compatibility mismatch. Mark it as automated
+  until a reviewer makes a decision.
+
+## Hand-authored decisions
+
+- Source and destination named Bruin connections: `TODO`.
+- Target isolation and naming: `TODO`.
+- Per-table strategy, primary key, incremental key, explicit bounds, and schema
+  contract: `TODO`.
+- Delete/history/CDC/system-column behavior: `TODO`.
+- Scheduling, monitoring, alerting, ownership, and rollback: `TODO`.
+
+## Column mappings
+
+| Source column | Target column | Type/cast | Action | Rationale / reviewer |
+| --- | --- | --- | --- | --- |
+| `TODO` | `TODO` | `TODO` | `keep | rename | cast | default | omit | generated` | `TODO` |
+
+## Unsupported features and non-mappings
+
+- Fivetran credentials, networking, cursor/checkpoint state, alerts, retries,
+  and managed schedules are not imported.
+- `SOFT_DELETE`, `HISTORY`, Query-Based PostgreSQL, and Fivetran system columns
+  require a separate approved design. `TODO`: record the selected treatment.
+- `TODO`: list service-specific source features the generated ingestr asset
+  cannot express.
+
+## Open human-review items — must be empty before a write
+
+- [ ] Exact initial-run scope: full history, bounded history, one table, or
+  another scope; list tables and explicit start/end bounds.
+- [ ] Isolated destination target is confirmed; replace/truncate permission is
+  explicit when relevant.
+- [ ] Source/destination connection preflight passed.
+- [ ] Primary keys, incremental keys, materialization, delete handling, and
+  schema ownership are approved for each selected table.
+- [ ] Column mapping, quality checks, validation boundary, expected cost, and
+  rollback condition are approved.
+- [ ] Schedule/monitoring ownership is assigned; Fivetran remains active until
+  cutover criteria are met.
+
+## v0 run and validation evidence
+
+- Requested scope and approval: `TODO`.
+- `bruin validate` result: `TODO`.
+- Run command, dates, and resulting target tables: `TODO`.
+- Source/destination profile: row count `TODO`, null keys `TODO`, duplicate
+  keys `TODO`.
+- `bruin data-diff --full --tolerance 0 --fail-if-diff` result: `TODO`.
+- Mismatches, accepted differences, and follow-up: `TODO`.
+
+## Run history
+
+Add one dated entry for every connection preflight, validation attempt, and v0
+run. Keep detailed output only in `.artifacts/`; this plan records the
+reviewable summary and the next human decision.
+
+### `YYYY-MM-DDTHH:MM:SSZ` — `preflight | validation | v0_run`
+
+- Approved scope and source consistency boundary: `TODO`.
+- Source/target connections and isolated tables: `TODO`.
+- Commands and evidence locations under `.artifacts/`: `TODO`.
+- Result: `passed | failed | paused`; profile/data-diff outcome: `TODO`.
+- Mismatches, rollback decision, owner, and next action: `TODO`.
+
+## Completing the migration
+
+Complete this section only after the user requests final review and metadata
+updates.
+
+- [ ] Review pipeline/column metadata and `bruin ai enhance --codex` changes.
+- [ ] Publish a pipeline README and assign an operating owner.
+- [ ] Run final bounded reconciliation and document a rollback decision.
+- [ ] Refactor downstream assets/models/tables from Fivetran-specific names and
+  system-column assumptions.
+- [ ] Enable approved Bruin scheduling, monitoring, alerting, and runbook.
+- [ ] Pause/disable Fivetran only after the documented validation boundary and
+  rollback window are satisfied.
+- [ ] Retire Fivetran credentials, billing/configuration, and legacy artifacts
+  under the owner's change-control process.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -6,4 +6,6 @@ import (
 
 //go:embed *
 //go:embed */.bruin.yml
+//go:embed migration-fivetran/.gitignore
+//go:embed migration-fivetran/.agents/skills/bruin-fivetran-migrator/*
 var Templates embed.FS


### PR DESCRIPTION
## Summary

Adds a `migration-fivetran` template for review-gated migration of one Fivetran connection to Bruin.

- Bundles the empty `bruin/` pipeline, migration prompt, plan, safe importer, and agent skill.
- Documents the template and embeds its hidden files in the template filesystem.
- Avoids parsing an unrelated repository `.bruin.yml` for templates that do not provide configuration, so local duplicate YAML keys do not block initialization.

## Validation

- `make format`
- `make test`
- `make build`
- `npm run docs:build`