### PR TITLE
Add cloud scheduled-agents run-states CLI commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3937,7 +3937,7 @@ func cloudScheduledAgentsRunStates() *cli.Command {
 
 // scheduledAgentIDFlag is the required parent-scope flag shared by the run-state
 // commands (a run-state file only exists in the context of a scheduled agent).
-func scheduledAgentIDFlag() cli.Flag {
+func scheduledAgentIDFlag() *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:     "scheduled-agent-id",
 		Usage:    "scheduled agent the run-state file belongs to",
@@ -3945,7 +3945,7 @@ func scheduledAgentIDFlag() cli.Flag {
 	}
 }
 
-func runStateNameFlag() cli.Flag {
+func runStateNameFlag() *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:     "name",
 		Usage:    "run-state file name",

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3915,8 +3915,225 @@ func CloudScheduledAgents() *cli.Command {
 			cloudScheduledAgentsGet(),
 			cloudScheduledAgentsCreate(),
 			cloudScheduledAgentsUpdate(),
+			cloudScheduledAgentsRunStates(),
 		},
 	}
+}
+
+// cloudScheduledAgentsRunStates groups the CRUD commands for a scheduled agent's
+// run-state ("memory") files — the markdown the agent persists across runs.
+func cloudScheduledAgentsRunStates() *cli.Command {
+	return &cli.Command{
+		Name:  "run-states",
+		Usage: "Manage a scheduled agent's run-state (\"memory\") files",
+		Commands: []*cli.Command{
+			cloudRunStatesList(),
+			cloudRunStatesGet(),
+			cloudRunStatesSet(),
+			cloudRunStatesDelete(),
+		},
+	}
+}
+
+// scheduledAgentIDFlag is the required parent-scope flag shared by the run-state
+// commands (a run-state file only exists in the context of a scheduled agent).
+func scheduledAgentIDFlag() cli.Flag {
+	return &cli.IntFlag{
+		Name:     "scheduled-agent-id",
+		Usage:    "scheduled agent the run-state file belongs to",
+		Required: true,
+	}
+}
+
+func runStateNameFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:     "name",
+		Usage:    "run-state file name",
+		Required: true,
+	}
+}
+
+func cloudRunStatesList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List a scheduled agent's run-state files",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			scheduledAgentIDFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			states, err := client.ListRunStates(ctx, c.Int("scheduled-agent-id"))
+			if err != nil {
+				printError(err, output, "Failed to list run states")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(states, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Name", "Size (bytes)", "Updated"})
+			for _, s := range states {
+				t.AppendRow(table.Row{s.Name, len(s.Content), derefString(s.UpdatedAt)})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudRunStatesGet() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "Get a run-state file (prints its content; use --output json for the full record)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			scheduledAgentIDFlag(),
+			runStateNameFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			state, err := client.GetRunState(ctx, c.Int("scheduled-agent-id"), c.String("name"))
+			if err != nil {
+				printError(err, output, "Failed to get run state")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(state, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			// Print the raw content so it can be redirected to a file.
+			fmt.Print(state.Content)
+			return nil
+		},
+	}
+}
+
+func cloudRunStatesSet() *cli.Command {
+	return &cli.Command{
+		Name:  "set",
+		Usage: "Create or replace a run-state file from --content or --content-file",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			scheduledAgentIDFlag(),
+			runStateNameFlag(),
+			&cli.StringFlag{Name: "content", Usage: "the file content"},
+			&cli.StringFlag{Name: "content-file", Usage: "path to a file whose contents become the run-state content"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			content, err := resolveRunStateContent(c)
+			if err != nil {
+				printError(err, output, "Invalid content")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			state, err := client.SetRunState(ctx, c.Int("scheduled-agent-id"), c.String("name"), content)
+			if err != nil {
+				printError(err, output, "Failed to set run state")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(state, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Saved run-state file '%s' on scheduled agent %d.\n", state.Name, c.Int("scheduled-agent-id"))
+			return nil
+		},
+	}
+}
+
+func cloudRunStatesDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a run-state file",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			scheduledAgentIDFlag(),
+			runStateNameFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteRunState(ctx, c.Int("scheduled-agent-id"), c.String("name")); err != nil {
+				printError(err, output, "Failed to delete run state")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted run-state file '%s' from scheduled agent %d.\n", c.String("name"), c.Int("scheduled-agent-id"))
+			return nil
+		},
+	}
+}
+
+// resolveRunStateContent reads the run-state content from exactly one of
+// --content or --content-file.
+func resolveRunStateContent(c *cli.Command) (string, error) {
+	if c.IsSet("content") && c.IsSet("content-file") {
+		return "", errors.New("pass only one of --content or --content-file")
+	}
+	if c.IsSet("content-file") {
+		data, err := os.ReadFile(c.String("content-file"))
+		if err != nil {
+			return "", fmt.Errorf("failed to read --content-file: %w", err)
+		}
+		return string(data), nil
+	}
+	if c.IsSet("content") {
+		return c.String("content"), nil
+	}
+	return "", errors.New("provide the content with --content or --content-file")
 }
 
 func cloudScheduledAgentsList() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -452,7 +452,7 @@ func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	cmd := CloudScheduledAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "scheduled-agents", cmd.Name)
-	require.Len(t, cmd.Commands, 4)
+	require.Len(t, cmd.Commands, 5)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -462,6 +462,24 @@ func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "get")
 	assert.Contains(t, subNames, "create")
 	assert.Contains(t, subNames, "update")
+	assert.Contains(t, subNames, "run-states")
+}
+
+func TestCloudScheduledAgentsRunStatesCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := cloudScheduledAgentsRunStates()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "run-states", cmd.Name)
+	require.Len(t, cmd.Commands, 4)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "list")
+	assert.Contains(t, subNames, "get")
+	assert.Contains(t, subNames, "set")
+	assert.Contains(t, subNames, "delete")
 }
 
 func TestMessagePairIDFromEnv(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -914,6 +914,28 @@ bruin cloud scheduled-agents update --scheduled-agent-id 42 --cron "0 8 * * 1"
 bruin cloud scheduled-agents update --scheduled-agent-id 42 --state-file ./plan.yaml
 ```
 
+#### `run-states`
+
+Manage a scheduled agent's **run-state** files — the markdown "memory" the agent
+persists across runs (keyed by name, upserted on write). Reads and writes both
+require only the `scheduled-agent:list` ability, so any Cloud-CLI-enabled agent
+can manage its own run state.
+
+```bash
+# List the files on a scheduled agent
+bruin cloud scheduled-agents run-states list --scheduled-agent-id 42
+
+# Print one file's content (redirect to save it)
+bruin cloud scheduled-agents run-states get --scheduled-agent-id 42 --name memory.md > memory.md
+
+# Create or replace a file (upsert), inline or from a file
+bruin cloud scheduled-agents run-states set --scheduled-agent-id 42 --name memory.md --content "notes..."
+bruin cloud scheduled-agents run-states set --scheduled-agent-id 42 --name memory.md --content-file ./memory.md
+
+# Delete a file
+bruin cloud scheduled-agents run-states delete --scheduled-agent-id 42 --name memory.md
+```
+
 ---
 
 ### `cost`

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -781,6 +781,44 @@ func (c *APIClient) UpdateScheduledAgent(ctx context.Context, scheduledAgentID i
 	return &result, nil
 }
 
+// --- Scheduled agent run state ---
+
+// ListRunStates returns the run-state ("memory") files persisted on a scheduled
+// agent. Each is a markdown file the agent carries across runs, keyed by name.
+func (c *APIClient) ListRunStates(ctx context.Context, scheduledAgentID int) ([]RunState, error) {
+	var resp struct {
+		RunStates []RunState `json:"run_states"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/scheduled-agents/%d/run-states", scheduledAgentID), nil, &resp)
+	return resp.RunStates, err
+}
+
+// GetRunState returns a single run-state file by name.
+func (c *APIClient) GetRunState(ctx context.Context, scheduledAgentID int, name string) (*RunState, error) {
+	var result RunState
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/scheduled-agents/%d/run-states/%s", scheduledAgentID, url.PathEscape(name)), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// SetRunState creates or replaces a run-state file (the server upserts on name).
+func (c *APIClient) SetRunState(ctx context.Context, scheduledAgentID int, name, content string) (*RunState, error) {
+	var result RunState
+	body := map[string]any{"content": content}
+	err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf("/scheduled-agents/%d/run-states/%s", scheduledAgentID, url.PathEscape(name)), body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteRunState removes a run-state file by name.
+func (c *APIClient) DeleteRunState(ctx context.Context, scheduledAgentID int, name string) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/scheduled-agents/%d/run-states/%s", scheduledAgentID, url.PathEscape(name)), nil, nil)
+}
+
 // --- Audit logs ---
 
 // ListAuditLogs returns a page of the team's audit trail, most recent first.

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1252,3 +1252,77 @@ func TestListAuditLogs(t *testing.T) {
 	assert.Equal(t, "login", logs[0].Type)
 	assert.Equal(t, "alice@example.com", logs[0].UserIdentifier)
 }
+
+func TestListRunStates(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/scheduled-agents/7/run-states", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"run_states":[{"name":"a.md","content":"x"},{"name":"b.md","content":"y"}]}`))
+	})
+
+	states, err := client.ListRunStates(t.Context(), 7)
+	require.NoError(t, err)
+	require.Len(t, states, 2)
+	assert.Equal(t, "a.md", states[0].Name)
+	assert.Equal(t, "x", states[0].Content)
+}
+
+func TestGetRunState(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/scheduled-agents/7/run-states/notes.md", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"notes.md","content":"hello"}`))
+	})
+
+	state, err := client.GetRunState(t.Context(), 7, "notes.md")
+	require.NoError(t, err)
+	assert.Equal(t, "notes.md", state.Name)
+	assert.Equal(t, "hello", state.Content)
+}
+
+func TestSetRunState(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/scheduled-agents/7/run-states/notes.md", r.URL.Path)
+		assert.Equal(t, http.MethodPut, r.Method)
+		body := readJSON(t, r)
+		assert.Equal(t, "new content", body["content"])
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"name":"notes.md","content":"new content"}`))
+	})
+
+	state, err := client.SetRunState(t.Context(), 7, "notes.md", "new content")
+	require.NoError(t, err)
+	assert.Equal(t, "new content", state.Content)
+}
+
+// A name with characters that need percent-encoding must be escaped in the path
+// so it can't break out of the run-states segment.
+func TestSetRunStateEscapesName(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/scheduled-agents/7/run-states/my%20notes.md", r.URL.EscapedPath())
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"my notes.md","content":"x"}`))
+	})
+
+	_, err := client.SetRunState(t.Context(), 7, "my notes.md", "x")
+	require.NoError(t, err)
+}
+
+func TestDeleteRunState(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/scheduled-agents/7/run-states/gone.md", r.URL.Path)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	})
+
+	err := client.DeleteRunState(t.Context(), 7, "gone.md")
+	require.NoError(t, err)
+}

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -325,6 +325,9 @@ type RunState struct {
 	UpdatedAt *string `json:"updated_at"`
 }
 
+// ScheduledAgent represents a Bruin Cloud scheduled agent — a cron-based
+// recurring agent task. The nested plan fields (verified SQLs, memory, ...) are
+// kept as raw JSON so `--output json` round-trips the full server response.
 type ScheduledAgent struct {
 	ID                int             `json:"id"`
 	Title             *string         `json:"title"`

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -316,6 +316,15 @@ type Dashboard struct {
 // ScheduledAgent represents a Bruin Cloud scheduled agent — a cron-based recurring
 // agent task. The nested plan fields (verified SQLs, memory, ...) are kept as raw
 // JSON so `--output json` round-trips the full server response faithfully.
+// RunState is a single markdown "memory" file persisted across runs of a
+// scheduled agent, keyed by name. Content may be empty.
+type RunState struct {
+	Name      string  `json:"name"`
+	Content   string  `json:"content"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+}
+
 type ScheduledAgent struct {
 	ID                int             `json:"id"`
 	Title             *string         `json:"title"`


### PR DESCRIPTION
## What
Adds a `run-states` command group under `bruin cloud scheduled-agents` for managing a scheduled agent's **run-state ("memory") files** — the markdown the agent persists across runs. Pairs with the cloud API PR (`bruin-data/cloud#2914`).

## Changes
- **`pkg/bruincloud/api.go`** — `ListRunStates` / `GetRunState` / `SetRunState` / `DeleteRunState`, calling the v1 `/scheduled-agents/{id}/run-states[/{name}]` endpoints with the file name percent-escaped in the path.
- **`pkg/bruincloud/types.go`** — `RunState` type (`name`, `content`, timestamps).
- **`cmd/cloud.go`** — `run-states` sub-group under `scheduled-agents` with `list` / `get` / `set` / `delete`. `get` prints the raw content (so it can be redirected to a file); `set` upserts from `--content` or `--content-file`.
- **`cmd/cloud_test.go`**, **`pkg/bruincloud/api_test.go`** — command-structure tests and client tests (paths, methods, request body, name escaping).
- **`docs/commands/cloud.md`** — documents the new sub-group.

Run state is a sub-resource of a scheduled run, so the commands live under the existing `scheduled-agents` group rather than a new top-level command.

## How to test
```bash
make test    # includes cmd/ + pkg/bruincloud tests
```
End-to-end against Bruin Cloud:
```bash
bruin cloud scheduled-agents run-states set    --scheduled-agent-id 42 --name memory.md --content "notes..."
bruin cloud scheduled-agents run-states list   --scheduled-agent-id 42
bruin cloud scheduled-agents run-states get    --scheduled-agent-id 42 --name memory.md
bruin cloud scheduled-agents run-states delete --scheduled-agent-id 42 --name memory.md
```

## Risk & rollback
- **Risk:** low — additive CLI subcommands and client methods; no change to existing behaviour.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make format`) — `make format` clean (0 lint issues), `make test` green
- [ ] Integration tests pass if affected (`make integration-test`) — not affected
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered — the file name is percent-escaped in the request path; authorization is enforced server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhHGRMALLvx4sKyCAGcCX9)_