### PR TITLE
Document Data Vault strategies and fix silent mis-loads

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -59,6 +59,9 @@ The strategy used for the materialization, can be one of the following:
 - `merge`: merge the existing records with the new records, requires a primary key to be set.
 - `time_interval`: incrementally load time-based data within specific time windows.
 - `ddl`: create a new table using a DDL (Data Definition Language) statement.
+- `datavault_hub`: incrementally load unique business entities into a Data Vault hub.
+- `datavault_link`: incrementally load unique relationships into a Data Vault link.
+- `datavault_satellite`: incrementally load descriptive history into a Data Vault satellite.
 - `scd2_by_column`: implement SCD2 logic that tracks changes based on column value differences.
 - `scd2_by_time`: implement SCD2 logic that tracks changes based on time-based incremental key.
 
@@ -511,6 +514,186 @@ in the materialization definition with the following keys:
 - `partition_by`
 - `cluster_by`
 
+### Data Vault strategies
+
+Bruin provides three strategies for loading a Raw Data Vault: `datavault_hub`, `datavault_link`, and `datavault_satellite`. They are supported for PostgreSQL and DuckDB SQL assets with `type: table` materialization. Redshift reuses the PostgreSQL SQL generator but produces statements Redshift cannot execute. On any other platform an incremental run fails with an unsupported strategy error, while a `--full-refresh` run silently falls back to `create+replace` and drops the Data Vault loading rules, which `bruin validate` does not flag.
+
+The asset query must calculate the hash keys and hashdiff and return every column declared in `columns`. Bruin uses those values to apply the loading rules; it does not calculate hashes. Every declared column must have both a `name` and a database-compatible `type`.
+
+#### Data Vault column roles
+
+Set a column's role with `meta.datavault_role`. Explicit roles are recommended, especially when an asset contains multiple hash key columns.
+
+| Column purpose | Accepted `datavault_role` values | Naming or configuration fallback |
+| --- | --- | --- |
+| Hub hash key | `hash_key`, `hub_hash_key` | First column with `primary_key: true`, or the only column ending in `_hk` |
+| Hub business key | `business_key` | Columns ending in `_bk`, in addition to the explicitly roled columns |
+| Link hash key | `link_hash_key`, `hash_key` | First column with `primary_key: true`, or the only column ending in `_hk` |
+| Related hash keys in a link | `hub_hash_key`, `parent_hash_key`, `foreign_hash_key` | Other columns ending in `_hk` |
+| Satellite parent hash key | `parent_hash_key`, `hub_hash_key`, `hash_key` | First column with `primary_key: true`, or the only column ending in `_hk` |
+| Satellite hashdiff | `hashdiff`, `hash_diff` | A column named `hashdiff` or `hash_diff` |
+| Load datetime | `load_datetime`, `load_dts` | A column named `load_dts`, `load_datetime`, or `loaded_at` |
+| Record source | `record_source` | A column named `record_source` |
+
+Role values and naming fallbacks are case-insensitive. For a link with several `_hk` columns, identify the link hash key explicitly with `datavault_role: link_hash_key` or `primary_key: true`; Bruin treats the remaining `_hk` columns as related hash keys.
+
+In a hub, every column ending in `_bk` is added to the business keys, and in a link every column ending in `_hk` other than the link hash key is added to the related hash keys. Both happen in addition to the explicitly roled columns rather than instead of them, so a descriptive column carrying one of those suffixes becomes a required column. Rename such columns if you do not want them to take part in the key.
+
+All three strategies:
+
+- Create the schema, when the asset name has the form `schema.table`, and create the target table if it does not exist.
+- Define every role-bearing column as `NOT NULL`, meaning hash keys, business keys, the satellite hashdiff, the load datetime, and the record source, and skip source rows that contain `NULL` in any of them. A column you declare with `nullable: false` also becomes `NOT NULL` in the table definition, but it takes no part in the skip filter, so a `NULL` there fails the run instead of dropping the row.
+- Run the table creation and incremental load in one transaction.
+- Drop and recreate the target table when the asset runs with `--full-refresh`, then apply the same Data Vault loading rules to the refreshed data. An asset with `full_refresh_restricted: true` keeps its incremental behavior and is not dropped.
+
+On incremental runs, `CREATE TABLE IF NOT EXISTS` does not alter an existing target. If you change the declared columns or their types, migrate the table separately or run a full refresh.
+
+#### `datavault_hub`
+
+The `datavault_hub` strategy loads one row per hub hash key. Within the current asset query, Bruin keeps the row with the earliest load datetime for each hash key. It inserts that row only when the hash key does not already exist in the target, making repeated loads idempotent.
+
+A hub requires:
+
+- One hub hash key
+- One or more business keys
+- One load datetime
+- One record source
+
+```bruin-sql
+/* @bruin
+name: rdv.hub_customer
+type: duckdb.sql
+
+materialization:
+  type: table
+  strategy: datavault_hub
+
+columns:
+  - name: customer_hk
+    type: VARCHAR
+    meta:
+      datavault_role: hash_key
+  - name: customer_id
+    type: VARCHAR
+    meta:
+      datavault_role: business_key
+  - name: load_dts
+    type: TIMESTAMP
+    meta:
+      datavault_role: load_datetime
+  - name: record_source
+    type: VARCHAR
+    meta:
+      datavault_role: record_source
+@bruin */
+
+SELECT customer_hk, customer_id, load_dts, record_source
+FROM stg.customer_hashed
+```
+
+Bruin creates `customer_hk` as the target table's primary key.
+
+#### `datavault_link`
+
+The `datavault_link` strategy loads one row per link hash key. As with hubs, Bruin keeps the earliest row per link hash key from the current query and inserts it only when that key does not already exist in the target.
+
+A link requires:
+
+- One link hash key
+- One or more related hub, parent, or foreign hash keys
+- One load datetime
+- One record source
+
+```bruin-sql
+/* @bruin
+name: rdv.link_customer_order
+type: duckdb.sql
+
+materialization:
+  type: table
+  strategy: datavault_link
+
+columns:
+  - name: customer_order_hk
+    type: VARCHAR
+    meta:
+      datavault_role: link_hash_key
+  - name: customer_hk
+    type: VARCHAR
+    meta:
+      datavault_role: hub_hash_key
+  - name: order_hk
+    type: VARCHAR
+    meta:
+      datavault_role: hub_hash_key
+  - name: load_dts
+    type: TIMESTAMP
+    meta:
+      datavault_role: load_datetime
+  - name: record_source
+    type: VARCHAR
+    meta:
+      datavault_role: record_source
+@bruin */
+
+SELECT customer_order_hk, customer_hk, order_hk, load_dts, record_source
+FROM stg.customer_orders_hashed
+```
+
+Bruin creates `customer_order_hk` as the target table's primary key.
+
+#### `datavault_satellite`
+
+The `datavault_satellite` strategy preserves descriptive history for a parent hash key. Bruin orders incoming rows for each parent by load datetime, compares their hashdiff values with the latest target row and with the preceding row in the current batch, and inserts only new changes. Consecutive rows with an unchanged hashdiff are not inserted.
+
+Bruin loads at most one row per target primary key, which is the parent hash key and load datetime by default. Rows that collide on that key within a batch are collapsed into one, and rows whose key already exists in the target are skipped rather than updated. Give each version of a parent a distinct load datetime so that no version is dropped.
+
+A satellite requires:
+
+- One parent hash key
+- One hashdiff
+- One load datetime
+- One record source
+- Any number of descriptive columns
+
+```bruin-sql
+/* @bruin
+name: rdv.sat_customer_details
+type: duckdb.sql
+
+materialization:
+  type: table
+  strategy: datavault_satellite
+
+columns:
+  - name: customer_hk
+    type: VARCHAR
+    meta:
+      datavault_role: parent_hash_key
+  - name: hashdiff
+    type: VARCHAR
+    meta:
+      datavault_role: hashdiff
+  - name: load_dts
+    type: TIMESTAMP
+    meta:
+      datavault_role: load_datetime
+  - name: record_source
+    type: VARCHAR
+    meta:
+      datavault_role: record_source
+  - name: customer_name
+    type: VARCHAR
+  - name: email
+    type: VARCHAR
+@bruin */
+
+SELECT customer_hk, hashdiff, load_dts, record_source, customer_name, email
+FROM stg.customer_hashed
+```
+
+By default, Bruin creates a composite primary key from the parent hash key and load datetime. You can define a different primary key by marking its columns with `primary_key: true`; marking only the parent hash key keeps the default parent-hash-key and load-datetime primary key. When you define a custom primary key, set `datavault_role: parent_hash_key` on the parent hash key column as well, because Bruin otherwise falls back to the first `primary_key: true` column and can pick the wrong one.
+
 ### `scd2_by_column`
 
 The `scd2_by_column` strategy implements [Slowly Changing Dimension Type 2](https://en.wikipedia.org/wiki/Slowly_changing_dimension) logic, which maintains a full history of data changes over time. This strategy is useful when you want to track changes to records and preserve the historical state of your data.
@@ -555,6 +738,7 @@ materialization:
 ```
 
 When `incremental_key` is specified:
+
 - `_valid_from` for new/updated records will be set to the value of the `incremental_key` column
 - `_valid_until` for records being expired (due to changes) will be set to the value of the `incremental_key` column from the new record
 - Records expiring because they're no longer in the source data will still use `CURRENT_TIMESTAMP()` for `_valid_until`

--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -516,7 +516,7 @@ in the materialization definition with the following keys:
 
 ### Data Vault strategies
 
-Bruin provides three strategies for loading a Raw Data Vault: `datavault_hub`, `datavault_link`, and `datavault_satellite`. They are supported for PostgreSQL and DuckDB SQL assets with `type: table` materialization. Redshift reuses the PostgreSQL SQL generator but produces statements Redshift cannot execute. On any other platform an incremental run fails with an unsupported strategy error, while a `--full-refresh` run silently falls back to `create+replace` and drops the Data Vault loading rules, which `bruin validate` does not flag.
+Bruin provides three strategies for loading a Raw Data Vault: `datavault_hub`, `datavault_link`, and `datavault_satellite`. They are supported for PostgreSQL and DuckDB SQL assets with `type: table` materialization. On any other platform, including Redshift, both incremental and `--full-refresh` runs fail with an unsupported strategy error, which `bruin validate` does not flag.
 
 The asset query must calculate the hash keys and hashdiff and return every column declared in `columns`. Bruin uses those values to apply the loading rules; it does not calculate hashes. Every declared column must have both a `name` and a database-compatible `type`.
 

--- a/pkg/duckdb/datavault_materialization.go
+++ b/pkg/duckdb/datavault_materialization.go
@@ -240,11 +240,9 @@ func resolveDataVaultHubColumns(asset *pipeline.Asset) (*pipeline.Column, []*pip
 		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires the `columns` field to be set")
 	}
 
-	hashKey := findDataVaultColumn(asset, []string{"hash_key", "hub_hash_key"}, func(col *pipeline.Column) bool {
-		return col.PrimaryKey
-	})
-	if hashKey == nil {
-		hashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	hashKey, err := findDataVaultHashKeyColumn(asset, []string{"hash_key", "hub_hash_key"}, "hash_key")
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	businessKeys := findDataVaultColumns(asset, []string{"business_key"}, func(col *pipeline.Column) bool {
@@ -272,11 +270,9 @@ func resolveDataVaultLinkColumns(asset *pipeline.Asset) (*pipeline.Column, []*pi
 		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires the `columns` field to be set")
 	}
 
-	linkHashKey := findDataVaultColumn(asset, []string{"link_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
-		return col.PrimaryKey
-	})
-	if linkHashKey == nil {
-		linkHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	linkHashKey, err := findDataVaultHashKeyColumn(asset, []string{"link_hash_key", "hash_key"}, "link_hash_key")
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	excludedColumns := []*pipeline.Column{linkHashKey}
@@ -305,11 +301,9 @@ func resolveDataVaultSatelliteColumns(asset *pipeline.Asset) (*pipeline.Column, 
 		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires the `columns` field to be set")
 	}
 
-	parentHashKey := findDataVaultColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
-		return col.PrimaryKey
-	})
-	if parentHashKey == nil {
-		parentHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	parentHashKey, err := findDataVaultHashKeyColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, "parent_hash_key")
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	hashDiff := findDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col *pipeline.Column) bool {
@@ -477,6 +471,30 @@ func findDataVaultRecordSourceColumn(asset *pipeline.Asset) *pipeline.Column {
 	return findDataVaultColumn(asset, []string{"record_source"}, func(col *pipeline.Column) bool {
 		return strings.EqualFold(col.Name, "record_source")
 	})
+}
+
+// findDataVaultHashKeyColumn resolves a hash key by explicit role first, then by primary_key, then by a
+// unique `_hk` suffix. When several columns are marked with primary_key there is no way to tell which one
+// is the hash key, so the caller is asked for an explicit role rather than silently taking the first one
+// in declaration order. Returns a nil column when nothing matches, leaving the specific error to the caller.
+func findDataVaultHashKeyColumn(asset *pipeline.Asset, roles []string, preferredRole string) (*pipeline.Column, error) {
+	if col := findDataVaultColumn(asset, roles, nil); col != nil {
+		return col, nil
+	}
+
+	if primaryKeys := asset.ColumnNamesWithPrimaryKey(); len(primaryKeys) > 1 {
+		return nil, fmt.Errorf(
+			"materialization strategy %s cannot determine which of the primary key columns (%s) is the hash key, mark it with datavault_role: %s",
+			asset.Materialization.Strategy, strings.Join(primaryKeys, ", "), preferredRole,
+		)
+	}
+	if col := findDataVaultColumn(asset, nil, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	}); col != nil {
+		return col, nil
+	}
+
+	return findSingleDataVaultColumnBySuffix(asset, "_hk", nil), nil
 }
 
 func findDataVaultColumn(asset *pipeline.Asset, roles []string, fallback func(*pipeline.Column) bool) *pipeline.Column {

--- a/pkg/duckdb/materialization_test.go
+++ b/pkg/duckdb/materialization_test.go
@@ -543,6 +543,52 @@ func TestDataVaultMaterializations(t *testing.T) {
 		assert.Contains(t, got, "CREATE TABLE IF NOT EXISTS rdv.hub_customer")
 		assert.NotContains(t, got, "CREATE TABLE rdv.hub_customer AS")
 	})
+
+	t.Run("refuses to guess the hash key when several columns are primary keys", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.sat_customer_details",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+			},
+			Columns: []pipeline.Column{
+				{Name: "load_dts", Type: "TIMESTAMP", PrimaryKey: true},
+				{Name: "customer_hk", Type: "VARCHAR", PrimaryKey: true},
+				{Name: "hashdiff", Type: "VARCHAR"},
+				{Name: "record_source", Type: "VARCHAR"},
+			},
+		}
+
+		_, err := NewMaterializer(false).Render(asset, "select customer_hk, hashdiff, load_dts, record_source from stg.crm_customer_hashed")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mark it with datavault_role: parent_hash_key")
+	})
+
+	t.Run("an explicit role resolves the hash key even with several primary keys", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.sat_customer_details",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+			},
+			Columns: []pipeline.Column{
+				{Name: "load_dts", Type: "TIMESTAMP", PrimaryKey: true},
+				{Name: "customer_hk", Type: "VARCHAR", PrimaryKey: true, Meta: map[string]string{"datavault_role": "parent_hash_key"}},
+				{Name: "hashdiff", Type: "VARCHAR"},
+				{Name: "record_source", Type: "VARCHAR"},
+			},
+		}
+
+		got, err := NewMaterializer(false).Render(asset, "select customer_hk, hashdiff, load_dts, record_source from stg.crm_customer_hashed")
+		require.NoError(t, err)
+
+		assert.Contains(t, got, "customer_hk VARCHAR NOT NULL")
+		assert.Contains(t, got, "PRIMARY KEY (load_dts, customer_hk)")
+	})
 }
 
 func TestDuckDBTimestampWithTimeZone(t *testing.T) {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1556,12 +1556,10 @@ func ensureDataVaultHubColumnsAreValid(asset *pipeline.Asset) []*Issue {
 		return issues
 	}
 
-	if !hasDataVaultColumn(asset, []string{"hash_key", "hub_hash_key"}, func(col pipeline.Column) bool {
-		return col.PrimaryKey || strings.HasSuffix(strings.ToLower(col.Name), "_hk")
-	}) {
+	if dataVaultHashKeyName(asset, []string{"hash_key", "hub_hash_key"}) == "" {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: "Materialization strategy 'datavault_hub' requires a hash key column",
+			Description: "Materialization strategy 'datavault_hub' requires a hash key column, identified by 'datavault_role: hash_key', 'primary_key: true', or a single column name ending in '_hk'",
 		})
 	}
 	if !hasDataVaultColumn(asset, []string{"business_key"}, func(col pipeline.Column) bool {
@@ -1582,17 +1580,11 @@ func ensureDataVaultLinkColumnsAreValid(asset *pipeline.Asset) []*Issue {
 		return issues
 	}
 
-	linkHashKeyName := ""
-	for _, col := range asset.Columns {
-		if dataVaultColumnMatches(col, []string{"link_hash_key", "hash_key"}) || col.PrimaryKey || strings.HasSuffix(strings.ToLower(col.Name), "_hk") {
-			linkHashKeyName = col.Name
-			break
-		}
-	}
+	linkHashKeyName := dataVaultHashKeyName(asset, []string{"link_hash_key", "hash_key"})
 	if linkHashKeyName == "" {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: "Materialization strategy 'datavault_link' requires a link hash key column",
+			Description: "Materialization strategy 'datavault_link' requires a link hash key column, identified by 'datavault_role: link_hash_key', 'primary_key: true', or a single column name ending in '_hk'",
 		})
 	}
 
@@ -1622,12 +1614,10 @@ func ensureDataVaultSatelliteColumnsAreValid(asset *pipeline.Asset) []*Issue {
 		return issues
 	}
 
-	if !hasDataVaultColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, func(col pipeline.Column) bool {
-		return col.PrimaryKey || strings.HasSuffix(strings.ToLower(col.Name), "_hk")
-	}) {
+	if dataVaultHashKeyName(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}) == "" {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: "Materialization strategy 'datavault_satellite' requires a parent hash key column",
+			Description: "Materialization strategy 'datavault_satellite' requires a parent hash key column, identified by 'datavault_role: parent_hash_key', 'primary_key: true', or a single column name ending in '_hk'",
 		})
 	}
 	if !hasDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col pipeline.Column) bool {
@@ -1692,6 +1682,35 @@ func appendCommonDataVaultColumnIssues(asset *pipeline.Asset, strategy string, i
 			Description: fmt.Sprintf("Materialization strategy '%s' requires a record source column", strategy),
 		})
 	}
+}
+
+// dataVaultHashKeyName mirrors the hash key resolution used by the materializers: an explicit role
+// wins, then the first column marked with primary_key, and the '_hk' suffix only counts when exactly
+// one column carries it. Keeping the two in sync stops `bruin validate` from accepting assets that
+// then fail at run time with an unresolvable hash key.
+func dataVaultHashKeyName(asset *pipeline.Asset, roles []string) string {
+	for _, col := range asset.Columns {
+		if dataVaultColumnMatches(col, roles) {
+			return col.Name
+		}
+	}
+	for _, col := range asset.Columns {
+		if col.PrimaryKey {
+			return col.Name
+		}
+	}
+
+	name := ""
+	for _, col := range asset.Columns {
+		if !strings.HasSuffix(strings.ToLower(col.Name), "_hk") {
+			continue
+		}
+		if name != "" {
+			return ""
+		}
+		name = col.Name
+	}
+	return name
 }
 
 func hasDataVaultColumn(asset *pipeline.Asset, roles []string, fallback func(pipeline.Column) bool) bool {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1559,7 +1559,7 @@ func ensureDataVaultHubColumnsAreValid(asset *pipeline.Asset) []*Issue {
 	if dataVaultHashKeyName(asset, []string{"hash_key", "hub_hash_key"}) == "" {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: "Materialization strategy 'datavault_hub' requires a hash key column, identified by 'datavault_role: hash_key', 'primary_key: true', or a single column name ending in '_hk'",
+			Description: "Materialization strategy 'datavault_hub' requires exactly one hash key column, identified by 'datavault_role: hash_key', a single column with 'primary_key: true', or a single column name ending in '_hk'",
 		})
 	}
 	if !hasDataVaultColumn(asset, []string{"business_key"}, func(col pipeline.Column) bool {
@@ -1584,7 +1584,7 @@ func ensureDataVaultLinkColumnsAreValid(asset *pipeline.Asset) []*Issue {
 	if linkHashKeyName == "" {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: "Materialization strategy 'datavault_link' requires a link hash key column, identified by 'datavault_role: link_hash_key', 'primary_key: true', or a single column name ending in '_hk'",
+			Description: "Materialization strategy 'datavault_link' requires exactly one link hash key column, identified by 'datavault_role: link_hash_key', a single column with 'primary_key: true', or a single column name ending in '_hk'",
 		})
 	}
 
@@ -1617,7 +1617,7 @@ func ensureDataVaultSatelliteColumnsAreValid(asset *pipeline.Asset) []*Issue {
 	if dataVaultHashKeyName(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}) == "" {
 		issues = append(issues, &Issue{
 			Task:        asset,
-			Description: "Materialization strategy 'datavault_satellite' requires a parent hash key column, identified by 'datavault_role: parent_hash_key', 'primary_key: true', or a single column name ending in '_hk'",
+			Description: "Materialization strategy 'datavault_satellite' requires exactly one parent hash key column, identified by 'datavault_role: parent_hash_key', a single column with 'primary_key: true', or a single column name ending in '_hk'",
 		})
 	}
 	if !hasDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col pipeline.Column) bool {
@@ -1685,7 +1685,7 @@ func appendCommonDataVaultColumnIssues(asset *pipeline.Asset, strategy string, i
 }
 
 // dataVaultHashKeyName mirrors the hash key resolution used by the materializers: an explicit role
-// wins, then the first column marked with primary_key, and the '_hk' suffix only counts when exactly
+// wins, then a single column marked with primary_key, and the '_hk' suffix only counts when exactly
 // one column carries it. Keeping the two in sync stops `bruin validate` from accepting assets that
 // then fail at run time with an unresolvable hash key.
 func dataVaultHashKeyName(asset *pipeline.Asset, roles []string) string {
@@ -1694,10 +1694,15 @@ func dataVaultHashKeyName(asset *pipeline.Asset, roles []string) string {
 			return col.Name
 		}
 	}
-	for _, col := range asset.Columns {
-		if col.PrimaryKey {
-			return col.Name
-		}
+
+	// The materializers refuse to guess which of several primary key columns is the hash key, so
+	// validate has to reject that too rather than accepting whichever one is declared first.
+	primaryKeys := asset.ColumnNamesWithPrimaryKey()
+	if len(primaryKeys) > 1 {
+		return ""
+	}
+	if len(primaryKeys) == 1 {
+		return primaryKeys[0]
 	}
 
 	name := ""

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1604,6 +1604,29 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 				"Materialization strategy 'datavault_hub' requires the 'columns' field to be set with actual columns",
 			},
 		},
+		{
+			name: "table materialization has datavault_hub with an ambiguous hash key",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultHub,
+					},
+					Columns: []pipeline.Column{
+						{Name: "customer_hk", Type: "text"},
+						{Name: "order_hk", Type: "text"},
+						{Name: "customer_bk", Type: "text"},
+						{Name: "load_dts", Type: "timestamp"},
+						{Name: "record_source", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: []string{
+				"Materialization strategy 'datavault_hub' requires a hash key column, identified by 'datavault_role: hash_key', 'primary_key: true', or a single column name ending in '_hk'",
+			},
+		},
 	}
 	ctx := t.Context()
 	for _, tt := range tests {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -1624,8 +1624,49 @@ func TestEnsureMaterializationValuesAreValid(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 			want: []string{
-				"Materialization strategy 'datavault_hub' requires a hash key column, identified by 'datavault_role: hash_key', 'primary_key: true', or a single column name ending in '_hk'",
+				"Materialization strategy 'datavault_hub' requires exactly one hash key column, identified by 'datavault_role: hash_key', a single column with 'primary_key: true', or a single column name ending in '_hk'",
 			},
+		},
+		{
+			name: "table materialization has datavault_satellite with several primary keys and no explicit role",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+					},
+					Columns: []pipeline.Column{
+						{Name: "load_dts", Type: "timestamp", PrimaryKey: true},
+						{Name: "customer_hk", Type: "text", PrimaryKey: true},
+						{Name: "hashdiff", Type: "text"},
+						{Name: "record_source", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: []string{
+				"Materialization strategy 'datavault_satellite' requires exactly one parent hash key column, identified by 'datavault_role: parent_hash_key', a single column with 'primary_key: true', or a single column name ending in '_hk'",
+			},
+		},
+		{
+			name: "table materialization has datavault_satellite with several primary keys and an explicit role",
+			assets: []*pipeline.Asset{
+				{
+					Name: "task1",
+					Materialization: pipeline.Materialization{
+						Type:     pipeline.MaterializationTypeTable,
+						Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+					},
+					Columns: []pipeline.Column{
+						{Name: "load_dts", Type: "timestamp", PrimaryKey: true},
+						{Name: "customer_hk", Type: "text", PrimaryKey: true, Meta: map[string]string{"datavault_role": "parent_hash_key"}},
+						{Name: "hashdiff", Type: "text"},
+						{Name: "record_source", Type: "text"},
+					},
+				},
+			},
+			wantErr: assert.NoError,
 		},
 	}
 	ctx := t.Context()

--- a/pkg/pipeline/materializer.go
+++ b/pkg/pipeline/materializer.go
@@ -32,7 +32,13 @@ func (m *Materializer) Render(asset *Asset, query string) (string, error) {
 		// This strategy should never be overridden, even with full refresh
 		// Also respect full refresh restriction - if true, don't drop/recreate the table
 		if mat.Strategy != MaterializationStrategyDDL && (asset.RefreshRestricted == nil || !*asset.RefreshRestricted) {
-			strategy = MaterializationStrategyCreateReplace
+			// Data Vault strategies are only overridden on platforms that implement them, since
+			// those route CreateReplace back into their own builders. Overriding it elsewhere would
+			// silently produce a plain table dump with none of the Data Vault loading rules applied.
+			_, dataVaultSupported := m.MaterializationMap[mat.Type][mat.Strategy]
+			if !mat.Strategy.IsDataVault() || dataVaultSupported {
+				strategy = MaterializationStrategyCreateReplace
+			}
 		}
 	}
 

--- a/pkg/pipeline/materializer_test.go
+++ b/pkg/pipeline/materializer_test.go
@@ -92,6 +92,53 @@ func TestMaterializer_Render(t *testing.T) {
 	}
 }
 
+func TestMaterializer_RenderFullRefreshWithDataVaultStrategy(t *testing.T) {
+	t.Parallel()
+
+	render := func(matMap AssetMaterializationMap) (string, error) {
+		materializer := Materializer{MaterializationMap: matMap, FullRefresh: true}
+		return materializer.Render(&Asset{
+			Materialization: Materialization{
+				Type:     MaterializationTypeTable,
+				Strategy: MaterializationStrategyDataVaultHub,
+			},
+		}, "SELECT * FROM table")
+	}
+
+	t.Run("platforms implementing the strategy still route through create+replace", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := render(AssetMaterializationMap{
+			MaterializationTypeTable: {
+				MaterializationStrategyDataVaultHub: func(_ *Asset, query string) (string, error) {
+					return "HUB;" + query, nil
+				},
+				MaterializationStrategyCreateReplace: func(_ *Asset, query string) (string, error) {
+					return "CREATE OR REPLACE;" + query, nil
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "CREATE OR REPLACE;SELECT * FROM table", result)
+	})
+
+	t.Run("platforms without the strategy fail instead of silently dropping the loading rules", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := render(AssetMaterializationMap{
+			MaterializationTypeTable: {
+				MaterializationStrategyCreateReplace: func(_ *Asset, query string) (string, error) {
+					return "CREATE OR REPLACE;" + query, nil
+				},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported materialization type - strategy combination")
+	})
+}
+
 type stringMaterializer struct {
 	out string
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -621,6 +621,18 @@ const (
 	MaterializationStrategyDataVaultSatellite MaterializationStrategy        = "datavault_satellite"
 )
 
+// IsDataVault reports whether the strategy is one of the Data Vault loading strategies.
+// These carry their own full-refresh handling, so they must never be silently swapped
+// for another strategy on a platform that does not implement them.
+func (s MaterializationStrategy) IsDataVault() bool {
+	switch s {
+	case MaterializationStrategyDataVaultHub, MaterializationStrategyDataVaultLink, MaterializationStrategyDataVaultSatellite:
+		return true
+	default:
+		return false
+	}
+}
+
 var AllAvailableMaterializationStrategies = []MaterializationStrategy{
 	MaterializationStrategyCreateReplace,
 	MaterializationStrategyDeleteInsert,

--- a/pkg/postgres/materialization.go
+++ b/pkg/postgres/materialization.go
@@ -354,6 +354,10 @@ func buildDataVaultHubQuery(asset *pipeline.Asset, query string) (string, error)
 }
 
 func buildDataVaultHubQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	if err := ensureDataVaultIsSupported(asset); err != nil {
+		return "", err
+	}
+
 	hashKey, businessKeys, loadDatetime, recordSource, err := resolveDataVaultHubColumns(asset)
 	if err != nil {
 		return "", err
@@ -409,6 +413,10 @@ func buildDataVaultLinkQuery(asset *pipeline.Asset, query string) (string, error
 }
 
 func buildDataVaultLinkQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	if err := ensureDataVaultIsSupported(asset); err != nil {
+		return "", err
+	}
+
 	linkHashKey, relatedHashKeys, loadDatetime, recordSource, err := resolveDataVaultLinkColumns(asset)
 	if err != nil {
 		return "", err
@@ -464,6 +472,10 @@ func buildDataVaultSatelliteQuery(asset *pipeline.Asset, query string) (string, 
 }
 
 func buildDataVaultSatelliteQueryWithOptions(asset *pipeline.Asset, query string, fullRefresh bool) (string, error) {
+	if err := ensureDataVaultIsSupported(asset); err != nil {
+		return "", err
+	}
+
 	parentHashKey, hashDiff, loadDatetime, recordSource, err := resolveDataVaultSatelliteColumns(asset)
 	if err != nil {
 		return "", err
@@ -486,12 +498,18 @@ __bruin_valid AS (
   FROM __bruin_source AS source
   WHERE %s
 ),
+__bruin_dedup AS (
+  SELECT DISTINCT ON (%s)
+    %s
+  FROM __bruin_valid AS valid
+  ORDER BY %s, valid.%s
+),
 __bruin_ordered AS (
   SELECT
-    valid.*,
-    LAG(valid.%s) OVER (PARTITION BY valid.%s ORDER BY valid.%s, valid.%s) AS __bruin_previous_hashdiff,
-    ROW_NUMBER() OVER (PARTITION BY valid.%s ORDER BY valid.%s, valid.%s) AS __bruin_row_number
-  FROM __bruin_valid AS valid
+    dedup.*,
+    LAG(dedup.%s) OVER (PARTITION BY dedup.%s ORDER BY dedup.%s, dedup.%s) AS __bruin_previous_hashdiff,
+    ROW_NUMBER() OVER (PARTITION BY dedup.%s ORDER BY dedup.%s, dedup.%s) AS __bruin_row_number
+  FROM __bruin_dedup AS dedup
 ),
 __bruin_latest AS (
   SELECT DISTINCT ON (target.%s)
@@ -518,6 +536,10 @@ ON CONFLICT (%s) DO NOTHING`,
 		trimMaterializationQuery(query),
 		dataVaultIndentedSelectList(asset, "source", 4),
 		strings.Join(dataVaultNotNullConditions("source", mandatoryColumns), " AND "),
+		strings.Join(dataVaultAliasColumnNames("valid", primaryKeys), ", "),
+		dataVaultIndentedSelectList(asset, "valid", 4),
+		strings.Join(dataVaultAliasColumnNames("valid", primaryKeys), ", "),
+		QuoteIdentifier(hashDiff.Name),
 		QuoteIdentifier(hashDiff.Name),
 		QuoteIdentifier(parentHashKey.Name),
 		QuoteIdentifier(loadDatetime.Name),
@@ -553,11 +575,9 @@ func resolveDataVaultHubColumns(asset *pipeline.Asset) (*pipeline.Column, []*pip
 		return nil, nil, nil, nil, errors.New("materialization strategy datavault_hub requires the `columns` field to be set")
 	}
 
-	hashKey := findDataVaultColumn(asset, []string{"hash_key", "hub_hash_key"}, func(col *pipeline.Column) bool {
-		return col.PrimaryKey
-	})
-	if hashKey == nil {
-		hashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	hashKey, err := findDataVaultHashKeyColumn(asset, []string{"hash_key", "hub_hash_key"}, "hash_key")
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	businessKeys := findDataVaultColumns(asset, []string{"business_key"}, func(col *pipeline.Column) bool {
@@ -585,11 +605,9 @@ func resolveDataVaultLinkColumns(asset *pipeline.Asset) (*pipeline.Column, []*pi
 		return nil, nil, nil, nil, errors.New("materialization strategy datavault_link requires the `columns` field to be set")
 	}
 
-	linkHashKey := findDataVaultColumn(asset, []string{"link_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
-		return col.PrimaryKey
-	})
-	if linkHashKey == nil {
-		linkHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	linkHashKey, err := findDataVaultHashKeyColumn(asset, []string{"link_hash_key", "hash_key"}, "link_hash_key")
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	excludedColumns := []*pipeline.Column{linkHashKey}
@@ -618,11 +636,9 @@ func resolveDataVaultSatelliteColumns(asset *pipeline.Asset) (*pipeline.Column, 
 		return nil, nil, nil, nil, errors.New("materialization strategy datavault_satellite requires the `columns` field to be set")
 	}
 
-	parentHashKey := findDataVaultColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, func(col *pipeline.Column) bool {
-		return col.PrimaryKey
-	})
-	if parentHashKey == nil {
-		parentHashKey = findSingleDataVaultColumnBySuffix(asset, "_hk", nil)
+	parentHashKey, err := findDataVaultHashKeyColumn(asset, []string{"parent_hash_key", "hub_hash_key", "hash_key"}, "parent_hash_key")
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	hashDiff := findDataVaultColumn(asset, []string{"hashdiff", "hash_diff"}, func(col *pipeline.Column) bool {
@@ -702,6 +718,16 @@ func createSchemaStatement(name string) string {
 	return "CREATE SCHEMA IF NOT EXISTS " + QuoteIdentifier(parts[0])
 }
 
+// ensureDataVaultIsSupported rejects asset types that share this materializer but cannot run the
+// SQL it generates. Redshift reuses the Postgres builders, yet the Data Vault statements rely on
+// DISTINCT ON and ON CONFLICT, which Redshift does not implement.
+func ensureDataVaultIsSupported(asset *pipeline.Asset) error {
+	if asset.Type == pipeline.AssetTypeRedshiftQuery || asset.Type == pipeline.AssetTypeRedshiftSeed {
+		return fmt.Errorf("materialization strategy %s is not supported for asset type %s", asset.Materialization.Strategy, asset.Type)
+	}
+	return nil
+}
+
 func dataVaultTransaction(statements []string) string {
 	return "BEGIN TRANSACTION;\n" + strings.Join(statements, ";\n") + ";\nCOMMIT;"
 }
@@ -751,6 +777,14 @@ func dataVaultNotNullConditions(tableAlias string, columns []*pipeline.Column) [
 	return conditions
 }
 
+func dataVaultAliasColumnNames(tableAlias string, columns []string) []string {
+	aliased := make([]string, 0, len(columns))
+	for _, col := range columns {
+		aliased = append(aliased, fmt.Sprintf("%s.%s", tableAlias, QuoteIdentifier(col)))
+	}
+	return aliased
+}
+
 func quoteNames(names []string) []string {
 	quoted := make([]string, 0, len(names))
 	for _, name := range names {
@@ -774,6 +808,30 @@ func findDataVaultRecordSourceColumn(asset *pipeline.Asset) *pipeline.Column {
 	return findDataVaultColumn(asset, []string{"record_source"}, func(col *pipeline.Column) bool {
 		return strings.EqualFold(col.Name, "record_source")
 	})
+}
+
+// findDataVaultHashKeyColumn resolves a hash key by explicit role first, then by primary_key, then by a
+// unique `_hk` suffix. When several columns are marked with primary_key there is no way to tell which one
+// is the hash key, so the caller is asked for an explicit role rather than silently taking the first one
+// in declaration order. Returns a nil column when nothing matches, leaving the specific error to the caller.
+func findDataVaultHashKeyColumn(asset *pipeline.Asset, roles []string, preferredRole string) (*pipeline.Column, error) {
+	if col := findDataVaultColumn(asset, roles, nil); col != nil {
+		return col, nil
+	}
+
+	if primaryKeys := asset.ColumnNamesWithPrimaryKey(); len(primaryKeys) > 1 {
+		return nil, fmt.Errorf(
+			"materialization strategy %s cannot determine which of the primary key columns (%s) is the hash key, mark it with datavault_role: %s",
+			asset.Materialization.Strategy, strings.Join(primaryKeys, ", "), preferredRole,
+		)
+	}
+	if col := findDataVaultColumn(asset, nil, func(col *pipeline.Column) bool {
+		return col.PrimaryKey
+	}); col != nil {
+		return col, nil
+	}
+
+	return findSingleDataVaultColumnBySuffix(asset, "_hk", nil), nil
 }
 
 func findDataVaultColumn(asset *pipeline.Asset, roles []string, fallback func(*pipeline.Column) bool) *pipeline.Column {

--- a/pkg/postgres/materialization_test.go
+++ b/pkg/postgres/materialization_test.go
@@ -602,7 +602,9 @@ COMMIT;`, got)
 		require.NoError(t, err)
 
 		assert.Contains(t, got, `primary key ("customer_hk", "load_dts")`)
-		assert.Contains(t, got, `LAG(valid."hashdiff") OVER (PARTITION BY valid."customer_hk" ORDER BY valid."load_dts", valid."hashdiff") AS __bruin_previous_hashdiff`)
+		assert.Contains(t, got, `SELECT DISTINCT ON (valid."customer_hk", valid."load_dts")`)
+		assert.Contains(t, got, `ORDER BY valid."customer_hk", valid."load_dts", valid."hashdiff"`)
+		assert.Contains(t, got, `LAG(dedup."hashdiff") OVER (PARTITION BY dedup."customer_hk" ORDER BY dedup."load_dts", dedup."hashdiff") AS __bruin_previous_hashdiff`)
 		assert.Contains(t, got, `SELECT DISTINCT ON (target."customer_hk")`)
 		assert.Contains(t, got, `latest."hashdiff" IS DISTINCT FROM source."hashdiff"`)
 		assert.Contains(t, got, `source.__bruin_previous_hashdiff IS DISTINCT FROM source."hashdiff"`)
@@ -633,6 +635,51 @@ COMMIT;`, got)
 		assert.Contains(t, got, `CREATE TABLE IF NOT EXISTS "rdv"."hub_customer"`)
 		assert.Contains(t, got, `ON CONFLICT ("customer_hk") DO NOTHING`)
 		assert.NotContains(t, got, `CREATE TABLE "rdv"."hub_customer" AS`)
+	})
+
+	t.Run("rejects Redshift assets, whose SQL dialect cannot run the generated statements", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.hub_customer",
+			Type: pipeline.AssetTypeRedshiftQuery,
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultHub,
+			},
+			Columns: []pipeline.Column{
+				{Name: "customer_hk", Type: "text", PrimaryKey: true},
+				{Name: "customer_bk", Type: "text"},
+				{Name: "load_dts", Type: "timestamptz"},
+				{Name: "record_source", Type: "text"},
+			},
+		}
+
+		_, err := NewMaterializer(false).Render(asset, "select customer_hk, customer_bk, load_dts, record_source from stg.crm_customer_hashed")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not supported for asset type rs.sql")
+	})
+
+	t.Run("refuses to guess the hash key when several columns are primary keys", func(t *testing.T) {
+		t.Parallel()
+
+		asset := &pipeline.Asset{
+			Name: "rdv.sat_customer_details",
+			Materialization: pipeline.Materialization{
+				Type:     pipeline.MaterializationTypeTable,
+				Strategy: pipeline.MaterializationStrategyDataVaultSatellite,
+			},
+			Columns: []pipeline.Column{
+				{Name: "load_dts", Type: "timestamptz", PrimaryKey: true},
+				{Name: "customer_hk", Type: "text", PrimaryKey: true},
+				{Name: "hashdiff", Type: "text"},
+				{Name: "record_source", Type: "text"},
+			},
+		}
+
+		_, err := NewMaterializer(false).Render(asset, "select customer_hk, hashdiff, load_dts, record_source from stg.crm_customer_hashed")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mark it with datavault_role: parent_hash_key")
 	})
 
 	t.Run("requires typed columns", func(t *testing.T) {


### PR DESCRIPTION
## What

Documents the three Data Vault materialization strategies, and fixes five cases found while writing those docs where a Data Vault asset ran without error but produced the wrong table.

## Changes

- `docs/assets/materialization.md` — new section covering `datavault_hub`, `datavault_link` and `datavault_satellite`: column roles, naming fallbacks, shared loading rules, and an example per strategy.
- `pkg/pipeline/materializer.go` — `--full-refresh` rewrote the strategy to `create+replace` before the platform lookup. Only DuckDB and PostgreSQL route that back into their Data Vault builders, so everywhere else the asset emitted a plain dump of the staging query with no keys and no error. The rewrite now only applies where the strategy is registered.
- `pkg/postgres/materialization.go` — reject Redshift, which reuses this materializer but cannot run the `DISTINCT ON` / `ON CONFLICT` SQL it generates; add the within-batch satellite dedup the DuckDB builder already had.
- `pkg/duckdb/datavault_materialization.go`, `pkg/postgres/materialization.go` — the hash key fell back to the first `primary_key` column in declaration order, so a satellite with a custom composite key could pick the load datetime as its parent hash key. Ambiguous cases now ask for an explicit `datavault_role`.
- `pkg/lint/rules.go` — lint accepted any `_hk`-suffixed column as the hash key while the materializer requires exactly one, so `validate` passed assets that failed at run time.

## How to test

1. `make test` and `make integration-test-light`.
2. Render a `bigquery.sql` asset with `strategy: datavault_hub` under `--full-refresh` and confirm it now errors instead of emitting `CREATE OR REPLACE TABLE ... AS`.
3. Run `bruin validate` on a hub with two unroled `_hk` columns and confirm it is flagged rather than failing later at run time.

## Risk & rollback

- **Risk:** low for the docs, medium for the fixes — configurations that previously worked by guessing now error. That is deliberate, since the guess was column-order dependent, and each message names the `datavault_role` to add.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues

