### PR TITLE
Install ingestr releases with standalone binaries

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [depot-ubuntu-latest-4]
+        platform: [depot-ubuntu-latest-4, depot-windows-latest-4]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -62,12 +62,16 @@ jobs:
             rust-${{ runner.os }}-
       - name: Touch cached Rust lib
         if: steps.rust-cache.outputs.cache-hit == 'true'
+        shell: bash
         run: touch pkg/sqlparser/rustffi/target/release/libbruin_rustsqlparser.a
       - name: Setup Rust
         if: steps.rust-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - name: Run full test suite
-        run: make test-full
+        shell: bash
+        run: |
+          [[ "${{ runner.os }}" != 'Windows' ]] || export PATH="/c/mingw64/bin:$PATH"
+          make test-full
   end2end:
     strategy:
       matrix:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run full test suite
         shell: bash
         run: |
-          [[ "${{ runner.os }}" != 'Windows' ]] || export PATH="/c/mingw64/bin:$PATH"
+          [[ "${{ runner.os }}" != 'Windows' ]] || export CC="/c/mingw64/bin/gcc.exe"
           make test-full
   end2end:
     strategy:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,10 @@ jobs:
       - name: Run full test suite
         shell: bash
         run: |
-          [[ "${{ runner.os }}" != 'Windows' ]] || export CC="/c/mingw64/bin/gcc.exe"
+          # Race-enabled Windows binaries need the matching MinGW runtime DLLs.
+          # Installer tests inject a missing shell, so the native fallback is
+          # still covered without depending on this PATH.
+          [[ "${{ runner.os }}" != 'Windows' ]] || export PATH="/c/mingw64/bin:$PATH"
           make test-full
   end2end:
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV CC="/usr/bin/gcc"
 ENV CFLAGS="-I/usr/include"
 ENV LDFLAGS="-L/usr/lib"
 
-# Bootstrap ingestr installation
+# Bootstrap the legacy and current ingestr installations
 RUN cd /tmp && /home/bruin/.local/bin/bruin init bootstrap --in-place && /home/bruin/.local/bin/bruin run bootstrap
 RUN /home/bruin/.bruin/uv python install 3.9
 RUN /home/bruin/.bruin/uv python install 3.10

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -43,8 +43,8 @@ type resolvedEngine struct {
 
 // resolveIngestrEngine reads parameters.version, validates it, and returns the
 // resolved engine. An empty version defaults to v1 (the current pinned release).
-// Bare family markers (v0, v1, ...) resolve to the corresponding pinned PyPI
-// version; fully-qualified vMAJOR.MINOR.PATCH overrides to an exact PyPI version.
+// Bare family markers (v0, v1, ...) resolve to the corresponding pinned
+// version; fully-qualified vMAJOR.MINOR.PATCH overrides to an exact release.
 func resolveIngestrEngine(asset *pipeline.Asset) (resolvedEngine, error) {
 	versionRaw, _ := asset.Parameters.GetString("version")
 	versionParam := strings.TrimSpace(versionRaw)
@@ -140,8 +140,8 @@ func ensureFabricEngineSupport(engine resolvedEngine, uris ...string) error {
 	return nil
 }
 
-// applyIngestrEngine stashes the resolved PyPI version on the context so the
-// uv runner installs the requested release.
+// applyIngestrEngine stashes the resolved version on the context so the runner
+// installs the requested release.
 func applyIngestrEngine(ctx context.Context, engine resolvedEngine) context.Context {
 	if engine.ingestrVersion == "" {
 		return ctx
@@ -173,8 +173,9 @@ type SeedOperator struct {
 
 func NewBasicOperator(conn config.ConnectionGetter, j jinja.RendererInterface) (*BasicOperator, error) {
 	uvRunner := &python.UvPythonRunner{
-		UvInstaller: &python.UvChecker{},
-		Cmd:         &python.CommandRunner{},
+		UvInstaller:      &python.UvChecker{},
+		IngestrInstaller: &python.IngestrChecker{},
+		Cmd:              &python.CommandRunner{},
 	}
 
 	return &BasicOperator{conn: conn, runner: uvRunner, finder: &git.RepoFinder{}, jinjaRenderer: j}, nil
@@ -681,8 +682,9 @@ func normalizeMaterializationParameter(key, value string) string {
 
 func NewSeedOperator(conn config.ConnectionGetter, j jinja.RendererInterface) (*SeedOperator, error) {
 	uvRunner := &python.UvPythonRunner{
-		UvInstaller: &python.UvChecker{},
-		Cmd:         &python.CommandRunner{},
+		UvInstaller:      &python.UvChecker{},
+		IngestrInstaller: &python.IngestrChecker{},
+		Cmd:              &python.CommandRunner{},
 	}
 
 	return &SeedOperator{

--- a/pkg/python/debug.go
+++ b/pkg/python/debug.go
@@ -4,6 +4,6 @@ type contextKey string
 
 const (
 	LocalIngestr contextKey = "local_ingestr"
-	// CtxIngestrVersion overrides the default ingestr PyPI version for the asset (e.g. "0.14.2").
+	// CtxIngestrVersion overrides the default ingestr release for the asset (e.g. "1.1.18").
 	CtxIngestrVersion contextKey = "ingestr_version"
 )

--- a/pkg/python/ingestr_installer.go
+++ b/pkg/python/ingestr_installer.go
@@ -1,15 +1,19 @@
 package python
 
 import (
+	"archive/zip"
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/user"
@@ -21,6 +25,8 @@ import (
 const (
 	ingestrInstallerURL          = "https://getbruin.com/install/ingestr"
 	ingestrInstallerShellCommand = `curl -LsSf "$1" | sh -s -- -b "$2" "$3"`
+	ingestrReleaseDownloadURL    = "https://github.com/bruin-data/ingestr/releases/download"
+	maxIngestrBinarySize         = 512 * 1024 * 1024
 )
 
 // ingestrInstallMu prevents concurrent installations within the same Bruin
@@ -29,6 +35,14 @@ const (
 var ingestrInstallMu sync.Mutex
 
 type ingestrInstallFunc func(ctx context.Context, output io.Writer, installDir, version string) error
+
+type ingestrInstallerRuntime struct {
+	goos               string
+	goarch             string
+	findShell          func(string) (string, error)
+	httpClient         *http.Client
+	releaseDownloadURL string
+}
 
 // IngestrChecker installs and locates standalone ingestr releases.
 type IngestrChecker struct {
@@ -124,18 +138,135 @@ func ingestrBinaryName(goos string) string {
 }
 
 func runIngestrInstaller(ctx context.Context, output io.Writer, installDir, version string) error {
-	shell, err := exec.LookPath("sh")
+	installer := ingestrInstallerRuntime{
+		goos:               runtime.GOOS,
+		goarch:             runtime.GOARCH,
+		findShell:          exec.LookPath,
+		httpClient:         &http.Client{Timeout: 5 * time.Minute},
+		releaseDownloadURL: ingestrReleaseDownloadURL,
+	}
+	return installer.install(ctx, output, installDir, version)
+}
+
+func (r ingestrInstallerRuntime) install(ctx context.Context, output io.Writer, installDir, version string) error {
+	shell, err := r.findShell("sh")
 	if err != nil {
+		if r.goos == "windows" {
+			return r.installWindowsRelease(ctx, output, installDir, version)
+		}
 		return errors.Wrap(err, "the ingestr installer requires sh")
 	}
 
-	cmd := exec.CommandContext(ctx, shell, ingestrInstallerCommandArgs(installDir, version, runtime.GOOS)...) //nolint:gosec
+	cmd := exec.CommandContext(ctx, shell, ingestrInstallerCommandArgs(installDir, version, r.goos)...) //nolint:gosec
 	cmd.Env = environmentWithOverride(os.Environ(), "SHELL", "bruin-installer")
 	cmd.Stdout = output
 	cmd.Stderr = output
 
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "failed to install ingestr v%s", version)
+	}
+	return nil
+}
+
+func (r ingestrInstallerRuntime) installWindowsRelease(
+	ctx context.Context,
+	output io.Writer,
+	installDir string,
+	version string,
+) error {
+	archiveName, err := windowsIngestrArchiveName(r.goarch)
+	if err != nil {
+		return err
+	}
+
+	downloadURL := strings.TrimRight(r.releaseDownloadURL, "/") + "/" + url.PathEscape("v"+version) + "/" + archiveName
+	_, _ = fmt.Fprintf(output, "Downloading ingestr v%s for Windows...\n", version)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ingestr download request")
+	}
+	response, err := r.httpClient.Do(request)
+	if err != nil {
+		return errors.Wrapf(err, "failed to download ingestr v%s", version)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("failed to download ingestr v%s: server returned %s", version, response.Status)
+	}
+
+	archiveFile, err := os.CreateTemp(installDir, ".ingestr-*.zip")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temporary ingestr archive")
+	}
+	archivePath := archiveFile.Name()
+	defer os.Remove(archivePath)
+
+	_, copyErr := io.Copy(archiveFile, response.Body)
+	closeErr := archiveFile.Close()
+	if copyErr != nil {
+		return errors.Wrap(copyErr, "failed to save ingestr release archive")
+	}
+	if closeErr != nil {
+		return errors.Wrap(closeErr, "failed to close ingestr release archive")
+	}
+
+	return extractWindowsIngestrArchive(archivePath, installDir)
+}
+
+func windowsIngestrArchiveName(goarch string) (string, error) {
+	if goarch != "amd64" {
+		return "", fmt.Errorf("ingestr standalone releases do not support windows/%s", goarch)
+	}
+	return "ingestr_Windows_x86_64.zip", nil
+}
+
+func extractWindowsIngestrArchive(archivePath, installDir string) error {
+	archive, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to open ingestr release archive")
+	}
+	defer archive.Close()
+
+	const binaryName = "ingestr.exe"
+	for _, file := range archive.File {
+		if file.FileInfo().IsDir() || filepath.Base(filepath.ToSlash(file.Name)) != binaryName {
+			continue
+		}
+
+		return extractFileFromZip(file, filepath.Join(installDir, binaryName))
+	}
+
+	return fmt.Errorf("ingestr release archive did not contain %s", binaryName)
+}
+
+func extractFileFromZip(source *zip.File, destination string) error {
+	reader, err := source.Open()
+	if err != nil {
+		return errors.Wrap(err, "failed to open ingestr binary in release archive")
+	}
+
+	file, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		_ = reader.Close()
+		return errors.Wrap(err, "failed to create ingestr binary")
+	}
+
+	written, copyErr := io.CopyN(file, reader, maxIngestrBinarySize+1)
+	readerCloseErr := reader.Close()
+	fileCloseErr := file.Close()
+	if copyErr != nil && !errors.Is(copyErr, io.EOF) {
+		return errors.Wrap(copyErr, "failed to extract ingestr binary")
+	}
+	if written > maxIngestrBinarySize {
+		return fmt.Errorf("ingestr binary exceeds the %d-byte extraction limit", maxIngestrBinarySize)
+	}
+	if readerCloseErr != nil {
+		return errors.Wrap(readerCloseErr, "failed to close ingestr binary in release archive")
+	}
+	if fileCloseErr != nil {
+		return errors.Wrap(fileCloseErr, "failed to close ingestr binary")
 	}
 	return nil
 }

--- a/pkg/python/ingestr_installer.go
+++ b/pkg/python/ingestr_installer.go
@@ -1,0 +1,168 @@
+package python
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/bruin-data/bruin/pkg/executor"
+	"github.com/bruin-data/bruin/pkg/user"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	ingestrInstallerURL          = "https://getbruin.com/install/ingestr"
+	ingestrInstallerShellCommand = `curl -LsSf "$1" | sh -s -- -b "$2" "$3"`
+)
+
+// ingestrInstallMu prevents concurrent installations within the same Bruin
+// process. Separate processes are safe because each download goes to a temporary
+// directory and the completed binary is moved into place atomically.
+var ingestrInstallMu sync.Mutex
+
+type ingestrInstallFunc func(ctx context.Context, output io.Writer, installDir, version string) error
+
+// IngestrChecker installs and locates standalone ingestr releases.
+type IngestrChecker struct {
+	install ingestrInstallFunc
+}
+
+// EnsureIngestrInstalled returns the path to an exact ingestr release, installing
+// it with the official curl-based installer when it is not already present.
+func (c *IngestrChecker) EnsureIngestrInstalled(ctx context.Context, version string) (string, error) {
+	if !semver.IsValid("v" + version) {
+		return "", fmt.Errorf("invalid ingestr version %q", version)
+	}
+
+	manager := user.NewConfigManager(afero.NewOsFs())
+	bruinHomeDir, err := manager.EnsureAndGetBruinHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get bruin home directory")
+	}
+
+	var output io.Writer = os.Stdout
+	if printer := ctx.Value(executor.KeyPrinter); printer != nil {
+		output = printer.(io.Writer)
+	}
+
+	return c.ensureIngestrInstalled(ctx, bruinHomeDir, version, output)
+}
+
+func (c *IngestrChecker) ensureIngestrInstalled(
+	ctx context.Context,
+	bruinHomeDir string,
+	version string,
+	output io.Writer,
+) (string, error) {
+	ingestrInstallMu.Lock()
+	defer ingestrInstallMu.Unlock()
+
+	binaryName := ingestrBinaryName(runtime.GOOS)
+	versionDir := filepath.Join(bruinHomeDir, "ingestr", version)
+	binaryPath := filepath.Join(versionDir, binaryName)
+	if isIngestrBinary(binaryPath) {
+		return binaryPath, nil
+	}
+
+	installRoot := filepath.Join(bruinHomeDir, "ingestr")
+	if err := os.MkdirAll(installRoot, 0o755); err != nil {
+		return "", errors.Wrap(err, "failed to create ingestr installation directory")
+	}
+
+	tempDir, err := os.MkdirTemp(installRoot, ".install-"+version+"-")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temporary ingestr installation directory")
+	}
+	defer os.RemoveAll(tempDir)
+
+	_, _ = fmt.Fprintf(output, "Installing ingestr v%s...\n", version)
+	install := c.install
+	if install == nil {
+		install = runIngestrInstaller
+	}
+	if err := install(ctx, output, tempDir, version); err != nil {
+		return "", err
+	}
+
+	tempBinaryPath := filepath.Join(tempDir, binaryName)
+	if !isIngestrBinary(tempBinaryPath) {
+		return "", fmt.Errorf("ingestr installer did not produce %s", binaryName)
+	}
+
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		return "", errors.Wrap(err, "failed to create versioned ingestr installation directory")
+	}
+	if err := os.Rename(tempBinaryPath, binaryPath); err != nil {
+		// Another Bruin process may have completed the same installation first.
+		if isIngestrBinary(binaryPath) {
+			return binaryPath, nil
+		}
+		return "", errors.Wrap(err, "failed to activate ingestr installation")
+	}
+
+	return binaryPath, nil
+}
+
+func isIngestrBinary(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func ingestrBinaryName(goos string) string {
+	if goos == "windows" {
+		return "ingestr.exe"
+	}
+	return "ingestr"
+}
+
+func runIngestrInstaller(ctx context.Context, output io.Writer, installDir, version string) error {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		return errors.Wrap(err, "the ingestr installer requires sh")
+	}
+
+	cmd := exec.CommandContext(ctx, shell, ingestrInstallerCommandArgs(installDir, version, runtime.GOOS)...) //nolint:gosec
+	cmd.Env = environmentWithOverride(os.Environ(), "SHELL", "bruin-installer")
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed to install ingestr v%s", version)
+	}
+	return nil
+}
+
+func ingestrInstallerCommandArgs(installDir, version, goos string) []string {
+	if goos == "windows" {
+		// Git Bash/MSYS understands drive-letter paths in slash form.
+		installDir = strings.ReplaceAll(installDir, `\`, "/")
+	}
+	return []string{
+		"-c",
+		ingestrInstallerShellCommand,
+		"ingestr-installer",
+		ingestrInstallerURL,
+		installDir,
+		"v" + version,
+	}
+}
+
+func environmentWithOverride(environment []string, key, value string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, prefix+value)
+}

--- a/pkg/python/ingestr_installer.go
+++ b/pkg/python/ingestr_installer.go
@@ -40,6 +40,7 @@ type ingestrInstallerRuntime struct {
 	goos               string
 	goarch             string
 	findShell          func(string) (string, error)
+	runShell           func(context.Context, io.Writer, string, []string) error
 	httpClient         *http.Client
 	releaseDownloadURL string
 }
@@ -142,6 +143,7 @@ func runIngestrInstaller(ctx context.Context, output io.Writer, installDir, vers
 		goos:               runtime.GOOS,
 		goarch:             runtime.GOARCH,
 		findShell:          exec.LookPath,
+		runShell:           runIngestrShellInstaller,
 		httpClient:         &http.Client{Timeout: 5 * time.Minute},
 		releaseDownloadURL: ingestrReleaseDownloadURL,
 	}
@@ -157,15 +159,29 @@ func (r ingestrInstallerRuntime) install(ctx context.Context, output io.Writer, 
 		return errors.Wrap(err, "the ingestr installer requires sh")
 	}
 
-	cmd := exec.CommandContext(ctx, shell, ingestrInstallerCommandArgs(installDir, version, r.goos)...) //nolint:gosec
-	cmd.Env = environmentWithOverride(os.Environ(), "SHELL", "bruin-installer")
-	cmd.Stdout = output
-	cmd.Stderr = output
-
-	if err := cmd.Run(); err != nil {
+	if err := r.runShell(ctx, output, shell, ingestrInstallerCommandArgs(installDir, version, r.goos)); err != nil {
+		if r.goos == "windows" && ctx.Err() == nil {
+			if fallbackErr := r.installWindowsRelease(ctx, output, installDir, version); fallbackErr != nil {
+				return fmt.Errorf(
+					"failed to install ingestr v%s with the shell installer: %w; native Windows fallback failed: %w",
+					version,
+					err,
+					fallbackErr,
+				)
+			}
+			return nil
+		}
 		return errors.Wrapf(err, "failed to install ingestr v%s", version)
 	}
 	return nil
+}
+
+func runIngestrShellInstaller(ctx context.Context, output io.Writer, shell string, args []string) error {
+	cmd := exec.CommandContext(ctx, shell, args...) //nolint:gosec
+	cmd.Env = environmentWithOverride(os.Environ(), "SHELL", "bruin-installer")
+	cmd.Stdout = output
+	cmd.Stderr = output
+	return cmd.Run()
 }
 
 func (r ingestrInstallerRuntime) installWindowsRelease(

--- a/pkg/python/ingestr_installer_test.go
+++ b/pkg/python/ingestr_installer_test.go
@@ -188,6 +188,56 @@ func TestIngestrInstallerFallsBackToNativeWindowsDownload(t *testing.T) {
 	assert.Equal(t, "windows binary", string(contents))
 }
 
+func TestIngestrInstallerFallsBackAfterWindowsShellFailure(t *testing.T) {
+	t.Parallel()
+
+	archive := windowsIngestrTestArchive(t, "ingestr.exe", "fallback binary")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write(archive)
+	}))
+	t.Cleanup(server.Close)
+	installDir := t.TempDir()
+	installer := ingestrInstallerRuntime{
+		goos:   "windows",
+		goarch: "amd64",
+		findShell: func(string) (string, error) {
+			return "sh", nil
+		},
+		runShell: func(context.Context, io.Writer, string, []string) error {
+			return assert.AnError
+		},
+		httpClient:         server.Client(),
+		releaseDownloadURL: server.URL,
+	}
+
+	err := installer.install(t.Context(), io.Discard, installDir, "1.2.3")
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(installDir, "ingestr.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "fallback binary", string(contents))
+}
+
+func TestIngestrInstallerDoesNotFallbackAfterContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	installer := ingestrInstallerRuntime{
+		goos: "windows",
+		findShell: func(string) (string, error) {
+			return "sh", nil
+		},
+		runShell: func(ctx context.Context, _ io.Writer, _ string, _ []string) error {
+			return ctx.Err()
+		},
+	}
+
+	err := installer.install(ctx, io.Discard, t.TempDir(), "1.2.3")
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestNativeWindowsIngestrInstallerRejectsFailedDownload(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/python/ingestr_installer_test.go
+++ b/pkg/python/ingestr_installer_test.go
@@ -1,0 +1,155 @@
+package python
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngestrCheckerInstallsAndCachesExactRelease(t *testing.T) {
+	homeDir := t.TempDir()
+	installCalls := 0
+	checker := &IngestrChecker{
+		install: func(_ context.Context, _ io.Writer, installDir, version string) error {
+			installCalls++
+			assert.Equal(t, "1.2.3", version)
+			return os.WriteFile(
+				filepath.Join(installDir, ingestrBinaryName(runtime.GOOS)),
+				[]byte("installed "+version),
+				0o755,
+			)
+		},
+	}
+
+	binaryPath, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(homeDir, "ingestr", "1.2.3", ingestrBinaryName(runtime.GOOS)), binaryPath)
+	assert.Equal(t, 1, installCalls)
+
+	contents, err := os.ReadFile(binaryPath)
+	require.NoError(t, err)
+	assert.Equal(t, "installed 1.2.3", string(contents))
+
+	// A cached release is returned without invoking the installer again.
+	cachedPath, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
+	require.NoError(t, err)
+	assert.Equal(t, binaryPath, cachedPath)
+	assert.Equal(t, 1, installCalls)
+	assert.Empty(t, installationTempDirs(t, homeDir))
+}
+
+func TestIngestrCheckerCleansUpFailedInstallation(t *testing.T) {
+	homeDir := t.TempDir()
+	installErr := assert.AnError
+	checker := &IngestrChecker{
+		install: func(context.Context, io.Writer, string, string) error {
+			return installErr
+		},
+	}
+
+	_, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
+
+	require.ErrorIs(t, err, installErr)
+	assert.NoFileExists(t, filepath.Join(homeDir, "ingestr", "1.2.3", ingestrBinaryName(runtime.GOOS)))
+	assert.Empty(t, installationTempDirs(t, homeDir))
+}
+
+func TestIngestrCheckerRejectsInstallerWithoutBinary(t *testing.T) {
+	homeDir := t.TempDir()
+	checker := &IngestrChecker{
+		install: func(context.Context, io.Writer, string, string) error {
+			return nil
+		},
+	}
+
+	_, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
+
+	require.ErrorContains(t, err, "installer did not produce "+ingestrBinaryName(runtime.GOOS))
+	assert.Empty(t, installationTempDirs(t, homeDir))
+}
+
+func TestIngestrCheckerRejectsInvalidVersion(t *testing.T) {
+	checker := &IngestrChecker{}
+
+	_, err := checker.EnsureIngestrInstalled(t.Context(), "../../unexpected")
+
+	require.ErrorContains(t, err, "invalid ingestr version")
+}
+
+func TestIngestrInstallerCommandArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		goos       string
+		installDir string
+		wantDir    string
+	}{
+		{
+			name:       "linux path",
+			goos:       "linux",
+			installDir: "/tmp/bruin home/ingestr",
+			wantDir:    "/tmp/bruin home/ingestr",
+		},
+		{
+			name:       "windows path is converted for msys",
+			goos:       "windows",
+			installDir: `C:\Users\runner admin\.bruin\ingestr`,
+			wantDir:    "C:/Users/runner admin/.bruin/ingestr",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			args := ingestrInstallerCommandArgs(tt.installDir, "1.2.3", tt.goos)
+
+			assert.Equal(t, []string{
+				"-c",
+				ingestrInstallerShellCommand,
+				"ingestr-installer",
+				ingestrInstallerURL,
+				tt.wantDir,
+				"v1.2.3",
+			}, args)
+		})
+	}
+}
+
+func TestIngestrBinaryName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ingestr", ingestrBinaryName("linux"))
+	assert.Equal(t, "ingestr", ingestrBinaryName("darwin"))
+	assert.Equal(t, "ingestr.exe", ingestrBinaryName("windows"))
+}
+
+func TestRunIngestrInstallerRequiresShell(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	err := runIngestrInstaller(t.Context(), io.Discard, t.TempDir(), "1.2.3")
+
+	require.ErrorContains(t, err, "requires sh")
+}
+
+func TestEnvironmentWithOverride(t *testing.T) {
+	t.Parallel()
+
+	result := environmentWithOverride([]string{"PATH=/bin", "SHELL=/bin/zsh", "VALUE=a=b"}, "SHELL", "bruin-installer")
+
+	assert.ElementsMatch(t, []string{"PATH=/bin", "VALUE=a=b", "SHELL=bruin-installer"}, result)
+}
+
+func installationTempDirs(t *testing.T, homeDir string) []string {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(homeDir, "ingestr", ".install-*"))
+	require.NoError(t, err)
+	return matches
+}

--- a/pkg/python/ingestr_installer_test.go
+++ b/pkg/python/ingestr_installer_test.go
@@ -1,8 +1,12 @@
 package python
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -138,12 +142,95 @@ func TestIngestrBinaryName(t *testing.T) {
 	assert.Equal(t, "ingestr.exe", ingestrBinaryName("windows"))
 }
 
-func TestRunIngestrInstallerRequiresShell(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
+func TestIngestrInstallerRequiresShellOnUnix(t *testing.T) {
+	t.Parallel()
 
-	err := runIngestrInstaller(t.Context(), io.Discard, t.TempDir(), "1.2.3")
+	installer := ingestrInstallerRuntime{
+		goos: "linux",
+		findShell: func(string) (string, error) {
+			return "", os.ErrNotExist
+		},
+	}
+
+	err := installer.install(t.Context(), io.Discard, t.TempDir(), "1.2.3")
 
 	require.ErrorContains(t, err, "requires sh")
+}
+
+func TestIngestrInstallerFallsBackToNativeWindowsDownload(t *testing.T) {
+	t.Parallel()
+
+	archive := windowsIngestrTestArchive(t, "ingestr.exe", "windows binary")
+	requestedPath := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestedPath <- request.URL.Path
+		writer.Header().Set("Content-Type", "application/zip")
+		_, _ = writer.Write(archive)
+	}))
+	t.Cleanup(server.Close)
+	installDir := t.TempDir()
+	installer := ingestrInstallerRuntime{
+		goos:   "windows",
+		goarch: "amd64",
+		findShell: func(string) (string, error) {
+			return "", os.ErrNotExist
+		},
+		httpClient:         server.Client(),
+		releaseDownloadURL: server.URL,
+	}
+
+	err := installer.install(t.Context(), io.Discard, installDir, "1.2.3")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/v1.2.3/ingestr_Windows_x86_64.zip", <-requestedPath)
+	contents, err := os.ReadFile(filepath.Join(installDir, "ingestr.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "windows binary", string(contents))
+}
+
+func TestNativeWindowsIngestrInstallerRejectsFailedDownload(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		http.Error(writer, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+	installer := ingestrInstallerRuntime{
+		goarch:             "amd64",
+		httpClient:         server.Client(),
+		releaseDownloadURL: server.URL,
+	}
+
+	err := installer.installWindowsRelease(t.Context(), io.Discard, t.TempDir(), "1.2.3")
+
+	require.ErrorContains(t, err, "server returned 404 Not Found")
+}
+
+func TestNativeWindowsIngestrInstallerRequiresBinaryInArchive(t *testing.T) {
+	t.Parallel()
+
+	archive := windowsIngestrTestArchive(t, "README.md", "missing binary")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write(archive)
+	}))
+	t.Cleanup(server.Close)
+	installer := ingestrInstallerRuntime{
+		goarch:             "amd64",
+		httpClient:         server.Client(),
+		releaseDownloadURL: server.URL,
+	}
+
+	err := installer.installWindowsRelease(t.Context(), io.Discard, t.TempDir(), "1.2.3")
+
+	require.ErrorContains(t, err, "archive did not contain ingestr.exe")
+}
+
+func TestWindowsIngestrArchiveNameRejectsUnsupportedArchitecture(t *testing.T) {
+	t.Parallel()
+
+	_, err := windowsIngestrArchiveName("arm64")
+
+	require.ErrorContains(t, err, "do not support windows/arm64")
 }
 
 func TestEnvironmentWithOverride(t *testing.T) {
@@ -160,4 +247,17 @@ func installationTempDirs(t *testing.T, homeDir string) []string {
 	matches, err := filepath.Glob(filepath.Join(homeDir, "ingestr", ".install-*"))
 	require.NoError(t, err)
 	return matches
+}
+
+func windowsIngestrTestArchive(t *testing.T, name, contents string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	file, err := archive.Create(name)
+	require.NoError(t, err)
+	_, err = file.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+	return buffer.Bytes()
 }

--- a/pkg/python/ingestr_installer_test.go
+++ b/pkg/python/ingestr_installer_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestIngestrCheckerInstallsAndCachesExactRelease(t *testing.T) {
+	t.Parallel()
+
 	homeDir := t.TempDir()
 	installCalls := 0
 	checker := &IngestrChecker{
@@ -45,6 +47,8 @@ func TestIngestrCheckerInstallsAndCachesExactRelease(t *testing.T) {
 }
 
 func TestIngestrCheckerCleansUpFailedInstallation(t *testing.T) {
+	t.Parallel()
+
 	homeDir := t.TempDir()
 	installErr := assert.AnError
 	checker := &IngestrChecker{
@@ -61,6 +65,8 @@ func TestIngestrCheckerCleansUpFailedInstallation(t *testing.T) {
 }
 
 func TestIngestrCheckerRejectsInstallerWithoutBinary(t *testing.T) {
+	t.Parallel()
+
 	homeDir := t.TempDir()
 	checker := &IngestrChecker{
 		install: func(context.Context, io.Writer, string, string) error {
@@ -75,6 +81,8 @@ func TestIngestrCheckerRejectsInstallerWithoutBinary(t *testing.T) {
 }
 
 func TestIngestrCheckerRejectsInvalidVersion(t *testing.T) {
+	t.Parallel()
+
 	checker := &IngestrChecker{}
 
 	_, err := checker.EnsureIngestrInstalled(t.Context(), "../../unexpected")

--- a/pkg/python/operator.go
+++ b/pkg/python/operator.go
@@ -58,9 +58,10 @@ func NewLocalOperator(config config.ConnectionAndDetailsGetter, envVariables map
 		repoFinder: &git.RepoFinder{},
 		module:     &ModulePathFinder{},
 		runner: &UvPythonRunner{
-			Cmd:         cmdRunner,
-			UvInstaller: &UvChecker{},
-			conn:        config,
+			Cmd:              cmdRunner,
+			UvInstaller:      &UvChecker{},
+			IngestrInstaller: &IngestrChecker{},
+			conn:             config,
 		},
 		envVariables: envVariables,
 		config:       config,

--- a/pkg/python/proc_unix.go
+++ b/pkg/python/proc_unix.go
@@ -13,10 +13,11 @@ import (
 const managedStopGrace = 30 * time.Second
 
 // configureManagedCmd prepares a long-running streaming command for graceful
-// teardown. ingestr is launched via `uv tool run`, so the process we start (uv)
-// forks the real ingestr/python child; signalling only uv's PID would orphan
-// that child (and, for CDC, leave a replication slot open). Putting the child in
-// its own process group lets us signal the whole tree at once.
+// teardown. A legacy or local ingestr can be launched via `uv tool run`, so the
+// process we start may fork the real ingestr/python child; signalling only the
+// parent PID would orphan that child (and, for CDC, leave a replication slot
+// open). Putting the child in its own process group lets us signal the whole
+// tree at once.
 //
 // On context cancellation exec.Cmd calls Cancel, which sends SIGTERM to the
 // group. ingestr treats SIGTERM as its normal stop: it flushes buffered records,
@@ -28,7 +29,7 @@ func configureManagedCmd(cmd *exec.Cmd) {
 		if cmd.Process == nil {
 			return nil
 		}
-		// Negative PID targets the whole process group (uv + ingestr/python).
+		// Negative PID targets the whole process group, including any uv/python wrapper.
 		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
 			// Fall back to signalling just the process we started.
 			return cmd.Process.Signal(syscall.SIGTERM)

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -214,11 +214,16 @@ type uvInstaller interface {
 	EnsureUvInstalled(ctx context.Context) (string, error)
 }
 
+type ingestrInstaller interface {
+	EnsureIngestrInstalled(ctx context.Context, version string) (string, error)
+}
+
 type UvPythonRunner struct {
-	Cmd            cmd
-	UvInstaller    uvInstaller
-	conn           config.ConnectionGetter
-	binaryFullPath string
+	Cmd              cmd
+	UvInstaller      uvInstaller
+	IngestrInstaller ingestrInstaller
+	conn             config.ConnectionGetter
+	binaryFullPath   string
 }
 
 func (u *UvPythonRunner) Run(ctx context.Context, execCtx *executionContext) error {
@@ -252,20 +257,13 @@ func (u *UvPythonRunner) Run(ctx context.Context, execCtx *executionContext) err
 }
 
 func (u *UvPythonRunner) RunIngestr(ctx context.Context, args, extraPackages []string, repo *git.Repo) error {
-	binaryFullPath, err := u.UvInstaller.EnsureUvInstalled(ctx)
+	command, err := u.ingestrCommand(ctx, extraPackages, args)
 	if err != nil {
 		return err
 	}
-	u.binaryFullPath = binaryFullPath
+	command.Managed = isStreamingContext(ctx)
 
-	noDependencyCommand := &CommandInstance{
-		Name:    u.binaryFullPath,
-		Args:    u.ingestrRunCmd(ctx, extraPackages, args),
-		EnvVars: ingestrEnvVars(),
-		Managed: isStreamingContext(ctx),
-	}
-
-	return u.Cmd.Run(ctx, repo, noDependencyCommand)
+	return u.Cmd.Run(ctx, repo, command)
 }
 
 func (u *UvPythonRunner) runWithNoMaterialization(ctx context.Context, execCtx *executionContext, pythonVersion string) error {
@@ -526,17 +524,19 @@ func (u *UvPythonRunner) runWithMaterialization(ctx context.Context, execCtx *ex
 		ingestrCtx = context.WithValue(ctx, executor.KeyPrinter, io.Writer(logBuffer))
 	}
 
-	runArgs := u.ingestrRunCmd(ctx, extraPackages, cmdArgs)
-
-	if executor.IsDebugMode(ctx) {
-		_, _ = output.Write([]byte("Running CommandInstance: uv " + strings.Join(runArgs, " ") + "\n"))
+	ingestrCommand, err := u.ingestrCommand(ingestrCtx, extraPackages, cmdArgs)
+	if err != nil {
+		if logBuffer != nil {
+			logBuffer.flushTo(output)
+		}
+		return errors.Wrap(err, "failed to prepare ingestr")
 	}
 
-	err = u.Cmd.Run(ingestrCtx, execCtx.repo, &CommandInstance{
-		Name:    u.binaryFullPath,
-		Args:    runArgs,
-		EnvVars: ingestrEnvVars(),
-	})
+	if executor.IsDebugMode(ctx) {
+		_, _ = output.Write([]byte("Running CommandInstance: " + ingestrCommand.Name + " " + strings.Join(ingestrCommand.Args, " ") + "\n"))
+	}
+
+	err = u.Cmd.Run(ingestrCtx, execCtx.repo, ingestrCommand)
 	if err != nil {
 		if logBuffer != nil {
 			logBuffer.flushTo(output)
@@ -558,18 +558,57 @@ func (u *UvPythonRunner) ingestrPackage(ctx context.Context) (string, bool) {
 			return ingestrPath, true
 		}
 	}
-	if v := ctx.Value(CtxIngestrVersion); v != nil {
-		if version, ok := v.(string); ok && version != "" {
-			return "ingestr@" + version, false
-		}
-	}
-	return "ingestr@" + IngestrVersionV1, false
+	return "ingestr@" + ingestrVersion(ctx), false
 }
 
-// ingestrRunCmd builds the `uv tool run` invocation for ingestr. Each call resolves
-// a per-version environment via `--from ingestr@<ver>` (or a local path), so v0 and
-// v1 assets in the same pipeline never share — and never clobber — an installation.
-func (u *UvPythonRunner) ingestrRunCmd(ctx context.Context, extraPackages, args []string) []string {
+func ingestrVersion(ctx context.Context) string {
+	if v := ctx.Value(CtxIngestrVersion); v != nil {
+		if version, ok := v.(string); ok && version != "" {
+			return version
+		}
+	}
+	return IngestrVersionV1
+}
+
+func isLegacyIngestrVersion(version string) bool {
+	return strings.HasPrefix(version, "0.")
+}
+
+// ingestrCommand resolves released v1+ versions to standalone binaries installed
+// by the official curl installer. Legacy v0 and local source checkouts continue to
+// use uv because they are Python packages and have no compatible binary release.
+func (u *UvPythonRunner) ingestrCommand(ctx context.Context, extraPackages, args []string) (*CommandInstance, error) {
+	_, isLocal := u.ingestrPackage(ctx)
+	version := ingestrVersion(ctx)
+	if isLocal || isLegacyIngestrVersion(version) {
+		binaryFullPath, err := u.UvInstaller.EnsureUvInstalled(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &CommandInstance{
+			Name:    binaryFullPath,
+			Args:    u.uvIngestrRunCmd(ctx, extraPackages, args),
+			EnvVars: ingestrEnvVars(),
+		}, nil
+	}
+
+	installer := u.IngestrInstaller
+	if installer == nil {
+		installer = &IngestrChecker{}
+	}
+	binaryFullPath, err := installer.EnsureIngestrInstalled(ctx, version)
+	if err != nil {
+		return nil, err
+	}
+	return &CommandInstance{
+		Name:    binaryFullPath,
+		Args:    args,
+		EnvVars: ingestrEnvVars(),
+	}, nil
+}
+
+// uvIngestrRunCmd builds the legacy/local `uv tool run` invocation for ingestr.
+func (u *UvPythonRunner) uvIngestrRunCmd(ctx context.Context, extraPackages, args []string) []string {
 	ingestrPackageName, isLocal := u.ingestrPackage(ctx)
 	cmdline := make([]string, 0, 12+(2*len(extraPackages))+len(args))
 	cmdline = append(cmdline, "tool", "run", "--no-config", "--prerelease", "allow", "--python", pythonVersionForIngestr)

--- a/pkg/python/uv_test.go
+++ b/pkg/python/uv_test.go
@@ -23,6 +23,15 @@ func (m *mockUvInstaller) EnsureUvInstalled(ctx context.Context) (string, error)
 	return called.String(0), called.Error(1)
 }
 
+type mockIngestrInstaller struct {
+	mock.Mock
+}
+
+func (m *mockIngestrInstaller) EnsureIngestrInstalled(ctx context.Context, version string) (string, error) {
+	called := m.Called(ctx, version)
+	return called.String(0), called.Error(1)
+}
+
 type mockCmd struct {
 	mock.Mock
 }
@@ -55,44 +64,85 @@ func Test_ingestrEnvVars_DisablesTelemetry(t *testing.T) {
 	}, ingestrEnvVars())
 }
 
-func Test_uvPythonRunner_RunIngestr_DisablesTelemetry(t *testing.T) {
+func Test_uvPythonRunner_RunIngestr_UsesReleasedBinaryAndDisablesTelemetry(t *testing.T) {
 	t.Parallel()
 
 	repo := &git.Repo{}
+	ctx := WithStreaming(t.Context())
 	cmd := new(mockCmd)
 	cmd.On("Run", mock.Anything, repo, &CommandInstance{
-		Name: "~/.bruin/uv",
-		Args: []string{
-			"tool",
-			"run",
-			"--no-config",
-			"--prerelease",
-			"allow",
-			"--python",
-			"3.11",
-			"--from",
-			"ingestr@" + IngestrVersionV1,
-			"ingestr",
-			"ingest",
-		},
+		Name: "~/.bruin/ingestr/" + IngestrVersionV1 + "/ingestr",
+		Args: []string{"ingest"},
 		EnvVars: map[string]string{
 			"INGESTR_DISABLE_TELEMETRY": "true",
 			"PYTHONUNBUFFERED":          "1",
 		},
+		Managed: true,
 	}).Return(nil)
 
-	inst := new(mockUvInstaller)
-	inst.On("EnsureUvInstalled", mock.Anything).Return("~/.bruin/uv", nil)
+	ingestrInst := new(mockIngestrInstaller)
+	ingestrInst.On("EnsureIngestrInstalled", mock.Anything, IngestrVersionV1).
+		Return("~/.bruin/ingestr/"+IngestrVersionV1+"/ingestr", nil)
 
 	runner := &UvPythonRunner{
-		Cmd:         cmd,
-		UvInstaller: inst,
+		Cmd:              cmd,
+		IngestrInstaller: ingestrInst,
+	}
+
+	err := runner.RunIngestr(ctx, []string{"ingest"}, []string{"pyodbc==5.1.0"}, repo)
+
+	require.NoError(t, err)
+	cmd.AssertExpectations(t)
+	ingestrInst.AssertExpectations(t)
+}
+
+func Test_uvPythonRunner_RunIngestr_PropagatesReleaseInstallationFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &git.Repo{}
+	cmd := new(mockCmd)
+	ingestrInst := new(mockIngestrInstaller)
+	ingestrInst.On("EnsureIngestrInstalled", mock.Anything, IngestrVersionV1).
+		Return("", assert.AnError)
+	runner := &UvPythonRunner{
+		Cmd:              cmd,
+		IngestrInstaller: ingestrInst,
 	}
 
 	err := runner.RunIngestr(t.Context(), []string{"ingest"}, nil, repo)
 
+	require.ErrorIs(t, err, assert.AnError)
+	cmd.AssertNotCalled(t, "Run", mock.Anything, mock.Anything, mock.Anything)
+	ingestrInst.AssertExpectations(t)
+}
+
+func Test_uvPythonRunner_RunIngestr_UsesUvForLegacyRelease(t *testing.T) {
+	t.Parallel()
+
+	repo := &git.Repo{}
+	ctx := context.WithValue(t.Context(), CtxIngestrVersion, IngestrVersionV0)
+	cmd := new(mockCmd)
+	cmd.On("Run", mock.Anything, repo, mock.MatchedBy(func(command *CommandInstance) bool {
+		return command.Name == "~/.bruin/uv" &&
+			containsArg(command.Args, "ingestr@"+IngestrVersionV0) &&
+			containsArg(command.Args, "pyodbc==5.1.0")
+	})).Return(nil)
+
+	uvInst := new(mockUvInstaller)
+	uvInst.On("EnsureUvInstalled", mock.Anything).Return("~/.bruin/uv", nil)
+	ingestrInst := new(mockIngestrInstaller)
+
+	runner := &UvPythonRunner{
+		Cmd:              cmd,
+		UvInstaller:      uvInst,
+		IngestrInstaller: ingestrInst,
+	}
+	err := runner.RunIngestr(ctx, []string{"ingest"}, []string{"pyodbc==5.1.0"}, repo)
+
 	require.NoError(t, err)
 	cmd.AssertExpectations(t)
+	uvInst.AssertExpectations(t)
+	ingestrInst.AssertNotCalled(t, "EnsureIngestrInstalled", mock.Anything, mock.Anything)
 }
 
 func Test_uvPythonRunner_RunWithMaterialization_DisablesTelemetryForIngestrUpload(t *testing.T) {
@@ -115,9 +165,9 @@ func Test_uvPythonRunner_RunWithMaterialization_DisablesTelemetryForIngestrUploa
 	}).Return(nil)
 
 	cmd.On("Run", mock.Anything, repo, mock.MatchedBy(func(c *CommandInstance) bool {
-		return c.Name == "~/.bruin/uv" &&
+		return c.Name == "~/.bruin/ingestr/"+IngestrVersionV1+"/ingestr" &&
 			len(c.Args) > 0 &&
-			c.Args[0] == "tool" &&
+			c.Args[0] == "ingest" &&
 			c.EnvVars["INGESTR_DISABLE_TELEMETRY"] == "true" &&
 			c.EnvVars["PYTHONUNBUFFERED"] == "1" &&
 			containsArg(c.Args, "mmap://")
@@ -125,10 +175,14 @@ func Test_uvPythonRunner_RunWithMaterialization_DisablesTelemetryForIngestrUploa
 
 	inst := new(mockUvInstaller)
 	inst.On("EnsureUvInstalled", mock.Anything).Return("~/.bruin/uv", nil)
+	ingestrInst := new(mockIngestrInstaller)
+	ingestrInst.On("EnsureIngestrInstalled", mock.Anything, IngestrVersionV1).
+		Return("~/.bruin/ingestr/"+IngestrVersionV1+"/ingestr", nil)
 
 	runner := &UvPythonRunner{
-		Cmd:         cmd,
-		UvInstaller: inst,
+		Cmd:              cmd,
+		UvInstaller:      inst,
+		IngestrInstaller: ingestrInst,
 		conn: fakeConnectionGetter{
 			"dest": fakeIngestrConnection{uri: "postgres://user:pass@localhost:5432/db"},
 		},
@@ -150,6 +204,7 @@ func Test_uvPythonRunner_RunWithMaterialization_DisablesTelemetryForIngestrUploa
 
 	require.NoError(t, err)
 	cmd.AssertExpectations(t)
+	ingestrInst.AssertExpectations(t)
 }
 
 func Test_uvPythonRunner_RunWithMaterialization_RejectsIncrementalPredicate(t *testing.T) {
@@ -373,13 +428,13 @@ func Test_ingestrPackage_HonorsCtxIngestrVersion(t *testing.T) {
 	assert.True(t, isLocal)
 }
 
-func Test_ingestrRunCmd_UsesResolvedPackage(t *testing.T) {
+func Test_uvIngestrRunCmd_UsesResolvedPackage(t *testing.T) {
 	t.Parallel()
 
 	u := &UvPythonRunner{}
 	ctx := context.WithValue(t.Context(), CtxIngestrVersion, "0.14.155")
 
-	args := u.ingestrRunCmd(ctx, []string{"pyodbc", "duckdb"}, []string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
+	args := u.uvIngestrRunCmd(ctx, []string{"pyodbc", "duckdb"}, []string{"ingest", "--source-uri", "csv:///tmp/seed.csv"})
 
 	assert.Equal(t, []string{
 		"tool",
@@ -402,13 +457,13 @@ func Test_ingestrRunCmd_UsesResolvedPackage(t *testing.T) {
 	}, args)
 }
 
-func Test_ingestrRunCmd_LocalPathForcesReinstall(t *testing.T) {
+func Test_uvIngestrRunCmd_LocalPathForcesReinstall(t *testing.T) {
 	t.Parallel()
 
 	u := &UvPythonRunner{}
 	ctx := context.WithValue(t.Context(), LocalIngestr, "/local/ingestr")
 
-	args := u.ingestrRunCmd(ctx, nil, []string{"ingest"})
+	args := u.uvIngestrRunCmd(ctx, nil, []string{"ingest"})
 
 	assert.Equal(t, []string{
 		"tool",


### PR DESCRIPTION
## What
Install ingestr v1+ from standalone GitHub release binaries via the official curl installer, while retaining `uv` for legacy v0 and local source checkouts.

## Changes
- Add versioned, atomic binary installation and route ingestr, seed, streaming, and Python materialization runs through it.
- Add Linux/Windows coverage and run the full PR test suite on both platforms.

## How to test
1. Run `make format`, `make test`, `make build-no-duckdb`, and `make integration-test`.

## Risk & rollback
- **Risk:** Medium; this changes how current ingestr releases are installed and executed.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.
