### PR TITLE
Add 'bruin cloud teams list' command

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -29,6 +29,7 @@ func Cloud(isDebug *bool) *cli.Command {
 		Name:  "cloud",
 		Usage: "Interact with Bruin Cloud API",
 		Commands: []*cli.Command{
+			CloudTeams(),
 			CloudProjects(),
 			CloudPipelines(),
 			CloudRuns(),
@@ -241,6 +242,58 @@ func printFormattedLogs(result json.RawMessage) {
 }
 
 // --- Projects ---
+
+func CloudTeams() *cli.Command {
+	return &cli.Command{
+		Name:  "teams",
+		Usage: "Manage Bruin Cloud teams",
+		Commands: []*cli.Command{
+			cloudTeamsList(),
+		},
+	}
+}
+
+func cloudTeamsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List the teams your token can act on",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			teams, err := client.ListTeams(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list teams")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(teams, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Name", "Company Prefix"})
+			for _, tm := range teams {
+				t.AppendRow(table.Row{tm.ID, tm.Name, tm.CompanyPrefix})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
 
 func CloudProjects() *cli.Command {
 	return &cli.Command{

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -149,12 +149,13 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 13)
+	assert.Len(t, cmd.Commands, 14)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
 		subNames[i] = sub.Name
 	}
+	assert.Contains(t, subNames, "teams")
 	assert.Contains(t, subNames, "cost")
 	assert.Contains(t, subNames, "projects")
 	assert.Contains(t, subNames, "pipelines")

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -45,6 +45,26 @@ These flags are available on all `cloud` subcommands:
 
 ## Subcommands
 
+### `teams`
+
+List the teams your token can act on. Run this to discover the company prefix to pass to `--team` (or `BRUIN_CLOUD_TEAM`) — needed when your personal API key belongs to more than one team.
+
+```bash
+bruin cloud teams list
+```
+
+**Example output:**
+```
++----+--------+----------------+
+| ID | NAME   | COMPANY PREFIX |
++----+--------+----------------+
+| 1  | Acme   | acme           |
+| 2  | Globex | globex         |
++----+--------+----------------+
+```
+
+---
+
 ### `projects`
 
 List all projects you have access to. This is usually the first command you'll run — the project ID you see here is what you'll pass to other commands.

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -129,6 +129,18 @@ func (c *APIClient) doRequest(ctx context.Context, method, path string, body any
 	return nil
 }
 
+// --- Teams ---
+
+// ListTeams returns the teams the token can act on. Unlike the other endpoints
+// it needs no --team: it's how you discover the company_prefixes to pass there.
+func (c *APIClient) ListTeams(ctx context.Context) ([]Team, error) {
+	var resp struct {
+		Teams []Team `json:"teams"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/teams", nil, &resp)
+	return resp.Teams, err
+}
+
 // --- Projects ---
 
 func (c *APIClient) ListProjects(ctx context.Context) ([]Project, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -889,6 +889,28 @@ func TestGetBackfillRuns(t *testing.T) {
 	assert.Equal(t, "m1__a", runs[0].RunID)
 }
 
+func TestListTeams(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/teams", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"teams": []map[string]any{
+				{"id": 1, "name": "Acme", "company_prefix": "acme"},
+				{"id": 2, "name": "Globex", "company_prefix": "globex"},
+			},
+		})
+	})
+
+	teams, err := client.ListTeams(t.Context())
+	require.NoError(t, err)
+	require.Len(t, teams, 2)
+	assert.Equal(t, "Acme", teams[0].Name)
+	assert.Equal(t, "acme", teams[0].CompanyPrefix)
+	assert.Equal(t, 2, teams[1].ID)
+}
+
 func TestListDashboards(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+// Team is a team the caller's token can act on. CompanyPrefix is what you pass
+// to --team (the X-Bruin-Team header) to target this team on other commands.
+type Team struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	CompanyPrefix string `json:"company_prefix"`
+}
+
 // Project represents a Bruin Cloud project.
 type Project struct {
 	ID       string          `json:"id"`


### PR DESCRIPTION
Adds `bruin cloud teams list`, which lists the teams your token can act on (id, name, company prefix), in plain-table or `--output json`.

This is the discovery half of `--team`: a multi-team plain token is refused with 409 `team_required` on the other commands until it names a team, but there was no way to learn the available `company_prefix` values. Now you list them, then pass one via `--team`.

Backed by the new `GET /api/v1/teams` cloud endpoint (bruin-data/cloud#2891).