### PR TITLE
Add per-model AI coding usage breakdown

### DIFF
--- a/docs/getting-started/templates-docs/ai-coding-usage-README.md
+++ b/docs/getting-started/templates-docs/ai-coding-usage-README.md
@@ -21,6 +21,7 @@ The marts provide progressively broader reporting tables:
 - `marts.anthropic_usage_by_user_day`: One Anthropic record per user and day.
 - `marts.cursor_usage_by_user_day`: One Cursor record per user and day.
 - `marts.ai_coding_usage_by_user_day`: One normalized record per user, day, and platform.
+- `marts.ai_coding_usage_by_user_model_day`: Token and cost usage per user, day, platform, and exact model or source-provided model set.
 - `marts.ai_coding_user_daily_summary`: One cross-platform record per user and day.
 - `marts.ai_coding_daily_summary`: Organization-wide daily usage.
 - `marts.ai_coding_user_summary`: Per-user totals across loaded history.
@@ -112,7 +113,7 @@ ORDER BY usage_date DESC;
 
 ## Open the dashboard
 
-The template includes a DAC dashboard with date and platform filters, headline adoption and consumption metrics, daily trends, platform comparisons, and a per-user table. Install the DAC CLI, then run these commands from the generated pipeline directory after the Bruin pipeline has populated DuckDB:
+The template includes a DAC dashboard with date and platform filters, headline adoption and consumption metrics, daily trends, platform and model comparisons, and detailed per-model and per-user tables. Install the DAC CLI, then run these commands from the generated pipeline directory after the Bruin pipeline has populated DuckDB:
 
 ```shell
 dac validate --dir dashboards
@@ -130,6 +131,7 @@ dac build --dir dashboards --dashboard "AI Coding Usage" --output build
 
 - User email addresses are lowercased so the same person can be joined across Anthropic and Cursor. Anthropic API actors retain their API key name and use `user_type = 'api_key'`.
 - Anthropic costs and Cursor token-based event costs are converted from cents to US dollars.
+- Cursor model rows use each request event's exact model. The Anthropic ingestr source currently exposes exact totals for single-model records and aggregate totals plus a comma-separated model set for multi-model records; the model dashboard labels those aggregate rows as `model_set` instead of duplicating or estimating their tokens and cost.
 - Cursor request totals prefer daily Composer, chat, and agent counts; usage-event counts are used when daily request totals are unavailable.
 - Cursor total line changes and accepted AI line changes are kept separately.
 - Anthropic usage covers the first-party Anthropic API and does not include Claude Code traffic routed through Amazon Bedrock or Google Vertex AI.

--- a/templates/ai-coding-usage/README.md
+++ b/templates/ai-coding-usage/README.md
@@ -21,6 +21,7 @@ The marts provide progressively broader reporting tables:
 - `marts.anthropic_usage_by_user_day`: One Anthropic record per user and day.
 - `marts.cursor_usage_by_user_day`: One Cursor record per user and day.
 - `marts.ai_coding_usage_by_user_day`: One normalized record per user, day, and platform.
+- `marts.ai_coding_usage_by_user_model_day`: Token and cost usage per user, day, platform, and exact model or source-provided model set.
 - `marts.ai_coding_user_daily_summary`: One cross-platform record per user and day.
 - `marts.ai_coding_daily_summary`: Organization-wide daily usage.
 - `marts.ai_coding_user_summary`: Per-user totals across loaded history.
@@ -112,7 +113,7 @@ ORDER BY usage_date DESC;
 
 ## Open the dashboard
 
-The template includes a DAC dashboard with date and platform filters, headline adoption and consumption metrics, daily trends, platform comparisons, and a per-user table. Install the DAC CLI, then run these commands from the generated pipeline directory after the Bruin pipeline has populated DuckDB:
+The template includes a DAC dashboard with date and platform filters, headline adoption and consumption metrics, daily trends, platform and model comparisons, and detailed per-model and per-user tables. Install the DAC CLI, then run these commands from the generated pipeline directory after the Bruin pipeline has populated DuckDB:
 
 ```shell
 dac validate --dir dashboards
@@ -130,6 +131,7 @@ dac build --dir dashboards --dashboard "AI Coding Usage" --output build
 
 - User email addresses are lowercased so the same person can be joined across Anthropic and Cursor. Anthropic API actors retain their API key name and use `user_type = 'api_key'`.
 - Anthropic costs and Cursor token-based event costs are converted from cents to US dollars.
+- Cursor model rows use each request event's exact model. The Anthropic ingestr source currently exposes exact totals for single-model records and aggregate totals plus a comma-separated model set for multi-model records; the model dashboard labels those aggregate rows as `model_set` instead of duplicating or estimating their tokens and cost.
 - Cursor request totals prefer daily Composer, chat, and agent counts; usage-event counts are used when daily request totals are unavailable.
 - Cursor total line changes and accepted AI line changes are kept separately.
 - Anthropic usage covers the first-party Anthropic API and does not include Claude Code traffic routed through Amazon Bedrock or Google Vertex AI.

--- a/templates/ai-coding-usage/assets/marts/ai_coding_usage_by_user_model_day.sql
+++ b/templates/ai-coding-usage/assets/marts/ai_coding_usage_by_user_model_day.sql
@@ -1,0 +1,139 @@
+/* @bruin
+
+name: marts.ai_coding_usage_by_user_model_day
+type: duckdb.sql
+
+description: Cross-platform token and cost usage by user, UTC day, platform, and model or source-provided model set.
+
+materialization:
+  type: table
+  strategy: time_interval
+  incremental_key: usage_date
+  time_granularity: date
+
+depends:
+  - staging.claude_code_usage
+  - staging.cursor_usage_events
+
+columns:
+  - name: usage_date
+    type: date
+    description: UTC usage date.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_id
+    type: varchar
+    description: Normalized user email or API key name.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: user_type
+    type: varchar
+    description: User or API key actor classification.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: platform
+    type: varchar
+    description: Anthropic or Cursor.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: model
+    type: varchar
+    description: Exact model, source-provided model set, or unknown when no model was reported.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: model_attribution
+    type: varchar
+    description: Whether metrics are attributed to an exact model, a model set, or an unknown model.
+    checks:
+      - name: not_null
+  - name: total_tokens
+    type: hugeint
+    description: Input, output, cache-read, and cache-creation tokens combined.
+    checks:
+      - name: non_negative
+  - name: estimated_cost_usd
+    type: double
+    description: Estimated model or model-set cost in US dollars.
+    checks:
+      - name: non_negative
+
+@bruin */
+
+WITH anthropic_labeled AS (
+  SELECT
+    usage_date,
+    user_id,
+    user_type,
+    CASE
+      WHEN models_used IS NULL OR TRIM(models_used) = '' THEN 'unknown'
+      ELSE TRIM(models_used)
+    END AS model,
+    CASE
+      WHEN models_used IS NULL OR TRIM(models_used) = '' THEN 'unknown'
+      WHEN STRPOS(models_used, ',') > 0 THEN 'model_set'
+      ELSE 'exact'
+    END AS model_attribution,
+    num_sessions AS sessions,
+    total_input_tokens AS input_tokens,
+    total_output_tokens AS output_tokens,
+    total_cache_read_tokens AS cache_read_tokens,
+    total_cache_creation_tokens AS cache_creation_tokens,
+    total_tokens,
+    estimated_cost_usd
+  FROM staging.claude_code_usage
+  WHERE usage_date BETWEEN CAST('{{ start_date }}' AS DATE) AND CAST('{{ end_date }}' AS DATE)
+),
+anthropic_rollup AS (
+  SELECT
+    usage_date,
+    user_id,
+    user_type,
+    'anthropic' AS platform,
+    model,
+    model_attribution,
+    SUM(sessions) AS sessions,
+    CAST(0 AS HUGEINT) AS requests,
+    SUM(input_tokens) AS input_tokens,
+    SUM(output_tokens) AS output_tokens,
+    SUM(cache_read_tokens) AS cache_read_tokens,
+    SUM(cache_creation_tokens) AS cache_creation_tokens,
+    SUM(total_tokens) AS total_tokens,
+    SUM(estimated_cost_usd) AS estimated_cost_usd
+  FROM anthropic_labeled
+  GROUP BY usage_date, user_id, user_type, model, model_attribution
+),
+cursor_rollup AS (
+  SELECT
+    usage_date,
+    user_id,
+    'user' AS user_type,
+    'cursor' AS platform,
+    CASE
+      WHEN model IS NULL OR TRIM(model) = '' THEN 'unknown'
+      ELSE TRIM(model)
+    END AS model,
+    CASE
+      WHEN model IS NULL OR TRIM(model) = '' THEN 'unknown'
+      ELSE 'exact'
+    END AS model_attribution,
+    CAST(0 AS HUGEINT) AS sessions,
+    CAST(COUNT(*) AS HUGEINT) AS requests,
+    SUM(input_tokens) AS input_tokens,
+    SUM(output_tokens) AS output_tokens,
+    SUM(cache_read_tokens) AS cache_read_tokens,
+    SUM(cache_creation_tokens) AS cache_creation_tokens,
+    SUM(total_tokens) AS total_tokens,
+    SUM(estimated_cost_usd) AS estimated_cost_usd
+  FROM staging.cursor_usage_events
+  WHERE usage_date BETWEEN CAST('{{ start_date }}' AS DATE) AND CAST('{{ end_date }}' AS DATE)
+  GROUP BY usage_date, user_id, model, model_attribution
+)
+
+SELECT * FROM anthropic_rollup
+UNION ALL
+SELECT * FROM cursor_rollup;

--- a/templates/ai-coding-usage/dashboards/ai-coding-usage.yml
+++ b/templates/ai-coding-usage/dashboards/ai-coding-usage.yml
@@ -59,6 +59,36 @@ queries:
       GROUP BY usage_date
       ORDER BY usage_date
 
+  model_usage:
+    sql: |
+      SELECT
+        platform,
+        model,
+        model_attribution,
+        platform || ' / ' || CASE
+          WHEN model_attribution = 'model_set' THEN model || ' (model set)'
+          WHEN model_attribution = 'unknown' THEN 'Unknown model'
+          ELSE model
+        END AS model_label,
+        COUNT(DISTINCT user_type || ':' || user_id) AS active_users,
+        COUNT(DISTINCT usage_date) AS active_days,
+        SUM(sessions) AS sessions,
+        SUM(requests) AS requests,
+        SUM(input_tokens) AS input_tokens,
+        SUM(output_tokens) AS output_tokens,
+        SUM(cache_read_tokens) AS cache_read_tokens,
+        SUM(cache_creation_tokens) AS cache_creation_tokens,
+        SUM(total_tokens) AS total_tokens,
+        ROUND(SUM(estimated_cost_usd), 2) AS estimated_cost_usd
+      FROM marts.ai_coding_usage_by_user_model_day
+      WHERE usage_date >= CAST('{{ filters.date_range.start }}' AS DATE)
+        AND usage_date <= CAST('{{ filters.date_range.end }}' AS DATE)
+      {% if filters.platform != 'All' %}
+        AND platform = '{{ filters.platform }}'
+      {% endif %}
+      GROUP BY platform, model, model_attribution
+      ORDER BY estimated_cost_usd DESC, total_tokens DESC
+
   user_summary:
     sql: |
       SELECT
@@ -185,6 +215,54 @@ rows:
         x: platform
         y: [requests]
         col: 6
+
+  - widgets:
+      - name: Tokens by Model
+        type: chart
+        chart: bar
+        query: model_usage
+        x: model_label
+        y: [total_tokens]
+        col: 6
+
+      - name: Cost by Model
+        type: chart
+        chart: bar
+        query: model_usage
+        x: model_label
+        y: [estimated_cost_usd]
+        col: 6
+
+  - widgets:
+      - name: Model Usage Breakdown
+        type: table
+        query: model_usage
+        col: 12
+        columns:
+          - name: platform
+            label: Platform
+          - name: model
+            label: Model / Model Set
+          - name: model_attribution
+            label: Attribution
+          - name: active_users
+            label: Active Users
+            format: number
+          - name: active_days
+            label: Active Days
+            format: number
+          - name: sessions
+            label: Sessions
+            format: number
+          - name: requests
+            label: Requests
+            format: number
+          - name: total_tokens
+            label: Total Tokens
+            format: number
+          - name: estimated_cost_usd
+            label: Estimated Cost
+            format: currency
 
   - widgets:
       - name: User Consumption


### PR DESCRIPTION
## What
Add model-level token and cost visibility to the AI coding usage template.

## Changes
- Add the per-user/model/day mart and model attribution handling.
- Add dashboard model charts and a detailed breakdown table.
- Update both template README copies.

## How to test
1. Run the generated Bruin pipeline, then validate/build the DAC dashboard and inspect the model breakdown.
2. `git diff --check`

## Risk & rollback
- **Risk:** low — scoped to the AI coding usage template and dashboard.
- **Rollback:** Revert the merge commit.

## Checklist
- [ ] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
<!-- Link the issue(s) this PR closes, e.g. Closes #1234 -->