### PR TITLE
docs: clarify interval modifiers are CLI opt-in but automatic in Bruin Cloud

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -244,7 +244,7 @@ The start date for the asset, used when running with full refresh (`--full-refre
 
 ## `interval_modifiers`
 
-Controls how the processing window is adjusted by shifting the start and end times. Requires the `--apply-interval-modifiers` flag when running the pipeline.
+Controls how the processing window is adjusted by shifting the start and end times. On the CLI this requires the `--apply-interval-modifiers` flag; Bruin Cloud applies the modifiers automatically. See [enabling interval modifiers](./interval-modifiers#enabling-interval-modifiers).
 
 ```yaml
 interval_modifiers:

--- a/docs/assets/interval-modifiers.md
+++ b/docs/assets/interval-modifiers.md
@@ -6,6 +6,9 @@ You can shift the start or end of the interval either forward or backward, depen
 
 This works for SQL, Python, and ingestr assets and is primarily designed for regularly scheduled pipeline runs.
 
+> [!IMPORTANT]
+> Interval modifiers are **opt-in on the CLI** (`--apply-interval-modifiers`) and **applied automatically in Bruin Cloud**. See [Enabling interval modifiers](#enabling-interval-modifiers).
+
 ## How It Works
 
 Use the `interval_modifiers` block in your asset definition to control how much to shift the window and supports both lookback and lookahead:
@@ -65,15 +68,41 @@ Each interval is a scalar string with a single unit:
 ✅ Valid: `5m`, `2h`, `1d`, `-1M`, `500ms`, `1000ns`
 ❌ Invalid: `1h30m`, `2h:30m`, `90min`
 
-## Usage
+## Enabling interval modifiers
 
-To apply interval modifiers when running your pipeline, you must include the `--apply-interval-modifiers` flag in your run command:
+Defining `interval_modifiers` in an asset or in the pipeline `default` block is not enough on its own — the modifiers still have to be *applied* at run time. Whether that happens automatically depends on where the pipeline runs.
+
+| Where | Default | How to control it |
+|-------|---------|-------------------|
+| Bruin CLI (`bruin run`, `bruin render`) | **Off** | Pass `--apply-interval-modifiers` |
+| Bruin Cloud (scheduled runs, manual runs, backfills) | **On** | Always applied; no flag or toggle needed |
+| VS Code extension | Off | [Apply Interval Modifiers](/vscode-extension/configuration) setting |
+
+### On the CLI
 
 ```bash
-bruin run --apply-interval-modifiers my_asset 
+bruin run --apply-interval-modifiers my_asset
 ```
 
-Without this flag, the pipeline will use the default interval without any modifications.
+Without the flag, the run uses the interval as given and your `interval_modifiers` are ignored silently — no error, no warning. If you are debugging "my modifiers don't seem to do anything" locally, this is almost always the reason.
+
+The reason it is opt-in on the CLI: you usually pass `--start-date` / `--end-date` yourself, and silently shifting the window you explicitly asked for would be surprising — for example when re-running a single day to reproduce an issue, or when comparing output against an exact window.
+
+To confirm what a run will actually see, render the asset with and without the flag:
+
+```bash
+bruin render my_asset                              # unmodified interval
+bruin render --apply-interval-modifiers my_asset   # modified interval
+```
+
+> [!NOTE]
+> `--apply-interval-modifiers` is ignored when `--full-refresh` is used, since a full refresh does not process an interval. Bruin prints a warning when both are given.
+
+### In Bruin Cloud
+
+Bruin Cloud owns the schedule, so it computes the interval for each run itself and applies your `interval_modifiers` on top of it automatically. Scheduled runs, manual runs, and [backfill](/cloud/backfills) child runs all use the modified window — there is no flag to set.
+
+This means the same pipeline can process a different window locally and in Cloud unless you add `--apply-interval-modifiers` to your local command. When reproducing a Cloud run on your machine, include the flag.
 
 ## Example
 

--- a/docs/cloud/backfills.md
+++ b/docs/cloud/backfills.md
@@ -81,6 +81,7 @@ For retries, cancels, and per-asset reruns inside a single backfill run, open th
 - **Up to 250 child runs** per backfill.
 - Child runs honour the pipeline's normal asset dependencies — assets within each run still wait on their upstreams.
 - Cross-pipeline sensors apply: if an asset in the backfill depends on an external upstream via [URI](/cloud/cross-pipeline), it waits for that upstream interval to complete.
+- [Interval modifiers](/assets/interval-modifiers) are applied to every child interval, the same as scheduled runs. There is no toggle — unlike the CLI, which needs `--apply-interval-modifiers`. Overlapping windows are worth keeping in mind when child runs write to the same partitions.
 - Marking the backfill as success or failed is recorded in the [audit log](/cloud/audit-logs).
 
 ## Related

--- a/docs/cloud/pipelines.md
+++ b/docs/cloud/pipelines.md
@@ -85,6 +85,8 @@ The **New run** button (top right) triggers a manual run. Options:
 - Add **notes** and **tags**. They show up in the activity log.
 - Run a single interval, or create multiple jobs across intervals.
 
+Any [interval modifiers](/assets/interval-modifiers) defined on your assets are applied automatically, for both scheduled and manual runs. There is no flag or toggle for it in Cloud — the CLI equivalent is `bruin run --apply-interval-modifiers`.
+
 #### Backfills
 
 - **Auto-split by schedule:** one job per scheduled interval. A 23-day range on a daily schedule produces 23 jobs.

--- a/docs/commands/render.md
+++ b/docs/commands/render.md
@@ -24,7 +24,7 @@ bruin render [path to asset definition] [flags]
 | `--full-refresh`      | `-r`  | Truncate the table before running the query. Also sets the `full_refresh` jinja variable to `True`. |
 | `--start-date`        |       | Specify the start date in `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, or `YYYY-MM-DD HH:MM:SS.ffffff` format.|
 | `--end-date`          |       | Specify the end date in `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, or `YYYY-MM-DD HH:MM:SS.ffffff` format. |
-| `--apply-interval-modifiers` |       | Apply interval modifiers if flag is given. |
+| `--apply-interval-modifiers` |       | Apply [interval modifiers](/assets/interval-modifiers). Off unless the flag is given — useful for previewing the window a Bruin Cloud run would use, since Cloud always applies them. |
 | `--var`               |       | Override pipeline variables with custom values. |
 | `--output [format]`   | `-o`  | Specify the output format (e.g., `json`). Defaults to console output.  |
 | `--config-file`       |       | The path to the `.bruin.yml` file. |

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -42,7 +42,7 @@ table td:first-child {
 | `--no-log-file` | bool | `false` | Do not create a log file for this run. |
 | `--sensor-mode` | str | `'once'` | Set sensor mode: `skip`, `once`, or `wait`. |
 | `--full-refresh` | bool | `false` | Truncate the table before running. Also sets the `full_refresh` jinja variable to `True` and `BRUIN_FULL_REFRESH` environment variable to `1`. |
-| `--apply-interval-modifiers` | bool | `false` | Apply interval modifiers. |
+| `--apply-interval-modifiers` | bool | `false` | Apply [interval modifiers](/assets/interval-modifiers). Off by default on the CLI because you pass the dates yourself; Bruin Cloud applies them automatically. Ignored together with `--full-refresh`. |
 | `--continue` | bool | `false` | Continue from the last failed asset. |
 | `--selector` | str | - | Select assets with dbt-style syntax. Supports `tag:`, `path:`, `file:`, `fqn:`, `+`, `n+`, `@`, space unions, and comma intersections. |
 | `--tag` | str | - | Pick assets with the given tag. |

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -461,7 +461,7 @@ Fields:
 | snowflake          | Object                     | —       | Snowflake-specific defaults      |
 | athena             | Object                     | —       | Athena-specific defaults         |
 | routing            | Object                     | —       | Runtime routing defaults for assets |
-| interval_modifiers | Object                     | —       | See [Interval Modifiers](/assets/interval-modifiers) |
+| interval_modifiers | Object                     | —       | See [Interval Modifiers](/assets/interval-modifiers). Applied automatically in Bruin Cloud; needs `--apply-interval-modifiers` on the CLI |
 | hooks              | Object                     | —       | See [Hooks](/assets/definition-schema#hooks) |
 | retries            | Integer                    | —       | Default asset retries            |
 | timeout            | String (Go duration)       | —       | Default asset timeout (for example, `1h30m`) |

--- a/docs/vscode-extension/configuration.md
+++ b/docs/vscode-extension/configuration.md
@@ -21,7 +21,7 @@ Set your preferred path separator in the extension settings under `Bruin > Path 
 
 The extension provides checkbox settings to control default enabled/disabled states for various features:
 
-- **Apply Interval Modifiers**: Controls the default state of the `--apply-interval-modifiers` flag
+- **Apply Interval Modifiers**: Controls the default state of the `--apply-interval-modifiers` flag. Like the CLI, it is off unless you turn it on; Bruin Cloud applies [interval modifiers](/assets/interval-modifiers) automatically
 - **Full Refresh Confirmation**: Enable/disable confirmation prompts before running with `full-refresh`
 - **Auto-save Materialization**: Control whether materialization changes are auto-saved
 


### PR DESCRIPTION
## What
Interval modifiers require `--apply-interval-modifiers` on the CLI but are applied automatically by Bruin Cloud, and the docs only documented the flag — so users (and coding agents reading the docs) assumed the feature was globally opt-in and were surprised when Cloud runs used a different window than their local runs.

## Changes
- `docs/assets/interval-modifiers.md` — replaced the `Usage` section with `Enabling interval modifiers`: a CLI / Cloud / VS Code defaults table, the rationale for the CLI default (you pass `--start-date` / `--end-date` yourself, so silently shifting that window would be surprising), a note that the modifiers are ignored *silently* without the flag, the `--full-refresh` interaction, a `bruin render` recipe for comparing both windows, and an `IMPORTANT` callout at the top of the page.
- `docs/commands/run.md`, `docs/commands/render.md`, `docs/assets/definition-schema.md`, `docs/pipelines/definition.md`, `docs/vscode-extension/configuration.md` — flag/field descriptions now state the CLI ↔ Cloud difference and link to the new section.
- `docs/cloud/pipelines.md`, `docs/cloud/backfills.md` — document that scheduled runs, manual runs, and backfill child runs all apply interval modifiers with no toggle.

## How to test
1. `cd docs && npm install && npm run docs:dev`, then open `/assets/interval-modifiers` and confirm the new table, callouts, and the `#enabling-interval-modifiers` anchor link from `/assets/definition-schema` resolve.
2. Spot-check the cross-links on `/commands/run`, `/commands/render`, `/pipelines/definition`, `/cloud/pipelines`, `/cloud/backfills`, and `/vscode-extension/configuration`.

## Risk & rollback
- **Risk:** low — documentation only, no Go/Python code or test fixtures touched.
- **Rollback:** Revert the merge commit.

## Checklist
- [ ] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
<!-- None. -->

---

Notes for the reviewer:
- Per `CLAUDE.md`, `make format` / `make test` were **not** run because this change touches documentation only; validation was limited to inspecting the diff and verifying link targets and the new anchor. The vitepress build was not run.
- The CLI behaviour is verified against the source: the flag defaults to `false` and `cmd/run.go:561` (`setApplyIntervalModifiers`) drops it with a warning when `--full-refresh` is set.
- The Bruin Cloud "always on" statement comes from product knowledge, not from this repo (the Cloud scheduler is not open source). If that is inaccurate, it is stated in one place on the interval modifiers page plus the short cross-references listed above.
