### PR TITLE
docs: add Fivetran migration template guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -548,6 +548,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             {text: "firebase", link: "/getting-started/templates-docs/firebase-README"},
                         ],
                     },
+                    {
+                        text: "Migration Templates",
+                        collapsed: false,
+                        items: [
+                            {text: "migration-fivetran", link: "/getting-started/templates-docs/migration-fivetran"},
+                        ],
+                    },
                 ],
             },
             {

--- a/docs/getting-started/templates-docs/migration-fivetran.md
+++ b/docs/getting-started/templates-docs/migration-fivetran.md
@@ -1,0 +1,45 @@
+# Migrate a Fivetran connection to Bruin
+
+The `migration-fivetran` template provides a review-gated workspace for migrating one Fivetran connection to a Bruin `ingestr` pipeline. It captures the Fivetran configuration with read-only API requests, records decisions in a migration plan, and pauses for your approval before connection tests or destination writes.
+
+## Create the migration workspace
+
+Create a new project, then move into it:
+
+```bash
+bruin init migration-fivetran my-migration-project
+cd my-migration-project
+```
+
+The template includes:
+
+- `fivetran-bruin-prompt.md`: staged instructions for your coding agent.
+- `plan.md`: the migration inventory, decisions, open questions, and validation evidence.
+- `.agents/skills/bruin-fivetran-migrator/`: the agent skill and a read-only Fivetran configuration importer.
+- `bruin/`: an empty pipeline where the reviewed `ingestr` assets are created.
+
+The local `.bruin.yml` file and imported captures under `.artifacts/` are Git-ignored. Keep credentials, source data, and Fivetran cursor state out of Git and out of `plan.md`.
+
+## Configure the connections
+
+Add the source and destination connections you will use with [the connections command](/commands/connections). Use an isolated destination schema or target for the first run.
+
+The importer also needs two generic values in the repository-root `.bruin.yml`. Their names must be exactly `fivetran_api_key` and `fivetran_api_secret`. Keep their values local; never paste them into an agent chat, the migration plan, or a committed file.
+
+## Start the migration agent
+
+Open a fresh agent chat from the migration-project root and send:
+
+```text
+Read @fivetran-bruin-prompt.md and execute that prompt. The connections are already configured in the root .bruin.yml.
+```
+
+The agent asks you to select one Fivetran connection, imports its redacted configuration into `.artifacts/`, and updates `plan.md` with the inventory and any compatibility gaps. It then pauses for connection readiness, drafts the pipeline and assets, and asks for explicit approval before a v0 write.
+
+## Review before running
+
+Before approving a v0 load, review the source and destination mappings, primary and incremental keys, date bounds, delete or history behavior, schema ownership, and validation checks. Approve only the isolated targets and scope you intend to test.
+
+After the run, review the recorded row counts, key checks, incremental ranges, quality checks, and any approved parity comparison. Keep Fivetran active and do not enable a schedule or cut over production until your team has approved the final validation and rollback plan.
+
+For the generated asset format, see [Ingestr assets](/assets/ingestr). For the available template catalog, return to [Templates](/getting-started/templates).

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -216,12 +216,16 @@ An Iceberg connection is a **catalog** (where table metadata lives) plus **stora
 
 ## Migration templates
 
-Migration templates provide a review-gated starting point for moving existing
-data integrations to Bruin.
+Migration templates provide a review-gated starting point for moving existing data integrations to Bruin.
 
-| Template | Use when you want to start with |
-| --- | --- |
-| `migration-fivetran` | A review-gated Fivetran migration workspace with a blank `bruin/` pipeline, migration prompt, plan, and agent skill. |
+<div class="template-grid">
+  <a class="template-card" href="./templates-docs/migration-fivetran.html">
+    <span class="template-card__category">Review-gated migration</span>
+    <strong>migration-fivetran</strong>
+    <span>Migrate one Fivetran connection at a time with a staged agent prompt, migration plan, and read-only configuration importer.</span>
+    <span class="template-card__tags"><code>Fivetran</code><code>ingestr</code><code>AI agents</code></span>
+  </a>
+</div>
 
 ## Other bundled templates
 


### PR DESCRIPTION
## Summary

- add a concise guide for the `migration-fivetran` template
- add a Migration Templates section, clickable card, and sidebar entry

## Validation

- `npm run docs:build`
- `npx markdownlint-cli2 --config .markdownlint-cli2.jsonc --no-globs docs/getting-started/templates.md docs/getting-started/templates-docs/migration-fivetran.md`

The repository-wide Markdown lint command still reports existing violations in unrelated documentation.