### PR TITLE
Add 'bruin cloud agents mcp' commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2197,6 +2197,7 @@ func CloudAgents() *cli.Command {
 			cloudAgentsGetPrompt(),
 			cloudAgentsSetPrompt(),
 			cloudAgentsConnections(),
+			cloudAgentsMcp(),
 		},
 	}
 }
@@ -2487,6 +2488,229 @@ func cloudAgentsUpdate() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func cloudAgentsMcp() *cli.Command {
+	return &cli.Command{
+		Name:  "mcp",
+		Usage: "Manage an agent's external MCP servers (Linear, GitHub, …)",
+		Commands: []*cli.Command{
+			cloudAgentsMcpList(),
+			cloudAgentsMcpSet(),
+			cloudAgentsMcpRemove(),
+		},
+	}
+}
+
+func cloudAgentsMcpList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List an agent's MCP servers and the connections available for each kind",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			resp, err := client.ListAgentMcpServers(ctx, c.Int("agent-id"))
+			if err != nil {
+				printError(err, output, "Failed to list agent MCP servers")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(resp, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Kind", "Connection", "Display Name"})
+			for _, s := range resp.MCPIntegrations {
+				display := ""
+				if s.DisplayName != nil {
+					display = *s.DisplayName
+				}
+				t.AppendRow(table.Row{s.Kind, s.ConnectionName, display})
+			}
+			t.Render()
+
+			// Show what can be configured: every supported kind and the
+			// connections eligible from the agent's dev-env set.
+			kinds := make([]string, 0, len(resp.MCPKinds))
+			for k := range resp.MCPKinds {
+				kinds = append(kinds, k)
+			}
+			sort.Strings(kinds)
+			infoPrinter.Println("\nAvailable kinds (eligible connections):")
+			for _, k := range kinds {
+				infoPrinter.Printf("  %s (%s): %s\n", k, resp.MCPKinds[k], strings.Join(resp.ConnectionsByMcpKind[k], ", "))
+			}
+			return nil
+		},
+	}
+}
+
+func cloudAgentsMcpSet() *cli.Command {
+	return &cli.Command{
+		Name:  "set",
+		Usage: "Attach or update an MCP server on an agent",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "kind",
+				Usage:    "MCP kind (e.g. linear, github, notion)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "connection",
+				Usage:    "bruin.yml connection name backing this MCP server",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+			agentID := c.Int("agent-id")
+			kind := c.String("kind")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			// Read-modify-write: the API replaces the whole set, so merge the new
+			// pick into the current one to keep the other kinds intact.
+			current, err := client.ListAgentMcpServers(ctx, agentID)
+			if err != nil {
+				printError(err, output, "Failed to load current MCP servers")
+				return cli.Exit("", 1)
+			}
+
+			servers := upsertMcpServer(current.MCPIntegrations, kind, c.String("connection"))
+
+			agent, err := client.SetAgentMcpServers(ctx, agentID, servers)
+			if err != nil {
+				printError(err, output, "Failed to set MCP server")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(agent, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Set MCP server %q on agent %d\n", kind, agentID)
+			return nil
+		},
+	}
+}
+
+func cloudAgentsMcpRemove() *cli.Command {
+	return &cli.Command{
+		Name:  "remove",
+		Usage: "Detach an MCP server from an agent",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "kind",
+				Usage:    "MCP kind to remove (e.g. linear, github)",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+			agentID := c.Int("agent-id")
+			kind := c.String("kind")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			current, err := client.ListAgentMcpServers(ctx, agentID)
+			if err != nil {
+				printError(err, output, "Failed to load current MCP servers")
+				return cli.Exit("", 1)
+			}
+
+			servers, removed := removeMcpServer(current.MCPIntegrations, kind)
+			if !removed {
+				printError(fmt.Errorf("agent %d has no MCP server of kind %q", agentID, kind), output, "Nothing to remove")
+				return cli.Exit("", 1)
+			}
+
+			if _, err := client.SetAgentMcpServers(ctx, agentID, servers); err != nil {
+				printError(err, output, "Failed to remove MCP server")
+				return cli.Exit("", 1)
+			}
+
+			infoPrinter.Printf("Removed MCP server %q from agent %d\n", kind, agentID)
+			return nil
+		},
+	}
+}
+
+// upsertMcpServer returns servers with kind set to connection — updating the
+// existing entry in place or appending a new one.
+func upsertMcpServer(servers []bruincloud.AgentMcpServer, kind, connection string) []bruincloud.AgentMcpServer {
+	out := make([]bruincloud.AgentMcpServer, 0, len(servers)+1)
+	found := false
+	for _, s := range servers {
+		if s.Kind == kind {
+			s.ConnectionName = connection
+			found = true
+		}
+		out = append(out, bruincloud.AgentMcpServer{Kind: s.Kind, ConnectionName: s.ConnectionName})
+	}
+	if !found {
+		out = append(out, bruincloud.AgentMcpServer{Kind: kind, ConnectionName: connection})
+	}
+	return out
+}
+
+// removeMcpServer returns servers without kind, and whether it was present.
+func removeMcpServer(servers []bruincloud.AgentMcpServer, kind string) ([]bruincloud.AgentMcpServer, bool) {
+	out := make([]bruincloud.AgentMcpServer, 0, len(servers))
+	removed := false
+	for _, s := range servers {
+		if s.Kind == kind {
+			removed = true
+			continue
+		}
+		out = append(out, bruincloud.AgentMcpServer{Kind: s.Kind, ConnectionName: s.ConnectionName})
+	}
+	return out, removed
 }
 
 func cloudAgentsCreate() *cli.Command {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2519,6 +2519,13 @@ func cloudAgentsMcpList() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
+			// Fail fast on an invalid id rather than sending a bad request and
+			// surfacing a generic remote error.
+			if c.Int("agent-id") <= 0 {
+				printError(fmt.Errorf("--agent-id must be a positive integer, got %d", c.Int("agent-id")), output, "Invalid --agent-id")
+				return cli.Exit("", 1)
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
@@ -2594,6 +2601,13 @@ func cloudAgentsMcpSet() *cli.Command {
 			agentID := c.Int("agent-id")
 			kind := c.String("kind")
 
+			// Fail fast on an invalid id rather than sending a bad request and
+			// surfacing a generic remote error.
+			if agentID <= 0 {
+				printError(fmt.Errorf("--agent-id must be a positive integer, got %d", agentID), output, "Invalid --agent-id")
+				return cli.Exit("", 1)
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
@@ -2651,6 +2665,13 @@ func cloudAgentsMcpRemove() *cli.Command {
 			output := c.String("output")
 			agentID := c.Int("agent-id")
 			kind := c.String("kind")
+
+			// Fail fast on an invalid id rather than sending a bad request and
+			// surfacing a generic remote error.
+			if agentID <= 0 {
+				printError(fmt.Errorf("--agent-id must be a positive integer, got %d", agentID), output, "Invalid --agent-id")
+				return cli.Exit("", 1)
+			}
 
 			client, err := newCloudClient(c)
 			if err != nil {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -309,13 +309,14 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 11)
+	require.Len(t, cmd.Commands, 12)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
 		subNames[i] = sub.Name
 	}
 	assert.Contains(t, subNames, "connections")
+	assert.Contains(t, subNames, "mcp")
 }
 
 func TestCloudDashboardsCommand_Help(t *testing.T) {
@@ -726,4 +727,50 @@ func TestFormatCostCell(t *testing.T) {
 	assert.Equal(t, "daily-etl", formatCostCell("daily-etl"))
 	assert.Equal(t, "74123", formatCostCell(float64(74123)))
 	assert.JSONEq(t, `{"pipeline_id":"p"}`, formatCostCell(map[string]any{"pipeline_id": "p"}))
+}
+
+func TestUpsertMcpServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("appends a new kind", func(t *testing.T) {
+		t.Parallel()
+		out := upsertMcpServer([]bruincloud.AgentMcpServer{{Kind: "linear", ConnectionName: "a"}}, "github", "b")
+		require.Len(t, out, 2)
+		assert.Equal(t, "linear", out[0].Kind)
+		assert.Equal(t, "github", out[1].Kind)
+		assert.Equal(t, "b", out[1].ConnectionName)
+	})
+
+	t.Run("updates an existing kind in place", func(t *testing.T) {
+		t.Parallel()
+		out := upsertMcpServer([]bruincloud.AgentMcpServer{
+			{Kind: "linear", ConnectionName: "old"},
+			{Kind: "github", ConnectionName: "gh"},
+		}, "linear", "new")
+		require.Len(t, out, 2)
+		assert.Equal(t, "new", out[0].ConnectionName)
+		assert.Equal(t, "gh", out[1].ConnectionName)
+	})
+}
+
+func TestRemoveMcpServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("drops the kind and reports it", func(t *testing.T) {
+		t.Parallel()
+		out, removed := removeMcpServer([]bruincloud.AgentMcpServer{
+			{Kind: "linear", ConnectionName: "a"},
+			{Kind: "github", ConnectionName: "b"},
+		}, "linear")
+		assert.True(t, removed)
+		require.Len(t, out, 1)
+		assert.Equal(t, "github", out[0].Kind)
+	})
+
+	t.Run("reports when the kind is absent", func(t *testing.T) {
+		t.Parallel()
+		out, removed := removeMcpServer([]bruincloud.AgentMcpServer{{Kind: "linear", ConnectionName: "a"}}, "github")
+		assert.False(t, removed)
+		require.Len(t, out, 1)
+	})
 }

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -385,6 +385,36 @@ func TestCloudAgentsConnections_RejectsNonPositiveAgentID(t *testing.T) {
 	}
 }
 
+func TestCloudAgentsMcp_RejectsNonPositiveAgentID(t *testing.T) {
+	t.Parallel()
+	// Each mcp subcommand must reject a non-positive --agent-id locally rather
+	// than sending a bad request. Required flags are supplied so parsing reaches
+	// the Action guard.
+	cases := []struct {
+		name string
+		cmd  func() *cli.Command
+		args []string
+	}{
+		{"list", cloudAgentsMcpList, []string{"list", "--api-key", "k"}},
+		{"set", cloudAgentsMcpSet, []string{"set", "--api-key", "k", "--kind", "linear", "--connection", "c"}},
+		{"remove", cloudAgentsMcpRemove, []string{"remove", "--api-key", "k", "--kind", "linear"}},
+	}
+	for _, tc := range cases {
+		for _, v := range []string{"0", "-3"} {
+			cmd := tc.cmd()
+			exitCode := 0
+			cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, err error) {
+				var ec cli.ExitCoder
+				if errors.As(err, &ec) {
+					exitCode = ec.ExitCode()
+				}
+			}
+			_ = runCLI(t.Context(), cmd, append(tc.args, "--agent-id", v))
+			assert.Equalf(t, 1, exitCode, "%s: agent-id %q should be rejected", tc.name, v)
+		}
+	}
+}
+
 func TestCloudAgentsConnectionsAdd_RejectsNonPositiveAgentID(t *testing.T) {
 	t.Parallel()
 	for _, v := range []string{"0", "-3"} {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -567,6 +567,30 @@ bruin cloud agents connections add \
   --credentials '{"username":"u","password":"p","host":"db.example.com","database":"main"}'
 ```
 
+#### `mcp`
+
+Manage an agent's external MCP servers (Linear, GitHub, Notion, …). Each MCP kind
+is backed by a `bruin.yml` connection from the agent's dev-env set.
+
+`list` shows the agent's current picks plus the connections eligible for each kind:
+
+```bash
+bruin cloud agents mcp list --agent-id 7
+bruin cloud agents mcp list --agent-id 7 --output json
+```
+
+`set` attaches or updates one kind (leaving the others intact):
+
+```bash
+bruin cloud agents mcp set --agent-id 7 --kind linear --connection my-linear
+```
+
+`remove` detaches a kind:
+
+```bash
+bruin cloud agents mcp remove --agent-id 7 --kind linear
+```
+
 #### `send`
 
 Send a message to an agent:

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -555,6 +555,23 @@ func (c *APIClient) UpdateAgent(ctx context.Context, agentID int, fields map[str
 	return &result, nil
 }
 
+// ListAgentMcpServers returns the agent's current external MCP server picks
+// along with the supported kinds and the connections eligible for each.
+func (c *APIClient) ListAgentMcpServers(ctx context.Context, agentID int) (*AgentMcpServersResponse, error) {
+	var result AgentMcpServersResponse
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%d/mcp-servers", agentID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// SetAgentMcpServers replaces the agent's external MCP picks with the given set.
+// This is a full replace: any kind not in servers is detached.
+func (c *APIClient) SetAgentMcpServers(ctx context.Context, agentID int, servers []AgentMcpServer) (*Agent, error) {
+	return c.UpdateAgent(ctx, agentID, map[string]any{"mcp_integrations": servers})
+}
+
 func (c *APIClient) SendAgentMessage(ctx context.Context, agentID int, message string, threadID *int) (json.RawMessage, error) {
 	body := map[string]any{
 		"message": message,

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -648,6 +648,52 @@ func TestUpdateAgent(t *testing.T) {
 	assert.Equal(t, "renamed", agent.Name)
 }
 
+func TestListAgentMcpServers(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/agents/7/mcp-servers", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"mcp_integrations": []AgentMcpServer{
+				{Kind: "linear", ConnectionName: "my-linear"},
+			},
+			"mcp_kinds":               map[string]string{"linear": "Linear", "github": "GitHub"},
+			"connections_by_mcp_kind": map[string][]string{"linear": {"my-linear"}, "github": {}},
+		})
+	})
+
+	resp, err := client.ListAgentMcpServers(t.Context(), 7)
+	require.NoError(t, err)
+	require.Len(t, resp.MCPIntegrations, 1)
+	assert.Equal(t, "linear", resp.MCPIntegrations[0].Kind)
+	assert.Equal(t, "Linear", resp.MCPKinds["linear"])
+	assert.Equal(t, []string{"my-linear"}, resp.ConnectionsByMcpKind["linear"])
+}
+
+func TestSetAgentMcpServers(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/agents/7", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		integrations, ok := body["mcp_integrations"].([]any)
+		require.True(t, ok)
+		require.Len(t, integrations, 1)
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, Agent{ID: 7, Name: "a", Visibility: "team"})
+	})
+
+	agent, err := client.SetAgentMcpServers(t.Context(), 7, []AgentMcpServer{
+		{Kind: "linear", ConnectionName: "my-linear"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 7, agent.ID)
+}
+
 func TestListAgentThreads(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -680,8 +680,8 @@ func TestSetAgentMcpServers(t *testing.T) {
 		var body map[string]any
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		integrations, ok := body["mcp_integrations"].([]any)
-		require.True(t, ok)
-		require.Len(t, integrations, 1)
+		assert.True(t, ok)
+		assert.Len(t, integrations, 1)
 
 		w.WriteHeader(http.StatusOK)
 		writeJSON(t, w, Agent{ID: 7, Name: "a", Visibility: "team"})

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -122,10 +122,28 @@ type GlossaryEntity struct {
 
 // Agent represents a Bruin Cloud agent.
 type Agent struct {
-	ID          int     `json:"id"`
-	Name        string  `json:"name"`
-	Description *string `json:"description"`
-	Visibility  string  `json:"visibility"`
+	ID              int              `json:"id"`
+	Name            string           `json:"name"`
+	Description     *string          `json:"description"`
+	Visibility      string           `json:"visibility"`
+	MCPIntegrations []AgentMcpServer `json:"mcp_integrations,omitempty"`
+}
+
+// AgentMcpServer is one external MCP server attached to an agent — a supported
+// kind (linear, github, …) backed by a bruin.yml connection in the agent's
+// dev-env set.
+type AgentMcpServer struct {
+	Kind           string  `json:"kind"`
+	ConnectionName string  `json:"connection_name"`
+	DisplayName    *string `json:"display_name"`
+}
+
+// AgentMcpServersResponse is the payload of the agent MCP-servers endpoint: the
+// current picks plus the options for configuring them.
+type AgentMcpServersResponse struct {
+	MCPIntegrations      []AgentMcpServer    `json:"mcp_integrations"`
+	MCPKinds             map[string]string   `json:"mcp_kinds"`
+	ConnectionsByMcpKind map[string][]string `json:"connections_by_mcp_kind"`
 }
 
 // AgentConnection is one connection available to an agent — name and type only


### PR DESCRIPTION
Adds `bruin cloud agents mcp list/set/remove` to manage an agent's external-MCP integrations (Linear/GitHub/Notion/etc.) from the CLI.

- `list` shows the agent's current MCP picks.
- `set --kind --connection` and `remove --kind` are read-modify-write: fetch the current set, merge, then PATCH the full set (the API replaces the whole set).
- New client methods `ListAgentMcpServers` / `SetAgentMcpServers` and types `AgentMcpServer` / `AgentMcpServersResponse` + `Agent.MCPIntegrations`.

Cloud counterpart: bruin-data/cloud `mcp-integration-cloud-agent`.