### PR TITLE
Add Stripe BigQuery starter template

### DIFF
--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -2,9 +2,11 @@
 package cmd
 
 import (
+	iofs "io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/templates"
@@ -93,6 +95,87 @@ func TestInitShopifyClickHouseCopiesPipelineTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(orderLinesAsset), "strategy: delete+insert")
 	require.Contains(t, string(orderLinesAsset), "incremental_key: order_id")
+}
+
+func TestInitStripeBigQueryCopiesStarterTemplate(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+
+	gitInit := exec.CommandContext(t.Context(), "git", "init")
+	gitInit.Dir = targetRoot
+	out, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	err = Init().Run(t.Context(), []string{"init", "stripe-bigquery"})
+	require.NoError(t, err)
+
+	pipelineRoot := filepath.Join(targetRoot, "stripe-bigquery")
+	require.FileExists(t, filepath.Join(pipelineRoot, "pipeline.yml"))
+	require.FileExists(t, filepath.Join(pipelineRoot, ".gitignore"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "assets", "stripe_raw", "customer.asset.yml"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "assets", "stripe_reports", "monthly_subscription_kpis.sql"))
+	require.NoFileExists(t, filepath.Join(pipelineRoot, "assets", "stripe_raw", "refund.asset.yml"))
+
+	pipeline, err := os.ReadFile(filepath.Join(pipelineRoot, "pipeline.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(pipeline), "name: stripe-bigquery")
+
+	configContent, err := os.ReadFile(filepath.Join(targetRoot, ".bruin.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(configContent), "name: gcp-default")
+	require.Contains(t, string(configContent), "name: stripe-default")
+}
+
+func TestStripeBigQueryStarterTemplateHasFocusedAssetSet(t *testing.T) {
+	t.Parallel()
+
+	expectedAssets := []string{
+		"stripe_raw/customer.asset.yml",
+		"stripe_raw/product.asset.yml",
+		"stripe_raw/price.asset.yml",
+		"stripe_raw/subscription.asset.yml",
+		"stripe_raw/subscription_item.asset.yml",
+		"stripe_raw/invoice.asset.yml",
+		"stripe_stage/customers.sql",
+		"stripe_stage/products.sql",
+		"stripe_stage/prices.sql",
+		"stripe_stage/subscriptions.sql",
+		"stripe_stage/subscription_items.sql",
+		"stripe_stage/invoices.sql",
+		"stripe_stage/invoice_line_items.sql",
+		"stripe_stage/subscription_item_daily_snapshot.sql",
+		"stripe_stage/customer_currency_daily_mrr_snapshot.sql",
+		"stripe_reports/monthly_mrr_by_customer.sql",
+		"stripe_reports/monthly_mrr_movements.sql",
+		"stripe_reports/monthly_subscription_kpis.sql",
+		"stripe_reports/monthly_invoice_billings.sql",
+	}
+
+	var actualAssets []string
+	err := iofs.WalkDir(templates.Templates, "stripe-bigquery/assets", func(path string, entry iofs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		actualAssets = append(actualAssets, strings.TrimPrefix(path, "stripe-bigquery/assets/"))
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, actualAssets, 19)
+	require.ElementsMatch(t, expectedAssets, actualAssets)
+
+	pipeline, err := templates.Templates.ReadFile("stripe-bigquery/pipeline.yml")
+	require.NoError(t, err)
+	require.Contains(t, string(pipeline), "name: stripe-bigquery")
+	require.Contains(t, string(pipeline), "source_connection: stripe-default")
+	require.Contains(t, string(pipeline), "destination: bigquery")
+
+	readme, err := templates.Templates.ReadFile("stripe-bigquery/README.md")
+	require.NoError(t, err)
+	require.Contains(t, string(readme), "Stripe Billing Analytics to BigQuery")
 }
 
 func TestInitMigrationFivetranCopiesMigrationWorkspace(t *testing.T) {

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -541,6 +541,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         items: [
                             {text: "shopify-bigquery", link: "/getting-started/templates-docs/shopify-bigquery-README"},
                             {text: "shopify-duckdb", link: "/getting-started/templates-docs/shopify-duckdb-README"},
+                            {text: "stripe-bigquery", link: "/getting-started/templates-docs/stripe-bigquery-README"},
                             {text: "gsheet-bigquery", link: "/getting-started/templates-docs/gsheet-bigquery-README"},
                             {text: "gsheet-duckdb", link: "/getting-started/templates-docs/gsheet-duckdb-README"},
                             {text: "notion", link: "/getting-started/templates-docs/notion-README"},

--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -159,22 +159,23 @@ bruin init stripe-bigquery my-stripe-pipeline
 ```
 
 Set `start_date` in `pipeline.yml` to the earliest Stripe history you need,
-then validate the generated project:
+then run the fast validation checks:
 
 ```bash
-bruin validate my-stripe-pipeline
+bruin validate --fast my-stripe-pipeline
 ```
 
-For the first load, run a full refresh:
+On a new BigQuery destination, load every table before running query validation:
 
 ```bash
-bruin run --full-refresh my-stripe-pipeline
+bruin run --full-refresh --no-validation my-stripe-pipeline
 ```
 
-After the initial load, run the pipeline on its daily schedule. The raw tables
-hold the Stripe objects returned by incremental discovery; schedule periodic
-full refreshes or targeted reloads when your reporting needs to account for
-changes to older mutable Stripe records.
+After that initial load, run `bruin validate my-stripe-pipeline` and schedule
+the pipeline daily. The raw tables hold the Stripe objects returned by
+incremental discovery; schedule periodic full refreshes or targeted reloads
+when your reporting needs to account for changes to older mutable Stripe
+records.
 
 ## Customize it
 

--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -1,0 +1,184 @@
+# Stripe Billing Analytics to BigQuery
+
+`stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery.
+It loads the customer, product, price, subscription, subscription-item, and
+invoice resources into `stripe_raw`; builds reusable billing models in
+`stripe_stage`; and publishes recurring-revenue and invoice-billing reports in
+`stripe_reports`.
+
+The template contains 19 assets across three layers. It is a practical starting
+point for analyzing Stripe subscription billing while keeping the data model
+small enough to adapt to your own reporting needs.
+
+## Project structure
+
+```text
+stripe-bigquery/
+├── pipeline.yml
+├── README.md
+└── assets/
+    ├── stripe_raw/
+    │   ├── customer.asset.yml
+    │   ├── product.asset.yml
+    │   ├── price.asset.yml
+    │   ├── subscription.asset.yml
+    │   ├── subscription_item.asset.yml
+    │   └── invoice.asset.yml
+    ├── stripe_stage/
+    │   ├── customers.sql
+    │   ├── products.sql
+    │   ├── prices.sql
+    │   ├── subscriptions.sql
+    │   ├── subscription_items.sql
+    │   ├── invoices.sql
+    │   ├── invoice_line_items.sql
+    │   ├── subscription_item_daily_snapshot.sql
+    │   └── customer_currency_daily_mrr_snapshot.sql
+    └── stripe_reports/
+        ├── monthly_mrr_by_customer.sql
+        ├── monthly_mrr_movements.sql
+        ├── monthly_subscription_kpis.sql
+        └── monthly_invoice_billings.sql
+```
+
+## What it creates
+
+### Raw Stripe data
+
+The `stripe_raw` dataset contains the six Stripe resources that underpin the
+billing models. Ingestr loads them with the shared `stripe-default` connection,
+and BigQuery is the destination. The source assets use Stripe's `created` field
+for incremental discovery and merge the records returned by Stripe.
+
+### Conformed billing models
+
+The `stripe_stage` dataset exposes typed customer, product, price,
+subscription, subscription-item, invoice, and invoice-line-item models. It
+also records immutable daily snapshots of subscription items and customer MRR
+by native currency. Run the pipeline daily after a consistent UTC cutoff so
+the snapshots represent a reliable observation history.
+
+### Billing reports
+
+The `stripe_reports` dataset provides four ready-to-query tables:
+
+- `monthly_mrr_by_customer` — month-end observed MRR and annualized run rate by billing customer and currency.
+- `monthly_mrr_movements` — customer-level new, reactivation, expansion, contraction, and churn movements.
+- `monthly_subscription_kpis` — recurring-revenue, retention, and customer-count metrics by currency.
+- `monthly_invoice_billings` — non-draft, non-void invoice billings by finalization month, with a labeled creation-date fallback.
+
+## Example report rows
+
+The following illustrative rows use minor currency units: `9900` USD means
+$99.00. Query the four tables in `stripe_reports` directly, then adapt the
+columns to the definitions used by your finance and revenue teams.
+
+### `monthly_mrr_by_customer`
+
+| metric_month | as_of_snapshot_date | stripe_customer_id | currency | active_subscription_count | ending_mrr_minor | run_rate_arr_minor |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| 2026-01-01 | 2026-01-31 | cus_acme | usd | 1 | 9900 | 118800 |
+| 2026-02-01 | 2026-02-28 | cus_acme | usd | 1 | 12900 | 154800 |
+| 2026-02-01 | 2026-02-28 | cus_pine | usd | 2 | 4900 | 58800 |
+
+### `monthly_mrr_movements`
+
+| metric_month | stripe_customer_id | currency | beginning_mrr_minor | ending_mrr_minor | expansion_mrr_minor | churned_mrr_minor | movement_type |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 2026-02-01 | cus_acme | usd | 9900 | 12900 | 3000 | 0 | expansion |
+| 2026-02-01 | cus_oak | usd | 2500 | 0 | 0 | 2500 | churn |
+| 2026-02-01 | cus_pine | usd | 0 | 4900 | 0 | 0 | new |
+
+### `monthly_subscription_kpis`
+
+| metric_month | currency | ending_mrr_minor | new_mrr_minor | expansion_mrr_minor | churned_mrr_minor | ending_active_customer_count | net_revenue_retention_rate_excluding_reactivation |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2026-01-01 | usd | 12400 | 12400 | 0 | 0 | 2 | — |
+| 2026-02-01 | usd | 17800 | 4900 | 3000 | 2500 | 2 | 1.04 |
+| 2026-02-01 | eur | 8100 | 0 | 1100 | 0 | 1 | 1.16 |
+
+### `monthly_invoice_billings`
+
+| invoice_billing_month | invoice_billing_date_basis | currency | issued_invoice_count | subscription_invoice_count | invoiced_billings_minor | invoiced_subscription_billings_minor |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| 2026-01-01 | invoice_finalized_at | usd | 14 | 12 | 139400 | 128700 |
+| 2026-02-01 | invoice_finalized_at | usd | 16 | 13 | 171800 | 160200 |
+| 2026-02-01 | invoice_created_at_fallback | eur | 2 | 2 | 16200 | 16200 |
+
+## Metric policy
+
+All monetary values remain in each currency's minor units. Do not add amounts
+across currencies without an FX source and explicit conversion policy.
+
+MRR is a gross list-price run rate from active and past-due subscriptions with
+licensed recurring monthly or annual prices. Free, one-time, metered, and
+discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither
+measure is recognized revenue, bookings, cash, or a financial statement.
+
+The daily snapshots capture the Stripe state visible when the pipeline runs.
+The first run creates a baseline observation and does not reconstruct prior
+daily MRR history from current Stripe records.
+
+## Configure connections
+
+Initializing the template adds placeholder connections to the repository-level
+`.bruin.yml`. Keep the connection names `gcp-default` and `stripe-default`, or
+rename them consistently in both `.bruin.yml` and `pipeline.yml`.
+
+```yaml
+default_environment: default
+
+environments:
+  default:
+    connections:
+      google_cloud_platform:
+        - name: gcp-default
+          project_id: your-gcp-project-id
+          service_account_file: /path/to/service-account.json
+      stripe:
+        - name: stripe-default
+          api_key: ${STRIPE_API_KEY}
+```
+
+Set the Stripe secret key in your shell before running the pipeline:
+
+```bash
+export STRIPE_API_KEY='sk_test_your_secret_key'
+```
+
+Use either an `sk_test_...` or `sk_live_...` secret key. A publishable
+`pk_...` key cannot read Stripe data. Keep test and live data in separate
+BigQuery projects or datasets and do not commit credentials.
+
+## Run the pipeline
+
+Initialize a project from the template:
+
+```bash
+bruin init stripe-bigquery my-stripe-pipeline
+```
+
+Set `start_date` in `pipeline.yml` to the earliest Stripe history you need,
+then validate the generated project:
+
+```bash
+bruin validate my-stripe-pipeline
+```
+
+For the first load, run a full refresh:
+
+```bash
+bruin run --full-refresh my-stripe-pipeline
+```
+
+After the initial load, run the pipeline on its daily schedule. The raw tables
+hold the Stripe objects returned by incremental discovery; schedule periodic
+full refreshes or targeted reloads when your reporting needs to account for
+changes to older mutable Stripe records.
+
+## Customize it
+
+Use the stage models as a stable interface for your own reports. Review the
+selected assets, source fields, quality checks, and metric policy before using
+the results for financial reporting. Extend the pipeline with your business
+definitions, identity mapping, and FX policy where required.

--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -171,11 +171,15 @@ On a new BigQuery destination, load every table before running query validation:
 bruin run --full-refresh --no-validation my-stripe-pipeline
 ```
 
-After that initial load, run `bruin validate my-stripe-pipeline` and schedule
+Run this pipeline-wide full refresh only for the first load, or when you
+intentionally reset the reporting history. It recreates the daily snapshot
+tables, so re-running it removes the observations used by the MRR movement and
+retention reports.
+
+After the initial load, run `bruin validate my-stripe-pipeline` and schedule
 the pipeline daily. The raw tables hold the Stripe objects returned by
-incremental discovery; schedule periodic full refreshes or targeted reloads
-when your reporting needs to account for changes to older mutable Stripe
-records.
+incremental discovery. When you need to reload older mutable Stripe records,
+use a targeted reload and keep the snapshot tables intact.
 
 ## Customize it
 

--- a/docs/getting-started/templates.md
+++ b/docs/getting-started/templates.md
@@ -182,6 +182,12 @@ An Iceberg connection is a **catalog** (where table metadata lives) plus **stora
     <span>Ingests Shopify data into ClickHouse and builds configurable models for orders, customers, products, and daily reporting.</span>
     <span class="template-card__tags"><code>Shopify</code><code>ClickHouse</code><code>ingestr</code></span>
   </a>
+  <a class="template-card" href="./templates-docs/stripe-bigquery-README.html">
+    <span class="template-card__category">Billing analytics</span>
+    <strong>stripe-bigquery</strong>
+    <span>Loads core Stripe billing data into BigQuery and builds focused subscription, MRR, and invoice-billing reports.</span>
+    <span class="template-card__tags"><code>Stripe</code><code>BigQuery</code><code>billing</code></span>
+  </a>
   <a class="template-card" href="./templates-docs/gsheet-bigquery-README.html">
     <span class="template-card__category">Spreadsheet source</span>
     <strong>gsheet-bigquery</strong>
@@ -260,7 +266,7 @@ bruin init nyc-taxi my-taxi-pipeline
 | --- | --- |
 | Learn Bruin locally without cloud credentials | `duckdb`, `python`, `frankfurter`, `chess`, or `iceberg-sqlite-local` |
 | Load into an Iceberg lakehouse | `iceberg-sqlite-local` to try it, then `iceberg-glue-s3`, `iceberg-postgres-gcs`, `iceberg-rest-minio`, or `iceberg-hadoop-gcsinterop` |
-| Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `shopify-clickhouse`, `gsheet-bigquery`, `notion`, or `gorgias` |
+| Build a source-to-warehouse ingestion pipeline | `ai-coding-usage`, `shopify-bigquery`, `shopify-clickhouse`, `stripe-bigquery`, `gsheet-bigquery`, `notion`, or `gorgias` |
 | Migrate one Fivetran connection to a review-gated Bruin project | `migration-fivetran` |
 | Explore a complete demo with generated data | `demo-snowflake-sales-analytics` or `demo-snowflake-salesforce` |
 | Scaffold ecommerce reporting | `ecommerce` |

--- a/templates/stripe-bigquery/.bruin.yml
+++ b/templates/stripe-bigquery/.bruin.yml
@@ -1,0 +1,12 @@
+default_environment: default
+
+environments:
+  default:
+    connections:
+      google_cloud_platform:
+        - name: gcp-default
+          project_id: your-gcp-project-id
+          service_account_file: /path/to/service-account.json
+      stripe:
+        - name: stripe-default
+          api_key: ${STRIPE_API_KEY}

--- a/templates/stripe-bigquery/.gitignore
+++ b/templates/stripe-bigquery/.gitignore
@@ -1,0 +1,1 @@
+.bruin.yml

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -159,22 +159,23 @@ bruin init stripe-bigquery my-stripe-pipeline
 ```
 
 Set `start_date` in `pipeline.yml` to the earliest Stripe history you need,
-then validate the generated project:
+then run the fast validation checks:
 
 ```bash
-bruin validate my-stripe-pipeline
+bruin validate --fast my-stripe-pipeline
 ```
 
-For the first load, run a full refresh:
+On a new BigQuery destination, load every table before running query validation:
 
 ```bash
-bruin run --full-refresh my-stripe-pipeline
+bruin run --full-refresh --no-validation my-stripe-pipeline
 ```
 
-After the initial load, run the pipeline on its daily schedule. The raw tables
-hold the Stripe objects returned by incremental discovery; schedule periodic
-full refreshes or targeted reloads when your reporting needs to account for
-changes to older mutable Stripe records.
+After that initial load, run `bruin validate my-stripe-pipeline` and schedule
+the pipeline daily. The raw tables hold the Stripe objects returned by
+incremental discovery; schedule periodic full refreshes or targeted reloads
+when your reporting needs to account for changes to older mutable Stripe
+records.
 
 ## Customize it
 

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -1,0 +1,184 @@
+# Stripe Billing Analytics to BigQuery
+
+`stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery.
+It loads the customer, product, price, subscription, subscription-item, and
+invoice resources into `stripe_raw`; builds reusable billing models in
+`stripe_stage`; and publishes recurring-revenue and invoice-billing reports in
+`stripe_reports`.
+
+The template contains 19 assets across three layers. It is a practical starting
+point for analyzing Stripe subscription billing while keeping the data model
+small enough to adapt to your own reporting needs.
+
+## Project structure
+
+```text
+stripe-bigquery/
+├── pipeline.yml
+├── README.md
+└── assets/
+    ├── stripe_raw/
+    │   ├── customer.asset.yml
+    │   ├── product.asset.yml
+    │   ├── price.asset.yml
+    │   ├── subscription.asset.yml
+    │   ├── subscription_item.asset.yml
+    │   └── invoice.asset.yml
+    ├── stripe_stage/
+    │   ├── customers.sql
+    │   ├── products.sql
+    │   ├── prices.sql
+    │   ├── subscriptions.sql
+    │   ├── subscription_items.sql
+    │   ├── invoices.sql
+    │   ├── invoice_line_items.sql
+    │   ├── subscription_item_daily_snapshot.sql
+    │   └── customer_currency_daily_mrr_snapshot.sql
+    └── stripe_reports/
+        ├── monthly_mrr_by_customer.sql
+        ├── monthly_mrr_movements.sql
+        ├── monthly_subscription_kpis.sql
+        └── monthly_invoice_billings.sql
+```
+
+## What it creates
+
+### Raw Stripe data
+
+The `stripe_raw` dataset contains the six Stripe resources that underpin the
+billing models. Ingestr loads them with the shared `stripe-default` connection,
+and BigQuery is the destination. The source assets use Stripe's `created` field
+for incremental discovery and merge the records returned by Stripe.
+
+### Conformed billing models
+
+The `stripe_stage` dataset exposes typed customer, product, price,
+subscription, subscription-item, invoice, and invoice-line-item models. It
+also records immutable daily snapshots of subscription items and customer MRR
+by native currency. Run the pipeline daily after a consistent UTC cutoff so
+the snapshots represent a reliable observation history.
+
+### Billing reports
+
+The `stripe_reports` dataset provides four ready-to-query tables:
+
+- `monthly_mrr_by_customer` — month-end observed MRR and annualized run rate by billing customer and currency.
+- `monthly_mrr_movements` — customer-level new, reactivation, expansion, contraction, and churn movements.
+- `monthly_subscription_kpis` — recurring-revenue, retention, and customer-count metrics by currency.
+- `monthly_invoice_billings` — non-draft, non-void invoice billings by finalization month, with a labeled creation-date fallback.
+
+## Example report rows
+
+The following illustrative rows use minor currency units: `9900` USD means
+$99.00. Query the four tables in `stripe_reports` directly, then adapt the
+columns to the definitions used by your finance and revenue teams.
+
+### `monthly_mrr_by_customer`
+
+| metric_month | as_of_snapshot_date | stripe_customer_id | currency | active_subscription_count | ending_mrr_minor | run_rate_arr_minor |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| 2026-01-01 | 2026-01-31 | cus_acme | usd | 1 | 9900 | 118800 |
+| 2026-02-01 | 2026-02-28 | cus_acme | usd | 1 | 12900 | 154800 |
+| 2026-02-01 | 2026-02-28 | cus_pine | usd | 2 | 4900 | 58800 |
+
+### `monthly_mrr_movements`
+
+| metric_month | stripe_customer_id | currency | beginning_mrr_minor | ending_mrr_minor | expansion_mrr_minor | churned_mrr_minor | movement_type |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 2026-02-01 | cus_acme | usd | 9900 | 12900 | 3000 | 0 | expansion |
+| 2026-02-01 | cus_oak | usd | 2500 | 0 | 0 | 2500 | churn |
+| 2026-02-01 | cus_pine | usd | 0 | 4900 | 0 | 0 | new |
+
+### `monthly_subscription_kpis`
+
+| metric_month | currency | ending_mrr_minor | new_mrr_minor | expansion_mrr_minor | churned_mrr_minor | ending_active_customer_count | net_revenue_retention_rate_excluding_reactivation |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2026-01-01 | usd | 12400 | 12400 | 0 | 0 | 2 | — |
+| 2026-02-01 | usd | 17800 | 4900 | 3000 | 2500 | 2 | 1.04 |
+| 2026-02-01 | eur | 8100 | 0 | 1100 | 0 | 1 | 1.16 |
+
+### `monthly_invoice_billings`
+
+| invoice_billing_month | invoice_billing_date_basis | currency | issued_invoice_count | subscription_invoice_count | invoiced_billings_minor | invoiced_subscription_billings_minor |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| 2026-01-01 | invoice_finalized_at | usd | 14 | 12 | 139400 | 128700 |
+| 2026-02-01 | invoice_finalized_at | usd | 16 | 13 | 171800 | 160200 |
+| 2026-02-01 | invoice_created_at_fallback | eur | 2 | 2 | 16200 | 16200 |
+
+## Metric policy
+
+All monetary values remain in each currency's minor units. Do not add amounts
+across currencies without an FX source and explicit conversion policy.
+
+MRR is a gross list-price run rate from active and past-due subscriptions with
+licensed recurring monthly or annual prices. Free, one-time, metered, and
+discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither
+measure is recognized revenue, bookings, cash, or a financial statement.
+
+The daily snapshots capture the Stripe state visible when the pipeline runs.
+The first run creates a baseline observation and does not reconstruct prior
+daily MRR history from current Stripe records.
+
+## Configure connections
+
+Initializing the template adds placeholder connections to the repository-level
+`.bruin.yml`. Keep the connection names `gcp-default` and `stripe-default`, or
+rename them consistently in both `.bruin.yml` and `pipeline.yml`.
+
+```yaml
+default_environment: default
+
+environments:
+  default:
+    connections:
+      google_cloud_platform:
+        - name: gcp-default
+          project_id: your-gcp-project-id
+          service_account_file: /path/to/service-account.json
+      stripe:
+        - name: stripe-default
+          api_key: ${STRIPE_API_KEY}
+```
+
+Set the Stripe secret key in your shell before running the pipeline:
+
+```bash
+export STRIPE_API_KEY='sk_test_your_secret_key'
+```
+
+Use either an `sk_test_...` or `sk_live_...` secret key. A publishable
+`pk_...` key cannot read Stripe data. Keep test and live data in separate
+BigQuery projects or datasets and do not commit credentials.
+
+## Run the pipeline
+
+Initialize a project from the template:
+
+```bash
+bruin init stripe-bigquery my-stripe-pipeline
+```
+
+Set `start_date` in `pipeline.yml` to the earliest Stripe history you need,
+then validate the generated project:
+
+```bash
+bruin validate my-stripe-pipeline
+```
+
+For the first load, run a full refresh:
+
+```bash
+bruin run --full-refresh my-stripe-pipeline
+```
+
+After the initial load, run the pipeline on its daily schedule. The raw tables
+hold the Stripe objects returned by incremental discovery; schedule periodic
+full refreshes or targeted reloads when your reporting needs to account for
+changes to older mutable Stripe records.
+
+## Customize it
+
+Use the stage models as a stable interface for your own reports. Review the
+selected assets, source fields, quality checks, and metric policy before using
+the results for financial reporting. Extend the pipeline with your business
+definitions, identity mapping, and FX policy where required.

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -171,11 +171,15 @@ On a new BigQuery destination, load every table before running query validation:
 bruin run --full-refresh --no-validation my-stripe-pipeline
 ```
 
-After that initial load, run `bruin validate my-stripe-pipeline` and schedule
+Run this pipeline-wide full refresh only for the first load, or when you
+intentionally reset the reporting history. It recreates the daily snapshot
+tables, so re-running it removes the observations used by the MRR movement and
+retention reports.
+
+After the initial load, run `bruin validate my-stripe-pipeline` and schedule
 the pipeline daily. The raw tables hold the Stripe objects returned by
-incremental discovery; schedule periodic full refreshes or targeted reloads
-when your reporting needs to account for changes to older mutable Stripe
-records.
+incremental discovery. When you need to reload older mutable Stripe records,
+use a targeted reload and keep the snapshot tables intact.
 
 ## Customize it
 

--- a/templates/stripe-bigquery/assets/stripe_raw/customer.asset.yml
+++ b/templates/stripe-bigquery/assets/stripe_raw/customer.asset.yml
@@ -1,0 +1,7 @@
+name: stripe_raw.customer
+type: ingestr
+
+description: Raw-layer ingestion of Stripe customer data into BigQuery.
+
+parameters:
+  source_table: customer

--- a/templates/stripe-bigquery/assets/stripe_raw/invoice.asset.yml
+++ b/templates/stripe-bigquery/assets/stripe_raw/invoice.asset.yml
@@ -1,0 +1,7 @@
+name: stripe_raw.invoice
+type: ingestr
+
+description: Raw-layer ingestion of Stripe invoice data into BigQuery.
+
+parameters:
+  source_table: invoice

--- a/templates/stripe-bigquery/assets/stripe_raw/price.asset.yml
+++ b/templates/stripe-bigquery/assets/stripe_raw/price.asset.yml
@@ -1,0 +1,7 @@
+name: stripe_raw.price
+type: ingestr
+
+description: Raw-layer ingestion of Stripe price data into BigQuery.
+
+parameters:
+  source_table: price

--- a/templates/stripe-bigquery/assets/stripe_raw/product.asset.yml
+++ b/templates/stripe-bigquery/assets/stripe_raw/product.asset.yml
@@ -1,0 +1,7 @@
+name: stripe_raw.product
+type: ingestr
+
+description: Raw-layer ingestion of Stripe product data into BigQuery.
+
+parameters:
+  source_table: product

--- a/templates/stripe-bigquery/assets/stripe_raw/subscription.asset.yml
+++ b/templates/stripe-bigquery/assets/stripe_raw/subscription.asset.yml
@@ -1,0 +1,15 @@
+name: stripe_raw.subscription
+type: ingestr
+
+description: >
+  Raw-layer ingestion of Stripe subscription data into BigQuery. Explicitly
+  types ended_at because Stripe can omit that nullable field when no
+  subscription has ended.
+
+parameters:
+  source_table: subscription
+  enforce_schema: true
+
+columns:
+  - name: ended_at
+    type: integer

--- a/templates/stripe-bigquery/assets/stripe_raw/subscription_item.asset.yml
+++ b/templates/stripe-bigquery/assets/stripe_raw/subscription_item.asset.yml
@@ -1,0 +1,7 @@
+name: stripe_raw.subscription_item
+type: ingestr
+
+description: Raw-layer ingestion of Stripe subscription item data into BigQuery.
+
+parameters:
+  source_table: subscription_item

--- a/templates/stripe-bigquery/assets/stripe_reports/monthly_invoice_billings.sql
+++ b/templates/stripe-bigquery/assets/stripe_reports/monthly_invoice_billings.sql
@@ -1,0 +1,52 @@
+/* @bruin
+name: stripe_reports.monthly_invoice_billings
+type: bq.sql
+description: >
+  Monthly invoice billings by native currency. Billings are grouped by Stripe's
+  invoice_finalized_at when it is available; rows with
+  invoice_created_at_fallback use the invoice creation timestamp because the
+  finalization transition was unavailable. This report excludes draft and void
+  invoices and does not present current paid status as historical collections.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_stage.invoices
+
+tags:
+  - stripe_reports
+  - stripe
+  - finance
+  - billing
+@bruin */
+
+WITH billable_invoices AS (
+  SELECT
+    currency,
+    is_subscription_invoice,
+    invoice_total_minor,
+    COALESCE(invoice_finalized_at, invoice_created_at) AS invoice_billing_at,
+    CASE
+      WHEN invoice_finalized_at IS NOT NULL THEN 'invoice_finalized_at'
+      ELSE 'invoice_created_at_fallback'
+    END AS invoice_billing_date_basis
+  FROM stripe_stage.invoices
+  WHERE invoice_status NOT IN ('draft', 'void')
+)
+
+SELECT
+  DATE_TRUNC(DATE(invoice_billing_at), MONTH) AS invoice_billing_month,
+  invoice_billing_date_basis,
+  currency,
+  COUNT(*) AS issued_invoice_count,
+  COUNTIF(is_subscription_invoice) AS subscription_invoice_count,
+  SUM(COALESCE(invoice_total_minor, 0)) AS invoiced_billings_minor,
+  SUM(IF(
+    is_subscription_invoice,
+    COALESCE(invoice_total_minor, 0),
+    CAST(0 AS NUMERIC)
+  )) AS invoiced_subscription_billings_minor
+FROM billable_invoices
+GROUP BY 1, 2, 3;

--- a/templates/stripe-bigquery/assets/stripe_reports/monthly_mrr_by_customer.sql
+++ b/templates/stripe-bigquery/assets/stripe_reports/monthly_mrr_by_customer.sql
@@ -1,0 +1,64 @@
+/* @bruin
+name: stripe_reports.monthly_mrr_by_customer
+type: bq.sql
+description: >
+  End-of-month observed recurring revenue by Stripe billing customer and native
+  currency. Every customer-currency row in a month uses one global daily
+  snapshot date. MRR is gross list-price run rate from active or past-due
+  licensed subscriptions, not recognized revenue, cash, or bookings.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_stage.customer_currency_daily_mrr_snapshot
+  - stripe_stage.customers
+
+tags:
+  - stripe_reports
+  - stripe
+  - billing
+  - mrr
+@bruin */
+
+WITH available_reporting_months AS (
+  SELECT
+    DATE_TRUNC(snapshot_date, MONTH) AS metric_month,
+    MAX(snapshot_date) AS as_of_snapshot_date
+  FROM stripe_stage.customer_currency_daily_mrr_snapshot
+  GROUP BY 1
+),
+global_reporting_snapshot_dates AS (
+  SELECT
+    *,
+    LAG(metric_month) OVER (ORDER BY metric_month)
+      AS previous_reporting_month
+  FROM available_reporting_months
+)
+
+SELECT
+  snapshots.metric_month,
+  snapshots.as_of_snapshot_date,
+  snapshots.previous_reporting_month IS NOT NULL
+    AND DATE_DIFF(
+      snapshots.metric_month,
+      snapshots.previous_reporting_month,
+      MONTH
+    ) = 1 AS has_contiguous_global_prior_snapshot,
+  snapshot.stripe_customer_id,
+  snapshot.currency,
+  customer.crm_account_id,
+  customer.customer_segment,
+  customer.customer_region,
+  customer.sales_owner,
+  customer.acquisition_channel,
+  snapshot.active_subscription_count,
+  snapshot.active_subscription_item_count,
+  snapshot.ending_mrr_minor,
+  snapshot.ending_mrr_minor * 12 AS run_rate_arr_minor
+FROM global_reporting_snapshot_dates AS snapshots
+INNER JOIN stripe_stage.customer_currency_daily_mrr_snapshot AS snapshot
+  ON snapshots.as_of_snapshot_date = snapshot.snapshot_date
+LEFT JOIN stripe_stage.customers AS customer
+  ON snapshot.stripe_customer_id = customer.stripe_customer_id;

--- a/templates/stripe-bigquery/assets/stripe_reports/monthly_mrr_movements.sql
+++ b/templates/stripe-bigquery/assets/stripe_reports/monthly_mrr_movements.sql
@@ -1,0 +1,169 @@
+/* @bruin
+name: stripe_reports.monthly_mrr_movements
+type: bq.sql
+description: >
+  Customer-level MRR movement ledger. Movements are classified after summing all
+  subscriptions for a billing customer, preventing internal plan swaps from
+  appearing as separate churn and new-business events.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_reports.monthly_mrr_by_customer
+
+tags:
+  - stripe_reports
+  - stripe
+  - billing
+  - mrr
+  - movements
+
+custom_checks:
+  - name: mrr movements roll forward to ending mrr
+    description: >
+      For reconcilable customer months, aggregate ending MRR must equal
+      beginning MRR plus classified new, reactivation, expansion, contraction,
+      and churn movements in the same native currency.
+    query: |
+      WITH monthly_roll_forward AS (
+        SELECT
+          metric_month,
+          currency,
+          SUM(beginning_mrr_minor) AS beginning_mrr_minor,
+          SUM(ending_mrr_minor) AS ending_mrr_minor,
+          SUM(net_mrr_change_minor) AS recorded_net_mrr_change_minor,
+          SUM(
+            new_mrr_minor
+            + reactivation_mrr_minor
+            + expansion_mrr_minor
+            - contraction_mrr_minor
+            - churned_mrr_minor
+          ) AS classified_net_mrr_change_minor
+        FROM {{ this }}
+        WHERE net_mrr_change_minor IS NOT NULL
+        GROUP BY 1, 2
+      )
+      SELECT COUNT(*)
+      FROM monthly_roll_forward
+      WHERE ending_mrr_minor IS DISTINCT FROM (
+        beginning_mrr_minor + classified_net_mrr_change_minor
+      )
+        OR recorded_net_mrr_change_minor IS DISTINCT FROM
+          classified_net_mrr_change_minor
+    value: 0
+@bruin */
+
+WITH customer_mrr_history AS (
+  SELECT
+    *,
+    LAG(metric_month) OVER customer_window AS previous_observed_month,
+    LAG(ending_mrr_minor) OVER customer_window AS previous_mrr_minor,
+    COUNTIF(ending_mrr_minor > 0) OVER (
+      customer_window
+      ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+    ) AS prior_positive_mrr_month_count
+  FROM stripe_reports.monthly_mrr_by_customer
+  WINDOW customer_window AS (
+    PARTITION BY stripe_customer_id, currency
+    ORDER BY metric_month
+  )
+),
+movement_base AS (
+  SELECT
+    *,
+    previous_observed_month IS NOT NULL
+      AND DATE_DIFF(metric_month, previous_observed_month, MONTH) = 1
+      AS has_contiguous_prior_snapshot,
+    COALESCE(previous_mrr_minor, CAST(0 AS NUMERIC)) AS beginning_mrr_minor
+  FROM customer_mrr_history
+)
+
+SELECT
+  metric_month,
+  as_of_snapshot_date,
+  has_contiguous_global_prior_snapshot,
+  stripe_customer_id,
+  currency,
+  crm_account_id,
+  customer_segment,
+  customer_region,
+  sales_owner,
+  acquisition_channel,
+  previous_observed_month,
+  has_contiguous_prior_snapshot,
+  beginning_mrr_minor,
+  ending_mrr_minor,
+  CASE
+    WHEN has_contiguous_prior_snapshot
+      THEN ending_mrr_minor - beginning_mrr_minor
+    WHEN previous_observed_month IS NULL
+      AND has_contiguous_global_prior_snapshot
+      THEN ending_mrr_minor
+    ELSE NULL
+  END AS net_mrr_change_minor,
+  CASE
+    WHEN (
+      has_contiguous_prior_snapshot
+      OR (
+        previous_observed_month IS NULL
+        AND has_contiguous_global_prior_snapshot
+      )
+    )
+      AND beginning_mrr_minor = 0
+      AND ending_mrr_minor > 0
+      AND prior_positive_mrr_month_count = 0
+      THEN ending_mrr_minor
+    ELSE CAST(0 AS NUMERIC)
+  END AS new_mrr_minor,
+  CASE
+    WHEN has_contiguous_prior_snapshot
+      AND beginning_mrr_minor = 0
+      AND ending_mrr_minor > 0
+      AND prior_positive_mrr_month_count > 0
+      THEN ending_mrr_minor
+    ELSE CAST(0 AS NUMERIC)
+  END AS reactivation_mrr_minor,
+  CASE
+    WHEN has_contiguous_prior_snapshot
+      AND beginning_mrr_minor > 0
+      AND ending_mrr_minor > beginning_mrr_minor
+      THEN ending_mrr_minor - beginning_mrr_minor
+    ELSE CAST(0 AS NUMERIC)
+  END AS expansion_mrr_minor,
+  CASE
+    WHEN has_contiguous_prior_snapshot
+      AND beginning_mrr_minor > ending_mrr_minor
+      AND ending_mrr_minor > 0
+      THEN beginning_mrr_minor - ending_mrr_minor
+    ELSE CAST(0 AS NUMERIC)
+  END AS contraction_mrr_minor,
+  CASE
+    WHEN has_contiguous_prior_snapshot
+      AND beginning_mrr_minor > 0
+      AND ending_mrr_minor = 0
+      THEN beginning_mrr_minor
+    ELSE CAST(0 AS NUMERIC)
+  END AS churned_mrr_minor,
+  CASE
+    WHEN previous_observed_month IS NULL
+      AND has_contiguous_global_prior_snapshot
+      AND ending_mrr_minor > 0 THEN 'new'
+    WHEN previous_observed_month IS NULL THEN 'first_observed_month'
+    WHEN NOT has_contiguous_prior_snapshot THEN 'snapshot_gap'
+    WHEN beginning_mrr_minor = 0
+      AND ending_mrr_minor > 0
+      AND prior_positive_mrr_month_count = 0 THEN 'new'
+    WHEN beginning_mrr_minor = 0
+      AND ending_mrr_minor > 0
+      AND prior_positive_mrr_month_count > 0 THEN 'reactivation'
+    WHEN beginning_mrr_minor > 0
+      AND ending_mrr_minor > beginning_mrr_minor THEN 'expansion'
+    WHEN beginning_mrr_minor > ending_mrr_minor
+      AND ending_mrr_minor > 0 THEN 'contraction'
+    WHEN beginning_mrr_minor > 0
+      AND ending_mrr_minor = 0 THEN 'churn'
+    ELSE 'no_change'
+  END AS movement_type
+FROM movement_base;

--- a/templates/stripe-bigquery/assets/stripe_reports/monthly_subscription_kpis.sql
+++ b/templates/stripe-bigquery/assets/stripe_reports/monthly_subscription_kpis.sql
@@ -1,0 +1,130 @@
+/* @bruin
+name: stripe_reports.monthly_subscription_kpis
+type: bq.sql
+description: >
+  Monthly recurring-revenue scorecard. Retention metrics use only
+  contiguous monthly snapshots and exclude reactivation from NRR by policy.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_reports.monthly_mrr_movements
+
+tags:
+  - stripe_reports
+  - stripe
+  - billing
+  - kpis
+@bruin */
+
+SELECT
+  metric_month,
+  currency,
+  MAX(as_of_snapshot_date) AS as_of_snapshot_date,
+  SUM(IF(
+    has_contiguous_prior_snapshot,
+    beginning_mrr_minor,
+    CAST(0 AS NUMERIC)
+  )) AS beginning_mrr_minor,
+  SUM(ending_mrr_minor) AS ending_mrr_minor,
+  SUM(ending_mrr_minor) * 12 AS ending_run_rate_arr_minor,
+  SUM(new_mrr_minor) AS new_mrr_minor,
+  SUM(reactivation_mrr_minor) AS reactivation_mrr_minor,
+  SUM(expansion_mrr_minor) AS expansion_mrr_minor,
+  SUM(contraction_mrr_minor) AS contraction_mrr_minor,
+  SUM(churned_mrr_minor) AS churned_mrr_minor,
+  COUNT(DISTINCT IF(
+    has_contiguous_prior_snapshot AND beginning_mrr_minor > 0,
+    stripe_customer_id,
+    NULL
+  )) AS beginning_active_customer_count,
+  COUNT(DISTINCT IF(
+    ending_mrr_minor > 0,
+    stripe_customer_id,
+    NULL
+  )) AS ending_active_customer_count,
+  COUNT(DISTINCT IF(movement_type = 'new', stripe_customer_id, NULL))
+    AS new_customer_count,
+  COUNT(DISTINCT IF(movement_type = 'reactivation', stripe_customer_id, NULL))
+    AS reactivated_customer_count,
+  COUNT(DISTINCT IF(movement_type = 'churn', stripe_customer_id, NULL))
+    AS churned_customer_count,
+  SAFE_DIVIDE(
+    SUM(ending_mrr_minor),
+    NULLIF(
+      COUNT(DISTINCT IF(ending_mrr_minor > 0, stripe_customer_id, NULL)),
+      0
+    )
+  ) AS average_revenue_per_active_customer_minor,
+  SAFE_DIVIDE(
+    SUM(churned_mrr_minor),
+    NULLIF(
+      SUM(IF(
+        has_contiguous_prior_snapshot,
+        beginning_mrr_minor,
+        CAST(0 AS NUMERIC)
+      )),
+      0
+    )
+  ) AS gross_revenue_churn_rate,
+  SAFE_DIVIDE(
+    SUM(contraction_mrr_minor) + SUM(churned_mrr_minor),
+    NULLIF(
+      SUM(IF(
+        has_contiguous_prior_snapshot,
+        beginning_mrr_minor,
+        CAST(0 AS NUMERIC)
+      )),
+      0
+    )
+  ) AS gross_revenue_retention_loss_rate,
+  SAFE_DIVIDE(
+    SUM(IF(
+      has_contiguous_prior_snapshot,
+      beginning_mrr_minor,
+      CAST(0 AS NUMERIC)
+    ))
+      - SUM(contraction_mrr_minor)
+      - SUM(churned_mrr_minor),
+    NULLIF(
+      SUM(IF(
+        has_contiguous_prior_snapshot,
+        beginning_mrr_minor,
+        CAST(0 AS NUMERIC)
+      )),
+      0
+    )
+  ) AS gross_revenue_retention_rate,
+  SAFE_DIVIDE(
+    SUM(IF(
+      has_contiguous_prior_snapshot,
+      beginning_mrr_minor,
+      CAST(0 AS NUMERIC)
+    ))
+      + SUM(expansion_mrr_minor)
+      - SUM(contraction_mrr_minor)
+      - SUM(churned_mrr_minor),
+    NULLIF(
+      SUM(IF(
+        has_contiguous_prior_snapshot,
+        beginning_mrr_minor,
+        CAST(0 AS NUMERIC)
+      )),
+      0
+    )
+  ) AS net_revenue_retention_rate_excluding_reactivation,
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(movement_type = 'churn', stripe_customer_id, NULL)),
+    NULLIF(
+      COUNT(DISTINCT IF(
+        has_contiguous_prior_snapshot AND beginning_mrr_minor > 0,
+        stripe_customer_id,
+        NULL
+      )),
+      0
+    )
+  ) AS logo_churn_rate
+FROM stripe_reports.monthly_mrr_movements
+GROUP BY 1, 2;

--- a/templates/stripe-bigquery/assets/stripe_stage/customer_currency_daily_mrr_snapshot.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/customer_currency_daily_mrr_snapshot.sql
@@ -1,0 +1,120 @@
+/* @bruin
+name: stripe_stage.customer_currency_daily_mrr_snapshot
+type: bq.sql
+description: >
+  Insert-only daily MRR snapshot at Stripe customer and native-currency grain.
+  It starts from subscriptions and left joins subscription items, retaining a
+  zero-MRR row when a cancelled or itemless subscription has no MRR-eligible
+  items.
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - stripe_stage.subscriptions
+  - stripe_stage.subscription_items
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - snapshot
+  - mrr
+
+custom_checks:
+  - name: snapshot keys are unique
+    description: >
+      Each daily reporting snapshot must contain at most one row per snapshot
+      date, Stripe customer, and native currency.
+    query: |
+      SELECT COUNT(*)
+      FROM (
+        SELECT
+          snapshot_date,
+          stripe_customer_id,
+          currency
+        FROM {{ this }}
+        GROUP BY 1, 2, 3
+        HAVING COUNT(*) > 1
+      )
+    value: 0
+  - name: current customer currencies are covered by this snapshot
+    description: >
+      Every current subscription customer/currency pair must be represented
+      for the pipeline end date. An empty Stripe account passes this check.
+    query: |
+      SELECT COUNT(*)
+      FROM (
+        SELECT DISTINCT
+          stripe_customer_id,
+          currency
+        FROM {{ schema_prefix }}stripe_stage.subscriptions
+        WHERE stripe_customer_id IS NOT NULL
+          AND currency IS NOT NULL
+      ) AS source
+      LEFT JOIN {{ this }} AS snapshot
+        ON snapshot.snapshot_date = DATE('{{ end_date }}')
+        AND snapshot.stripe_customer_id = source.stripe_customer_id
+        AND snapshot.currency = source.currency
+      WHERE snapshot.stripe_customer_id IS NULL
+    value: 0
+
+columns:
+  - name: snapshot_date
+    type: DATE
+    description: UTC date represented by the snapshot.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: stripe_customer_id
+    type: STRING
+    description: Stripe billing customer identifier.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: currency
+    type: STRING
+    description: Native Stripe currency.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: active_subscription_count
+    type: INT64
+    description: Count of subscriptions with at least one MRR-eligible item.
+  - name: active_subscription_item_count
+    type: INT64
+    description: Count of MRR-eligible subscription items.
+  - name: ending_mrr_minor
+    type: NUMERIC
+    description: Ending gross list-price MRR in native-currency minor units.
+  - name: is_live_mode
+    type: BOOL
+    description: Stripe live-mode flag.
+@bruin */
+
+SELECT
+  DATE('{{ end_date }}') AS snapshot_date,
+  subscription.stripe_customer_id,
+  subscription.currency,
+  COUNT(DISTINCT IF(
+    COALESCE(item.is_mrr_eligible, FALSE),
+    subscription.stripe_subscription_id,
+    NULL
+  )) AS active_subscription_count,
+  COUNTIF(COALESCE(item.is_mrr_eligible, FALSE)) AS active_subscription_item_count,
+  COALESCE(
+    SUM(IF(
+      COALESCE(item.is_mrr_eligible, FALSE),
+      item.gross_mrr_minor,
+      CAST(0 AS NUMERIC)
+    )),
+    CAST(0 AS NUMERIC)
+  ) AS ending_mrr_minor,
+  LOGICAL_OR(COALESCE(subscription.is_live_mode, FALSE)) AS is_live_mode
+FROM stripe_stage.subscriptions AS subscription
+LEFT JOIN stripe_stage.subscription_items AS item
+  ON subscription.stripe_subscription_id = item.stripe_subscription_id
+WHERE subscription.stripe_customer_id IS NOT NULL
+  AND subscription.currency IS NOT NULL
+GROUP BY 1, 2, 3;

--- a/templates/stripe-bigquery/assets/stripe_stage/customers.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/customers.sql
@@ -1,0 +1,44 @@
+/* @bruin
+name: stripe_stage.customers
+type: bq.sql
+description: >
+  Conformed Stripe billing accounts. This model keeps customer identifiers and
+  metadata available for downstream billing analytics; direct contact details
+  remain in the raw source and are intentionally excluded from reports.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_raw.customer
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - customers
+
+columns:
+  - name: stripe_customer_id
+    type: STRING
+    description: Stripe billing customer identifier and natural key.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+SELECT
+  id AS stripe_customer_id,
+  TIMESTAMP_SECONDS(SAFE_CAST(created AS INT64)) AS customer_created_at,
+  name AS customer_name,
+  email AS customer_email,
+  livemode AS is_live_mode,
+  metadata AS customer_metadata,
+  JSON_VALUE(metadata, '$.crm_account_id') AS crm_account_id,
+  JSON_VALUE(metadata, '$.segment') AS customer_segment,
+  JSON_VALUE(metadata, '$.region') AS customer_region,
+  JSON_VALUE(metadata, '$.sales_owner') AS sales_owner,
+  JSON_VALUE(metadata, '$.acquisition_channel') AS acquisition_channel
+FROM stripe_raw.customer;

--- a/templates/stripe-bigquery/assets/stripe_stage/invoice_line_items.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/invoice_line_items.sql
@@ -1,0 +1,177 @@
+/* @bruin
+name: stripe_stage.invoice_line_items
+type: bq.sql
+description: >
+  Invoice lines flattened from Stripe's expanded invoice.lines payload. Stripe
+  can paginate exceptionally large embedded line lists, so validate this model
+  before using it as a complete accounting subledger. The source pagination
+  indicator is propagated as invoice_lines_has_more for each flattened line.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_stage.invoices
+  - stripe_stage.prices
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - invoice-lines
+
+columns:
+  - name: stripe_invoice_line_item_id
+    type: STRING
+    description: Stripe invoice-line identifier within an invoice.
+    checks:
+      - name: not_null
+  - name: stripe_invoice_id
+    type: STRING
+    description: Stripe invoice that contains the line.
+    checks:
+      - name: not_null
+  - name: invoice_lines_has_more
+    type: BOOL
+    description: >
+      Whether the source invoice has additional embedded line pages. True
+      means this flattened invoice is incomplete.
+
+custom_checks:
+  - name: invoice line keys are unique
+    description: >
+      Stripe invoice-line identifiers must be unique within each source
+      invoice after flattening.
+    query: |
+      SELECT COUNT(*)
+      FROM (
+        SELECT
+          stripe_invoice_id,
+          stripe_invoice_line_item_id
+        FROM {{ this }}
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1
+      )
+    value: 0
+  - name: embedded invoice lines are not paginated
+    description: >
+      Non-blocking signal: a non-zero result means Stripe reported additional
+      invoice.lines pages, so this model is not a complete invoice subledger.
+    query: |
+      SELECT COUNTIF(invoice_lines_has_more IS TRUE)
+      FROM {{ this }}
+    value: 0
+    blocking: false
+@bruin */
+
+WITH flattened_lines AS (
+  SELECT
+    invoice.stripe_invoice_id,
+    invoice.stripe_customer_id,
+    invoice.invoice_created_at,
+    invoice.invoice_status,
+    invoice.billing_reason,
+    invoice.currency AS invoice_currency,
+    invoice.is_subscription_invoice,
+    invoice.invoice_lines_has_more,
+    line AS line_json
+  FROM stripe_stage.invoices AS invoice
+  CROSS JOIN UNNEST(
+    IFNULL(JSON_QUERY_ARRAY(invoice.invoice_lines, '$.data'), ARRAY<JSON>[])
+  ) AS line
+),
+typed_lines AS (
+  SELECT
+    *,
+    JSON_VALUE(line_json, '$.id') AS stripe_invoice_line_item_id,
+    COALESCE(
+      JSON_VALUE(line_json, '$.pricing.price_details.price'),
+      JSON_VALUE(line_json, '$.price.id'),
+      JSON_VALUE(line_json, '$.price'),
+      JSON_VALUE(line_json, '$.plan.id')
+    ) AS stripe_price_id,
+    COALESCE(
+      JSON_VALUE(line_json, '$.parent.subscription_item_details.subscription'),
+      JSON_VALUE(line_json, '$.subscription')
+    ) AS stripe_subscription_id,
+    COALESCE(
+      JSON_VALUE(line_json, '$.parent.subscription_item_details.subscription_item'),
+      JSON_VALUE(line_json, '$.subscription_item')
+    ) AS stripe_subscription_item_id
+  FROM flattened_lines
+)
+
+SELECT
+  line.stripe_invoice_line_item_id,
+  line.stripe_invoice_id,
+  line.stripe_customer_id,
+  line.stripe_subscription_id,
+  line.stripe_subscription_item_id,
+  line.invoice_created_at,
+  line.invoice_status,
+  line.billing_reason,
+  line.is_subscription_invoice,
+  line.invoice_lines_has_more,
+  line.stripe_price_id,
+  price.stripe_product_id,
+  price.product_name,
+  COALESCE(JSON_VALUE(line.line_json, '$.currency'), line.invoice_currency) AS currency,
+  JSON_VALUE(line.line_json, '$.description') AS line_description,
+  COALESCE(
+    JSON_VALUE(line.line_json, '$.type'),
+    JSON_VALUE(line.line_json, '$.parent.type'),
+    'unknown'
+  ) AS line_type,
+  COALESCE(
+    SAFE_CAST(JSON_VALUE(line.line_json, '$.quantity') AS INT64),
+    1
+  ) AS quantity,
+  TIMESTAMP_SECONDS(
+    SAFE_CAST(JSON_VALUE(line.line_json, '$.period.start') AS INT64)
+  ) AS service_period_started_at,
+  TIMESTAMP_SECONDS(
+    SAFE_CAST(JSON_VALUE(line.line_json, '$.period.end') AS INT64)
+  ) AS service_period_ends_at,
+  COALESCE(
+    SAFE_CAST(JSON_VALUE(line.line_json, '$.proration') AS BOOL),
+    SAFE_CAST(
+      JSON_VALUE(
+        line.line_json,
+        '$.parent.subscription_item_details.proration'
+      ) AS BOOL
+    ),
+    FALSE
+  ) AS is_proration,
+  SAFE_CAST(JSON_VALUE(line.line_json, '$.amount') AS NUMERIC) AS line_amount_minor,
+  (
+    SELECT COALESCE(
+      SUM(SAFE_CAST(JSON_VALUE(discount, '$.amount') AS NUMERIC)),
+      CAST(0 AS NUMERIC)
+    )
+    FROM UNNEST(
+      IFNULL(
+        JSON_QUERY_ARRAY(line.line_json, '$.discount_amounts'),
+        ARRAY<JSON>[]
+      )
+    ) AS discount
+  ) AS line_discount_minor,
+  SAFE_CAST(JSON_VALUE(line.line_json, '$.amount') AS NUMERIC)
+    - (
+      SELECT COALESCE(
+        SUM(SAFE_CAST(JSON_VALUE(discount, '$.amount') AS NUMERIC)),
+        CAST(0 AS NUMERIC)
+      )
+      FROM UNNEST(
+        IFNULL(
+          JSON_QUERY_ARRAY(line.line_json, '$.discount_amounts'),
+          ARRAY<JSON>[]
+        )
+      ) AS discount
+    ) AS line_net_amount_minor,
+  price.is_recurring AS is_recurring_price,
+  price.recurring_interval,
+  price.recurring_usage_type
+FROM typed_lines AS line
+LEFT JOIN stripe_stage.prices AS price
+  ON line.stripe_price_id = price.stripe_price_id;

--- a/templates/stripe-bigquery/assets/stripe_stage/invoices.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/invoices.sql
@@ -1,0 +1,67 @@
+/* @bruin
+name: stripe_stage.invoices
+type: bq.sql
+description: >
+  Conformed invoice facts for billings, current AR, and invoice-line analysis.
+  Amounts are native-currency minor units and are not accounting revenue.
+  invoice_lines_has_more flags Stripe's paginated embedded line payload; a true
+  value means the flattened invoice-line model is not a complete subledger.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_raw.invoice
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - invoices
+
+columns:
+  - name: stripe_invoice_id
+    type: STRING
+    description: Stripe invoice identifier and natural key.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: invoice_lines_has_more
+    type: BOOL
+    description: >
+      Whether Stripe reports more pages in the embedded invoice.lines payload.
+      True means invoice_line_items is incomplete; null means the source did
+      not provide a parseable pagination indicator.
+@bruin */
+
+SELECT
+  id AS stripe_invoice_id,
+  customer AS stripe_customer_id,
+  TIMESTAMP_SECONDS(SAFE_CAST(created AS INT64)) AS invoice_created_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(due_date AS INT64)) AS invoice_due_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(
+    JSON_VALUE(status_transitions, '$.finalized_at') AS INT64
+  )) AS invoice_finalized_at,
+  status AS invoice_status,
+  billing_reason,
+  collection_method,
+  currency,
+  livemode AS is_live_mode,
+  paid AS is_paid,
+  SAFE_CAST(attempt_count AS INT64) AS payment_attempt_count,
+  SAFE_CAST(amount_due AS NUMERIC) AS invoice_amount_due_minor,
+  SAFE_CAST(amount_paid AS NUMERIC) AS invoice_amount_paid_minor,
+  SAFE_CAST(amount_remaining AS NUMERIC) AS invoice_amount_remaining_minor,
+  SAFE_CAST(subtotal AS NUMERIC) AS invoice_subtotal_minor,
+  SAFE_CAST(total AS NUMERIC) AS invoice_total_minor,
+  billing_reason IN (
+    'subscription_create',
+    'subscription_cycle',
+    'subscription_update',
+    'subscription_threshold'
+  ) AS is_subscription_invoice,
+  SAFE_CAST(JSON_VALUE(lines, '$.has_more') AS BOOL) AS invoice_lines_has_more,
+  lines AS invoice_lines
+FROM stripe_raw.invoice;

--- a/templates/stripe-bigquery/assets/stripe_stage/prices.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/prices.sql
@@ -1,0 +1,57 @@
+/* @bruin
+name: stripe_stage.prices
+type: bq.sql
+description: >
+  Conformed Stripe prices with recurring-cadence attributes and monetary values
+  retained in native-currency minor units.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_raw.price
+  - stripe_stage.products
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - prices
+
+columns:
+  - name: stripe_price_id
+    type: STRING
+    description: Stripe price identifier and natural key.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+SELECT
+  p.id AS stripe_price_id,
+  p.product AS stripe_product_id,
+  product.product_name,
+  TIMESTAMP_SECONDS(SAFE_CAST(p.created AS INT64)) AS price_created_at,
+  p.currency,
+  p.type AS price_type,
+  p.active AS is_active,
+  p.livemode AS is_live_mode,
+  SAFE_CAST(p.unit_amount AS NUMERIC) AS unit_amount_minor,
+  p.billing_scheme,
+  p.recurring AS recurring_config,
+  p.type = 'recurring' AS is_recurring,
+  JSON_VALUE(p.recurring, '$.interval') AS recurring_interval,
+  COALESCE(
+    SAFE_CAST(JSON_VALUE(p.recurring, '$.interval_count') AS INT64),
+    1
+  ) AS recurring_interval_count,
+  COALESCE(
+    JSON_VALUE(p.recurring, '$.usage_type'),
+    'licensed'
+  ) AS recurring_usage_type,
+  p.metadata AS price_metadata
+FROM stripe_raw.price AS p
+LEFT JOIN stripe_stage.products AS product
+  ON p.product = product.stripe_product_id;

--- a/templates/stripe-bigquery/assets/stripe_stage/products.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/products.sql
@@ -1,0 +1,36 @@
+/* @bruin
+name: stripe_stage.products
+type: bq.sql
+description: Conformed Stripe product catalog for plan and packaging analysis.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_raw.product
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - products
+
+columns:
+  - name: stripe_product_id
+    type: STRING
+    description: Stripe product identifier and natural key.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+@bruin */
+
+SELECT
+  id AS stripe_product_id,
+  TIMESTAMP_SECONDS(SAFE_CAST(created AS INT64)) AS product_created_at,
+  name AS product_name,
+  active AS is_active,
+  livemode AS is_live_mode,
+  metadata AS product_metadata
+FROM stripe_raw.product;

--- a/templates/stripe-bigquery/assets/stripe_stage/subscription_item_daily_snapshot.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/subscription_item_daily_snapshot.sql
@@ -1,0 +1,155 @@
+/* @bruin
+name: stripe_stage.subscription_item_daily_snapshot
+type: bq.sql
+description: >
+  Insert-only daily snapshot of current subscription-item MRR state. It starts
+  on the first pipeline run and cannot reconstruct historic state from mutable
+  Stripe subscription records.
+
+materialization:
+  type: table
+  strategy: merge
+
+depends:
+  - stripe_stage.subscription_items
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - snapshot
+
+custom_checks:
+  - name: snapshot keys are unique
+    description: >
+      Each daily snapshot must contain at most one row per snapshot date and
+      Stripe subscription item.
+    query: |
+      SELECT COUNT(*)
+      FROM (
+        SELECT
+          snapshot_date,
+          stripe_subscription_item_id
+        FROM {{ this }}
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1
+      )
+    value: 0
+  - name: current subscription items are covered by this snapshot
+    description: >
+      Every current subscription item with an identifier must be represented
+      in the snapshot for the pipeline end date. An empty Stripe account passes
+      this check.
+    query: |
+      SELECT COUNT(*)
+      FROM {{ schema_prefix }}stripe_stage.subscription_items AS source
+      LEFT JOIN {{ this }} AS snapshot
+        ON snapshot.snapshot_date = DATE('{{ end_date }}')
+        AND snapshot.stripe_subscription_item_id = source.stripe_subscription_item_id
+      WHERE source.stripe_subscription_item_id IS NOT NULL
+        AND snapshot.stripe_subscription_item_id IS NULL
+    value: 0
+
+columns:
+  - name: snapshot_date
+    type: DATE
+    description: UTC date represented by the snapshot.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: stripe_subscription_item_id
+    type: STRING
+    description: Stripe subscription-item identifier.
+    primary_key: true
+    checks:
+      - name: not_null
+  - name: stripe_subscription_id
+    type: STRING
+    description: Stripe subscription identifier.
+  - name: stripe_customer_id
+    type: STRING
+    description: Stripe billing customer identifier.
+  - name: subscription_status
+    type: STRING
+    description: Current Stripe subscription status.
+  - name: cancel_at_period_end
+    type: BOOL
+    description: Whether the subscription is scheduled to cancel at period end.
+  - name: cancel_at
+    type: TIMESTAMP
+    description: Scheduled cancellation timestamp.
+  - name: trial_started_at
+    type: TIMESTAMP
+    description: Trial start timestamp.
+  - name: trial_ends_at
+    type: TIMESTAMP
+    description: Trial end timestamp.
+  - name: current_period_started_at
+    type: TIMESTAMP
+    description: Current billing period start timestamp.
+  - name: current_period_ends_at
+    type: TIMESTAMP
+    description: Current billing period end timestamp.
+  - name: stripe_price_id
+    type: STRING
+    description: Stripe price identifier.
+  - name: stripe_product_id
+    type: STRING
+    description: Stripe product identifier.
+  - name: product_name
+    type: STRING
+    description: Product name.
+  - name: currency
+    type: STRING
+    description: Native Stripe currency.
+  - name: recurring_interval
+    type: STRING
+    description: Stripe recurring interval.
+  - name: recurring_interval_count
+    type: INT64
+    description: Number of recurring intervals in one billing period.
+  - name: recurring_usage_type
+    type: STRING
+    description: Stripe recurring usage type.
+  - name: quantity
+    type: INT64
+    description: Subscription-item quantity.
+  - name: is_mrr_eligible
+    type: BOOL
+    description: Whether the item contributes to gross list-price MRR.
+  - name: mrr_exclusion_reason
+    type: STRING
+    description: Reason the item does not contribute to MRR.
+  - name: gross_mrr_minor
+    type: NUMERIC
+    description: Gross list-price MRR in native-currency minor units.
+  - name: is_live_mode
+    type: BOOL
+    description: Stripe live-mode flag.
+@bruin */
+
+SELECT
+  DATE('{{ end_date }}') AS snapshot_date,
+  stripe_subscription_item_id,
+  stripe_subscription_id,
+  stripe_customer_id,
+  subscription_status,
+  cancel_at_period_end,
+  cancel_at,
+  trial_started_at,
+  trial_ends_at,
+  current_period_started_at,
+  current_period_ends_at,
+  stripe_price_id,
+  stripe_product_id,
+  product_name,
+  currency,
+  recurring_interval,
+  recurring_interval_count,
+  recurring_usage_type,
+  quantity,
+  is_mrr_eligible,
+  mrr_exclusion_reason,
+  gross_mrr_minor,
+  is_live_mode
+FROM stripe_stage.subscription_items;

--- a/templates/stripe-bigquery/assets/stripe_stage/subscription_items.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/subscription_items.sql
@@ -1,0 +1,171 @@
+/* @bruin
+name: stripe_stage.subscription_items
+type: bq.sql
+description: >
+  Current subscription-item state joined to prices and products. gross_mrr_minor
+  is normalized from active or past-due monthly and annual licensed recurring
+  prices only. price_based_recurring_mrr_minor normalizes the same price shape
+  regardless of subscription status for operational risk and trial-conversion
+  reporting, with each currency reported independently.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_raw.subscription_item
+  - stripe_stage.subscriptions
+  - stripe_stage.prices
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - subscription-items
+
+columns:
+  - name: stripe_subscription_item_id
+    type: STRING
+    description: Stripe subscription-item identifier and natural key.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: stripe_subscription_id
+    type: STRING
+    description: Stripe subscription that owns the item.
+    checks:
+      - name: not_null
+@bruin */
+
+WITH raw_subscription_items AS (
+  SELECT
+    id AS stripe_subscription_item_id,
+    subscription AS stripe_subscription_id,
+    TIMESTAMP_SECONDS(SAFE_CAST(created AS INT64)) AS subscription_item_created_at,
+    TIMESTAMP_SECONDS(
+      SAFE_CAST(current_period_start AS INT64)
+    ) AS current_period_started_at,
+    TIMESTAMP_SECONDS(
+      SAFE_CAST(current_period_end AS INT64)
+    ) AS current_period_ends_at,
+    COALESCE(SAFE_CAST(quantity AS INT64), 1) AS quantity,
+    COALESCE(
+      JSON_VALUE(price, '$.id'),
+      JSON_VALUE(price, '$')
+    ) AS stripe_price_id,
+    metadata AS subscription_item_metadata
+  FROM stripe_raw.subscription_item
+),
+subscription_item_context AS (
+  SELECT
+    item.stripe_subscription_item_id,
+    item.stripe_subscription_id,
+    subscription.stripe_customer_id,
+    subscription.subscription_status,
+    subscription.cancel_at_period_end,
+    subscription.cancel_at,
+    subscription.trial_started_at,
+    subscription.trial_ends_at,
+    item.subscription_item_created_at,
+    COALESCE(
+      item.current_period_started_at,
+      subscription.current_period_started_at
+    ) AS current_period_started_at,
+    COALESCE(
+      item.current_period_ends_at,
+      subscription.current_period_ends_at
+    ) AS current_period_ends_at,
+    item.stripe_price_id,
+    price.stripe_product_id,
+    price.product_name,
+    price.currency,
+    price.recurring_interval,
+    price.recurring_interval_count,
+    price.recurring_usage_type,
+    price.unit_amount_minor,
+    item.quantity,
+    price.is_recurring,
+    CASE
+      WHEN NOT COALESCE(price.is_recurring, FALSE)
+        THEN 'non_recurring_price'
+      WHEN COALESCE(price.recurring_usage_type, 'licensed') = 'metered'
+        THEN 'metered_price'
+      WHEN COALESCE(price.unit_amount_minor, 0) <= 0
+        THEN 'zero_amount_price'
+      WHEN price.recurring_interval NOT IN ('month', 'year')
+        THEN 'unsupported_cadence'
+      ELSE NULL
+    END AS price_based_mrr_exclusion_reason,
+    CASE
+      WHEN COALESCE(price.is_recurring, FALSE)
+        AND COALESCE(price.recurring_usage_type, 'licensed') != 'metered'
+        AND COALESCE(price.unit_amount_minor, 0) > 0
+        AND price.recurring_interval = 'month'
+        THEN SAFE_DIVIDE(
+          price.unit_amount_minor * item.quantity,
+          price.recurring_interval_count
+        )
+      WHEN COALESCE(price.is_recurring, FALSE)
+        AND COALESCE(price.recurring_usage_type, 'licensed') != 'metered'
+        AND COALESCE(price.unit_amount_minor, 0) > 0
+        AND price.recurring_interval = 'year'
+        THEN SAFE_DIVIDE(
+          price.unit_amount_minor * item.quantity,
+          12 * price.recurring_interval_count
+        )
+      ELSE CAST(0 AS NUMERIC)
+    END AS price_based_recurring_mrr_minor,
+    subscription.is_live_mode,
+    item.subscription_item_metadata
+  FROM raw_subscription_items AS item
+  INNER JOIN stripe_stage.subscriptions AS subscription
+    ON item.stripe_subscription_id = subscription.stripe_subscription_id
+  LEFT JOIN stripe_stage.prices AS price
+    ON item.stripe_price_id = price.stripe_price_id
+)
+
+SELECT
+  stripe_subscription_item_id,
+  stripe_subscription_id,
+  stripe_customer_id,
+  subscription_status,
+  cancel_at_period_end,
+  cancel_at,
+  trial_started_at,
+  trial_ends_at,
+  subscription_item_created_at,
+  current_period_started_at,
+  current_period_ends_at,
+  stripe_price_id,
+  stripe_product_id,
+  product_name,
+  currency,
+  recurring_interval,
+  recurring_interval_count,
+  recurring_usage_type,
+  unit_amount_minor,
+  quantity,
+  is_recurring,
+  CASE
+    WHEN subscription_status IN ('active', 'past_due')
+      AND price_based_mrr_exclusion_reason IS NULL THEN TRUE
+    ELSE FALSE
+  END AS is_mrr_eligible,
+  CASE
+    WHEN subscription_status = 'trialing' THEN 'trialing_subscription'
+    WHEN subscription_status NOT IN ('active', 'past_due')
+      THEN 'subscription_status'
+    ELSE price_based_mrr_exclusion_reason
+  END AS mrr_exclusion_reason,
+  CASE
+    WHEN subscription_status IN ('active', 'past_due')
+      AND price_based_mrr_exclusion_reason IS NULL
+      THEN price_based_recurring_mrr_minor
+    ELSE CAST(0 AS NUMERIC)
+  END AS gross_mrr_minor,
+  price_based_mrr_exclusion_reason,
+  price_based_recurring_mrr_minor,
+  is_live_mode,
+  subscription_item_metadata
+FROM subscription_item_context;

--- a/templates/stripe-bigquery/assets/stripe_stage/subscriptions.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/subscriptions.sql
@@ -1,0 +1,58 @@
+/* @bruin
+name: stripe_stage.subscriptions
+type: bq.sql
+description: >
+  Current Stripe subscription state, including trial, cancellation, and renewal
+  fields. Stripe subscriptions are mutable; use the daily subscription-item
+  snapshot for durable as-of reporting.
+
+materialization:
+  type: table
+  strategy: truncate+insert
+
+depends:
+  - stripe_raw.subscription
+
+tags:
+  - stripe_stage
+  - stripe
+  - billing
+  - subscriptions
+
+columns:
+  - name: stripe_subscription_id
+    type: STRING
+    description: Stripe subscription identifier and natural key.
+    primary_key: true
+    checks:
+      - name: not_null
+      - name: unique
+  - name: stripe_customer_id
+    type: STRING
+    description: Stripe billing customer associated with the subscription.
+    checks:
+      - name: not_null
+@bruin */
+
+SELECT
+  id AS stripe_subscription_id,
+  customer AS stripe_customer_id,
+  status AS subscription_status,
+  currency,
+  livemode AS is_live_mode,
+  TIMESTAMP_SECONDS(SAFE_CAST(created AS INT64)) AS subscription_created_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(start_date AS INT64)) AS subscription_started_at,
+  TIMESTAMP_SECONDS(
+    SAFE_CAST(current_period_start AS INT64)
+  ) AS current_period_started_at,
+  TIMESTAMP_SECONDS(
+    SAFE_CAST(current_period_end AS INT64)
+  ) AS current_period_ends_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(cancel_at AS INT64)) AS cancel_at,
+  cancel_at_period_end AS cancel_at_period_end,
+  TIMESTAMP_SECONDS(SAFE_CAST(canceled_at AS INT64)) AS canceled_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(ended_at AS INT64)) AS ended_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(trial_start AS INT64)) AS trial_started_at,
+  TIMESTAMP_SECONDS(SAFE_CAST(trial_end AS INT64)) AS trial_ends_at,
+  metadata AS subscription_metadata
+FROM stripe_raw.subscription;

--- a/templates/stripe-bigquery/pipeline.yml
+++ b/templates/stripe-bigquery/pipeline.yml
@@ -1,0 +1,15 @@
+name: stripe-bigquery
+schedule: daily
+start_date: "2023-01-01"
+catchup: false
+
+default:
+  type: ingestr
+  parameters:
+    source_connection: stripe-default
+    destination: bigquery
+    loader_file_format: jsonl
+
+default_connections:
+  google_cloud_platform: gcp-default
+  stripe: stripe-default

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -7,5 +7,6 @@ import (
 //go:embed *
 //go:embed */.bruin.yml
 //go:embed migration-fivetran/.gitignore
+//go:embed stripe-bigquery/.gitignore
 //go:embed migration-fivetran/.agents/skills/bruin-fivetran-migrator/*
 var Templates embed.FS


### PR DESCRIPTION
## Summary

- add the public `stripe-bigquery` starter template with 19 focused assets
- document the template in the public catalog and sidebar
- add generic billing analytics guidance, illustrative rows for all four final report tables, and an accurate first-load workflow
- add regression tests for template initialization and the exact asset set

## Validation

- `make format`
- `make build`
- `bruin internal parse-pipeline templates/stripe-bigquery`
- `make test`
- `npm run docs:build`
- initialized the template under `.context` and confirmed its 19 assets
- `bruin validate --fast` before the initial load
- live `bruin run --full-refresh --no-validation`: 19 assets and 28 quality checks passed
- full `bruin validate` after the initial load: 19 assets passed