### PR TITLE
Bootstrap missing tables for incremental materializations

### DIFF
--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -65,6 +65,8 @@ The strategy used for the materialization, can be one of the following:
 - `scd2_by_column`: implement SCD2 logic that tracks changes based on column value differences.
 - `scd2_by_time`: implement SCD2 logic that tracks changes based on time-based incremental key.
 
+On their first incremental run, `delete+insert`, `merge`, and `time_interval` automatically create an empty target table when it does not exist. The table schema is derived from the asset query, and supported partitioning or clustering settings are applied before the normal incremental statements run. `append` and `truncate+insert` still require an existing target table.
+
 ### `materialization > partition_by`
 
 Define the column that will be used for the partitioning of the resulting table. This is used to instruct the data warehouse to set the column for the partition key.

--- a/docs/platforms/bigquery.md
+++ b/docs/platforms/bigquery.md
@@ -119,7 +119,7 @@ where event_name = "install"
 
 #### BigQuery table options
 
-The top-level `bigquery` block configures BigQuery-specific table options and partition-scoped merge behavior. Table options are applied when Bruin creates a table with a `create+replace` or `ddl` materialization. Partition expiration is also supported during an SCD2 full refresh.
+The top-level `bigquery` block configures BigQuery-specific table options and partition-scoped merge behavior. Table options are applied whenever Bruin creates a table, including the first run of a `delete+insert`, `merge`, or `time_interval` materialization. Partition expiration is also supported during an SCD2 full refresh.
 
 ```bruin-sql
 /* @bruin

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -98,13 +98,14 @@ Runs a materialized ClickHouse asset or an SQL script. An unmaterialized asset c
 | --- | --- | --- |
 | `create+replace` | Supported | Runs `CREATE OR REPLACE TABLE <target> PRIMARY KEY <key> AS <asset query>`. Requires `columns` and exactly one column marked `primary_key: true`. |
 | `append` | Supported | Runs `INSERT INTO <target> <asset query>`. Bruin does not add filtering or deduplicate rows; make the asset query select only the new rows. |
-| `delete+insert` | Supported | Refreshes the values returned for an `incremental_key`: it writes the query result to a temporary table, deletes target rows whose incremental-key value occurs in that table, inserts the temporary-table rows, then drops the temporary table. Requires `incremental_key`, `columns`, and exactly one `primary_key: true` column. |
-| `time_interval` | Supported | On a normal run, deletes target rows in the requested date or timestamp interval, then inserts the asset query result with `SETTINGS insert_deduplicate = 0` so a rerun of the same interval is not suppressed by ClickHouse insert deduplication. Requires `incremental_key`, `time_granularity` (`date` or `timestamp`), and an existing target table. The asset query must filter itself to the same interval. A `--full-refresh` runs `create+replace` instead, which requires `columns` and exactly one `primary_key: true` column. |
+| `delete+insert` | Supported | Refreshes the values returned for an `incremental_key`: it writes the query result to a temporary table, creates an empty target from that staged result if needed, deletes target rows whose incremental-key value occurs in the temporary table, inserts the staged rows, then drops the temporary table. Requires `incremental_key`, `columns`, and exactly one `primary_key: true` column. |
+| `time_interval` | Supported | On a normal run, creates an empty `MergeTree` target from the query schema if needed, deletes target rows in the requested date or timestamp interval, then inserts the asset query result with `SETTINGS insert_deduplicate = 0` so a rerun of the same interval is not suppressed by ClickHouse insert deduplication. Requires `incremental_key` and `time_granularity` (`date` or `timestamp`). The asset query must filter itself to the same interval. A `--full-refresh` runs `create+replace` instead, which requires `columns` and exactly one `primary_key: true` column. |
 | `truncate+insert` | Supported | Truncates the existing table, then inserts the asset query result. This is a full-table refresh that preserves the table definition; it is not an incremental strategy. |
 | `ddl` | Supported | Creates the table if it does not already exist from the defined columns, primary key, and optional `partition_by`. Do not include a query in a DDL asset. |
-| `merge`, `scd2_by_column`, `scd2_by_time` | Not supported | Use `delete+insert`, `time_interval`, or an explicit ClickHouse SQL implementation instead. |
+| `merge` | Supported | Stages the query result, creates an empty target with the configured primary key if needed, then replaces rows matching the primary key. |
+| `scd2_by_column`, `scd2_by_time` | Not supported | Use an explicit ClickHouse SQL implementation instead. |
 
-Create the target table with `create+replace` or `ddl` before its first `append`, `delete+insert`, `time_interval`, or `truncate+insert` run. `create+replace`, including a `--full-refresh` of a `time_interval` asset, requires `columns` and exactly one `primary_key: true` column. The primary key is used in the `CREATE OR REPLACE TABLE` statement; Bruin does not use it to deduplicate or merge rows.
+`delete+insert`, `merge`, and `time_interval` create the target automatically on their first run. Create the target table with `create+replace` or `ddl` before its first `append` or `truncate+insert` run. `create+replace`, including a `--full-refresh` of a `time_interval` asset, requires `columns` and exactly one `primary_key: true` column. The primary key is used in the `CREATE OR REPLACE TABLE` statement; Bruin does not use it to deduplicate rows.
 
 View materializations support only the default strategy, which creates or replaces the view. Table-only strategies, including all incremental strategies, are not supported for views.
 
@@ -172,7 +173,7 @@ Running `bruin run --full-refresh` changes every ClickHouse table materializatio
 
 Bruin does not translate or validate ClickHouse column types against its own allowlist. For `ddl` materializations, it passes `columns[].type` through to ClickHouse. `precision`/`scale` or `length` are added to an unparameterized type when you provide them separately. ClickHouse is therefore the authority for whether a type is available on your server version and configuration; see its [data type reference](https://clickhouse.com/docs/sql-reference/data-types) for the complete, current list.
 
-For `create+replace`, `delete+insert`, and a `--full-refresh`, ClickHouse derives a new table's column types from the asset query's `SELECT` result. For `append`, `truncate+insert`, and normal `time_interval` runs, ClickHouse uses the existing target table's schema.
+For `create+replace`, `delete+insert`, `merge`, `time_interval`, and a `--full-refresh`, ClickHouse derives a missing table's column types from the asset query's `SELECT` result. Once the target exists, `append`, `truncate+insert`, and normal incremental runs use its existing schema.
 
 Common ClickHouse column types include:
 
@@ -296,7 +297,7 @@ The compatibility check catches errors such as a different number of staged and 
 
 Unlike merge implementations that expose `source` and `target` aliases, ClickHouse's `DELETE` statement has no target alias. A ClickHouse `incremental_predicate` must therefore reference target columns without qualification, for example `event_date >= toDate('2026-07-01')` rather than `target.event_date >= toDate('2026-07-01')`.
 
-Merge assets must declare `columns` and at least one `primary_key` column. Composite primary keys are supported. On a full refresh, Bruin falls back to `create+replace` (creating the table from the query result) so the target exists for subsequent incremental merges.
+Merge assets must declare `columns` and at least one `primary_key` column. Composite primary keys are supported. A normal first run creates an empty target from the staged query result before merging. On a full refresh, Bruin falls back to `create+replace` and recreates the table from the query result.
 
 Here's a sample asset with `merge` materialization:
 

--- a/docs/platforms/materialization.md
+++ b/docs/platforms/materialization.md
@@ -56,6 +56,8 @@ The result will be a table `dashboard.hello_bq` with the result of the query.
 
 `delete+insert` strategy is useful for incremental updates. It deletes the rows that are no longer present in the query results and inserts the new rows. This is useful when you have a large table and you want to minimize the amount of data that needs to be written.
 
+If the target table does not exist, Bruin first creates an empty table using the asset query's output schema. This first-run initialization also applies to the `merge` and `time_interval` strategies on platforms that support them.
+
 This strategy requires an `incremental_key` to be specified. This key is used to determine which rows to delete and which rows to insert.
 
 Bruin implements `delete+insert` strategy in the following way:

--- a/pkg/ansisql/materialization.go
+++ b/pkg/ansisql/materialization.go
@@ -33,6 +33,25 @@ func AddIncrementalPredicate(conditions []string, predicate string) []string {
 	return append(conditions, "("+predicate+")")
 }
 
+// BuildCreateTableIfNotExistsAsQuery builds an empty CTAS statement that
+// bootstraps a table without consuming the rows returned by the asset query.
+// Materializers can then run their normal incremental DML on both the first
+// and subsequent executions.
+func BuildCreateTableIfNotExistsAsQuery(tableName, tableOptions, query string) string {
+	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
+	tableOptions = strings.TrimSpace(tableOptions)
+	if tableOptions != "" {
+		tableOptions = " " + tableOptions
+	}
+
+	return fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s%s AS\nSELECT * FROM (\n%s\n) AS __bruin_bootstrap WHERE 1 = 0",
+		tableName,
+		tableOptions,
+		query,
+	)
+}
+
 // BuildTruncateInsertQuery creates a truncate+insert query that works for standard ANSI SQL databases.
 // This can be used by platforms that support standard TRUNCATE TABLE syntax with transactions.
 func BuildTruncateInsertQuery(task *pipeline.Asset, query string) (string, error) {

--- a/pkg/ansisql/materialization_test.go
+++ b/pkg/ansisql/materialization_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildCreateTableIfNotExistsAsQuery(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, `CREATE TABLE IF NOT EXISTS dataset.events PARTITION BY event_date AS
+SELECT * FROM (
+SELECT 1 AS id
+) AS __bruin_bootstrap WHERE 1 = 0`, BuildCreateTableIfNotExistsAsQuery(
+		"dataset.events",
+		"PARTITION BY event_date",
+		" SELECT 1 AS id; ",
+	))
+}
+
 func TestBuildTruncateInsertQuery(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/athena/materializer.go
+++ b/pkg/athena/materializer.go
@@ -40,12 +40,37 @@ func (m *Materializer) Render(asset *pipeline.Asset, query, location string) ([]
 	return []string{}, fmt.Errorf("unsupported materialization type - strategy combination: (`%s` - `%s`)", mat.Type, mat.Strategy)
 }
 
+// RenderInitialTable builds the CTAS statement used when an incremental target
+// is absent. Athena CTAS does not support IF NOT EXISTS, so the operator calls
+// this only after checking the Glue catalog through information_schema.
+func (m *Materializer) RenderInitialTable(asset *pipeline.Asset, query, location string) ([]string, error) {
+	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
+
+	partitionBy := ""
+	if asset.Materialization.PartitionBy != "" {
+		partitionBy = fmt.Sprintf(", partitioning = ARRAY['%s']", asset.Materialization.PartitionBy)
+	}
+
+	return []string{fmt.Sprintf(
+		"CREATE TABLE %s WITH (table_type='ICEBERG', is_external=false, location='%s/%s'%s) AS %s WITH NO DATA",
+		asset.Name,
+		location,
+		asset.Name,
+		partitionBy,
+		query,
+	)}, nil
+}
+
 func NewMaterializer(fullRefresh bool) *Materializer {
 	return &Materializer{
 		MaterializationMap: matMap,
 		fullRefresh:        fullRefresh,
 		randomName:         helpers.PrefixGenerator,
 	}
+}
+
+func (m *Materializer) IsFullRefresh() bool {
+	return m.fullRefresh
 }
 
 type Renderer struct {

--- a/pkg/athena/materializer_test.go
+++ b/pkg/athena/materializer_test.go
@@ -73,3 +73,32 @@ func TestLogIfFullRefreshAndDDL(t *testing.T) {
 		})
 	}
 }
+
+func TestMaterializer_RenderInitialTable(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "analytics.events",
+		Materialization: pipeline.Materialization{
+			Type:        pipeline.MaterializationTypeTable,
+			Strategy:    pipeline.MaterializationStrategyTimeInterval,
+			PartitionBy: "event_date",
+		},
+	}
+
+	queries, err := NewMaterializer(false).RenderInitialTable(
+		asset,
+		"SELECT event_date, event_name FROM raw_events;",
+		"s3://bucket/results",
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"CREATE TABLE analytics.events WITH (table_type='ICEBERG', is_external=false, location='s3://bucket/results/analytics.events', partitioning = ARRAY['event_date']) AS SELECT event_date, event_name FROM raw_events WITH NO DATA",
+	}, queries)
+}
+
+func TestMaterializer_IsFullRefresh(t *testing.T) {
+	t.Parallel()
+	require.False(t, NewMaterializer(false).IsFullRefresh())
+	require.True(t, NewMaterializer(true).IsFullRefresh())
+}

--- a/pkg/athena/operator.go
+++ b/pkg/athena/operator.go
@@ -21,6 +21,18 @@ type materializer interface {
 	LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error
 }
 
+type initialTableMaterializer interface {
+	RenderInitialTable(asset *pipeline.Asset, query, location string) ([]string, error)
+}
+
+type initialTableInsertionIndexer interface {
+	InitialTableInsertionIndex(asset *pipeline.Asset) int
+}
+
+type tableExistsQueryBuilder interface {
+	BuildTableExistsQuery(tableName string) (string, error)
+}
+
 type Client interface {
 	RunQueryWithoutResult(ctx context.Context, query *query.Query) error
 	Select(ctx context.Context, query *query.Query) ([][]interface{}, error)
@@ -108,6 +120,43 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
+	if shouldInitializeIncrementalTable(t) && !isFullRefreshMaterializer(o.materializer) {
+		initializer, canInitialize := o.materializer.(initialTableMaterializer)
+		tableChecker, canCheck := conn.(tableExistsQueryBuilder)
+		if canInitialize && canCheck {
+			existsQuery, err := tableChecker.BuildTableExistsQuery(t.Name)
+			if err != nil {
+				return errors.Wrap(err, "cannot build incremental target existence query")
+			}
+			result, err := conn.Select(ctx, &query.Query{Query: existsQuery})
+			if err != nil {
+				return errors.Wrap(err, "cannot check whether incremental target exists")
+			}
+			count, err := helpers.CastResultToInteger(result, true)
+			if err != nil {
+				return errors.Wrap(err, "cannot parse incremental target existence result")
+			}
+			if count == 0 {
+				initialQueries, err := initializer.RenderInitialTable(t, q.String(), conn.GetResultsLocation())
+				if err != nil {
+					return err
+				}
+				insertionIndex := 0
+				if indexer, ok := o.materializer.(initialTableInsertionIndexer); ok {
+					insertionIndex = indexer.InitialTableInsertionIndex(t)
+				}
+				if insertionIndex < 0 || insertionIndex > len(materializedQueries) {
+					insertionIndex = 0
+				}
+				withInitialTable := make([]string, 0, len(initialQueries)+len(materializedQueries))
+				withInitialTable = append(withInitialTable, materializedQueries[:insertionIndex]...)
+				withInitialTable = append(withInitialTable, initialQueries...)
+				withInitialTable = append(withInitialTable, materializedQueries[insertionIndex:]...)
+				materializedQueries = withInitialTable
+			}
+		}
+	}
+
 	var lastQuery *query.Query
 	for _, queryString := range materializedQueries {
 		queryObj := &query.Query{Query: queryString}
@@ -141,6 +190,26 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 	}
 
 	return nil
+}
+
+func shouldInitializeIncrementalTable(asset *pipeline.Asset) bool {
+	if asset.Materialization.Type != pipeline.MaterializationTypeTable {
+		return false
+	}
+
+	switch asset.Materialization.Strategy {
+	case pipeline.MaterializationStrategyDeleteInsert,
+		pipeline.MaterializationStrategyMerge,
+		pipeline.MaterializationStrategyTimeInterval:
+		return true
+	default:
+		return false
+	}
+}
+
+func isFullRefreshMaterializer(materializer materializer) bool {
+	fullRefresh, ok := materializer.(interface{ IsFullRefresh() bool })
+	return ok && fullRefresh.IsFullRefresh()
 }
 
 func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnCheckOperator {

--- a/pkg/athena/operator_test.go
+++ b/pkg/athena/operator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockExtractor struct {
@@ -40,6 +41,30 @@ func (m *mockMaterializer) Render(t *pipeline.Asset, query, location string) ([]
 
 func (m *mockMaterializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
 	return nil
+}
+
+type mockIncrementalMaterializer struct {
+	*mockMaterializer
+	fullRefresh bool
+}
+
+func (m *mockIncrementalMaterializer) RenderInitialTable(t *pipeline.Asset, query, location string) ([]string, error) {
+	res := m.Called(t, query, location)
+	return res.Get(0).([]string), res.Error(1)
+}
+
+func (m *mockIncrementalMaterializer) IsFullRefresh() bool {
+	return m.fullRefresh
+}
+
+type mockTableCheckingClient struct {
+	*mockQuerierWithResult
+	existsQuery string
+	buildErr    error
+}
+
+func (m *mockTableCheckingClient) BuildTableExistsQuery(_ string) (string, error) {
+	return m.existsQuery, m.buildErr
 }
 
 func TestBasicOperator_RunTask(t *testing.T) {
@@ -226,4 +251,90 @@ func TestBasicOperator_RunTask(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBasicOperator_InitializesMissingIncrementalTarget(t *testing.T) {
+	t.Parallel()
+
+	clientMock := new(mockQuerierWithResult)
+	client := &mockTableCheckingClient{
+		mockQuerierWithResult: clientMock,
+		existsQuery:           "SELECT COUNT(*) FROM information_schema.tables",
+	}
+	extractor := new(mockExtractor)
+	baseMaterializer := new(mockMaterializer)
+	materializer := &mockIncrementalMaterializer{mockMaterializer: baseMaterializer}
+	connections := new(mockConnectionFetcher)
+
+	asset := &pipeline.Asset{
+		Name: "analytics.events",
+		Type: pipeline.AssetTypeAthenaQuery,
+		ExecutableFile: pipeline.ExecutableFile{
+			Path:    "events.sql",
+			Content: "SELECT event_date FROM raw_events",
+		},
+		Materialization: pipeline.Materialization{
+			Type:           pipeline.MaterializationTypeTable,
+			Strategy:       pipeline.MaterializationStrategyDeleteInsert,
+			IncrementalKey: "event_date",
+		},
+	}
+
+	extractor.On("ExtractQueriesFromString", asset.ExecutableFile.Content).
+		Return([]*query.Query{{Query: asset.ExecutableFile.Content}}, nil)
+	baseMaterializer.On("Render", asset, asset.ExecutableFile.Content).
+		Return([]string{"DELETE FROM analytics.events", "INSERT INTO analytics.events SELECT event_date FROM raw_events"}, nil)
+	baseMaterializer.On(
+		"RenderInitialTable",
+		asset,
+		asset.ExecutableFile.Content,
+		"s3://test-bucket/test-location:",
+	).Return([]string{"CREATE TABLE analytics.events AS SELECT event_date FROM raw_events WITH NO DATA"}, nil)
+	clientMock.On(
+		"Select",
+		mock.Anything,
+		&query.Query{Query: client.existsQuery},
+	).Return([][]interface{}{{int64(0)}}, nil)
+	clientMock.On(
+		"RunQueryWithoutResult",
+		mock.Anything,
+		&query.Query{Query: "CREATE TABLE analytics.events AS SELECT event_date FROM raw_events WITH NO DATA"},
+	).Return(nil).Once()
+	clientMock.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "DELETE FROM analytics.events"}).Return(nil).Once()
+	clientMock.On(
+		"RunQueryWithoutResult",
+		mock.Anything,
+		&query.Query{Query: "INSERT INTO analytics.events SELECT event_date FROM raw_events"},
+	).Return(nil).Once()
+	connections.On("GetConnection", mock.Anything).Return(client)
+
+	operator := BasicOperator{
+		connection:   connections,
+		extractor:    extractor,
+		materializer: materializer,
+	}
+	require.NoError(t, operator.RunTask(t.Context(), &pipeline.Pipeline{}, asset))
+	baseMaterializer.AssertExpectations(t)
+	clientMock.AssertExpectations(t)
+}
+
+func TestShouldInitializeIncrementalTable(t *testing.T) {
+	t.Parallel()
+
+	for _, strategy := range []pipeline.MaterializationStrategy{
+		pipeline.MaterializationStrategyDeleteInsert,
+		pipeline.MaterializationStrategyMerge,
+		pipeline.MaterializationStrategyTimeInterval,
+	} {
+		asset := &pipeline.Asset{Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: strategy,
+		}}
+		require.True(t, shouldInitializeIncrementalTable(asset))
+	}
+
+	require.False(t, shouldInitializeIncrementalTable(&pipeline.Asset{Materialization: pipeline.Materialization{
+		Type:     pipeline.MaterializationTypeTable,
+		Strategy: pipeline.MaterializationStrategyAppend,
+	}}))
 }

--- a/pkg/bigquery/materialization.go
+++ b/pkg/bigquery/materialization.go
@@ -131,7 +131,7 @@ func mergeMaterializer(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnValues, allColumnValues),
 	}
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	return buildCreateTableIfNotExistsQuery(asset, query) + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
 }
 
 type mergePartitionExpression struct {
@@ -258,6 +258,7 @@ func buildPartitionedMergeQuery(
 
 	statements := []string{
 		fmt.Sprintf("DECLARE %s ARRAY<%s>", partitionVariable, partition.dataType),
+		buildCreateTableIfNotExistsQuery(asset, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", sourceTable, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf(
@@ -350,6 +351,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 	declaredVarName := "distinct_keys_" + randPrefix
 	queries := []string{
 		fmt.Sprintf("DECLARE %s array<%s>", declaredVarName, foundCol.Type),
+		buildCreateTableIfNotExistsQuery(asset, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf("SET %s = (SELECT array_agg(distinct %s) FROM %s)", declaredVarName, mat.IncrementalKey, tempTableName),
@@ -366,6 +368,7 @@ func buildIncrementalQueryWithoutTempVariable(asset *pipeline.Asset, query strin
 	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
 
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(asset, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", asset.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
@@ -546,6 +549,18 @@ func buildCreateReplaceQuery(asset *pipeline.Asset, query string) (string, error
 	}
 }
 
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) string {
+	options := make([]string, 0, 2)
+	if asset.Materialization.PartitionBy != "" {
+		options = append(options, "PARTITION BY "+asset.Materialization.PartitionBy)
+	}
+	if len(asset.Materialization.ClusterBy) > 0 {
+		options = append(options, "CLUSTER BY "+strings.Join(asset.Materialization.ClusterBy, ", "))
+	}
+
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, strings.Join(options, " "), query)
+}
+
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
 	if asset.Materialization.IncrementalKey == "" {
 		return "", errors.New("incremental_key is required for time_interval strategy")
@@ -570,6 +585,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(asset, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,

--- a/pkg/bigquery/materialization.go
+++ b/pkg/bigquery/materialization.go
@@ -131,7 +131,12 @@ func mergeMaterializer(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnValues, allColumnValues),
 	}
 
-	return buildCreateTableIfNotExistsQuery(asset, query) + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
+	bootstrapQuery, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
+
+	return bootstrapQuery + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
 }
 
 type mergePartitionExpression struct {
@@ -255,10 +260,14 @@ func buildPartitionedMergeQuery(
 	targetPartitionFilter := fmt.Sprintf("%s IN UNNEST(%s)", targetPartitionExpression, partitionVariable)
 	filteredMatchConditions := append([]string{targetPartitionFilter}, matchConditions...)
 	filteredMatchQuery := strings.Join(filteredMatchConditions, " AND ")
+	bootstrapQuery, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
 
 	statements := []string{
 		fmt.Sprintf("DECLARE %s ARRAY<%s>", partitionVariable, partition.dataType),
-		buildCreateTableIfNotExistsQuery(asset, query),
+		bootstrapQuery,
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", sourceTable, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf(
@@ -347,11 +356,15 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 
 	randPrefix := helpers.PrefixGenerator()
 	tempTableName := "__bruin_tmp_" + randPrefix
+	bootstrapQuery, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
 
 	declaredVarName := "distinct_keys_" + randPrefix
 	queries := []string{
 		fmt.Sprintf("DECLARE %s array<%s>", declaredVarName, foundCol.Type),
-		buildCreateTableIfNotExistsQuery(asset, query),
+		bootstrapQuery,
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf("SET %s = (SELECT array_agg(distinct %s) FROM %s)", declaredVarName, mat.IncrementalKey, tempTableName),
@@ -366,9 +379,13 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 func buildIncrementalQueryWithoutTempVariable(asset *pipeline.Asset, query string) (string, error) {
 	mat := asset.Materialization
 	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
+	bootstrapQuery, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
 
 	queries := []string{
-		buildCreateTableIfNotExistsQuery(asset, query),
+		bootstrapQuery,
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", asset.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
@@ -549,16 +566,23 @@ func buildCreateReplaceQuery(asset *pipeline.Asset, query string) (string, error
 	}
 }
 
-func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) string {
-	options := make([]string, 0, 2)
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) (string, error) {
+	options := make([]string, 0, 3)
 	if asset.Materialization.PartitionBy != "" {
 		options = append(options, "PARTITION BY "+asset.Materialization.PartitionBy)
 	}
 	if len(asset.Materialization.ClusterBy) > 0 {
 		options = append(options, "CLUSTER BY "+strings.Join(asset.Materialization.ClusterBy, ", "))
 	}
+	tableOptions, err := buildTableOptions(asset, asset.Materialization.PartitionBy != "")
+	if err != nil {
+		return "", err
+	}
+	if tableOptions != "" {
+		options = append(options, tableOptions)
+	}
 
-	return ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, strings.Join(options, " "), query)
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, strings.Join(options, " "), query), nil
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -583,9 +607,13 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 		startVar = "{{start_date}}"
 		endVar = "{{end_date}}"
 	}
+	bootstrapQuery, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
 
 	queries := []string{
-		buildCreateTableIfNotExistsQuery(asset, query),
+		bootstrapQuery,
 		"BEGIN TRANSACTION",
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,

--- a/pkg/bigquery/materialization_test.go
+++ b/pkg/bigquery/materialization_test.go
@@ -801,7 +801,9 @@ COMMIT TRANSACTION;`,
 				strategy == pipeline.MaterializationStrategyMerge ||
 				strategy == pipeline.MaterializationStrategyTimeInterval
 			if !tt.wantErr && !tt.fullRefresh && bootstrapStrategy {
-				bootstrap := buildCreateTableIfNotExistsQuery(tt.task, tt.query) + ";\n"
+				bootstrap, bootstrapErr := buildCreateTableIfNotExistsQuery(tt.task, tt.query)
+				require.NoError(t, bootstrapErr)
+				bootstrap += ";\n"
 				assert.Contains(t, render, bootstrap)
 				render = strings.Replace(render, bootstrap, "", 1)
 			}
@@ -813,6 +815,35 @@ COMMIT TRANSACTION;`,
 			}
 		})
 	}
+}
+
+func TestBuildCreateTableIfNotExistsQueryIncludesBigQueryOptions(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name: "analytics.events",
+		Columns: []pipeline.Column{
+			{Name: "account_id", Type: "INT64"},
+			{Name: "event_date", Type: "DATE", PrimaryKey: true},
+		},
+		Materialization: pipeline.Materialization{
+			Type:        pipeline.MaterializationTypeTable,
+			Strategy:    pipeline.MaterializationStrategyMerge,
+			PartitionBy: "event_date",
+			ClusterBy:   []string{"account_id"},
+		},
+		BigQuery: pipeline.BigQueryConfig{
+			RequirePartitionFilter:  boolp(true),
+			PartitionExpirationDays: floatp(7.5),
+		},
+	}
+
+	query, err := buildCreateTableIfNotExistsQuery(asset, "SELECT account_id, event_date FROM staging.events;")
+	require.NoError(t, err)
+	assert.Equal(t, `CREATE TABLE IF NOT EXISTS analytics.events PARTITION BY event_date CLUSTER BY account_id OPTIONS (require_partition_filter = TRUE, partition_expiration_days = 7.5) AS
+SELECT * FROM (
+SELECT account_id, event_date FROM staging.events
+) AS __bruin_bootstrap WHERE 1 = 0`, query)
 }
 
 func TestMergeRequiredPartitionFilterGeneratedSQL(t *testing.T) {
@@ -845,7 +876,7 @@ WHERE event_date >= DATE '2026-07-01';`
 	}
 
 	expectedFullSQL := `DECLARE bruin_merge_partitions_abcefghi ARRAY<DATE>;
-CREATE TABLE IF NOT EXISTS analytics.events PARTITION BY event_date AS
+CREATE TABLE IF NOT EXISTS analytics.events PARTITION BY event_date OPTIONS (require_partition_filter = TRUE) AS
 SELECT * FROM (
 SELECT
   id,
@@ -913,7 +944,7 @@ WHERE DATE(created_at) = DATE '2026-07-27';`
 	}
 
 	expectedFullSQL := `DECLARE bruin_merge_partitions_abcefghi ARRAY<DATE>;
-CREATE TABLE IF NOT EXISTS analytics.events_by_day PARTITION BY DATE(created_at) AS
+CREATE TABLE IF NOT EXISTS analytics.events_by_day PARTITION BY DATE(created_at) OPTIONS (require_partition_filter = TRUE) AS
 SELECT * FROM (
 SELECT
   id,

--- a/pkg/bigquery/materialization_test.go
+++ b/pkg/bigquery/materialization_test.go
@@ -796,6 +796,15 @@ COMMIT TRANSACTION;`,
 			} else {
 				require.NoError(t, err)
 			}
+			strategy := tt.task.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.wantErr && !tt.fullRefresh && bootstrapStrategy {
+				bootstrap := buildCreateTableIfNotExistsQuery(tt.task, tt.query) + ";\n"
+				assert.Contains(t, render, bootstrap)
+				render = strings.Replace(render, bootstrap, "", 1)
+			}
 
 			if tt.exactMatch {
 				assert.Equal(t, tt.want, render)
@@ -836,6 +845,15 @@ WHERE event_date >= DATE '2026-07-01';`
 	}
 
 	expectedFullSQL := `DECLARE bruin_merge_partitions_abcefghi ARRAY<DATE>;
+CREATE TABLE IF NOT EXISTS analytics.events PARTITION BY event_date AS
+SELECT * FROM (
+SELECT
+  id,
+  event_date,
+  payload
+FROM staging.events
+WHERE event_date >= DATE '2026-07-01'
+) AS __bruin_bootstrap WHERE 1 = 0;
 BEGIN TRANSACTION;
 CREATE TEMP TABLE __bruin_merge_source_abcefghi AS SELECT
   id,
@@ -895,6 +913,15 @@ WHERE DATE(created_at) = DATE '2026-07-27';`
 	}
 
 	expectedFullSQL := `DECLARE bruin_merge_partitions_abcefghi ARRAY<DATE>;
+CREATE TABLE IF NOT EXISTS analytics.events_by_day PARTITION BY DATE(created_at) AS
+SELECT * FROM (
+SELECT
+  id,
+  created_at,
+  payload
+FROM staging.raw_events
+WHERE DATE(created_at) = DATE '2026-07-27'
+) AS __bruin_bootstrap WHERE 1 = 0;
 BEGIN TRANSACTION;
 CREATE TEMP TABLE __bruin_merge_source_abcefghi AS SELECT
   id,

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -81,9 +81,10 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) ([]string, error)
 			query,
 		),
 		fmt.Sprintf(
-			"CREATE TABLE IF NOT EXISTS %s PRIMARY KEY %s AS SELECT * FROM %s LIMIT 0",
+			"CREATE TABLE IF NOT EXISTS %s PRIMARY KEY %s%s AS SELECT * FROM %s LIMIT 0",
 			task.Name,
 			task.ColumnNamesWithPrimaryKey()[0],
+			buildPartitionByClause(task),
 			tempTableName,
 		),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
@@ -148,7 +149,7 @@ func buildMergeQuery(task *pipeline.Asset, query string) ([]string, error) {
 	// deleting target rows. LIMIT 0 performs no write and avoids deduplication.
 	queries := []string{
 		fmt.Sprintf("CREATE TABLE %s ENGINE = MergeTree() PRIMARY KEY (%s) AS %s", tempTableName, keys, query),
-		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s ENGINE = MergeTree() PRIMARY KEY (%s) AS SELECT * FROM %s LIMIT 0", task.Name, keys, tempTableName),
+		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s ENGINE = MergeTree() PRIMARY KEY (%s)%s AS SELECT * FROM %s LIMIT 0", task.Name, keys, buildPartitionByClause(task), tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s LIMIT 0", task.Name, tempTableName),
 		fmt.Sprintf("DELETE FROM %s WHERE %s", task.Name, deleteCondition),
 		fmt.Sprintf("INSERT INTO %s SETTINGS insert_deduplicate = 0 SELECT * FROM %s", task.Name, tempTableName),
@@ -210,8 +211,9 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 
 	queries := []string{
 		fmt.Sprintf(
-			"CREATE TABLE IF NOT EXISTS %s ENGINE = MergeTree() ORDER BY tuple() AS SELECT * FROM (%s) AS __bruin_bootstrap WHERE 1 = 0",
+			"CREATE TABLE IF NOT EXISTS %s ENGINE = MergeTree() ORDER BY tuple()%s AS SELECT * FROM (%s) AS __bruin_bootstrap WHERE 1 = 0",
 			asset.Name,
+			buildPartitionByClause(asset),
 			strings.TrimSuffix(query, ";"),
 		),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN %s AND %s`,
@@ -224,6 +226,15 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 	}
 
 	return queries, nil
+}
+
+func buildPartitionByClause(asset *pipeline.Asset) string {
+	partitionBy := strings.TrimSpace(asset.Materialization.PartitionBy)
+	if partitionBy == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(" PARTITION BY (%s)", partitionBy)
 }
 
 func buildDDLQuery(asset *pipeline.Asset, query string) ([]string, error) {

--- a/pkg/clickhouse/materialization.go
+++ b/pkg/clickhouse/materialization.go
@@ -80,6 +80,12 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) ([]string, error)
 			task.ColumnNamesWithPrimaryKey()[0],
 			query,
 		),
+		fmt.Sprintf(
+			"CREATE TABLE IF NOT EXISTS %s PRIMARY KEY %s AS SELECT * FROM %s LIMIT 0",
+			task.Name,
+			task.ColumnNamesWithPrimaryKey()[0],
+			tempTableName,
+		),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
 		// An identical rerun must replace rows deleted above instead of being
 		// discarded by ClickHouse's block-level insert deduplication.
@@ -142,6 +148,7 @@ func buildMergeQuery(task *pipeline.Asset, query string) ([]string, error) {
 	// deleting target rows. LIMIT 0 performs no write and avoids deduplication.
 	queries := []string{
 		fmt.Sprintf("CREATE TABLE %s ENGINE = MergeTree() PRIMARY KEY (%s) AS %s", tempTableName, keys, query),
+		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s ENGINE = MergeTree() PRIMARY KEY (%s) AS SELECT * FROM %s LIMIT 0", task.Name, keys, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s LIMIT 0", task.Name, tempTableName),
 		fmt.Sprintf("DELETE FROM %s WHERE %s", task.Name, deleteCondition),
 		fmt.Sprintf("INSERT INTO %s SETTINGS insert_deduplicate = 0 SELECT * FROM %s", task.Name, tempTableName),
@@ -202,6 +209,11 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 	}
 
 	queries := []string{
+		fmt.Sprintf(
+			"CREATE TABLE IF NOT EXISTS %s ENGINE = MergeTree() ORDER BY tuple() AS SELECT * FROM (%s) AS __bruin_bootstrap WHERE 1 = 0",
+			asset.Name,
+			strings.TrimSuffix(query, ";"),
+		),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN %s AND %s`,
 			asset.Name,
 			asset.Materialization.IncrementalKey,

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -480,6 +480,78 @@ func TestMaterializer_Render(t *testing.T) {
 	}
 }
 
+func TestIncrementalBootstrapPreservesPartitioning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		asset *pipeline.Asset
+		query string
+	}{
+		{
+			name: "delete+insert",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
+					IncrementalKey: "dt",
+					PartitionBy:    "toYYYYMM(dt)",
+				},
+				Columns: []pipeline.Column{{Name: "id", PrimaryKey: true}},
+			},
+			query: "SELECT 1 AS id, toDate('2026-08-05') AS dt",
+		},
+		{
+			name: "merge",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:        pipeline.MaterializationTypeTable,
+					Strategy:    pipeline.MaterializationStrategyMerge,
+					PartitionBy: "toYYYYMM(dt)",
+				},
+				Columns: []pipeline.Column{{Name: "id", PrimaryKey: true}},
+			},
+			query: "SELECT 1 AS id, toDate('2026-08-05') AS dt",
+		},
+		{
+			name: "time interval",
+			asset: &pipeline.Asset{
+				Name: "my.asset",
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        pipeline.MaterializationStrategyTimeInterval,
+					IncrementalKey:  "dt",
+					TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+					PartitionBy:     "toYYYYMM(dt)",
+				},
+			},
+			query: "SELECT toDate('{{start_date}}') AS dt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			statements, err := NewMaterializer(false).Render(tt.asset, tt.query)
+			require.NoError(t, err)
+
+			var bootstrap string
+			for _, statement := range statements {
+				if strings.HasPrefix(statement, "CREATE TABLE IF NOT EXISTS ") {
+					bootstrap = statement
+					break
+				}
+			}
+
+			require.NotEmpty(t, bootstrap)
+			assert.Contains(t, bootstrap, " PARTITION BY (toYYYYMM(dt)) AS SELECT")
+		})
+	}
+}
+
 func intp(i int) *int { return &i }
 
 func TestColumnMetadataDDL(t *testing.T) {

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -456,6 +457,22 @@ func TestMaterializer_Render(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+			strategy := tt.task.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.wantErr && !tt.fullRefresh && bootstrapStrategy {
+				withoutBootstrap := make([]string, 0, len(render)-1)
+				for _, statement := range render {
+					if strings.HasPrefix(statement, "CREATE TABLE IF NOT EXISTS ") {
+						assert.Contains(t, statement, tt.task.Name)
+						continue
+					}
+					withoutBootstrap = append(withoutBootstrap, statement)
+				}
+				require.Len(t, withoutBootstrap, len(render)-1)
+				render = withoutBootstrap
 			}
 
 			assert.Equal(t, tt.want, render)

--- a/pkg/databricks/materialization.go
+++ b/pkg/databricks/materialization.go
@@ -64,6 +64,7 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) ([]string, error)
 
 	queries := []string{
 		fmt.Sprintf("CREATE TEMPORARY VIEW %s AS %s\n", tempTableName, query),
+		buildCreateTableIfNotExistsQuery(task, "SELECT * FROM "+tempTableName),
 		fmt.Sprintf("\nDELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", task.Name, tempTableName),
 		"DROP VIEW IF EXISTS " + tempTableName,
@@ -122,7 +123,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) ([]string, error) {
 	// Join all lines into a single MERGE statement
 	mergeQuery := strings.Join(mergeLines, "\n")
 
-	return []string{mergeQuery}, nil
+	return []string{buildCreateTableIfNotExistsQuery(asset, query), mergeQuery}, nil
 }
 
 func buildCreateReplaceQuery(task *pipeline.Asset, query string) ([]string, error) {
@@ -162,6 +163,15 @@ func buildCreateReplaceQuery(task *pipeline.Asset, query string) ([]string, erro
 	}, nil
 }
 
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) string {
+	partitionBy := ""
+	if asset.Materialization.PartitionBy != "" {
+		partitionBy = "PARTITIONED BY (" + asset.Materialization.PartitionBy + ")"
+	}
+
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, partitionBy, query)
+}
+
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, error) {
 	if asset.Materialization.IncrementalKey == "" {
 		return nil, errors.New("incremental_key is required for time_interval strategy")
@@ -183,6 +193,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 	}
 
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(asset, query),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,
 			asset.Materialization.IncrementalKey,

--- a/pkg/databricks/materialization_test.go
+++ b/pkg/databricks/materialization_test.go
@@ -699,6 +699,12 @@ func TestMaterializer_Render(t *testing.T) {
 				require.NoError(t, err)
 				// Join all rendered queries for pattern matching
 				fullOutput := strings.Join(render, "\n")
+				strategy := tt.task.Materialization.Strategy
+				if !tt.fullRefresh && (strategy == pipeline.MaterializationStrategyDeleteInsert ||
+					strategy == pipeline.MaterializationStrategyMerge ||
+					strategy == pipeline.MaterializationStrategyTimeInterval) {
+					require.Contains(t, fullOutput, "CREATE TABLE IF NOT EXISTS "+tt.task.Name)
+				}
 				for _, want := range tt.want {
 					require.Regexp(t, want, fullOutput, "Pattern %q not found in output:\n%s", want, fullOutput)
 				}

--- a/pkg/doris/materialization.go
+++ b/pkg/doris/materialization.go
@@ -100,6 +100,10 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 		newRowsAlias,
 		incrementalKey,
 	)
+	bootstrapTable, err := buildCreateTableIfNotExistsQuery(asset, "SELECT * FROM "+quoteIdentifier(newRowsTable))
+	if err != nil {
+		return "", err
+	}
 
 	queries := []string{
 		"DROP TABLE IF EXISTS " + quoteIdentifier(newRowsTable),
@@ -107,6 +111,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 PROPERTIES ("replication_num" = "1")
 AS
 %s`, quoteIdentifier(newRowsTable), trimmedQuery),
+		bootstrapTable,
 		"DROP TABLE IF EXISTS " + quoteIdentifier(replacementTable),
 		fmt.Sprintf(
 			`CREATE TABLE %s
@@ -231,7 +236,12 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)", strings.Join(quoteColumnNames(columnNames), ", "), strings.Join(sourceColumnValues, ", ")),
 	)
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	bootstrapTable, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
+
+	return bootstrapTable + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -254,8 +264,13 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 		startVar = "{{start_date}}"
 		endVar = "{{end_date}}"
 	}
+	bootstrapTable, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
 
 	queries := []string{
+		bootstrapTable,
 		fmt.Sprintf(
 			"DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'",
 			quoteIdentifier(asset.Name),
@@ -267,6 +282,26 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) (string, error) {
+	if requiresTypedCreateTable(asset) {
+		return buildCreateTableStatement(asset, true)
+	}
+
+	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
+	return fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s
+PROPERTIES (%s)
+AS
+SELECT * FROM (
+%s
+) AS %s WHERE 1 = 0`,
+		quoteIdentifier(asset.Name),
+		buildDorisProperties(asset),
+		query,
+		quoteColumnName("__bruin_bootstrap"),
+	), nil
 }
 
 func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {

--- a/pkg/doris/materialization_test.go
+++ b/pkg/doris/materialization_test.go
@@ -1,6 +1,7 @@
 package doris
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -325,9 +326,39 @@ func TestMaterializer_Render(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			strategy := tt.asset.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.fullRefresh && bootstrapStrategy {
+				var found bool
+				got, found = removeDorisBootstrap(got, tt.asset.Name)
+				assert.True(t, found, "incremental SQL should bootstrap a missing target")
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func removeDorisBootstrap(query, tableName string) (string, bool) {
+	start := strings.Index(query, "CREATE TABLE IF NOT EXISTS "+quoteIdentifier(tableName))
+	if start < 0 {
+		return query, false
+	}
+
+	endMarker := ") AS `__bruin_bootstrap` WHERE 1 = 0;\n"
+	end := strings.Index(query[start:], endMarker)
+	if end >= 0 {
+		end += start + len(endMarker)
+		return query[:start] + query[end:], true
+	}
+
+	end = strings.Index(query[start:], ";\n")
+	if end < 0 {
+		return query, false
+	}
+	end += start + len(";\n")
+	return query[:start] + query[end:], true
 }
 
 func TestQuoteIdentifier(t *testing.T) {

--- a/pkg/dremio/materialization.go
+++ b/pkg/dremio/materialization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
@@ -86,6 +87,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 
 	return fmt.Sprintf(
 		`
+%s;
 DELETE FROM %s
 WHERE %s IN (
     SELECT DISTINCT %s
@@ -94,7 +96,7 @@ WHERE %s IN (
 
 INSERT INTO %s
 SELECT * FROM (%s) AS new_data;`,
-		name, key, key, query, name, query,
+		ansisql.BuildCreateTableIfNotExistsAsQuery(name, "", query), name, key, key, query, name, query,
 	), nil
 }
 
@@ -131,12 +133,13 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 
 	return fmt.Sprintf(
 		`
+%s;
 DELETE FROM %s
 WHERE %s BETWEEN %s '%s' AND %s '%s';
 
 INSERT INTO %s
 %s;`,
-		name, key, timePrefix, startVar, timePrefix, endVar, name, query,
+		ansisql.BuildCreateTableIfNotExistsAsQuery(name, "", query), name, key, timePrefix, startVar, timePrefix, endVar, name, query,
 	), nil
 }
 

--- a/pkg/dremio/materialization_test.go
+++ b/pkg/dremio/materialization_test.go
@@ -119,3 +119,30 @@ SELECT * FROM source;`,
 		})
 	}
 }
+
+func TestMaterializer_IncrementalStrategiesBootstrapMissingTable(t *testing.T) {
+	t.Parallel()
+
+	for _, strategy := range []pipeline.MaterializationStrategy{
+		pipeline.MaterializationStrategyDeleteInsert,
+		pipeline.MaterializationStrategyTimeInterval,
+	} {
+		t.Run(string(strategy), func(t *testing.T) {
+			t.Parallel()
+			asset := &pipeline.Asset{
+				Name: "analytics.events",
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        strategy,
+					IncrementalKey:  "event_date",
+					TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+				},
+			}
+
+			got, err := NewMaterializer(false).Render(asset, "SELECT event_date FROM raw_events")
+			require.NoError(t, err)
+			assert.Contains(t, got, "CREATE TABLE IF NOT EXISTS \"analytics\".\"events\" AS")
+			assert.Contains(t, got, "AS __bruin_bootstrap WHERE 1 = 0")
+		})
+	}
+}

--- a/pkg/duckdb/materialization.go
+++ b/pkg/duckdb/materialization.go
@@ -99,6 +99,7 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
 	queries := []string{
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
+		ansisql.BuildCreateTableIfNotExistsAsQuery(task.Name, "", "SELECT * FROM "+tempTableName),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", task.Name, tempTableName),
 		"DROP TABLE IF EXISTS " + tempTableName,
@@ -136,6 +137,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		queries := []string{
 			"BEGIN TRANSACTION",
 			fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, query),
+			ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, "", "SELECT * FROM "+tempTableName),
 			fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s AS source WHERE NOT EXISTS (SELECT 1 FROM %s AS target WHERE %s)",
 				asset.Name, allColumnNames, allColumnNames, tempTableName, asset.Name, onCondition),
 			"DROP TABLE " + tempTableName,
@@ -158,6 +160,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	queries := []string{
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, query),
+		ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, "", "SELECT * FROM "+tempTableName),
 		fmt.Sprintf("UPDATE %s AS target SET %s FROM %s AS source WHERE %s",
 			asset.Name, updateClause, tempTableName, onCondition),
 		fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s AS source WHERE NOT EXISTS (SELECT 1 FROM %s AS target WHERE %s)",
@@ -216,6 +219,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 
 	queries := []string{
 		"BEGIN TRANSACTION",
+		ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, "", query),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,
 			asset.Materialization.IncrementalKey,

--- a/pkg/duckdb/materialization_test.go
+++ b/pkg/duckdb/materialization_test.go
@@ -1,6 +1,7 @@
 package duck
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -355,10 +356,34 @@ COMMIT;`,
 			} else {
 				require.NoError(t, err)
 			}
+			strategy := tt.task.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.wantErr && !tt.fullRefresh && bootstrapStrategy {
+				var found bool
+				render, found = removeDuckDBBootstrap(render, tt.task.Name)
+				assert.True(t, found, "incremental SQL should bootstrap a missing target")
+			}
 
 			assert.Regexp(t, tt.want, render)
 		})
 	}
+}
+
+func removeDuckDBBootstrap(query, tableName string) (string, bool) {
+	start := strings.Index(query, "CREATE TABLE IF NOT EXISTS "+tableName)
+	if start < 0 {
+		return query, false
+	}
+
+	endMarker := ") AS __bruin_bootstrap WHERE 1 = 0;\n"
+	end := strings.Index(query[start:], endMarker)
+	if end < 0 {
+		return query, false
+	}
+	end += start + len(endMarker)
+	return query[:start] + query[end:], true
 }
 
 func TestBuildDDLQuery(t *testing.T) {

--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -91,6 +91,12 @@ func buildDeleteInsertQuery(asset *pipeline.Asset, query string) (string, error)
 	queries := []string{
 		"DROP TABLE IF EXISTS " + tempName,
 		"CREATE TABLE " + tempName + " AS\n" + query,
+		fmt.Sprintf(
+			"IF OBJECT_ID('%s', 'U') IS NULL BEGIN CREATE TABLE %s AS SELECT * FROM %s WHERE 1 = 0 END",
+			strings.ReplaceAll(asset.Name, "'", "''"),
+			tableName,
+			tempName,
+		),
 		"DELETE FROM " + tableName + " WHERE EXISTS (\n  SELECT 1 FROM " + tempName + " WHERE " + deleteCondition + "\n)",
 		"INSERT INTO " + tableName + " SELECT * FROM " + tempName,
 		"DROP TABLE IF EXISTS " + tempName,

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -71,6 +71,7 @@ func TestBuildDeleteInsertQuery(t *testing.T) {
 		expected := "DROP TABLE IF EXISTS [dbo].[Table__bruin_tmp];\n" +
 			"CREATE TABLE [dbo].[Table__bruin_tmp] AS\n" +
 			"SELECT 1;\n" +
+			"IF OBJECT_ID('dbo.Table', 'U') IS NULL BEGIN CREATE TABLE [dbo].[Table] AS SELECT * FROM [dbo].[Table__bruin_tmp] WHERE 1 = 0 END;\n" +
 			"DELETE FROM [dbo].[Table] WHERE EXISTS (\n" +
 			"  SELECT 1 FROM [dbo].[Table__bruin_tmp] WHERE [dbo].[Table].[id] = [dbo].[Table__bruin_tmp].[id]\n" +
 			");\n" +
@@ -90,6 +91,7 @@ func TestBuildDeleteInsertQuery(t *testing.T) {
 		expected := "DROP TABLE IF EXISTS [dbo].[Table__bruin_tmp];\n" +
 			"CREATE TABLE [dbo].[Table__bruin_tmp] AS\n" +
 			"WITH cte AS (SELECT id, val FROM src) SELECT * FROM cte;\n" +
+			"IF OBJECT_ID('dbo.Table', 'U') IS NULL BEGIN CREATE TABLE [dbo].[Table] AS SELECT * FROM [dbo].[Table__bruin_tmp] WHERE 1 = 0 END;\n" +
 			"DELETE FROM [dbo].[Table] WHERE EXISTS (\n" +
 			"  SELECT 1 FROM [dbo].[Table__bruin_tmp] WHERE [dbo].[Table].[id] = [dbo].[Table__bruin_tmp].[id]\n" +
 			");\n" +

--- a/pkg/mssql/materialization.go
+++ b/pkg/mssql/materialization.go
@@ -118,6 +118,7 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
 	queries := []string{
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("SELECT alias.* INTO %s FROM (%s\n) AS alias", tempTableName, query),
+		buildCreateTableIfNotExistsQuery(task, "SELECT * FROM "+tempTableName),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", task.Name, tempTableName),
 		"DROP TABLE IF EXISTS " + tempTableName,
@@ -172,7 +173,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnValues, allColumnValues),
 	}
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	return buildCreateTableIfNotExistsQuery(asset, query) + "\n" + strings.Join(mergeLines, "\n") + ";", nil
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -197,6 +198,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 
 	queries := []string{
 		"BEGIN TRANSACTION",
+		buildCreateTableIfNotExistsQuery(asset, query),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,
 			asset.Materialization.IncrementalKey,
@@ -209,6 +211,16 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, selectQuery string) string {
+	selectQuery = strings.TrimSuffix(strings.TrimSpace(selectQuery), ";")
+	return fmt.Sprintf(
+		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\nSELECT __bruin_bootstrap.* INTO %s FROM (\n%s\n) AS __bruin_bootstrap WHERE 1 = 0\nEND",
+		sqlStringLiteral(asset.Name),
+		quoteIdentifier(asset.Name),
+		selectQuery,
+	)
 }
 
 func quoteIdentifier(identifier string) string {

--- a/pkg/mssql/materialization_test.go
+++ b/pkg/mssql/materialization_test.go
@@ -1,6 +1,7 @@
 package mssql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -377,10 +378,38 @@ func TestMaterializer_Render(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			strategy := tt.task.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.wantErr && !tt.fullRefresh && bootstrapStrategy {
+				var found bool
+				render, found = removeMSSQLBootstrap(render)
+				assert.True(t, found, "incremental SQL should bootstrap a missing target")
+			}
 
 			assert.Regexp(t, tt.want, render)
 		})
 	}
+}
+
+func removeMSSQLBootstrap(query string) (string, bool) {
+	start := strings.Index(query, "IF OBJECT_ID(")
+	if start < 0 {
+		return query, false
+	}
+
+	end := strings.Index(query[start:], "\nEND")
+	if end < 0 {
+		return query, false
+	}
+	end += start + len("\nEND")
+	if strings.HasPrefix(query[end:], ";\n") {
+		end += len(";\n")
+	} else if strings.HasPrefix(query[end:], "\n") {
+		end++
+	}
+	return query[:start] + query[end:], true
 }
 
 func TestCreateReplaceWithTypedColumns(t *testing.T) {

--- a/pkg/mysql/materialization.go
+++ b/pkg/mysql/materialization.go
@@ -70,6 +70,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
 
 	queries := []string{
+		ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, "", query),
 		"START TRANSACTION",
 		"DROP TEMPORARY TABLE IF EXISTS " + tempTableName,
 		fmt.Sprintf("CREATE TEMPORARY TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
@@ -135,6 +136,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	queries := []string{
+		ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, "", query),
 		"START TRANSACTION",
 		fmt.Sprintf("DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'",
 			asset.Name,
@@ -216,6 +218,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	onClause = strings.Join(ansisql.AddIncrementalPredicate([]string{onClause}, asset.Materialization.IncrementalPredicate), " AND ")
 
 	queries := []string{
+		ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, "", trimmedQuery),
 		"START TRANSACTION",
 		"DROP TEMPORARY TABLE IF EXISTS " + tempTableName,
 		fmt.Sprintf("CREATE TEMPORARY TABLE %s AS\n%s", tempTableName, trimmedQuery),

--- a/pkg/mysql/materialization_test.go
+++ b/pkg/mysql/materialization_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -548,6 +549,15 @@ COMMIT;$`,
 			}
 
 			require.NoError(t, err)
+			strategy := tt.asset.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.fullRefresh && bootstrapStrategy {
+				var found bool
+				got, found = removeMySQLBootstrap(got, tt.asset.Name)
+				assert.True(t, found, "incremental SQL should bootstrap a missing target")
+			}
 			switch {
 			case tt.wantRegex != nil:
 				assert.Regexp(t, tt.wantRegex, got)
@@ -565,4 +575,19 @@ COMMIT;$`,
 			}
 		})
 	}
+}
+
+func removeMySQLBootstrap(query, tableName string) (string, bool) {
+	start := strings.Index(query, "CREATE TABLE IF NOT EXISTS "+tableName)
+	if start < 0 {
+		return query, false
+	}
+
+	endMarker := ") AS __bruin_bootstrap WHERE 1 = 0;\n"
+	end := strings.Index(query[start:], endMarker)
+	if end < 0 {
+		return query, false
+	}
+	end += start + len(endMarker)
+	return query[:start] + query[end:], true
 }

--- a/pkg/oracle/materialization.go
+++ b/pkg/oracle/materialization.go
@@ -185,12 +185,16 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 		endVar = "{{end_date}}"
 	}
 
-	return fmt.Sprintf(`BEGIN
-   DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s';
-   INSERT INTO %s
-%s
-;
-END;`, asset.Name, asset.Materialization.IncrementalKey, startVar, endVar, asset.Name, query), nil
+	deleteQuery := fmt.Sprintf(
+		"DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'",
+		asset.Name,
+		asset.Materialization.IncrementalKey,
+		startVar,
+		endVar,
+	)
+	insertQuery := fmt.Sprintf("INSERT INTO %s\n%s", asset.Name, query)
+
+	return buildIncrementalPLSQLBlock(asset, query, deleteQuery, insertQuery), nil
 }
 
 func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {
@@ -269,18 +273,18 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
 
 	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
 
-	// Wrap DELETE + INSERT in a single PL/SQL block so both DML statements
-	// execute atomically through the Go driver in one ExecContext call.
 	// Uses EXISTS instead of IN (SELECT DISTINCT ...) to let Oracle's optimizer
 	// choose the best semi-join strategy without forcing a full DISTINCT sort.
-	return fmt.Sprintf(`BEGIN
-   DELETE FROM %s t WHERE EXISTS (
-      SELECT 1 FROM (%s) s WHERE s.%s = t.%s
-   );
-   INSERT INTO %s
-%s
-;
-END;`, task.Name, query, mat.IncrementalKey, mat.IncrementalKey, task.Name, query), nil
+	deleteQuery := fmt.Sprintf(
+		"DELETE FROM %s t WHERE EXISTS (\n   SELECT 1 FROM (%s) s WHERE s.%s = t.%s\n)",
+		task.Name,
+		query,
+		mat.IncrementalKey,
+		mat.IncrementalKey,
+	)
+	insertQuery := fmt.Sprintf("INSERT INTO %s\n%s", task.Name, query)
+
+	return buildIncrementalPLSQLBlock(task, query, deleteQuery, insertQuery), nil
 }
 
 func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -332,7 +336,38 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 	}
 	mergeLines = append(mergeLines, fmt.Sprintf("WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)", insertCols, getSourcePrefix(columnNames)))
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	return buildIncrementalPLSQLBlock(asset, query, strings.Join(mergeLines, "\n")), nil
+}
+
+// buildIncrementalPLSQLBlock defers parsing the incremental DML until after the
+// target has been created. Static SQL inside the block would be resolved before
+// the bootstrap DDL runs and would still fail with ORA-00942 on a first run.
+func buildIncrementalPLSQLBlock(asset *pipeline.Asset, query string, dmlStatements ...string) string {
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+	createTable := fmt.Sprintf(
+		"CREATE TABLE %s AS SELECT * FROM (%s) __bruin_bootstrap WHERE 1 = 0",
+		asset.Name,
+		query,
+	)
+
+	lines := []string{
+		"BEGIN",
+		"   BEGIN",
+		fmt.Sprintf("      EXECUTE IMMEDIATE '%s';", escapeOracleString(createTable)),
+		"   EXCEPTION",
+		"      WHEN OTHERS THEN",
+		"         IF SQLCODE != -955 THEN",
+		"            RAISE;",
+		"         END IF;",
+		"   END;",
+	}
+	for _, statement := range dmlStatements {
+		statement = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(statement), ";"))
+		lines = append(lines, fmt.Sprintf("   EXECUTE IMMEDIATE '%s';", escapeOracleString(statement)))
+	}
+	lines = append(lines, "END;")
+
+	return strings.Join(lines, "\n")
 }
 
 func getSourcePrefix(columns []string) string {

--- a/pkg/oracle/materialization.go
+++ b/pkg/oracle/materialization.go
@@ -350,7 +350,9 @@ func buildIncrementalPLSQLBlock(asset *pipeline.Asset, query string, dmlStatemen
 		query,
 	)
 
-	lines := []string{
+	lines := make([]string, 0, 10+len(dmlStatements))
+	lines = append(
+		lines,
 		"BEGIN",
 		"   BEGIN",
 		fmt.Sprintf("      EXECUTE IMMEDIATE '%s';", escapeOracleString(createTable)),
@@ -360,7 +362,7 @@ func buildIncrementalPLSQLBlock(asset *pipeline.Asset, query string, dmlStatemen
 		"            RAISE;",
 		"         END IF;",
 		"   END;",
-	}
+	)
 	for _, statement := range dmlStatements {
 		statement = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(statement), ";"))
 		lines = append(lines, fmt.Sprintf("   EXECUTE IMMEDIATE '%s';", escapeOracleString(statement)))

--- a/pkg/oracle/materialization_test.go
+++ b/pkg/oracle/materialization_test.go
@@ -125,6 +125,7 @@ func TestMaterializer_Render(t *testing.T) {
 				},
 			},
 			query: "SELECT 1 as dt",
+			//nolint:dupword // The expected output contains nested PL/SQL BEGIN blocks.
 			want: `BEGIN
 	BEGIN
 		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as dt) __bruin_bootstrap WHERE 1 = 0';
@@ -183,6 +184,7 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
+			//nolint:dupword // The expected output contains nested PL/SQL BEGIN blocks.
 			want: `BEGIN
 	BEGIN
 		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as id, ''abc'' as name) __bruin_bootstrap WHERE 1 = 0';
@@ -214,6 +216,7 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
+			//nolint:dupword // The expected output contains nested PL/SQL BEGIN blocks.
 			want: `BEGIN
 	BEGIN
 		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as id, ''abc'' as name) __bruin_bootstrap WHERE 1 = 0';
@@ -245,6 +248,7 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
+			//nolint:dupword // The expected output contains nested PL/SQL BEGIN blocks.
 			want: `BEGIN
 	BEGIN
 		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as id, ''abc'' as name) __bruin_bootstrap WHERE 1 = 0';

--- a/pkg/oracle/materialization_test.go
+++ b/pkg/oracle/materialization_test.go
@@ -330,6 +330,7 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as ts",
+			//nolint:dupword // The expected output contains nested PL/SQL BEGIN blocks.
 			want: `BEGIN
 	BEGIN
 		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as ts) __bruin_bootstrap WHERE 1 = 0';
@@ -356,6 +357,7 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as dt",
+			//nolint:dupword // The expected output contains nested PL/SQL BEGIN blocks.
 			want: `BEGIN
 	BEGIN
 		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as dt) __bruin_bootstrap WHERE 1 = 0';

--- a/pkg/oracle/materialization_test.go
+++ b/pkg/oracle/materialization_test.go
@@ -126,12 +126,19 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 			query: "SELECT 1 as dt",
 			want: `BEGIN
-   DELETE FROM my.asset t WHERE EXISTS (
-      SELECT 1 FROM (SELECT 1 as dt) s WHERE s.dt = t.dt
-   );
-   INSERT INTO my.asset
-SELECT 1 as dt
-;
+	BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as dt) __bruin_bootstrap WHERE 1 = 0';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;
+	EXECUTE IMMEDIATE 'DELETE FROM my.asset t WHERE EXISTS (
+   SELECT 1 FROM (SELECT 1 as dt) s WHERE s.dt = t.dt
+)';
+	EXECUTE IMMEDIATE 'INSERT INTO my.asset
+SELECT 1 as dt';
 END;`,
 		},
 		{
@@ -176,7 +183,22 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
-			want:  "MERGE INTO my.asset target\nUSING (\nSELECT 1 as id, 'abc' as name\n) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))\nWHEN MATCHED THEN UPDATE SET target.name = source.name\nWHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);",
+			want: `BEGIN
+	BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as id, ''abc'' as name) __bruin_bootstrap WHERE 1 = 0';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;
+	EXECUTE IMMEDIATE 'MERGE INTO my.asset target
+USING (
+SELECT 1 as id, ''abc'' as name
+) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))
+WHEN MATCHED THEN UPDATE SET target.name = source.name
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)';
+END;`,
 		},
 		{
 			name: "merge with custom MergeSQL expression",
@@ -192,7 +214,22 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
-			want:  "MERGE INTO my.asset target\nUSING (\nSELECT 1 as id, 'abc' as name\n) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))\nWHEN MATCHED THEN UPDATE SET target.name = COALESCE(source.name, target.name)\nWHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);",
+			want: `BEGIN
+	BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as id, ''abc'' as name) __bruin_bootstrap WHERE 1 = 0';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;
+	EXECUTE IMMEDIATE 'MERGE INTO my.asset target
+USING (
+SELECT 1 as id, ''abc'' as name
+) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))
+WHEN MATCHED THEN UPDATE SET target.name = COALESCE(source.name, target.name)
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)';
+END;`,
 		},
 		{
 			name: "merge insert-only, no UpdateOnMerge columns",
@@ -208,7 +245,21 @@ END;`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
-			want:  "MERGE INTO my.asset target\nUSING (\nSELECT 1 as id, 'abc' as name\n) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))\nWHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);",
+			want: `BEGIN
+	BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as id, ''abc'' as name) __bruin_bootstrap WHERE 1 = 0';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;
+	EXECUTE IMMEDIATE 'MERGE INTO my.asset target
+USING (
+SELECT 1 as id, ''abc'' as name
+) source ON ((target.id = source.id OR (target.id IS NULL AND source.id IS NULL)))
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)';
+END;`,
 		},
 		{
 			name: "semicolon trimming and schema-qualified table name",
@@ -276,10 +327,17 @@ END;`,
 			},
 			query: "SELECT 1 as ts",
 			want: `BEGIN
-   DELETE FROM my.asset WHERE ts BETWEEN '{{start_timestamp}}' AND '{{end_timestamp}}';
-   INSERT INTO my.asset
-SELECT 1 as ts
-;
+	BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as ts) __bruin_bootstrap WHERE 1 = 0';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;
+	EXECUTE IMMEDIATE 'DELETE FROM my.asset WHERE ts BETWEEN ''{{start_timestamp}}'' AND ''{{end_timestamp}}''';
+	EXECUTE IMMEDIATE 'INSERT INTO my.asset
+SELECT 1 as ts';
 END;`,
 		},
 		{
@@ -295,10 +353,17 @@ END;`,
 			},
 			query: "SELECT 1 as dt",
 			want: `BEGIN
-   DELETE FROM my.asset WHERE dt BETWEEN '{{start_date}}' AND '{{end_date}}';
-   INSERT INTO my.asset
-SELECT 1 as dt
-;
+	BEGIN
+		EXECUTE IMMEDIATE 'CREATE TABLE my.asset AS SELECT * FROM (SELECT 1 as dt) __bruin_bootstrap WHERE 1 = 0';
+	EXCEPTION
+		WHEN OTHERS THEN
+			IF SQLCODE != -955 THEN
+				RAISE;
+			END IF;
+	END;
+	EXECUTE IMMEDIATE 'DELETE FROM my.asset WHERE dt BETWEEN ''{{start_date}}'' AND ''{{end_date}}''';
+	EXECUTE IMMEDIATE 'INSERT INTO my.asset
+SELECT 1 as dt';
 END;`,
 		},
 		{
@@ -400,7 +465,8 @@ END;`,
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				if !assert.Equal(t, tt.want, render) {
+				want := strings.ReplaceAll(tt.want, "\t", "   ")
+				if !assert.Equal(t, want, render) {
 					t.Logf("\nWant:\n%s\nGot:\n%s", tt.want, render)
 				}
 			}

--- a/pkg/pipeline/materializer.go
+++ b/pkg/pipeline/materializer.go
@@ -215,6 +215,38 @@ func (m HookWrapperMaterializerListWithLocation) Render(asset *Asset, query, loc
 	return wrapHookQueriesList(materialized, asset.Hooks, m.Hoister, asset.Type), nil
 }
 
+// RenderInitialTable forwards optional first-run table initialization used by
+// location-aware materializers such as Athena.
+func (m HookWrapperMaterializerListWithLocation) RenderInitialTable(asset *Asset, query, location string) ([]string, error) {
+	if m.Mat == nil {
+		return nil, errors.New("hook wrapper materializer requires a base materializer")
+	}
+
+	initializer, ok := m.Mat.(interface {
+		RenderInitialTable(asset *Asset, query, location string) ([]string, error)
+	})
+	if !ok {
+		return nil, errors.New("base materializer does not support initial table rendering")
+	}
+
+	return initializer.RenderInitialTable(asset, query, location)
+}
+
+// InitialTableInsertionIndex keeps first-run table initialization after any
+// pre-hooks that may prepare objects referenced by the asset query.
+func (m HookWrapperMaterializerListWithLocation) InitialTableInsertionIndex(asset *Asset) int {
+	return len(formatHookQueries(asset.Hooks.Pre))
+}
+
+func (m HookWrapperMaterializerListWithLocation) IsFullRefresh() bool {
+	if m.Mat == nil {
+		return false
+	}
+
+	fullRefresh, ok := m.Mat.(interface{ IsFullRefresh() bool })
+	return ok && fullRefresh.IsFullRefresh()
+}
+
 func (m HookWrapperMaterializerListWithLocation) LogIfFullRefreshAndDDL(writer interface{}, asset *Asset) error {
 	if m.Mat == nil {
 		return errors.New("hook wrapper materializer requires a base materializer")

--- a/pkg/pipeline/materializer_test.go
+++ b/pkg/pipeline/materializer_test.go
@@ -169,8 +169,23 @@ func (m listMaterializerWithCleanup) RenderWithCleanup(_ *Asset, _ string) ([]st
 }
 
 type listWithLocationMaterializer struct {
-	out         []string
-	gotLocation string
+	out              []string
+	initialOut       []string
+	gotLocation      string
+	gotInitialQuery  string
+	gotInitialTarget string
+	fullRefresh      bool
+}
+
+func (m *listWithLocationMaterializer) RenderInitialTable(asset *Asset, query, location string) ([]string, error) {
+	m.gotInitialTarget = asset.Name
+	m.gotInitialQuery = query
+	m.gotLocation = location
+	return m.initialOut, nil
+}
+
+func (m *listWithLocationMaterializer) IsFullRefresh() bool {
+	return m.fullRefresh
 }
 
 func (m *listWithLocationMaterializer) Render(_ *Asset, _ string, location string) ([]string, error) {
@@ -258,4 +273,27 @@ func TestHookWrapperMaterializerListWithLocation_Render(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"select 1;", "select 3", "select 2;"}, got)
 	assert.Equal(t, "s3://bucket", base.gotLocation)
+}
+
+func TestHookWrapperMaterializerListWithLocation_IncrementalInitialization(t *testing.T) {
+	t.Parallel()
+
+	asset := &Asset{
+		Name:  "analytics.events",
+		Hooks: Hooks{Pre: []Hook{{Query: "prepare raw events"}}},
+	}
+	base := &listWithLocationMaterializer{
+		initialOut:  []string{"create empty table"},
+		fullRefresh: true,
+	}
+	wrapper := HookWrapperMaterializerListWithLocation{Mat: base}
+
+	got, err := wrapper.RenderInitialTable(asset, "select event_date from raw_events", "s3://bucket")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"create empty table"}, got)
+	assert.Equal(t, asset.Name, base.gotInitialTarget)
+	assert.Equal(t, "select event_date from raw_events", base.gotInitialQuery)
+	assert.Equal(t, "s3://bucket", base.gotLocation)
+	assert.True(t, wrapper.IsFullRefresh())
+	assert.Equal(t, 1, wrapper.InitialTableInsertionIndex(asset))
 }

--- a/pkg/postgres/materialization.go
+++ b/pkg/postgres/materialization.go
@@ -75,10 +75,15 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
 
 	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
 	quotedIncrementalKey := QuoteIdentifier(mat.IncrementalKey)
+	bootstrap := ansisql.BuildCreateTableIfNotExistsAsQuery(QuoteIdentifier(task.Name), "", "SELECT * FROM "+tempTableName)
+	if task.Type == pipeline.AssetTypeRedshiftQuery {
+		bootstrap = buildRedshiftCreateTableIfNotExistsLike(task.Name, tempTableName)
+	}
 
 	queries := []string{
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
+		bootstrap,
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", QuoteIdentifier(task.Name), quotedIncrementalKey, quotedIncrementalKey, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", QuoteIdentifier(task.Name), tempTableName),
 		"DROP TABLE IF EXISTS " + tempTableName,
@@ -169,7 +174,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnNamesStr, allColumnValuesStr),
 	}
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(QuoteIdentifier(asset.Name), "", query) + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
 }
 
 func buildRedshiftMergeQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -226,14 +231,28 @@ func buildRedshiftMergeQuery(asset *pipeline.Asset, query string) (string, error
 		whenMatchedThenQuery = "WHEN MATCHED THEN UPDATE SET " + matchedUpdateQuery
 	}
 
+	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
 	mergeLines := []string{
 		"MERGE INTO " + targetTableName,
-		fmt.Sprintf("USING (%s) source ON %s", strings.TrimSuffix(query, ";"), onQuery),
+		fmt.Sprintf("USING %s source ON %s", tempTableName, onQuery),
 		whenMatchedThenQuery,
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnNamesStr, allColumnValuesStr),
 	}
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	queries := []string{
+		"BEGIN TRANSACTION",
+		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
+		buildRedshiftCreateTableIfNotExistsLike(asset.Name, tempTableName),
+		strings.Join(mergeLines, "\n"),
+		"DROP TABLE IF EXISTS " + tempTableName,
+		"COMMIT",
+	}
+
+	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildRedshiftCreateTableIfNotExistsLike(tableName, sourceTableName string) string {
+	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (LIKE %s)", QuoteIdentifier(tableName), sourceTableName)
 }
 
 func buildCreateReplaceQuery(task *pipeline.Asset, query string) (string, error) {
@@ -277,9 +296,13 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	if asset.Materialization.TimeGranularity != pipeline.MaterializationTimeGranularityTimestamp && asset.Materialization.TimeGranularity != pipeline.MaterializationTimeGranularityDate {
 		return "", errors.New("time_granularity must be either 'date', or 'timestamp'")
 	}
+	if asset.Type == pipeline.AssetTypeRedshiftQuery {
+		return buildRedshiftTimeIntervalQuery(asset, query, startVar, endVar), nil
+	}
 	quotedIncrementalKey := QuoteIdentifier(asset.Materialization.IncrementalKey)
 	queries := []string{
 		"BEGIN TRANSACTION",
+		ansisql.BuildCreateTableIfNotExistsAsQuery(QuoteIdentifier(asset.Name), "", query),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			QuoteIdentifier(asset.Name),
 			quotedIncrementalKey,
@@ -292,6 +315,27 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildRedshiftTimeIntervalQuery(asset *pipeline.Asset, query, startVar, endVar string) string {
+	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
+	queries := []string{
+		"BEGIN TRANSACTION",
+		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
+		buildRedshiftCreateTableIfNotExistsLike(asset.Name, tempTableName),
+		fmt.Sprintf(
+			`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
+			QuoteIdentifier(asset.Name),
+			QuoteIdentifier(asset.Materialization.IncrementalKey),
+			startVar,
+			endVar,
+		),
+		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", QuoteIdentifier(asset.Name), tempTableName),
+		"DROP TABLE IF EXISTS " + tempTableName,
+		"COMMIT",
+	}
+
+	return strings.Join(queries, ";\n") + ";"
 }
 
 func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {

--- a/pkg/postgres/materialization_test.go
+++ b/pkg/postgres/materialization_test.go
@@ -139,6 +139,26 @@ COMMIT;`,
 				"COMMIT;$",
 		},
 		{
+			name: "redshift delete+insert bootstraps with like",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Type: pipeline.AssetTypeRedshiftQuery,
+				Materialization: pipeline.Materialization{
+					Type:           pipeline.MaterializationTypeTable,
+					Strategy:       pipeline.MaterializationStrategyDeleteInsert,
+					IncrementalKey: "dt",
+				},
+			},
+			query: "SELECT 1 as id, current_date as dt",
+			want: `^BEGIN TRANSACTION;
+CREATE TEMP TABLE __bruin_tmp_.+ AS SELECT 1 as id, current_date as dt;
+CREATE TABLE IF NOT EXISTS "my"\."asset" \(LIKE __bruin_tmp_.+\);
+DELETE FROM "my"\."asset" WHERE "dt" in \(SELECT DISTINCT "dt" FROM __bruin_tmp_.+\);
+INSERT INTO "my"\."asset" SELECT \* FROM __bruin_tmp_.+;
+DROP TABLE IF EXISTS __bruin_tmp_.+;
+COMMIT;$`,
+		},
+		{
 			name: "merge without columns",
 			task: &pipeline.Asset{
 				Name: "my.asset",
@@ -205,7 +225,7 @@ WHEN NOT MATCHED THEN INSERT\("id", "name"\) VALUES\("id", "name"\);$`,
 			name: "redshift merge with primary keys",
 			task: &pipeline.Asset{
 				Name: "my.asset",
-				Type: "rs.sql",
+				Type: pipeline.AssetTypeRedshiftQuery,
 				Materialization: pipeline.Materialization{
 					Type:     pipeline.MaterializationTypeTable,
 					Strategy: pipeline.MaterializationStrategyMerge,
@@ -216,10 +236,15 @@ WHEN NOT MATCHED THEN INSERT\("id", "name"\) VALUES\("id", "name"\);$`,
 				},
 			},
 			query: "SELECT 1 as id, 'abc' as name",
-			want: `^MERGE INTO "my"\."asset"
-USING \(SELECT 1 as id, 'abc' as name\) source ON "my"\."asset"\."id" = source\."id"
+			want: `^BEGIN TRANSACTION;
+CREATE TEMP TABLE __bruin_tmp_.+ AS SELECT 1 as id, 'abc' as name;
+CREATE TABLE IF NOT EXISTS "my"\."asset" \(LIKE __bruin_tmp_.+\);
+MERGE INTO "my"\."asset"
+USING __bruin_tmp_.+ source ON "my"\."asset"\."id" = source\."id"
 WHEN MATCHED THEN UPDATE SET "name" = source\."name"
-WHEN NOT MATCHED THEN INSERT\("id", "name"\) VALUES\(source."id", source."name"\);$`,
+WHEN NOT MATCHED THEN INSERT\("id", "name"\) VALUES\(source."id", source."name"\);
+DROP TABLE IF EXISTS __bruin_tmp_.+;
+COMMIT;$`,
 		},
 		{
 			name: "merge with incremental predicate",
@@ -388,6 +413,27 @@ WHEN NOT MATCHED THEN INSERT\("id", "col_a"\) VALUES\("id", "col_a"\);$`,
 				`COMMIT;$`,
 		},
 		{
+			name: "redshift time_interval bootstraps with like",
+			task: &pipeline.Asset{
+				Name: "my.asset",
+				Type: pipeline.AssetTypeRedshiftQuery,
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        pipeline.MaterializationStrategyTimeInterval,
+					TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+					IncrementalKey:  "dt",
+				},
+			},
+			query: "SELECT dt, event_name from source_table where dt between '{{start_date}}' and '{{end_date}}'",
+			want: `^BEGIN TRANSACTION;
+CREATE TEMP TABLE __bruin_tmp_.+ AS SELECT dt, event_name from source_table where dt between '\{\{start_date\}\}' and '\{\{end_date\}\}';
+CREATE TABLE IF NOT EXISTS "my"\."asset" \(LIKE __bruin_tmp_.+\);
+DELETE FROM "my"\."asset" WHERE "dt" BETWEEN '\{\{start_date\}\}' AND '\{\{end_date\}\}';
+INSERT INTO "my"\."asset" SELECT \* FROM __bruin_tmp_.+;
+DROP TABLE IF EXISTS __bruin_tmp_.+;
+COMMIT;$`,
+		},
+		{
 			name: "empty table",
 			task: &pipeline.Asset{
 				Name: "empty_table",
@@ -491,10 +537,34 @@ WHEN NOT MATCHED THEN INSERT\("id", "col_a"\) VALUES\("id", "col_a"\);$`,
 			} else {
 				require.NoError(t, err)
 			}
+			strategy := tt.task.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyMerge ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.wantErr && !tt.fullRefresh && bootstrapStrategy && tt.task.Type != pipeline.AssetTypeRedshiftQuery {
+				var found bool
+				render, found = removePostgresBootstrap(render, tt.task.Name)
+				assert.True(t, found, "incremental SQL should bootstrap a missing target")
+			}
 
 			assert.Regexp(t, tt.want, render)
 		})
 	}
+}
+
+func removePostgresBootstrap(query, tableName string) (string, bool) {
+	start := strings.Index(query, "CREATE TABLE IF NOT EXISTS "+QuoteIdentifier(tableName))
+	if start < 0 {
+		return query, false
+	}
+
+	endMarker := ") AS __bruin_bootstrap WHERE 1 = 0;\n"
+	end := strings.Index(query[start:], endMarker)
+	if end < 0 {
+		return query, false
+	}
+	end += start + len(endMarker)
+	return query[:start] + query[end:], true
 }
 
 func TestDataVaultMaterializations(t *testing.T) {

--- a/pkg/sail/materialization.go
+++ b/pkg/sail/materialization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
@@ -86,6 +87,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 
 	return fmt.Sprintf(
 		`
+%s;
 DELETE FROM %s
 WHERE %s IN (
     SELECT DISTINCT %s
@@ -94,7 +96,7 @@ WHERE %s IN (
 
 INSERT INTO %s
 SELECT * FROM (%s) AS new_data;`,
-		name, key, key, query, name, query,
+		buildCreateTableIfNotExistsQuery(asset, query), name, key, key, query, name, query,
 	), nil
 }
 
@@ -131,13 +133,23 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 
 	return fmt.Sprintf(
 		`
+%s;
 DELETE FROM %s
 WHERE %s BETWEEN %s '%s' AND %s '%s';
 
 INSERT INTO %s
 %s;`,
-		name, key, timePrefix, startVar, timePrefix, endVar, name, query,
+		buildCreateTableIfNotExistsQuery(asset, query), name, key, timePrefix, startVar, timePrefix, endVar, name, query,
 	), nil
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) string {
+	partitionBy := ""
+	if asset.Materialization.PartitionBy != "" {
+		partitionBy = "PARTITIONED BY (" + asset.Materialization.PartitionBy + ")"
+	}
+
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(quoteIdentifier(asset.Name), partitionBy, query)
 }
 
 func buildDDLQuery(asset *pipeline.Asset, query string) (string, error) {

--- a/pkg/sail/materialization_test.go
+++ b/pkg/sail/materialization_test.go
@@ -116,3 +116,31 @@ func TestMaterializer_Render(t *testing.T) {
 		})
 	}
 }
+
+func TestMaterializer_IncrementalStrategiesBootstrapMissingTable(t *testing.T) {
+	t.Parallel()
+
+	for _, strategy := range []pipeline.MaterializationStrategy{
+		pipeline.MaterializationStrategyDeleteInsert,
+		pipeline.MaterializationStrategyTimeInterval,
+	} {
+		t.Run(string(strategy), func(t *testing.T) {
+			t.Parallel()
+			asset := &pipeline.Asset{
+				Name: "analytics.events",
+				Materialization: pipeline.Materialization{
+					Type:            pipeline.MaterializationTypeTable,
+					Strategy:        strategy,
+					IncrementalKey:  "event_date",
+					TimeGranularity: pipeline.MaterializationTimeGranularityDate,
+					PartitionBy:     "event_date",
+				},
+			}
+
+			got, err := NewMaterializer(false).Render(asset, "SELECT event_date FROM raw_events")
+			require.NoError(t, err)
+			assert.Contains(t, got, "CREATE TABLE IF NOT EXISTS `analytics`.`events` PARTITIONED BY (event_date) AS")
+			assert.Contains(t, got, "AS __bruin_bootstrap WHERE 1 = 0")
+		})
+	}
+}

--- a/pkg/snowflake/materialization.go
+++ b/pkg/snowflake/materialization.go
@@ -61,6 +61,7 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
 	tempTableName := "__bruin_tmp_" + helpers.PrefixGenerator()
 
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(task, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("CREATE TEMP TABLE %s AS %s", tempTableName, strings.TrimSuffix(query, ";")),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
@@ -88,6 +89,15 @@ func buildCreateReplaceQuery(task *pipeline.Asset, query string) (string, error)
 	}
 
 	return fmt.Sprintf("CREATE OR REPLACE TABLE %s %s AS\n%s", task.Name, clusterByClause, query), nil
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) string {
+	clusterByClause := ""
+	if len(asset.Materialization.ClusterBy) > 0 {
+		clusterByClause = fmt.Sprintf("CLUSTER BY (%s)", strings.Join(asset.Materialization.ClusterBy, ", "))
+	}
+
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(asset.Name, clusterByClause, query)
 }
 
 func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -135,7 +145,7 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnValues, allColumnValues),
 	}
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	return buildCreateTableIfNotExistsQuery(asset, query) + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -157,6 +167,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 		return "", errors.New("time_granularity must be either 'date', or 'timestamp'")
 	}
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(asset, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,

--- a/pkg/snowflake/materialization_test.go
+++ b/pkg/snowflake/materialization_test.go
@@ -427,12 +427,23 @@ func TestMaterializer_Render(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				if !tt.fullRefresh && isBootstrapStrategy(tt.task.Materialization.Strategy) {
+					bootstrap := buildCreateTableIfNotExistsQuery(tt.task, tt.query) + ";\n"
+					require.Contains(t, render, bootstrap)
+					render = strings.Replace(render, bootstrap, "", 1)
+				}
 				if !assert.Regexp(t, tt.want, render) {
 					t.Logf("\nWant (regex): %s\nGot: %s", tt.want, render)
 				}
 			}
 		})
 	}
+}
+
+func isBootstrapStrategy(strategy pipeline.MaterializationStrategy) bool {
+	return strategy == pipeline.MaterializationStrategyDeleteInsert ||
+		strategy == pipeline.MaterializationStrategyMerge ||
+		strategy == pipeline.MaterializationStrategyTimeInterval
 }
 
 func TestBuildSCD2ByColumnQuery(t *testing.T) {

--- a/pkg/spark/materialization.go
+++ b/pkg/spark/materialization.go
@@ -172,7 +172,13 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		),
 	)
 
-	return strings.Join(lines, "\n") + ";", nil
+	partitionBy := ""
+	if asset.Materialization.PartitionBy != "" {
+		partitionBy = "PARTITIONED BY (" + asset.Materialization.PartitionBy + ")"
+	}
+	bootstrap := ansisql.BuildCreateTableIfNotExistsAsQuery(quoteIdentifier(asset.Name), partitionBy, query)
+
+	return bootstrap + ";\n" + strings.Join(lines, "\n") + ";", nil
 }
 
 func buildSCD2ByColumnFullRefresh(asset *pipeline.Asset, query string) (string, error) {

--- a/pkg/spark/materialization_test.go
+++ b/pkg/spark/materialization_test.go
@@ -32,7 +32,11 @@ func TestMaterializerMerge(t *testing.T) {
 	actual, err := NewMaterializer(false).Render(asset, "SELECT * FROM updates;")
 	require.NoError(t, err)
 	require.Equal(
-		t, "MERGE INTO `catalog`.`analytics`.`accounts` target\n"+
+		t, "CREATE TABLE IF NOT EXISTS `catalog`.`analytics`.`accounts` AS\n"+
+			"SELECT * FROM (\n"+
+			"SELECT * FROM updates\n"+
+			") AS __bruin_bootstrap WHERE 1 = 0;\n"+
+			"MERGE INTO `catalog`.`analytics`.`accounts` target\n"+
 			"USING (SELECT * FROM updates) source\n"+
 			"ON source.`account_id` <=> target.`account_id` AND source.`account_type` <=> target.`account_type` AND (target.created_at >= DATE '2026-01-01')\n"+
 			"WHEN MATCHED THEN UPDATE SET target.`account_name` = source.`account_name`, target.`score` = GREATEST(target.score, source.score)\n"+
@@ -209,6 +213,7 @@ func TestMaterializerQuotesIncrementalKeys(t *testing.T) {
 
 			actual, err := NewMaterializer(false).Render(asset, "SELECT * FROM updates")
 			require.NoError(t, err)
+			require.Contains(t, actual, "CREATE TABLE IF NOT EXISTS `catalog`.`analytics`.`events` AS")
 			require.Contains(t, actual, test.expected)
 		})
 	}

--- a/pkg/starrocks/materialization.go
+++ b/pkg/starrocks/materialization.go
@@ -101,6 +101,10 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 		newRowsAlias,
 		incrementalKey,
 	)
+	bootstrapTable, err := buildCreateTableIfNotExistsQuery(asset, "SELECT * FROM "+quoteIdentifier(newRowsTable))
+	if err != nil {
+		return "", err
+	}
 
 	queries := []string{
 		"DROP TABLE IF EXISTS " + quoteIdentifier(newRowsTable),
@@ -108,6 +112,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 PROPERTIES ("replication_num" = "1")
 AS
 %s`, quoteIdentifier(newRowsTable), trimmedQuery),
+		bootstrapTable,
 		"DROP TABLE IF EXISTS " + quoteIdentifier(replacementTable),
 		fmt.Sprintf(
 			`CREATE TABLE %s
@@ -242,8 +247,13 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 		startVar = "{{start_date}}"
 		endVar = "{{end_date}}"
 	}
+	bootstrapTable, err := buildCreateTableIfNotExistsQuery(asset, query)
+	if err != nil {
+		return "", err
+	}
 
 	queries := []string{
+		bootstrapTable,
 		fmt.Sprintf(
 			"DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'",
 			quoteIdentifier(asset.Name),
@@ -255,6 +265,26 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	return strings.Join(queries, ";\n") + ";", nil
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) (string, error) {
+	if requiresTypedCreateTable(asset) {
+		return buildCreateTableStatement(asset, true)
+	}
+
+	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
+	return fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s
+PROPERTIES (%s)
+AS
+SELECT * FROM (
+%s
+) AS %s WHERE 1 = 0`,
+		quoteIdentifier(asset.Name),
+		buildStarRocksProperties(asset),
+		query,
+		quoteColumnName("__bruin_bootstrap"),
+	), nil
 }
 
 func buildDDLQuery(asset *pipeline.Asset, _ string) (string, error) {

--- a/pkg/starrocks/materialization_test.go
+++ b/pkg/starrocks/materialization_test.go
@@ -1,6 +1,7 @@
 package starrocks
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -348,9 +349,32 @@ func TestMaterializer_Render(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			strategy := tt.asset.Materialization.Strategy
+			bootstrapStrategy := strategy == pipeline.MaterializationStrategyDeleteInsert ||
+				strategy == pipeline.MaterializationStrategyTimeInterval
+			if !tt.fullRefresh && bootstrapStrategy {
+				var found bool
+				got, found = removeStarRocksBootstrap(got, tt.asset.Name)
+				assert.True(t, found, "incremental SQL should bootstrap a missing target")
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func removeStarRocksBootstrap(query, tableName string) (string, bool) {
+	start := strings.Index(query, "CREATE TABLE IF NOT EXISTS "+quoteIdentifier(tableName))
+	if start < 0 {
+		return query, false
+	}
+
+	endMarker := ") AS `__bruin_bootstrap` WHERE 1 = 0;\n"
+	end := strings.Index(query[start:], endMarker)
+	if end < 0 {
+		return query, false
+	}
+	end += start + len(endMarker)
+	return query[:start] + query[end:], true
 }
 
 func TestQuoteIdentifier(t *testing.T) {

--- a/pkg/synapse/materialization.go
+++ b/pkg/synapse/materialization.go
@@ -82,6 +82,7 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) ([]string, error)
 
 	queries := []string{
 		fmt.Sprintf("SELECT alias.* INTO %s FROM (%s) AS alias;", tempTableName, query),
+		buildCreateTableIfNotExistsQuery(task, "SELECT * FROM "+tempTableName),
 		fmt.Sprintf("DELETE FROM %s WHERE %s in (SELECT DISTINCT %s FROM %s);", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s;", task.Name, tempTableName),
 		fmt.Sprintf("DROP TABLE %s;", tempTableName),
@@ -151,7 +152,10 @@ func buildMergeQuery(asset *pipeline.Asset, query string) ([]string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnValues, allColumnValues),
 	}
 
-	return []string{strings.Join(mergeLines, "\n") + ";"}, nil
+	return []string{
+		buildCreateTableIfNotExistsQuery(asset, query),
+		strings.Join(mergeLines, "\n") + ";",
+	}, nil
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, error) {
@@ -174,6 +178,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 	}
 
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(asset, query),
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,
 			asset.Materialization.IncrementalKey,
@@ -184,6 +189,16 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) ([]string, erro
 	}
 
 	return queries, nil
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, selectQuery string) string {
+	selectQuery = strings.TrimSuffix(strings.TrimSpace(selectQuery), ";")
+	return fmt.Sprintf(
+		"IF OBJECT_ID(%s, N'U') IS NULL\nBEGIN\nSELECT __bruin_bootstrap.* INTO %s FROM (\n%s\n) AS __bruin_bootstrap WHERE 1 = 0;\nEND;",
+		sqlStringLiteral(asset.Name),
+		quoteIdentifier(asset.Name),
+		selectQuery,
+	)
 }
 
 func quoteIdentifier(identifier string) string {

--- a/pkg/synapse/materialization_test.go
+++ b/pkg/synapse/materialization_test.go
@@ -1,6 +1,7 @@
 package synapse
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -276,13 +277,34 @@ func TestMaterializer_Render(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				if !tt.fullRefresh && isBootstrapStrategy(tt.task.Materialization.Strategy) {
+					var found bool
+					render, found = removeSynapseBootstrap(render)
+					require.True(t, found, "expected missing-table bootstrap in rendered SQL")
+				}
 			}
 
+			require.Len(t, render, len(tt.want))
 			for index, want := range tt.want {
 				assert.Regexp(t, want, render[index])
 			}
 		})
 	}
+}
+
+func isBootstrapStrategy(strategy pipeline.MaterializationStrategy) bool {
+	return strategy == pipeline.MaterializationStrategyDeleteInsert ||
+		strategy == pipeline.MaterializationStrategyMerge ||
+		strategy == pipeline.MaterializationStrategyTimeInterval
+}
+
+func removeSynapseBootstrap(queries []string) ([]string, bool) {
+	for index, query := range queries {
+		if strings.Contains(query, "IF OBJECT_ID(") && strings.Contains(query, "AS __bruin_bootstrap WHERE 1 = 0") {
+			return append(queries[:index:index], queries[index+1:]...), true
+		}
+	}
+	return queries, false
 }
 
 func intp(i int) *int { return &i }

--- a/pkg/trino/materialization.go
+++ b/pkg/trino/materialization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bruin-data/bruin/pkg/ansisql"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
@@ -69,6 +70,7 @@ func buildIncrementalQuery(asset *pipeline.Asset, query string) (string, error) 
 
 	return fmt.Sprintf(
 		`
+%s;
 DELETE FROM %s 
 WHERE %s IN (
     SELECT DISTINCT %s 
@@ -77,6 +79,7 @@ WHERE %s IN (
 
 INSERT INTO %s
 SELECT * FROM (%s) AS new_data;`,
+		buildCreateTableIfNotExistsQuery(asset, query),
 		quoteIdentifier(asset.Name),
 		key,
 		key,
@@ -102,19 +105,8 @@ func buildTruncateInsertQuery(asset *pipeline.Asset, query string) (string, erro
 }
 
 func buildCreateReplaceQuery(asset *pipeline.Asset, query string) (string, error) {
-	mat := asset.Materialization
 	query = strings.TrimSuffix(query, ";")
-
-	withClauses := []string{"format = 'PARQUET'"}
-
-	if mat.PartitionBy != "" {
-		withClauses = append(withClauses, fmt.Sprintf("partitioning = ARRAY['%s']", mat.PartitionBy))
-	}
-
-	withClause := ""
-	if len(withClauses) > 0 {
-		withClause = fmt.Sprintf("WITH (%s)", strings.Join(withClauses, ", "))
-	}
+	withClause := buildTableOptions(asset.Materialization)
 
 	return fmt.Sprintf(
 		`
@@ -126,6 +118,23 @@ CREATE TABLE %s %s AS
 		withClause,
 		query,
 	), nil
+}
+
+func buildTableOptions(mat pipeline.Materialization) string {
+	withClauses := []string{"format = 'PARQUET'"}
+	if mat.PartitionBy != "" {
+		withClauses = append(withClauses, fmt.Sprintf("partitioning = ARRAY['%s']", mat.PartitionBy))
+	}
+
+	return fmt.Sprintf("WITH (%s)", strings.Join(withClauses, ", "))
+}
+
+func buildCreateTableIfNotExistsQuery(asset *pipeline.Asset, query string) string {
+	return ansisql.BuildCreateTableIfNotExistsAsQuery(
+		quoteIdentifier(asset.Name),
+		buildTableOptions(asset.Materialization),
+		query,
+	)
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -154,11 +163,13 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 
 	return fmt.Sprintf(
 		`
+%s;
 DELETE FROM %s 
 WHERE %s BETWEEN %s '%s' AND %s '%s';
 
 INSERT INTO %s
 %s;`,
+		buildCreateTableIfNotExistsQuery(asset, query),
 		quoteIdentifier(asset.Name),
 		key,
 		timePrefix,

--- a/pkg/trino/materialization_test.go
+++ b/pkg/trino/materialization_test.go
@@ -112,7 +112,6 @@ SELECT 1 as col;`,
 			result, err := buildCreateReplaceQuery(tt.asset, tt.query)
 
 			require.NoError(t, err)
-
 			// Normalize whitespace for comparison
 			normalizeWhitespace := func(s string) string {
 				return strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
@@ -446,6 +445,9 @@ GROUP BY u.user_id, u.name) AS new_data;`,
 			result, err := buildIncrementalQuery(tt.asset, tt.query)
 
 			require.NoError(t, err)
+			bootstrap := buildCreateTableIfNotExistsQuery(tt.asset, strings.TrimSuffix(tt.query, ";")) + ";"
+			require.Contains(t, result, bootstrap)
+			result = strings.Replace(result, bootstrap, "", 1)
 
 			// Normalize whitespace for comparison
 			normalizeWhitespace := func(s string) string {
@@ -618,6 +620,9 @@ GROUP BY DATE_TRUNC('hour', created_at);`,
 			result, err := buildTimeIntervalQuery(tt.asset, tt.query)
 
 			require.NoError(t, err)
+			bootstrap := buildCreateTableIfNotExistsQuery(tt.asset, strings.TrimSuffix(tt.query, ";")) + ";"
+			require.Contains(t, result, bootstrap)
+			result = strings.Replace(result, bootstrap, "", 1)
 
 			// Normalize whitespace for comparison
 			normalizeWhitespace := func(s string) string {

--- a/pkg/vertica/materialization.go
+++ b/pkg/vertica/materialization.go
@@ -79,6 +79,7 @@ func buildIncrementalQuery(task *pipeline.Asset, query string) (string, error) {
 	// The DELETE+INSERT is wrapped in a transaction for atomicity.
 	queries := []string{
 		fmt.Sprintf("CREATE LOCAL TEMPORARY TABLE %s ON COMMIT PRESERVE ROWS AS (%s)", tempTableName, query),
+		buildCreateTableIfNotExistsQuery(task.Name, "SELECT * FROM "+tempTableName),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf("DELETE FROM %s WHERE %s IN (SELECT DISTINCT %s FROM %s)", task.Name, mat.IncrementalKey, mat.IncrementalKey, tempTableName),
 		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", task.Name, tempTableName),
@@ -140,7 +141,16 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 		fmt.Sprintf("WHEN NOT MATCHED THEN INSERT(%s) VALUES(%s)", allColumnValues, sourceValues),
 	}
 
-	return strings.Join(mergeLines, "\n") + ";", nil
+	return buildCreateTableIfNotExistsQuery(asset.Name, query) + ";\n" + strings.Join(mergeLines, "\n") + ";", nil
+}
+
+func buildCreateTableIfNotExistsQuery(tableName, query string) string {
+	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
+	return fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s AS (SELECT * FROM (%s) AS __bruin_bootstrap WHERE 1 = 0)",
+		tableName,
+		query,
+	)
 }
 
 func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error) {
@@ -164,6 +174,7 @@ func buildTimeIntervalQuery(asset *pipeline.Asset, query string) (string, error)
 	}
 
 	queries := []string{
+		buildCreateTableIfNotExistsQuery(asset.Name, query),
 		"BEGIN TRANSACTION",
 		fmt.Sprintf(`DELETE FROM %s WHERE %s BETWEEN '%s' AND '%s'`,
 			asset.Name,

--- a/pkg/vertica/materialization_test.go
+++ b/pkg/vertica/materialization_test.go
@@ -1,6 +1,7 @@
 package vertica
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -349,11 +350,36 @@ func TestMaterializer_Render(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				if !tt.fullRefresh && isBootstrapStrategy(tt.task.Materialization.Strategy) {
+					var found bool
+					render, found = removeVerticaBootstrap(render)
+					require.True(t, found, "expected missing-table bootstrap in rendered SQL")
+				}
 			}
 
 			assert.Regexp(t, tt.want, render)
 		})
 	}
+}
+
+func isBootstrapStrategy(strategy pipeline.MaterializationStrategy) bool {
+	return strategy == pipeline.MaterializationStrategyDeleteInsert ||
+		strategy == pipeline.MaterializationStrategyMerge ||
+		strategy == pipeline.MaterializationStrategyTimeInterval
+}
+
+func removeVerticaBootstrap(query string) (string, bool) {
+	start := strings.Index(query, "CREATE TABLE IF NOT EXISTS ")
+	if start < 0 {
+		return query, false
+	}
+	const endMarker = " AS __bruin_bootstrap WHERE 1 = 0);\n"
+	end := strings.Index(query[start:], endMarker)
+	if end < 0 {
+		return query, false
+	}
+	end += start + len(endMarker)
+	return query[:start] + query[end:], true
 }
 
 func intp(i int) *int { return &i }


### PR DESCRIPTION
## What
Incremental `merge`, `delete+insert`, and `time_interval` materializations now create an empty target from the asset query schema when the target does not exist.

## Changes
- Shared empty-CTAS helper plus dialect-specific implementations across supported SQL platforms
- Athena catalog check and hook-aware initialization, Oracle dynamic PL/SQL, and Redshift `LIKE` staging
- BigQuery bootstrap tables preserve partitioning, clustering, `require_partition_filter`, and `partition_expiration_days`
- Cross-platform regression tests and materialization documentation

## How to test
1. `make format`
2. `make test`
3. `make build-no-duckdb`

## Risk & rollback
- **Risk:** Medium — generated SQL changes across many warehouse dialects, with unit coverage but no live warehouse integration run.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
N/A