### PR TITLE
python: bump ingestr v1 pin to 1.1.19

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.15"
+	IngestrVersionV1 = "1.1.19"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
Updates Bruin's default v1 ingestr pin from 1.1.15 to 1.1.19 so default ingestr assets and parameters.version=v1 resolve to the upcoming release.