### PR TITLE
docs: explain BigQuery partition_by granularity

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -69,6 +69,8 @@ Define the column that will be used for the partitioning of the resulting table.
 - **Type:** `String`
 - **Default:** none
 
+On BigQuery, `partition_by` accepts a full partitioning expression, and the granularity comes from that expression. A bare column (`event_ts`) or `DATE(event_ts)` produces **day**-level partitioning; use a truncation function to choose another granularity — `TIMESTAMP_TRUNC(event_ts, HOUR)`, `DATETIME_TRUNC(event_ts, MONTH)`, or `DATE_TRUNC(event_dt, YEAR)` (`HOUR`, `DAY`, `MONTH`, and `YEAR` are supported). Note that a bare `TIMESTAMP`/`DATETIME` column is not a valid partition expression on BigQuery — wrap it in `DATE(...)` or a `*_TRUNC(...)` call.
+
 ### `materialization > cluster_by`
 
 Define the columns that will be used for the clustering of the resulting table. This is used to instruct the data warehouse to set the columns for the clustering.

--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -69,7 +69,7 @@ Define the column that will be used for the partitioning of the resulting table.
 - **Type:** `String`
 - **Default:** none
 
-On BigQuery, `partition_by` accepts a full partitioning expression, and the granularity comes from that expression. A bare column (`event_ts`) or `DATE(event_ts)` produces **day**-level partitioning; use a truncation function to choose another granularity — `TIMESTAMP_TRUNC(event_ts, HOUR)`, `DATETIME_TRUNC(event_ts, MONTH)`, or `DATE_TRUNC(event_dt, YEAR)` (`HOUR`, `DAY`, `MONTH`, and `YEAR` are supported). Note that a bare `TIMESTAMP`/`DATETIME` column is not a valid partition expression on BigQuery — wrap it in `DATE(...)` or a `*_TRUNC(...)` call.
+On BigQuery, `partition_by` takes a partitioning expression that sets the granularity. A bare `DATE` column or `DATE(ts)` gives **day**-level partitioning; for other granularities wrap a `TIMESTAMP`/`DATETIME` column in `TIMESTAMP_TRUNC`/`DATETIME_TRUNC` with `HOUR`/`DAY`/`MONTH`/`YEAR` (e.g. `TIMESTAMP_TRUNC(event_ts, HOUR)`). A bare `TIMESTAMP`/`DATETIME` column is not valid.
 
 ### `materialization > cluster_by`
 


### PR DESCRIPTION
## What

Adds a short explanation to the `materialization > partition_by` docs describing how partition **granularity** works on BigQuery — something that is currently undocumented.

## Why

`partition_by` is documented only as "the column used for partitioning", but on BigQuery it actually accepts a full partitioning expression and the granularity is derived from it. Users have no documented way to learn that:

- a bare column or `DATE(col)` gives **day**-level partitioning,
- `TIMESTAMP_TRUNC` / `DATETIME_TRUNC` / `DATE_TRUNC` let you pick `HOUR` / `DAY` / `MONTH` / `YEAR`,
- a bare `TIMESTAMP`/`DATETIME` column is **not** a valid partition expression and must be wrapped.

This matches the granularities bruin already parses in `IsSamePartitioning` (`pkg/bigquery/db.go`).