### PR TITLE
Add connection-aware curl command

### DIFF
--- a/cmd/curl.go
+++ b/cmd/curl.go
@@ -1,0 +1,263 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/jinja"
+	"github.com/bruin-data/bruin/pkg/telemetry"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v3"
+)
+
+type (
+	curlConnectionLookup         func(string) (any, error)
+	curlConnectionLookupResolver func(context.Context, *cli.Command) (curlConnectionLookup, error)
+	curlExecutor                 func(context.Context, []string, io.Reader, io.Writer, io.Writer) error
+)
+
+// Curl proxies arguments to the installed curl executable after rendering each
+// argument with Bruin connections. Curl arguments must follow -- so that curl's
+// option surface can evolve independently of Bruin.
+func Curl() *cli.Command {
+	return newCurlCommand(resolveCurlConnectionLookup, executeCurl)
+}
+
+func newCurlCommand(resolveConnections curlConnectionLookupResolver, execute curlExecutor) *cli.Command {
+	return &cli.Command{
+		Name:      "curl",
+		Usage:     "run curl with arguments rendered from Bruin connections",
+		ArgsUsage: "-- [curl options and URLs]",
+		Description: "Passes every argument after -- directly to the installed curl executable after Jinja rendering, without inspecting curl options. " +
+			"Connection fields are available as {{ bruin.connection(\"name\").field }}.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "environment",
+				Aliases: []string{"env"},
+				Usage:   "the environment to use, ignored when a secrets backend is selected",
+			},
+			&cli.StringFlag{
+				Name:    "config-file",
+				Sources: cli.EnvVars("BRUIN_CONFIG_FILE"),
+				Usage:   "the path to the .bruin.yml file, ignored when a secrets backend is selected",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			root := c.Root()
+
+			curlArgs := c.Args().Slice()
+			if len(curlArgs) == 0 {
+				return failCurlCommand(root, errors.New("at least one curl option or URL is required after --"))
+			}
+
+			connectionLookup, err := resolveConnections(ctx, c)
+			if err != nil {
+				return failCurlCommand(root, err)
+			}
+
+			renderedArgs, err := renderCurlArgs(curlArgs, connectionLookup)
+			if err != nil {
+				return failCurlCommand(root, err)
+			}
+
+			if err := execute(ctx, renderedArgs, root.Reader, root.Writer, root.ErrWriter); err != nil {
+				var exitError *exec.ExitError
+				if errors.As(err, &exitError) {
+					return cli.Exit("", curlExitCode(exitError))
+				}
+				return failCurlCommand(root, errors.Wrap(err, "failed to execute curl"))
+			}
+
+			return nil
+		},
+		Before: telemetry.BeforeCommand,
+		After:  telemetry.AfterCommand,
+	}
+}
+
+// failCurlCommand reports the error on stderr and exits with 1. curl owns stdout,
+// so Bruin's own diagnostics must never be mixed into the response body, and the
+// message stays uncolored because this command is meant to be scripted.
+func failCurlCommand(root *cli.Command, err error) error {
+	fmt.Fprintf(root.ErrWriter, "%v\n", err)
+	return cli.Exit("", 1)
+}
+
+// curlExitCode reports curl's own exit code, mapping a signalled curl onto the
+// 128+signal convention that a shell would have reported for curl itself.
+func curlExitCode(exitError *exec.ExitError) int {
+	code := exitError.ExitCode()
+	if code >= 0 {
+		return code
+	}
+	if status, ok := exitError.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return 128 + int(status.Signal())
+	}
+	return 1
+}
+
+func resolveCurlConnectionLookup(ctx context.Context, c *cli.Command) (curlConnectionLookup, error) {
+	var lookup curlConnectionLookup
+	return func(name string) (any, error) {
+		if lookup == nil {
+			resolved, err := loadCurlConnectionLookup(ctx, c)
+			if err != nil {
+				return nil, err
+			}
+			lookup = resolved
+		}
+		return lookup(name)
+	}, nil
+}
+
+// loadCurlConnectionLookup is deferred until a template actually calls
+// bruin.connection(), so plain curl passthrough and built-in-only templates do
+// not require a repository or create a .bruin.yml file.
+func loadCurlConnectionLookup(ctx context.Context, c *cli.Command) (curlConnectionLookup, error) {
+	ctx, cm, err := ingestrURIConfig(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	if secretsBackendFromContext(ctx) == "" {
+		connections := cm.SelectedEnvironment.Connections
+		return func(name string) (any, error) {
+			details := connections.GetConnection(name)
+			if details == nil {
+				return nil, config.NewConnectionNotFoundError(ctx, "", name)
+			}
+			return details, nil
+		}, nil
+	}
+
+	manager, errs := connectionManagerFromConfig(ctx, cm, makeLogger(false))
+	if len(errs) > 0 {
+		return nil, errors.Wrap(errs[0], "failed to create connection manager")
+	}
+
+	return func(name string) (any, error) {
+		details := manager.GetConnectionDetails(name)
+		if details == nil {
+			return nil, config.NewConnectionNotFoundError(ctx, "", name)
+		}
+		return details, nil
+	}, nil
+}
+
+func renderCurlArgs(args []string, lookupConnection curlConnectionLookup) ([]string, error) {
+	connectionCache := make(map[string]map[string]any)
+	var connectionLookupErr error
+
+	bruinContext := jinja.BuiltinFunctions()
+	bruinContext["connection"] = func(name string) map[string]any {
+		if connectionLookupErr != nil {
+			return nil
+		}
+		if fields, ok := connectionCache[name]; ok {
+			return fields
+		}
+
+		details, err := lookupConnection(name)
+		if err != nil {
+			connectionLookupErr = err
+			return nil
+		}
+		fields, err := connectionFields(details)
+		if err != nil {
+			connectionLookupErr = errors.Wrapf(err, "failed to prepare connection %q for rendering", name)
+			return nil
+		}
+
+		connectionCache[name] = fields
+		return fields
+	}
+
+	renderer := jinja.NewRenderer(jinja.Context{"bruin": bruinContext})
+	rendered := make([]string, len(args))
+	for i, arg := range args {
+		var err error
+		rendered[i], err = renderCurlArgument(renderer, arg)
+		if connectionLookupErr != nil {
+			return nil, errors.Wrapf(connectionLookupErr, "failed to render curl argument %d", i+1)
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to render curl argument %d", i+1)
+		}
+	}
+
+	return rendered, nil
+}
+
+// curl allows a variable to chain several functions, each separated by a colon,
+// e.g. {{name:trim:url}}.
+var curlVariableExpression = regexp.MustCompile(`\{\{[[:alnum:]_]+(?::[[:alnum:]_,]+)*\}\}`)
+
+func renderCurlArgument(renderer *jinja.Renderer, arg string) (string, error) {
+	curlVariables := curlVariableExpression.FindAllString(arg, -1)
+	protected := arg
+	placeholders := make([]string, len(curlVariables))
+	for i, variable := range curlVariables {
+		placeholder, err := newCurlVariablePlaceholder(protected)
+		if err != nil {
+			return "", err
+		}
+		placeholders[i] = placeholder
+		protected = strings.Replace(protected, variable, placeholder, 1)
+	}
+
+	rendered, err := renderer.Render(protected)
+	if err != nil {
+		return "", err
+	}
+	for i, variable := range curlVariables {
+		rendered = strings.ReplaceAll(rendered, placeholders[i], variable)
+	}
+	return rendered, nil
+}
+
+func newCurlVariablePlaceholder(protected string) (string, error) {
+	var token [16]byte
+	for {
+		if _, err := rand.Read(token[:]); err != nil {
+			return "", errors.Wrap(err, "failed to protect curl variable")
+		}
+		placeholder := "__BRUIN_CURL_VARIABLE_" + hex.EncodeToString(token[:]) + "__"
+		if !strings.Contains(protected, placeholder) {
+			return placeholder, nil
+		}
+	}
+}
+
+func connectionFields(details any) (map[string]any, error) {
+	serialized, err := json.Marshal(details)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := make(map[string]any)
+	decoder := json.NewDecoder(bytes.NewReader(serialized))
+	decoder.UseNumber()
+	if err := decoder.Decode(&fields); err != nil {
+		return nil, err
+	}
+
+	return fields, nil
+}
+
+func executeCurl(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	command := exec.CommandContext(ctx, "curl", args...) //nolint:gosec
+	command.Stdin = stdin
+	command.Stdout = stdout
+	command.Stderr = stderr
+	return command.Run()
+}

--- a/cmd/curl.go
+++ b/cmd/curl.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -16,6 +14,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/jinja"
 	"github.com/bruin-data/bruin/pkg/telemetry"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v3"
 )
@@ -239,15 +238,17 @@ func newCurlVariablePlaceholder(protected string) (string, error) {
 }
 
 func connectionFields(details any) (map[string]any, error) {
-	serialized, err := json.Marshal(details)
+	fields := make(map[string]any)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:  &fields,
+		TagName: "mapstructure",
+		Squash:  true,
+		Deep:    true,
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	fields := make(map[string]any)
-	decoder := json.NewDecoder(bytes.NewReader(serialized))
-	decoder.UseNumber()
-	if err := decoder.Decode(&fields); err != nil {
+	if err := decoder.Decode(details); err != nil {
 		return nil, err
 	}
 

--- a/cmd/curl_test.go
+++ b/cmd/curl_test.go
@@ -1,0 +1,279 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestRenderCurlArgs(t *testing.T) {
+	t.Parallel()
+
+	connections := map[string]any{
+		"warehouse": &config.PostgresConnection{
+			ConnectionMetadata: config.ConnectionMetadata{Name: "warehouse"},
+			Host:               "db.internal",
+			Username:           "api-user",
+			Password:           "secret-token",
+			Port:               5432,
+		},
+		"auth-api": map[string]any{
+			"credentials": map[string]any{"token": "nested-secret"},
+		},
+	}
+	lookupCounts := make(map[string]int)
+	lookup := func(name string) (any, error) {
+		lookupCounts[name]++
+		return connections[name], nil
+	}
+
+	actual, err := renderCurlArgs([]string{
+		"--url",
+		`https://{{ bruin.connection("warehouse").host }}:{{ bruin.connection("warehouse").port }}/health`,
+		"--header",
+		`Authorization: Bearer {{ bruin.connection("auth-api").credentials.token }}`,
+		`--user={{ bruin.connection("warehouse").username }}:{{ bruin.connection("warehouse").password }}`,
+		`X-Slug: {{ bruin.slugify("Hello World") }}`,
+	}, lookup)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--url",
+		"https://db.internal:5432/health",
+		"--header",
+		"Authorization: Bearer nested-secret",
+		"--user=api-user:secret-token",
+		"X-Slug: hello_world",
+	}, actual)
+	assert.Equal(t, map[string]int{"auth-api": 1, "warehouse": 1}, lookupCounts)
+}
+
+func TestRenderCurlArgsRendersEveryArgumentAndPreservesCurlVariables(t *testing.T) {
+	t.Parallel()
+
+	actual, err := renderCurlArgs([]string{
+		`--{{ bruin.connection("api").option }}`,
+		`https://{{ bruin.connection("api").host }}/{{path:trim:url}}/{{missing}}`,
+		"__BRUIN_CURL_VARIABLE_0__ {{path}}",
+	}, func(name string) (any, error) {
+		assert.Equal(t, "api", name)
+		return map[string]any{"option": "expand-url", "host": "example.com"}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--expand-url",
+		"https://example.com/{{path:trim:url}}/{{missing}}",
+		"__BRUIN_CURL_VARIABLE_0__ {{path}}",
+	}, actual)
+}
+
+func TestRenderCurlArgsReturnsArgumentIndexWithoutLeakingOtherArguments(t *testing.T) {
+	t.Parallel()
+
+	_, err := renderCurlArgs([]string{
+		"Authorization: Bearer private-value",
+		`{{ bruin.connection("api").missing }}`,
+	}, func(string) (any, error) {
+		return map[string]any{"token": "private-value"}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to render curl argument 2")
+	assert.NotContains(t, err.Error(), "private-value")
+}
+
+func TestRenderCurlArgsReportsConnectionLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := renderCurlArgs([]string{
+		`https://{{ bruin.connection("missing-api").host }}/health`,
+	}, func(name string) (any, error) {
+		return nil, config.NewConnectionNotFoundError(t.Context(), "", name)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to render curl argument 1")
+	assert.Contains(t, err.Error(), "connection 'missing-api' not found")
+	assert.NotContains(t, err.Error(), "bug in the jinja renderer")
+}
+
+func TestRenderCurlArgsDoesNotLookUpConnectionsForBuiltinOnlyTemplates(t *testing.T) {
+	t.Parallel()
+
+	actual, err := renderCurlArgs([]string{
+		`https://example.com/{{ bruin.slugify("Account Name") }}`,
+	}, func(string) (any, error) {
+		t.Fatal("connection lookup should not be called")
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://example.com/account_name"}, actual)
+}
+
+func TestCurlCommandPassesAllCurlArgumentsAfterSeparator(t *testing.T) { //nolint:paralleltest // cli mutates the global help flag
+	var executedArgs []string
+	var gotStdin io.Reader
+	var gotStdout, gotStderr io.Writer
+	resolver := func(_ context.Context, c *cli.Command) (curlConnectionLookup, error) {
+		assert.Equal(t, "production", c.String("environment"))
+		return func(name string) (any, error) {
+			connections := map[string]any{
+				"service": map[string]any{"host": "example.com"},
+				"auth":    map[string]any{"token": "resolved-secret"},
+			}
+			return connections[name], nil
+		}, nil
+	}
+	executor := func(_ context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+		executedArgs = args
+		gotStdin = stdin
+		gotStdout = stdout
+		gotStderr = stderr
+		return nil
+	}
+
+	stdin := bytes.NewBufferString("request body")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	command := newCurlCommand(resolver, executor)
+	command.Reader = stdin
+	command.Writer = stdout
+	command.ErrWriter = stderr
+
+	err := command.Run(t.Context(), []string{
+		"curl",
+		"--environment", "production",
+		"--",
+		"--request", "POST",
+		"--header", `Authorization: Bearer {{ bruin.connection("auth").token }}`,
+		`https://{{ bruin.connection("service").host }}`,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--request", "POST",
+		"--header", "Authorization: Bearer resolved-secret",
+		"https://example.com",
+	}, executedArgs)
+	assert.Same(t, stdin, gotStdin)
+	assert.Same(t, stdout, gotStdout)
+	assert.Same(t, stderr, gotStderr)
+}
+
+func TestCurlCommandRequiresCurlArguments(t *testing.T) { //nolint:paralleltest // cli mutates the global help flag
+	command := newCurlCommand(
+		func(context.Context, *cli.Command) (curlConnectionLookup, error) {
+			t.Fatal("resolver should not be called")
+			return nil, nil
+		},
+		func(context.Context, []string, io.Reader, io.Writer, io.Writer) error {
+			t.Fatal("executor should not be called")
+			return nil
+		},
+	)
+	stderr := &bytes.Buffer{}
+	command.ErrWriter = stderr
+	// cli exits the process for ExitCoder errors, which would kill the test binary.
+	command.ExitErrHandler = func(context.Context, *cli.Command, error) {}
+
+	err := command.Run(t.Context(), []string{"curl", "--"})
+
+	var exitErr cli.ExitCoder
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "at least one curl option or URL is required after --")
+}
+
+func TestCurlCommandReportsRenderFailuresOnStderr(t *testing.T) { //nolint:paralleltest // cli mutates the global help flag
+	command := newCurlCommand(
+		func(context.Context, *cli.Command) (curlConnectionLookup, error) {
+			return func(string) (any, error) {
+				return map[string]any{}, nil
+			}, nil
+		},
+		func(context.Context, []string, io.Reader, io.Writer, io.Writer) error {
+			t.Fatal("executor should not be called")
+			return nil
+		},
+	)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	command.Writer = stdout
+	command.ErrWriter = stderr
+	command.ExitErrHandler = func(context.Context, *cli.Command, error) {}
+
+	err := command.Run(t.Context(), []string{
+		"curl", "--", `https://example.com/{{ bruin.connection("service").missing }}`,
+	})
+
+	var exitErr cli.ExitCoder
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "failed to render curl argument 1")
+	assert.Empty(t, stdout.String())
+}
+
+func TestExecuteCurlPassesArgumentsUnchanged(t *testing.T) { //nolint:paralleltest // changes PATH
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX test executable")
+	}
+
+	binDir := t.TempDir()
+	curlPath := filepath.Join(binDir, "curl")
+	require.NoError(t, os.WriteFile(curlPath, []byte(`#!/bin/sh
+for arg in "$@"; do
+  printf '<%s>\n' "$arg"
+done
+`), 0o700))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	args := []string{
+		"--future-option=value",
+		"--unknown-option",
+		"value with spaces",
+		"-hall",
+		"https://example.com",
+	}
+	var stdout, stderr bytes.Buffer
+
+	err := executeCurl(t.Context(), args, strings.NewReader("request body"), &stdout, &stderr)
+
+	require.NoError(t, err)
+	assert.Equal(t, "<"+strings.Join(args, ">\n<")+">\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+// A signalled process has no exit code of its own, so Bruin reports the 128+signal
+// value a shell would have reported had it run curl directly.
+func TestCurlExitCode(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX signals")
+	}
+
+	failed := exec.Command("sh", "-c", "exit 7").Run()
+	var failedExit *exec.ExitError
+	require.ErrorAs(t, failed, &failedExit)
+	assert.Equal(t, 7, curlExitCode(failedExit))
+
+	signalled := exec.Command("sh", "-c", "kill -TERM $$")
+	require.NoError(t, signalled.Start())
+	var signalledExit *exec.ExitError
+	require.ErrorAs(t, signalled.Wait(), &signalledExit)
+	assert.Equal(t, 128+int(syscall.SIGTERM), curlExitCode(signalledExit))
+}

--- a/cmd/curl_test.go
+++ b/cmd/curl_test.go
@@ -45,6 +45,7 @@ func TestRenderCurlArgs(t *testing.T) {
 		"--header",
 		`Authorization: Bearer {{ bruin.connection("auth-api").credentials.token }}`,
 		`--user={{ bruin.connection("warehouse").username }}:{{ bruin.connection("warehouse").password }}`,
+		`schema={{ bruin.connection("warehouse").schema }},pool={{ bruin.connection("warehouse").pool_max_conns }},ssl={{ bruin.connection("warehouse").ssl_mode }}`,
 		`X-Slug: {{ bruin.slugify("Hello World") }}`,
 	}, lookup)
 
@@ -55,6 +56,7 @@ func TestRenderCurlArgs(t *testing.T) {
 		"--header",
 		"Authorization: Bearer nested-secret",
 		"--user=api-user:secret-token",
+		"schema=,pool=0,ssl=",
 		"X-Slug: hello_world",
 	}, actual)
 	assert.Equal(t, map[string]int{"auth-api": 1, "warehouse": 1}, lookupCounts)

--- a/cmd/curl_test.go
+++ b/cmd/curl_test.go
@@ -228,7 +228,7 @@ func TestCurlCommandReportsRenderFailuresOnStderr(t *testing.T) { //nolint:paral
 }
 
 func TestExecuteCurlPassesArgumentsUnchanged(t *testing.T) { //nolint:paralleltest // changes PATH
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("uses a POSIX test executable")
 	}
 
@@ -262,16 +262,16 @@ done
 func TestCurlExitCode(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("relies on POSIX signals")
 	}
 
-	failed := exec.Command("sh", "-c", "exit 7").Run()
+	failed := exec.CommandContext(t.Context(), "sh", "-c", "exit 7").Run()
 	var failedExit *exec.ExitError
 	require.ErrorAs(t, failed, &failedExit)
 	assert.Equal(t, 7, curlExitCode(failedExit))
 
-	signalled := exec.Command("sh", "-c", "kill -TERM $$")
+	signalled := exec.CommandContext(t.Context(), "sh", "-c", "kill -TERM $$")
 	require.NoError(t, signalled.Start())
 	var signalledExit *exec.ExitError
 	require.ErrorAs(t, signalled.Wait(), &signalledExit)

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -405,6 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     {text: "AI Skills", link: "/commands/ai-skills"},
                     {text: "Clean", link: "/commands/clean"},
                     {text: "Connections", link: "/commands/connections"},
+                    {text: "Curl", link: "/commands/curl"},
                     {text: "Data Diff", link: "/commands/data-diff"},
                     {text: "Environments", link: "/commands/environments"},
                     {text: "Format", link: "/commands/format"},

--- a/docs/commands/curl.md
+++ b/docs/commands/curl.md
@@ -50,9 +50,9 @@ are resolved only once. Fields nested inside a connection can be traversed with 
 ```
 
 The usual Bruin Jinja helpers remain available in the same namespace. For example,
-`{{ bruin.slugify("Account Name") }}` renders as `account_name`. Most other helpers generate SQL
-expressions and are primarily useful in asset templates; see [Jinja templating and built-in
-functions](/assets/templating/macros).
+<code v-pre>{{ bruin.slugify("Account Name") }}</code> renders as `account_name`. Most other helpers
+generate SQL expressions and are primarily useful in asset templates; see [Jinja templating and
+built-in functions](/assets/templating/macros).
 
 Use `--environment` (or `--env`) to select a non-default environment and `--config-file` to use a
 specific `.bruin.yml` file. Bruin's global `--secrets-backend` flag is also supported:
@@ -68,9 +68,9 @@ does not need to enumerate every secret in the backend.
 
 ## Curl variables
 
-Curl uses `{{name}}`-style expressions for values supplied with `--variable`, which overlaps with
-Jinja syntax. Bruin recognizes curl's variable syntax and leaves those expressions for curl while
-still rendering connection references in the same argument:
+Curl uses <code v-pre>{{name}}</code>-style expressions for values supplied with `--variable`, which
+overlaps with Jinja syntax. Bruin recognizes curl's variable syntax and leaves those expressions for
+curl while still rendering connection references in the same argument:
 
 ```bash
 bruin curl -- \
@@ -79,7 +79,7 @@ bruin curl -- \
 ```
 
 Curl variable names are alphanumeric with underscores and do not contain dots, optionally followed
-by colon-separated functions such as `{{path:trim:url}}`. Bruin connection expressions are
+by colon-separated functions such as <code v-pre>{{path:trim:url}}</code>. Bruin connection expressions are
 namespaced under `bruin.connection(...)`, which makes the two forms unambiguous.
 
 All curl arguments, including option names, option values, URLs, and curl variable declarations,

--- a/docs/commands/curl.md
+++ b/docs/commands/curl.md
@@ -1,0 +1,92 @@
+# Curl Command
+
+The `curl` command runs the installed `curl` executable with arguments rendered from Bruin
+connections. It is a pass-through wrapper, so it supports the complete option and variable
+surface of the installed curl version without Bruin needing to duplicate curl's flags.
+
+Put Bruin's flags before `--` and all curl flags, values, and URLs after it:
+
+```bash
+bruin curl -- \
+  --request GET \
+  --header 'Authorization: Bearer {{ bruin.connection("my-api").value }}' \
+  "https://api.example.com/v1/items"
+```
+
+Bruin renders each argument and passes the resulting argument list directly to the installed curl
+executable in the same order. It does not inspect, validate, or maintain a list of curl options, so
+options supported by the installed curl version work without a corresponding Bruin release. Curl
+alone interprets the rendered arguments and determines whether they are valid. Bruin connects
+curl's stdin, stdout, and stderr directly to the caller.
+
+## Referencing connections
+
+Call `bruin.connection("<name>")` from Jinja to retrieve a connection by its existing Bruin name.
+Its fields use the same snake_case names as `.bruin.yml`:
+
+```yaml
+environments:
+  default:
+    connections:
+      generic:
+        - name: my-api
+          value: secret-api-token
+        - name: analytics-api
+          value: analytics-token
+```
+
+```bash
+bruin curl -- \
+  --header 'Authorization: Bearer {{ bruin.connection("my-api").value }}' \
+  --header 'X-Analytics-Key: {{ bruin.connection("analytics-api").value }}' \
+  'https://api.example.com/accounts/{{ bruin.connection("my-api").name }}'
+```
+
+One command may reference any number of connections, and repeated references to the same connection
+are resolved only once. Fields nested inside a connection can be traversed with additional dots:
+
+```jinja
+{{ bruin.connection("service-api").credentials.client_id }}
+```
+
+The usual Bruin Jinja helpers remain available in the same namespace. For example,
+`{{ bruin.slugify("Account Name") }}` renders as `account_name`. Most other helpers generate SQL
+expressions and are primarily useful in asset templates; see [Jinja templating and built-in
+functions](/assets/templating/macros).
+
+Use `--environment` (or `--env`) to select a non-default environment and `--config-file` to use a
+specific `.bruin.yml` file. Bruin's global `--secrets-backend` flag is also supported:
+
+```bash
+bruin --secrets-backend vault curl -- \
+  --header 'Authorization: Bearer {{ bruin.connection("my-api").value }}' \
+  https://api.example.com
+```
+
+Connections from a secrets backend are fetched by the names used in the Jinja expressions; Bruin
+does not need to enumerate every secret in the backend.
+
+## Curl variables
+
+Curl uses `{{name}}`-style expressions for values supplied with `--variable`, which overlaps with
+Jinja syntax. Bruin recognizes curl's variable syntax and leaves those expressions for curl while
+still rendering connection references in the same argument:
+
+```bash
+bruin curl -- \
+  --variable path=items \
+  --expand-url 'https://{{ bruin.connection("my-api").host }}/v1/{{path:url}}'
+```
+
+Curl variable names are alphanumeric with underscores and do not contain dots, optionally followed
+by colon-separated functions such as `{{path:trim:url}}`. Bruin connection expressions are
+namespaced under `bruin.connection(...)`, which makes the two forms unambiguous.
+
+All curl arguments, including option names, option values, URLs, and curl variable declarations,
+are rendered independently. Use `bruin curl -- --help all` to view every option supported by the
+installed curl executable.
+
+> Rendered values are passed as curl process arguments and may be visible to local process-inspection
+> tools. Curl can also reveal credentials through `--verbose`, `--trace`, `--trace-ascii`, `--libcurl`,
+> and similar diagnostic output. Treat both the process arguments and diagnostic output as sensitive
+> when a command references connection fields.

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -48,6 +48,7 @@ bruin validate --help
 | [`render`](/commands/render) | Preview rendered Jinja templates |
 | [`lineage`](/commands/lineage) | Visualize asset dependencies |
 | [`query`](/commands/query) | Execute ad-hoc queries against connections |
+| [`curl`](/commands/curl) | Call remote services with connection-aware Jinja rendering |
 | [`data-diff`](/commands/data-diff) | Compare data between connections |
 
 ### Asset Operations

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		Commands: []*cli.Command{
 			cmd.Lint(&isDebug),
 			cmd.Run(&isDebug),
+			cmd.Curl(),
 			cmd.Render(),
 			cmd.RenderDDL(),
 			cmd.UnitTest(),


### PR DESCRIPTION
## What
Adds `bruin curl` for rendering curl arguments with named Bruin connections while passing the rendered arguments directly to the installed curl.

## Changes
- Adds lazy `bruin.connection("name")` Jinja lookups, built-in helpers, curl-variable preservation, direct argument passthrough, tests, and command documentation.
- Registers the command and adds it to the docs navigation.

## How to test
1. Run `make format`, `make test`, and `make build-no-duckdb`.
2. Run `bruin curl -- --version` and a connection-backed curl command.

## Risk & rollback
- **Risk:** Medium — rendered connection values are passed in curl process arguments; this is documented.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
N/A
