### PR TITLE
feat(connections): show filled field names in connections list

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	path2 "path"
+	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/git"
@@ -339,56 +340,32 @@ func (r *ConnectionsCommand) ListConnections(pathToProject, output, environment,
 		return nil
 	}
 
-	// Check if a specific environment is requested
+	envs := cm.Environments
 	if environment != "" {
 		env, exists := cm.Environments[environment]
 		if !exists {
 			errorPrinter.Printf("Environment '%s' not found.\n", environment)
 			return cli.Exit("", 1)
 		}
-
-		fmt.Println()
-		infoPrinter.Printf("Environment: %s\n", environment)
-
-		t := table.NewWriter()
-		t.SetOutputMirror(os.Stdout)
-		t.AppendHeader(table.Row{"Type", "Name"})
-
-		rows := env.Connections.ConnectionsSummaryList()
-
-		for row, connType := range rows {
-			t.AppendRow(table.Row{connType, row})
-		}
-		t.Render()
-		fmt.Println()
-
-		return nil
+		envs = map[string]config.Environment{environment: env}
 	}
-	// If no specific environment is requested, iterate through all environments
-	for envName, env := range cm.Environments {
+
+	for envName, env := range envs {
 		fmt.Println()
 		infoPrinter.Printf("Environment: %s\n", envName)
 
 		t := table.NewWriter()
 		t.SetOutputMirror(os.Stdout)
-		t.AppendHeader(table.Row{"Type", "Name"})
+		t.AppendHeader(table.Row{"Type", "Name", "Filled Fields"})
 
-		rows := env.Connections.ConnectionsSummaryList()
-
-		if len(rows) == 0 {
-			t.Render()
-			fmt.Println()
-			continue
-		}
-
-		for row, connType := range rows {
-			t.AppendRow(table.Row{connType, row})
+		for name, connType := range env.Connections.ConnectionsSummaryList() {
+			t.AppendRow(table.Row{connType, name, strings.Join(env.Connections.FilledFieldsForConnection(name), ", ")})
 		}
 		t.Render()
 		fmt.Println()
 	}
 
-	return err
+	return nil
 }
 
 func printErrorForOutput(output string, err error) {

--- a/docs/commands/connections.md
+++ b/docs/commands/connections.md
@@ -12,23 +12,23 @@ To list all the connections in the `.bruin.yml` file, run the following command:
 bruin connections list
 ```
 
-The output will look like this:
+The output will look like this. `FILLED FIELDS` lists the names of the fields that are set on each connection, never their values:
 
 ```plaintext
 Environment: default
-+---------+-----------+
-| TYPE    | NAME      |
-+---------+-----------+
-| generic | MY_SECRET |
-| gorgias | my_conn   |
-+---------+-----------+
++---------+-----------+------------------------+
+| TYPE    | NAME      | FILLED FIELDS          |
++---------+-----------+------------------------+
+| generic | MY_SECRET | value                  |
+| gorgias | my_conn   | api_key, domain, email |
++---------+-----------+------------------------+
 
 Environment: someother
-+---------+-----------+
-| TYPE    | NAME      |
-+---------+-----------+
-| generic | MY_SECRET |
-+---------+-----------+
++---------+-----------+---------------+
+| TYPE    | NAME      | FILLED FIELDS |
++---------+-----------+---------------+
+| generic | MY_SECRET | value         |
++---------+-----------+---------------+
 ```
 
 ### Flags

--- a/docs/commands/curl.md
+++ b/docs/commands/curl.md
@@ -49,6 +49,10 @@ are resolved only once. Fields nested inside a connection can be traversed with 
 {{ bruin.connection("service-api").credentials.client_id }}
 ```
 
+If you do not know which field a connection exposes — `api_key` or `api_token`, for instance — run
+`bruin connections list`. The `FILLED FIELDS` column lists the field names that are set on each
+connection, without printing their values.
+
 The usual Bruin Jinja helpers remain available in the same namespace. For example,
 <code v-pre>{{ bruin.slugify("Account Name") }}</code> renders as `account_name`. Most other helpers
 generate SQL expressions and are primarily useful in asset templates; see [Jinja templating and

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -39,7 +39,7 @@ bruin curl -- \
   https://api.linear.app/graphql
 ```
 
-Bruin flags (`--environment`, `--config-file`) go before `--`; everything after `--` belongs to curl. Field names match `.bruin.yml` (snake_case), and nested fields are traversed with dots: <code v-pre>{{ bruin.connection("service-api").credentials.client_id }}</code>. Run `bruin connections list` to see the available connections and their field names. See [curl](/commands/curl) for details.
+Bruin flags (`--environment`, `--config-file`) go before `--`; everything after `--` belongs to curl. Field names match `.bruin.yml` (snake_case), and nested fields are traversed with dots: <code v-pre>{{ bruin.connection("service-api").credentials.client_id }}</code>. Run `bruin connections list` to see the available connections and, in the `FILLED FIELDS` column, which field names are set on each one. See [curl](/commands/curl) for details.
 
 ### Command: Init (Create Project)
 

--- a/pkg/config/connection_fields.go
+++ b/pkg/config/connection_fields.go
@@ -87,6 +87,53 @@ func GetConnectionFieldsForType(typeName string) []ConnectionFieldDef {
 	return nil
 }
 
+// FilledFieldsForConnection returns the mapstructure names of the connection's
+// non-empty fields, sorted. It never returns values, so a caller can tell an
+// api_key connection from an api_token one, and a filled one from an empty one,
+// without a credential leaving the config.
+func (c *Connections) FilledFieldsForConnection(name string) []string {
+	v := reflect.Indirect(reflect.ValueOf(c.GetConnection(name)))
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+
+	filled := filledFields(v)
+	sort.Strings(filled)
+	return filled
+}
+
+// filledFields applies the same field selection as extractFields, but over a
+// value, so it reports which of those fields actually carry something.
+func filledFields(v reflect.Value) []string {
+	t := v.Type()
+	filled := make([]string, 0, t.NumField())
+
+	for i := range t.NumField() {
+		sf := t.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+
+		if sf.Anonymous {
+			if embedded := reflect.Indirect(v.Field(i)); embedded.Kind() == reflect.Struct {
+				filled = append(filled, filledFields(embedded)...)
+				continue
+			}
+		}
+
+		msTag, _, _ := strings.Cut(sf.Tag.Get("mapstructure"), ",")
+		if msTag == "" || msTag == "name" || kindToTypeString(sf.Type) == "" {
+			continue
+		}
+
+		if !v.Field(i).IsZero() {
+			filled = append(filled, msTag)
+		}
+	}
+
+	return filled
+}
+
 // extractFields reads the exported fields of a connection struct, skipping the
 // "name" field and non-primitive types (slices, maps, nested structs, complex
 // pointer types).

--- a/pkg/config/connection_fields_test.go
+++ b/pkg/config/connection_fields_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilledFieldsForConnection(t *testing.T) {
+	t.Parallel()
+
+	c := &Connections{
+		Linear: []LinearConnection{{
+			ConnectionMetadata: ConnectionMetadata{Name: "my-linear"},
+			APIKey:             "secret",
+		}},
+		Notion: []NotionConnection{{
+			ConnectionMetadata: ConnectionMetadata{Name: "empty-notion"},
+		}},
+	}
+
+	assert.Equal(t, []string{"api_key"}, c.FilledFieldsForConnection("my-linear"))
+	assert.Empty(t, c.FilledFieldsForConnection("empty-notion"))
+	assert.Nil(t, c.FilledFieldsForConnection("nope"))
+}


### PR DESCRIPTION
## What

`bruin connections list` gains a **Filled Fields** column listing the names of the fields that carry a value on each connection.

```
Environment: default
+-----------+---------------+--------------------------------------------------+
| TYPE      | NAME          | FILLED FIELDS                                    |
+-----------+---------------+--------------------------------------------------+
| snowflake | sf-prod       | account, database, password, username, warehouse |
| linear    | my-linear     | api_key                                          |
| linear    | broken-linear |                                                  |
+-----------+---------------+--------------------------------------------------+
```

## Why

Agents using `bruin curl` need to know which field a connection exposes — `{{ bruin.connection("x").api_key }}` vs `.api_token` — and whether it is set. Previously that meant reading `.bruin.yml` directly, i.e. reading the secrets.

It also surfaces a silent failure mode: the config decodes non-strictly, so an unknown key like `api_token` on a `linear` connection is dropped without error. Such a connection now shows an empty Filled Fields cell instead of looking healthy.

Only field **names** are printed, never values.

## Notes

- `--output json` is untouched — it is a deliberate full-config dump the VS Code extension depends on.
- The two duplicated table-rendering blocks in `ListConnections` are collapsed into one loop; the dead `len(rows) == 0` early-continue is dropped (the empty-map range already does the same thing).
- `docs/commands/connections.md` sample output updated.