### PR TITLE
Add relationships quality check

### DIFF
--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -72,6 +72,8 @@ columns:
     foreign_key:
       table: customers   # the name of another asset
       column: id         # the referenced column in that asset
+    checks:
+      - name: relationships # optionally validate the relationship after the asset runs
 ```
 
 | key      | type   | req? | description                                  |
@@ -84,6 +86,10 @@ a foreign key must name both a `table` and a `column`, the referenced asset must
 the pipeline, and the referenced column must exist on it. Numeric type detail is also
 checked — `precision`/`length` must be positive, `scale` must not be negative, and `scale`
 must not exceed `precision`.
+
+Adding the [`relationships`](../quality/available_checks.md#relationships) quality check
+turns the metadata into a runtime referential-integrity validation. Metadata alone does
+not cause Bruin to query the referenced table.
 
 ### Type detail
 

--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -89,7 +89,8 @@ must not exceed `precision`.
 
 Adding the [`relationships`](../quality/available_checks.md#relationships) quality check
 turns the metadata into a runtime referential-integrity validation. Metadata alone does
-not cause Bruin to query the referenced table.
+not cause Bruin to query the referenced table or create a scheduler dependency. Add the
+referenced asset to `depends` when it must be refreshed before the check runs.
 
 ### Type detail
 

--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -87,10 +87,7 @@ the pipeline, and the referenced column must exist on it. Numeric type detail is
 checked — `precision`/`length` must be positive, `scale` must not be negative, and `scale`
 must not exceed `precision`.
 
-Adding the [`relationships`](../quality/available_checks.md#relationships) quality check
-turns the metadata into a runtime referential-integrity validation. Metadata alone does
-not cause Bruin to query the referenced table or create a scheduler dependency. Add the
-referenced asset to `depends` when it must be refreshed before the check runs.
+Adding the [`relationships`](../quality/available_checks.md#relationships) quality check turns the metadata into a runtime referential-integrity validation. Metadata alone does not cause Bruin to query the referenced table or create a scheduler dependency. Add the referenced asset to `depends` when it must be refreshed before the check runs.
 
 ### Type detail
 

--- a/docs/quality/available_checks.md
+++ b/docs/quality/available_checks.md
@@ -120,6 +120,10 @@ the child asset's connection and returns the number of child rows whose keys are
 missing from the parent. It does not verify that the referenced parent column is
 unique; add a `unique` check to that column separately when required.
 
+Neither `foreign_key` metadata nor a `relationships` check creates a scheduler
+dependency. Add the referenced asset to the child asset's `depends` list when it
+must be refreshed before the relationship check runs.
+
 ## Unique
 
 This check will verify that no value in the specified column appears more than once

--- a/docs/quality/available_checks.md
+++ b/docs/quality/available_checks.md
@@ -100,9 +100,7 @@ columns:
 
 ## Relationships
 
-This check verifies referential integrity: every non-null value in the checked
-column must exist in the column identified by its `foreign_key` metadata. Null
-values are ignored; add a separate `not_null` check when nulls should fail.
+This check verifies referential integrity: every non-null value in the checked column must exist in the column identified by its `foreign_key` metadata. Null values are ignored; add a separate `not_null` check when nulls should fail.
 
 ```yaml
 columns:
@@ -115,14 +113,9 @@ columns:
       - name: relationships
 ```
 
-The referenced table must be another asset in the pipeline. The check runs on
-the child asset's connection and returns the number of child rows whose keys are
-missing from the parent. It does not verify that the referenced parent column is
-unique; add a `unique` check to that column separately when required.
+The referenced table must be another asset in the pipeline. The check runs on the child asset's connection and returns the number of child rows whose keys are missing from the parent. It does not verify that the referenced parent column is unique; add a `unique` check to that column separately when required.
 
-Neither `foreign_key` metadata nor a `relationships` check creates a scheduler
-dependency. Add the referenced asset to the child asset's `depends` list when it
-must be refreshed before the relationship check runs.
+Neither `foreign_key` metadata nor a `relationships` check creates a scheduler dependency. Add the referenced asset to the child asset's `depends` list when it must be refreshed before the relationship check runs.
 
 ## Unique
 

--- a/docs/quality/available_checks.md
+++ b/docs/quality/available_checks.md
@@ -8,6 +8,7 @@ Bruin provides the following checks to validate assets, ensuring that asset data
 - [**Not-Null**](#not-null)
 - [**Pattern**](#pattern)
 - [**Positive**](#positive)
+- [**Relationships**](#relationships)
 - [**Unique**](#unique)
 - [**Min**](#min)
 - [**Max**](#max)
@@ -96,6 +97,28 @@ columns:
     checks:
       - name: positive
 ```
+
+## Relationships
+
+This check verifies referential integrity: every non-null value in the checked
+column must exist in the column identified by its `foreign_key` metadata. Null
+values are ignored; add a separate `not_null` check when nulls should fail.
+
+```yaml
+columns:
+  - name: customer_id
+    type: integer
+    foreign_key:
+      table: analytics.customers
+      column: id
+    checks:
+      - name: relationships
+```
+
+The referenced table must be another asset in the pipeline. The check runs on
+the child asset's connection and returns the number of child rows whose keys are
+missing from the parent. It does not verify that the referenced parent column is
+unique; add a `unique` check to that column separately when required.
 
 ## Unique
 

--- a/integration-tests/.bruin.yml
+++ b/integration-tests/.bruin.yml
@@ -314,6 +314,18 @@ environments:
         - name: "duckdb-ddl"
           path: "duckdb-files/duckdb-ddl.db"
 
+  env-duckdb-relationships-valid:
+    connections:
+      duckdb:
+        - name: "duckdb-ddl"
+          path: "duckdb-files/duckdb-relationships-valid.db"
+
+  env-duckdb-relationships-orphan:
+    connections:
+      duckdb:
+        - name: "duckdb-ddl"
+          path: "duckdb-files/duckdb-relationships-orphan.db"
+
   env-validate-with-exclude-tag:
     connections:
       duckdb:

--- a/integration-tests/expectations/expected_connections.json
+++ b/integration-tests/expectations/expected_connections.json
@@ -202,6 +202,28 @@
       },
       "schema_prefix": ""
     },
+    "env-duckdb-relationships-orphan": {
+      "connections": {
+        "duckdb": [
+          {
+            "name": "duckdb-ddl",
+            "path": "duckdb-files/duckdb-relationships-orphan.db"
+          }
+        ]
+      },
+      "schema_prefix": ""
+    },
+    "env-duckdb-relationships-valid": {
+      "connections": {
+        "duckdb": [
+          {
+            "name": "duckdb-ddl",
+            "path": "duckdb-files/duckdb-relationships-valid.db"
+          }
+        ]
+      },
+      "schema_prefix": ""
+    },
     "env-ingestr": {
       "connections": {
         "duckdb": [

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -1570,6 +1570,47 @@ func TestIndividualTasks(t *testing.T) {
 			},
 		},
 		{
+			name: "test-relationships-check-duckdb",
+			task: e2e.Task{
+				Name:    "test-relationships-check-duckdb",
+				Command: binary,
+				Args:    []string{"run", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--env", "env-duckdb-relationships-valid", "--variant", "valid", filepath.Join(currentFolder, "test-pipelines/duckdb-relationships-check")},
+				Env:     []string{},
+				Expected: e2e.Output{
+					ExitCode: 0,
+					Contains: []string{
+						"Successfully validated 2 assets",
+						"Finished: relationship_test.orders:customer_id:relationships",
+						"bruin run completed",
+					},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
+			name: "test-relationships-check-duckdb-orphan",
+			task: e2e.Task{
+				Name:    "test-relationships-check-duckdb-orphan",
+				Command: binary,
+				Args:    []string{"run", "--config-file", filepath.Join(currentFolder, ".bruin.yml"), "--env", "env-duckdb-relationships-orphan", "--variant", "orphan", filepath.Join(currentFolder, "test-pipelines/duckdb-relationships-check")},
+				Env:     []string{},
+				Expected: e2e.Output{
+					ExitCode: 1,
+					Contains: []string{
+						"Failed: relationship_test.orders:customer_id:relationships",
+						"column 'customer_id' has 1 rows with values missing from 'relationship_test.customers.id'",
+					},
+				},
+				Asserts: []func(*e2e.Task) error{
+					e2e.AssertByExitCode,
+					e2e.AssertByContains,
+				},
+			},
+		},
+		{
 			name: "duckdb-sensor-timeout",
 			task: e2e.Task{
 				Name:    "duckdb-sensor-timeout",

--- a/integration-tests/test-pipelines/duckdb-relationships-check/assets/customers.sql
+++ b/integration-tests/test-pipelines/duckdb-relationships-check/assets/customers.sql
@@ -1,0 +1,20 @@
+/* @bruin
+name: relationship_test.customers
+type: duckdb.sql
+
+materialization:
+  type: table
+
+columns:
+  - name: id
+    type: integer
+    checks:
+      - name: unique
+
+@bruin */
+
+SELECT 1 AS id
+UNION ALL
+SELECT 2 AS id
+UNION ALL
+SELECT NULL AS id;

--- a/integration-tests/test-pipelines/duckdb-relationships-check/assets/orders.sql
+++ b/integration-tests/test-pipelines/duckdb-relationships-check/assets/orders.sql
@@ -5,6 +5,9 @@ type: duckdb.sql
 materialization:
   type: table
 
+depends:
+  - relationship_test.customers
+
 columns:
   - name: order_id
     type: integer

--- a/integration-tests/test-pipelines/duckdb-relationships-check/assets/orders.sql
+++ b/integration-tests/test-pipelines/duckdb-relationships-check/assets/orders.sql
@@ -1,0 +1,30 @@
+/* @bruin
+name: relationship_test.orders
+type: duckdb.sql
+
+materialization:
+  type: table
+
+columns:
+  - name: order_id
+    type: integer
+    primary_key: true
+  - name: customer_id
+    type: integer
+    foreign_key:
+      table: relationship_test.customers
+      column: id
+    checks:
+      - name: relationships
+
+@bruin */
+
+SELECT 10 AS order_id, 1 AS customer_id
+UNION ALL
+SELECT 11 AS order_id, 2 AS customer_id
+UNION ALL
+SELECT 12 AS order_id, NULL AS customer_id
+{% if var.include_orphan %}
+UNION ALL
+SELECT 13 AS order_id, 999 AS customer_id
+{% endif %};

--- a/integration-tests/test-pipelines/duckdb-relationships-check/pipeline.yml
+++ b/integration-tests/test-pipelines/duckdb-relationships-check/pipeline.yml
@@ -1,0 +1,15 @@
+name: duckdb_relationships_check
+
+default_connections:
+  duckdb: duckdb-ddl
+
+variables:
+  include_orphan:
+    type: boolean
+    default: false
+
+variants:
+  valid:
+    include_orphan: false
+  orphan:
+    include_orphan: true

--- a/pkg/ansisql/checks.go
+++ b/pkg/ansisql/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/helpers"
@@ -152,6 +153,52 @@ func (c *UniqueCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstan
 		checkName:     "unique",
 		customError: func(count int64) error {
 			return errors.Errorf("column '%s' has %d non-unique values", ti.Column.Name, count)
+		},
+	}).Check(ctx, ti)
+}
+
+// RelationshipsCheck verifies that every non-null value in a child column
+// exists in the column referenced by its foreign_key metadata. A non-correlated
+// NOT IN subquery works across all supported SQL dialects, including ClickHouse
+// versions from before correlated subqueries were supported. Nulls are removed
+// from both sides to make NOT IN null-safe. The query deliberately counts child
+// rows, matching dbt's relationships test semantics.
+type RelationshipsCheck struct {
+	conn config.ConnectionGetter
+}
+
+func NewRelationshipsCheck(conn config.ConnectionGetter) *RelationshipsCheck {
+	return &RelationshipsCheck{conn: conn}
+}
+
+func (c *RelationshipsCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
+	foreignKey := ti.Column.ForeignKey
+	if foreignKey == nil || strings.TrimSpace(foreignKey.Table) == "" || strings.TrimSpace(foreignKey.Column) == "" {
+		return errors.Errorf("relationships check on column '%s' requires foreign_key.table and foreign_key.column", ti.Column.Name)
+	}
+
+	qq := fmt.Sprintf(
+		"SELECT COUNT(*) FROM %s bruin_relationship_child WHERE bruin_relationship_child.%s IS NOT NULL AND bruin_relationship_child.%s NOT IN (SELECT bruin_relationship_parent.%s FROM %s bruin_relationship_parent WHERE bruin_relationship_parent.%s IS NOT NULL)",
+		ti.GetAsset().Name,
+		ti.Column.Name,
+		ti.Column.Name,
+		foreignKey.Column,
+		foreignKey.Table,
+		foreignKey.Column,
+	)
+
+	return (&CountableQueryCheck{
+		conn:          c.conn,
+		queryInstance: &query.Query{Query: qq},
+		checkName:     "relationships",
+		customError: func(count int64) error {
+			return errors.Errorf(
+				"column '%s' has %d rows with values missing from '%s.%s'",
+				ti.Column.Name,
+				count,
+				foreignKey.Table,
+				foreignKey.Column,
+			)
 		},
 	}).Check(ctx, ti)
 }

--- a/pkg/ansisql/checks.go
+++ b/pkg/ansisql/checks.go
@@ -241,14 +241,14 @@ func QuoteIdentifierWithBrackets(identifier string) string {
 
 func quoteIdentifier(identifier, openingQuote, closingQuote string, always bool) string {
 	identifier = strings.TrimSpace(identifier)
-	if isQuotedIdentifier(identifier) {
-		return identifier
-	}
-
-	parts := strings.Split(identifier, ".")
+	parts := splitIdentifierPath(identifier)
 	for index, part := range parts {
 		part = strings.TrimSpace(part)
-		if isQuotedIdentifier(part) || (!always && !identifierNeedsQuoting(part)) {
+		if unquoted, quoted := unquoteIdentifier(part); quoted {
+			parts[index] = openingQuote + strings.ReplaceAll(unquoted, closingQuote, closingQuote+closingQuote) + closingQuote
+			continue
+		}
+		if !always && !identifierNeedsQuoting(part) {
 			parts[index] = part
 			continue
 		}
@@ -257,13 +257,54 @@ func quoteIdentifier(identifier, openingQuote, closingQuote string, always bool)
 	return strings.Join(parts, ".")
 }
 
-func isQuotedIdentifier(identifier string) bool {
-	if len(identifier) < 2 {
-		return false
+func splitIdentifierPath(identifier string) []string {
+	parts := make([]string, 0, strings.Count(identifier, ".")+1)
+	start := 0
+	var closingQuote byte
+
+	for index := 0; index < len(identifier); index++ {
+		char := identifier[index]
+		if closingQuote != 0 {
+			if char != closingQuote {
+				continue
+			}
+			if index+1 < len(identifier) && identifier[index+1] == closingQuote {
+				index++
+				continue
+			}
+			closingQuote = 0
+			continue
+		}
+
+		switch char {
+		case '"', '`':
+			closingQuote = char
+		case '[':
+			closingQuote = ']'
+		case '.':
+			parts = append(parts, identifier[start:index])
+			start = index + 1
+		}
 	}
-	return (identifier[0] == '"' && identifier[len(identifier)-1] == '"') ||
-		(identifier[0] == '`' && identifier[len(identifier)-1] == '`') ||
-		(identifier[0] == '[' && identifier[len(identifier)-1] == ']')
+
+	return append(parts, identifier[start:])
+}
+
+func unquoteIdentifier(identifier string) (string, bool) {
+	if len(identifier) < 2 {
+		return identifier, false
+	}
+
+	switch {
+	case identifier[0] == '"' && identifier[len(identifier)-1] == '"':
+		return strings.ReplaceAll(identifier[1:len(identifier)-1], `""`, `"`), true
+	case identifier[0] == '`' && identifier[len(identifier)-1] == '`':
+		return strings.ReplaceAll(identifier[1:len(identifier)-1], "``", "`"), true
+	case identifier[0] == '[' && identifier[len(identifier)-1] == ']':
+		return strings.ReplaceAll(identifier[1:len(identifier)-1], "]]", "]"), true
+	default:
+		return identifier, false
+	}
 }
 
 func identifierNeedsQuoting(identifier string) bool {

--- a/pkg/ansisql/checks.go
+++ b/pkg/ansisql/checks.go
@@ -164,11 +164,12 @@ func (c *UniqueCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstan
 // from both sides to make NOT IN null-safe. The query deliberately counts child
 // rows, matching dbt's relationships test semantics.
 type RelationshipsCheck struct {
-	conn config.ConnectionGetter
+	conn            config.ConnectionGetter
+	quoteIdentifier func(string) string
 }
 
-func NewRelationshipsCheck(conn config.ConnectionGetter) *RelationshipsCheck {
-	return &RelationshipsCheck{conn: conn}
+func NewRelationshipsCheck(conn config.ConnectionGetter, quoteIdentifier func(string) string) *RelationshipsCheck {
+	return &RelationshipsCheck{conn: conn, quoteIdentifier: quoteIdentifier}
 }
 
 func (c *RelationshipsCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
@@ -179,12 +180,12 @@ func (c *RelationshipsCheck) Check(ctx context.Context, ti *scheduler.ColumnChec
 
 	qq := fmt.Sprintf(
 		"SELECT COUNT(*) FROM %s bruin_relationship_child WHERE bruin_relationship_child.%s IS NOT NULL AND bruin_relationship_child.%s NOT IN (SELECT bruin_relationship_parent.%s FROM %s bruin_relationship_parent WHERE bruin_relationship_parent.%s IS NOT NULL)",
-		ti.GetAsset().Name,
-		ti.Column.Name,
-		ti.Column.Name,
-		foreignKey.Column,
-		foreignKey.Table,
-		foreignKey.Column,
+		c.quoteIdentifier(ti.GetAsset().Name),
+		c.quoteIdentifier(ti.Column.Name),
+		c.quoteIdentifier(ti.Column.Name),
+		c.quoteIdentifier(foreignKey.Column),
+		c.quoteIdentifier(foreignKey.Table),
+		c.quoteIdentifier(foreignKey.Column),
 	)
 
 	return (&CountableQueryCheck{
@@ -201,6 +202,82 @@ func (c *RelationshipsCheck) Check(ctx context.Context, ti *scheduler.ColumnChec
 			)
 		},
 	}).Check(ctx, ti)
+}
+
+var reservedSQLIdentifiers = map[string]bool{
+	"ALL": true, "ALTER": true, "AND": true, "ANY": true, "AS": true, "ASC": true,
+	"BETWEEN": true, "BY": true, "CASE": true, "CAST": true, "CHECK": true, "COLUMN": true,
+	"CREATE": true, "CROSS": true, "CURRENT": true, "DATABASE": true, "DEFAULT": true,
+	"DELETE": true, "DESC": true, "DISTINCT": true, "DROP": true, "ELSE": true, "END": true,
+	"EXISTS": true, "FALSE": true, "FETCH": true, "FOR": true, "FOREIGN": true, "FROM": true,
+	"FULL": true, "GROUP": true, "HAVING": true, "IN": true, "INNER": true, "INSERT": true,
+	"INTERSECT": true, "INTO": true, "IS": true, "JOIN": true, "KEY": true, "LEFT": true,
+	"LIKE": true, "LIMIT": true, "MERGE": true, "NATURAL": true, "NOT": true, "NULL": true,
+	"OFFSET": true, "ON": true, "OR": true, "ORDER": true, "OUTER": true, "PRIMARY": true,
+	"REFERENCES": true, "RIGHT": true, "ROW": true, "SELECT": true, "SET": true, "TABLE": true,
+	"THEN": true, "TRUE": true, "UNION": true, "UNIQUE": true, "UPDATE": true, "USING": true,
+	"VALUES": true, "VIEW": true, "WHEN": true, "WHERE": true, "WITH": true,
+}
+
+// QuoteIdentifierWithDoubleQuotes quotes every dotted identifier component using ANSI double quotes.
+func QuoteIdentifierWithDoubleQuotes(identifier string) string {
+	return quoteIdentifier(identifier, `"`, `"`, true)
+}
+
+// QuoteIdentifierWithDoubleQuotesWhenNeeded preserves ordinary identifiers and quotes reserved or non-standard components.
+func QuoteIdentifierWithDoubleQuotesWhenNeeded(identifier string) string {
+	return quoteIdentifier(identifier, `"`, `"`, false)
+}
+
+// QuoteIdentifierWithBackticks quotes every dotted identifier component using backticks.
+func QuoteIdentifierWithBackticks(identifier string) string {
+	return quoteIdentifier(identifier, "`", "`", true)
+}
+
+// QuoteIdentifierWithBrackets quotes every dotted identifier component using SQL Server brackets.
+func QuoteIdentifierWithBrackets(identifier string) string {
+	return quoteIdentifier(identifier, "[", "]", true)
+}
+
+func quoteIdentifier(identifier, openingQuote, closingQuote string, always bool) string {
+	identifier = strings.TrimSpace(identifier)
+	if isQuotedIdentifier(identifier) {
+		return identifier
+	}
+
+	parts := strings.Split(identifier, ".")
+	for index, part := range parts {
+		part = strings.TrimSpace(part)
+		if isQuotedIdentifier(part) || (!always && !identifierNeedsQuoting(part)) {
+			parts[index] = part
+			continue
+		}
+		parts[index] = openingQuote + strings.ReplaceAll(part, closingQuote, closingQuote+closingQuote) + closingQuote
+	}
+	return strings.Join(parts, ".")
+}
+
+func isQuotedIdentifier(identifier string) bool {
+	if len(identifier) < 2 {
+		return false
+	}
+	return (identifier[0] == '"' && identifier[len(identifier)-1] == '"') ||
+		(identifier[0] == '`' && identifier[len(identifier)-1] == '`') ||
+		(identifier[0] == '[' && identifier[len(identifier)-1] == ']')
+}
+
+func identifierNeedsQuoting(identifier string) bool {
+	if identifier == "" || reservedSQLIdentifiers[strings.ToUpper(identifier)] {
+		return true
+	}
+	for index := range len(identifier) {
+		char := identifier[index]
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || char == '_' || (index > 0 && char >= '0' && char <= '9') {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 type PositiveCheck struct {

--- a/pkg/ansisql/checks_test.go
+++ b/pkg/ansisql/checks_test.go
@@ -121,14 +121,40 @@ func TestRelationshipsCheck_Check(t *testing.T) {
 		func(q *mockQuerierWithResult) CheckRunner {
 			conn := new(mockConnectionFetcher)
 			conn.On("GetConnection", "test").Return(q, nil)
-			return &RelationshipsCheck{conn: conn}
+			return NewRelationshipsCheck(conn, QuoteIdentifierWithDoubleQuotes)
 		},
-		"SELECT COUNT(*) FROM dataset.test_asset bruin_relationship_child WHERE bruin_relationship_child.test_column IS NOT NULL AND bruin_relationship_child.test_column NOT IN (SELECT bruin_relationship_parent.id FROM dataset.parent_asset bruin_relationship_parent WHERE bruin_relationship_parent.id IS NOT NULL)",
+		`SELECT COUNT(*) FROM "dataset"."test_asset" bruin_relationship_child WHERE bruin_relationship_child."test_column" IS NOT NULL AND bruin_relationship_child."test_column" NOT IN (SELECT bruin_relationship_parent."id" FROM "dataset"."parent_asset" bruin_relationship_parent WHERE bruin_relationship_parent."id" IS NOT NULL)`,
 		"column 'test_column' has 5 rows with values missing from 'dataset.parent_asset.id'",
 		&pipeline.ColumnCheck{
 			Name: "relationships",
 		},
 	)
+}
+
+func TestRelationshipIdentifierQuoters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		quote  func(string) string
+		input  string
+		expect string
+	}{
+		{name: "double quotes every component", quote: QuoteIdentifierWithDoubleQuotes, input: "analytics.OrderItems", expect: `"analytics"."OrderItems"`},
+		{name: "conditional double quotes preserve ordinary case folding", quote: QuoteIdentifierWithDoubleQuotesWhenNeeded, input: "analytics.OrderItems", expect: "analytics.OrderItems"},
+		{name: "conditional double quotes reserved identifiers", quote: QuoteIdentifierWithDoubleQuotesWhenNeeded, input: "analytics.order", expect: `analytics."order"`},
+		{name: "conditional double quotes punctuated identifiers", quote: QuoteIdentifierWithDoubleQuotesWhenNeeded, input: "sales data.order-items", expect: `"sales data"."order-items"`},
+		{name: "backticks every component", quote: QuoteIdentifierWithBackticks, input: "analytics.order-items", expect: "`analytics`.`order-items`"},
+		{name: "brackets every component and escape closing bracket", quote: QuoteIdentifierWithBrackets, input: "analytics.order]items", expect: "[analytics].[order]]items]"},
+		{name: "preserves an already quoted path", quote: QuoteIdentifierWithBackticks, input: "`my-project.analytics.order-items`", expect: "`my-project.analytics.order-items`"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.quote(tt.input))
+		})
+	}
 }
 
 func TestRelationshipsCheckRequiresForeignKey(t *testing.T) {

--- a/pkg/ansisql/checks_test.go
+++ b/pkg/ansisql/checks_test.go
@@ -147,6 +147,10 @@ func TestRelationshipIdentifierQuoters(t *testing.T) {
 		{name: "backticks every component", quote: QuoteIdentifierWithBackticks, input: "analytics.order-items", expect: "`analytics`.`order-items`"},
 		{name: "brackets every component and escape closing bracket", quote: QuoteIdentifierWithBrackets, input: "analytics.order]items", expect: "[analytics].[order]]items]"},
 		{name: "preserves an already quoted path", quote: QuoteIdentifierWithBackticks, input: "`my-project.analytics.order-items`", expect: "`my-project.analytics.order-items`"},
+		{name: "converts backticks to double quotes", quote: QuoteIdentifierWithDoubleQuotes, input: "`analytics`.`order-items`", expect: `"analytics"."order-items"`},
+		{name: "converts double quotes to backticks", quote: QuoteIdentifierWithBackticks, input: `"sales data"."order-items"`, expect: "`sales data`.`order-items`"},
+		{name: "converts and escapes brackets", quote: QuoteIdentifierWithBrackets, input: `"analytics"."order]items"`, expect: "[analytics].[order]]items]"},
+		{name: "preserves dots inside a quoted component", quote: QuoteIdentifierWithDoubleQuotes, input: "`my-project.analytics`.orders", expect: `"my-project.analytics"."orders"`},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ansisql/checks_test.go
+++ b/pkg/ansisql/checks_test.go
@@ -148,6 +148,7 @@ func TestRelationshipIdentifierQuoters(t *testing.T) {
 		{name: "brackets every component and escape closing bracket", quote: QuoteIdentifierWithBrackets, input: "analytics.order]items", expect: "[analytics].[order]]items]"},
 		{name: "preserves an already quoted path", quote: QuoteIdentifierWithBackticks, input: "`my-project.analytics.order-items`", expect: "`my-project.analytics.order-items`"},
 		{name: "converts backticks to double quotes", quote: QuoteIdentifierWithDoubleQuotes, input: "`analytics`.`order-items`", expect: `"analytics"."order-items"`},
+		{name: "conditional double quotes convert explicit quoting", quote: QuoteIdentifierWithDoubleQuotesWhenNeeded, input: "`analytics`.`orders`", expect: `"analytics"."orders"`},
 		{name: "converts double quotes to backticks", quote: QuoteIdentifierWithBackticks, input: `"sales data"."order-items"`, expect: "`sales data`.`order-items`"},
 		{name: "converts and escapes brackets", quote: QuoteIdentifierWithBrackets, input: `"analytics"."order]items"`, expect: "[analytics].[order]]items]"},
 		{name: "preserves dots inside a quoted component", quote: QuoteIdentifierWithDoubleQuotes, input: "`my-project.analytics`.orders", expect: `"my-project.analytics"."orders"`},

--- a/pkg/ansisql/checks_test.go
+++ b/pkg/ansisql/checks_test.go
@@ -113,6 +113,55 @@ func TestUniqueCheck_Check(t *testing.T) {
 	)
 }
 
+func TestRelationshipsCheck_Check(t *testing.T) {
+	t.Parallel()
+
+	runTestsFoCountZeroCheck(
+		t,
+		func(q *mockQuerierWithResult) CheckRunner {
+			conn := new(mockConnectionFetcher)
+			conn.On("GetConnection", "test").Return(q, nil)
+			return &RelationshipsCheck{conn: conn}
+		},
+		"SELECT COUNT(*) FROM dataset.test_asset bruin_relationship_child WHERE bruin_relationship_child.test_column IS NOT NULL AND bruin_relationship_child.test_column NOT IN (SELECT bruin_relationship_parent.id FROM dataset.parent_asset bruin_relationship_parent WHERE bruin_relationship_parent.id IS NOT NULL)",
+		"column 'test_column' has 5 rows with values missing from 'dataset.parent_asset.id'",
+		&pipeline.ColumnCheck{
+			Name: "relationships",
+		},
+	)
+}
+
+func TestRelationshipsCheckRequiresForeignKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		foreignKey *pipeline.ColumnReference
+	}{
+		{name: "missing foreign key"},
+		{name: "missing table", foreignKey: &pipeline.ColumnReference{Column: "id"}},
+		{name: "missing column", foreignKey: &pipeline.ColumnReference{Table: "dataset.parent_asset"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			check := &RelationshipsCheck{}
+			instance := &scheduler.ColumnCheckInstance{
+				AssetInstance: &scheduler.AssetInstance{
+					Asset:    &pipeline.Asset{Name: "dataset.test_asset"},
+					Pipeline: &pipeline.Pipeline{Name: "test"},
+				},
+				Column: &pipeline.Column{Name: "test_column", ForeignKey: tt.foreignKey},
+				Check:  &pipeline.ColumnCheck{Name: "relationships"},
+			}
+
+			assert.EqualError(t, check.Check(t.Context(), instance), "relationships check on column 'test_column' requires foreign_key.table and foreign_key.column")
+		})
+	}
+}
+
 func runTestsFoCountZeroCheck(t *testing.T, instanceBuilder func(q *mockQuerierWithResult) CheckRunner, expectedQueryString string, expectedErrorMessage string, checkInstance *pipeline.ColumnCheck) {
 	expectedQuery := &query.Query{Query: expectedQueryString}
 	setupFunc := func(val [][]interface{}, err error) func(n *mockQuerierWithResult) {
@@ -194,6 +243,12 @@ func runTestsFoCountZeroCheck(t *testing.T, instanceBuilder func(q *mockQuerierW
 				},
 				Column: &pipeline.Column{
 					Name: "test_column",
+					ForeignKey: func() *pipeline.ColumnReference {
+						if checkInstance.Name == "relationships" {
+							return &pipeline.ColumnReference{Table: "dataset.parent_asset", Column: "id"}
+						}
+						return nil
+					}(),
 					Checks: []pipeline.ColumnCheck{
 						{
 							Name: "not_null",

--- a/pkg/athena/operator.go
+++ b/pkg/athena/operator.go
@@ -147,6 +147,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/athena/operator.go
+++ b/pkg/athena/operator.go
@@ -147,7 +147,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithDoubleQuotesWhenNeeded),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -188,6 +188,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) (*ColumnCheckOperat
 		checkRunners: map[string]checkRunner{
 			"not_null":        ansisql.NewNotNullCheck(manager),
 			"unique":          ansisql.NewUniqueCheck(manager),
+			"relationships":   ansisql.NewRelationshipsCheck(manager),
 			"positive":        ansisql.NewPositiveCheck(manager),
 			"non_negative":    ansisql.NewNonNegativeCheck(manager),
 			"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -188,7 +188,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) (*ColumnCheckOperat
 		checkRunners: map[string]checkRunner{
 			"not_null":        ansisql.NewNotNullCheck(manager),
 			"unique":          ansisql.NewUniqueCheck(manager),
-			"relationships":   ansisql.NewRelationshipsCheck(manager),
+			"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 			"positive":        ansisql.NewPositiveCheck(manager),
 			"non_negative":    ansisql.NewNonNegativeCheck(manager),
 			"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/clickhouse/checks.go
+++ b/pkg/clickhouse/checks.go
@@ -72,6 +72,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/clickhouse/checks.go
+++ b/pkg/clickhouse/checks.go
@@ -72,7 +72,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/databricks/operator.go
+++ b/pkg/databricks/operator.go
@@ -158,6 +158,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/databricks/operator.go
+++ b/pkg/databricks/operator.go
@@ -158,7 +158,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/doris/checks.go
+++ b/pkg/doris/checks.go
@@ -17,7 +17,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/doris/checks.go
+++ b/pkg/doris/checks.go
@@ -17,6 +17,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/duckdb/operator.go
+++ b/pkg/duckdb/operator.go
@@ -164,6 +164,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/duckdb/operator.go
+++ b/pkg/duckdb/operator.go
@@ -164,7 +164,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithDoubleQuotes),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -46,9 +46,11 @@ func NewColumnCheckOperator(conn config.ConnectionGetter) *ColumnCheckOperator {
 	return &ColumnCheckOperator{
 		conn: conn,
 		checks: map[string]builder[CheckRunner]{
-			"not_null":        func(c *connectionRemapper) CheckRunner { return ansisql.NewNotNullCheck(c) },
-			"unique":          func(c *connectionRemapper) CheckRunner { return ansisql.NewUniqueCheck(c) },
-			"relationships":   func(c *connectionRemapper) CheckRunner { return ansisql.NewRelationshipsCheck(c) },
+			"not_null": func(c *connectionRemapper) CheckRunner { return ansisql.NewNotNullCheck(c) },
+			"unique":   func(c *connectionRemapper) CheckRunner { return ansisql.NewUniqueCheck(c) },
+			"relationships": func(c *connectionRemapper) CheckRunner {
+				return ansisql.NewRelationshipsCheck(c, ansisql.QuoteIdentifierWithBackticks)
+			},
 			"positive":        func(c *connectionRemapper) CheckRunner { return ansisql.NewPositiveCheck(c) },
 			"non_negative":    func(c *connectionRemapper) CheckRunner { return ansisql.NewNonNegativeCheck(c) },
 			"negative":        func(c *connectionRemapper) CheckRunner { return ansisql.NewNegativeCheck(c) },

--- a/pkg/emr_serverless/checks.go
+++ b/pkg/emr_serverless/checks.go
@@ -48,6 +48,7 @@ func NewColumnCheckOperator(conn config.ConnectionGetter) *ColumnCheckOperator {
 		checks: map[string]builder[CheckRunner]{
 			"not_null":        func(c *connectionRemapper) CheckRunner { return ansisql.NewNotNullCheck(c) },
 			"unique":          func(c *connectionRemapper) CheckRunner { return ansisql.NewUniqueCheck(c) },
+			"relationships":   func(c *connectionRemapper) CheckRunner { return ansisql.NewRelationshipsCheck(c) },
 			"positive":        func(c *connectionRemapper) CheckRunner { return ansisql.NewPositiveCheck(c) },
 			"non_negative":    func(c *connectionRemapper) CheckRunner { return ansisql.NewNonNegativeCheck(c) },
 			"negative":        func(c *connectionRemapper) CheckRunner { return ansisql.NewNegativeCheck(c) },

--- a/pkg/fabric/checks.go
+++ b/pkg/fabric/checks.go
@@ -17,6 +17,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        &NotNullCheck{conn: manager},
 		"unique":          &UniqueCheck{conn: manager},
+		"relationships":   &RelationshipsCheck{conn: manager},
 		"positive":        &PositiveCheck{conn: manager},
 		"non_negative":    &NonNegativeCheck{conn: manager},
 		"negative":        &NegativeCheck{conn: manager},
@@ -25,6 +26,37 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 		"accepted_values": &AcceptedValuesCheck{conn: manager},
 		"pattern":         &PatternCheck{conn: manager},
 	})
+}
+
+type RelationshipsCheck struct {
+	conn config.ConnectionGetter
+}
+
+func (c *RelationshipsCheck) Check(ctx context.Context, ti *scheduler.ColumnCheckInstance) error {
+	foreignKey := ti.Column.ForeignKey
+	if foreignKey == nil || strings.TrimSpace(foreignKey.Table) == "" || strings.TrimSpace(foreignKey.Column) == "" {
+		return errors.Errorf("relationships check on column '%s' requires foreign_key.table and foreign_key.column", ti.Column.Name)
+	}
+
+	qq := fmt.Sprintf(
+		"SELECT COUNT_BIG(*) FROM %s bruin_relationship_child WHERE bruin_relationship_child.%s IS NOT NULL AND bruin_relationship_child.%s NOT IN (SELECT bruin_relationship_parent.%s FROM %s bruin_relationship_parent WHERE bruin_relationship_parent.%s IS NOT NULL)",
+		QuoteIdentifier(ti.GetAsset().Name),
+		QuoteIdentifier(ti.Column.Name),
+		QuoteIdentifier(ti.Column.Name),
+		QuoteIdentifier(foreignKey.Column),
+		QuoteIdentifier(foreignKey.Table),
+		QuoteIdentifier(foreignKey.Column),
+	)
+
+	return ansisql.NewCountableQueryCheck(c.conn, 0, &query.Query{Query: qq}, "relationships", func(count int64) error {
+		return errors.Errorf(
+			"column '%s' has %d rows with values missing from '%s.%s'",
+			ti.Column.Name,
+			count,
+			foreignKey.Table,
+			foreignKey.Column,
+		)
+	}).Check(ctx, ti)
 }
 
 type AcceptedValuesCheck struct {

--- a/pkg/fabric/checks_test.go
+++ b/pkg/fabric/checks_test.go
@@ -1,0 +1,56 @@
+package fabric
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockFabricSelector struct {
+	mock.Mock
+}
+
+func (m *mockFabricSelector) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {
+	args := m.Called(ctx, q)
+	return args.Get(0).([][]interface{}), args.Error(1)
+}
+
+func TestRelationshipsCheckQuotesIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	expectedQuery := &query.Query{Query: "SELECT COUNT_BIG(*) FROM [sales data].[order] bruin_relationship_child WHERE bruin_relationship_child.[select] IS NOT NULL AND bruin_relationship_child.[select] NOT IN (SELECT bruin_relationship_parent.[customer id] FROM [sales data].[customer-table] bruin_relationship_parent WHERE bruin_relationship_parent.[customer id] IS NOT NULL)"}
+	selector := new(mockFabricSelector)
+	selector.On("Select", mock.Anything, expectedQuery).Return([][]interface{}{{0}}, nil).Once()
+
+	connections := new(mockFabricConnectionGetter)
+	connections.On("GetConnection", "fabric-default").Return(selector).Once()
+
+	instance := &scheduler.ColumnCheckInstance{
+		AssetInstance: &scheduler.AssetInstance{
+			Asset: &pipeline.Asset{
+				Name: "sales data.order",
+				Type: pipeline.AssetTypeFabricQuery,
+			},
+			Pipeline: &pipeline.Pipeline{
+				Name: "test",
+				DefaultConnections: map[string]string{
+					"fabric": "fabric-default",
+				},
+			},
+		},
+		Column: &pipeline.Column{
+			Name:       "select",
+			ForeignKey: &pipeline.ColumnReference{Table: "sales data.customer-table", Column: "customer id"},
+		},
+		Check: &pipeline.ColumnCheck{Name: "relationships"},
+	}
+
+	assert.NoError(t, (&RelationshipsCheck{conn: connections}).Check(t.Context(), instance))
+	selector.AssertExpectations(t)
+	connections.AssertExpectations(t)
+}

--- a/pkg/fabric/checks_test.go
+++ b/pkg/fabric/checks_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
 	"github.com/bruin-data/bruin/pkg/scheduler"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockFabricSelector struct {
@@ -50,7 +50,7 @@ func TestRelationshipsCheckQuotesIdentifiers(t *testing.T) {
 		Check: &pipeline.ColumnCheck{Name: "relationships"},
 	}
 
-	assert.NoError(t, (&RelationshipsCheck{conn: connections}).Check(t.Context(), instance))
+	require.NoError(t, (&RelationshipsCheck{conn: connections}).Check(t.Context(), instance))
 	selector.AssertExpectations(t)
 	connections.AssertExpectations(t)
 }

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -205,6 +205,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "blocking-relationships-check-references-downstream",
+			Fast:             true,
+			Severity:         ValidatorSeverityWarning,
+			AssetValidator:   WarnBlockingRelationshipsCheckReferencesDownstream,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "duplicate-tags",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1020,12 +1020,96 @@ func ValidateDuplicateColumnNames(ctx context.Context, p *pipeline.Pipeline, ass
 func ValidateColumnMetadata(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0, len(asset.Columns))
 
-	for _, column := range asset.Columns {
-		issues = append(issues, validateColumnForeignKey(p, asset, &column)...)
-		issues = append(issues, validateColumnTypeDetail(asset, &column)...)
+	for columnIndex := range asset.Columns {
+		column := &asset.Columns[columnIndex]
+		if column.HasCheck("relationships") && column.ForeignKey == nil {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: fmt.Sprintf("Column '%s' has a relationships check without foreign_key metadata", column.Name),
+			})
+		}
+		issues = append(issues, validateColumnForeignKey(p, asset, column)...)
+		issues = append(issues, validateColumnTypeDetail(asset, column)...)
 	}
 
 	return issues, nil
+}
+
+// WarnBlockingRelationshipsCheckReferencesDownstream warns when a blocking
+// relationships check references an asset that transitively depends on the
+// checked asset. The scheduler cannot wait for that referenced asset without
+// deadlocking, so it runs the check before the referenced asset is refreshed.
+func WarnBlockingRelationshipsCheckReferencesDownstream(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	issues := make([]*Issue, 0)
+
+	for columnIndex := range asset.Columns {
+		column := &asset.Columns[columnIndex]
+		if column.ForeignKey == nil || column.ForeignKey.Table == "" || column.ForeignKey.Table == asset.Name {
+			continue
+		}
+
+		for checkIndex := range column.Checks {
+			check := &column.Checks[checkIndex]
+			if check.Name != "relationships" || !check.Blocking.Bool() {
+				continue
+			}
+			if !assetTransitivelyDependsOn(p, column.ForeignKey.Table, asset.Name, make(map[string]bool)) {
+				continue
+			}
+
+			issues = append(issues, &Issue{
+				Task: asset,
+				Description: fmt.Sprintf(
+					"Column '%s' has a blocking relationships check referencing downstream asset '%s'; the check runs before that asset is refreshed. Set blocking to false or restructure the dependencies",
+					column.Name,
+					column.ForeignKey.Table,
+				),
+			})
+			break
+		}
+	}
+
+	return issues, nil
+}
+
+func assetTransitivelyDependsOn(p *pipeline.Pipeline, currentName, dependencyName string, visited map[string]bool) bool {
+	if currentName == dependencyName {
+		return true
+	}
+	if visited[currentName] {
+		return false
+	}
+	visited[currentName] = true
+
+	current := p.GetAssetByName(currentName)
+	if current == nil {
+		return false
+	}
+	for _, upstream := range current.Upstreams {
+		if upstream.Type != "asset" || upstream.Mode == pipeline.UpstreamModeSymbolic {
+			continue
+		}
+		if assetTransitivelyDependsOn(p, upstream.Value, dependencyName, visited) {
+			return true
+		}
+	}
+	for columnIndex := range current.Columns {
+		column := &current.Columns[columnIndex]
+		if column.ForeignKey == nil || column.ForeignKey.Table == "" {
+			continue
+		}
+		for checkIndex := range column.Checks {
+			check := &column.Checks[checkIndex]
+			if check.Name != "relationships" || !check.Blocking.Bool() {
+				continue
+			}
+			if assetTransitivelyDependsOn(p, column.ForeignKey.Table, dependencyName, visited) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func validateColumnForeignKey(p *pipeline.Pipeline, asset *pipeline.Asset, column *pipeline.Column) []*Issue {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1037,8 +1037,8 @@ func ValidateColumnMetadata(ctx context.Context, p *pipeline.Pipeline, asset *pi
 
 // WarnBlockingRelationshipsCheckReferencesDownstream warns when a blocking
 // relationships check references an asset that transitively depends on the
-// checked asset. The scheduler cannot wait for that referenced asset without
-// deadlocking, so it runs the check before the referenced asset is refreshed.
+// checked asset. Since downstream assets wait for blocking checks, the check
+// runs before the referenced asset is refreshed.
 func WarnBlockingRelationshipsCheckReferencesDownstream(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	issues := make([]*Issue, 0)
 
@@ -1091,21 +1091,6 @@ func assetTransitivelyDependsOn(p *pipeline.Pipeline, currentName, dependencyNam
 		}
 		if assetTransitivelyDependsOn(p, upstream.Value, dependencyName, visited) {
 			return true
-		}
-	}
-	for columnIndex := range current.Columns {
-		column := &current.Columns[columnIndex]
-		if column.ForeignKey == nil || column.ForeignKey.Table == "" {
-			continue
-		}
-		for checkIndex := range column.Checks {
-			check := &column.Checks[checkIndex]
-			if check.Name != "relationships" || !check.Blocking.Bool() {
-				continue
-			}
-			if assetTransitivelyDependsOn(p, column.ForeignKey.Table, dependencyName, visited) {
-				return true
-			}
 		}
 	}
 

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3210,6 +3210,21 @@ func TestValidateColumnMetadata(t *testing.T) {
 			wantDescs: nil,
 		},
 		{
+			name: "self-referential relationships check is valid",
+			asset: &pipeline.Asset{
+				Name: "orders",
+				Columns: []pipeline.Column{
+					{Name: "id"},
+					{
+						Name:       "parent_order_id",
+						ForeignKey: &pipeline.ColumnReference{Table: "orders", Column: "id"},
+						Checks:     []pipeline.ColumnCheck{{Name: "relationships"}},
+					},
+				},
+			},
+			wantDescs: nil,
+		},
+		{
 			name: "foreign key missing table and column",
 			asset: &pipeline.Asset{
 				Name: "orders",
@@ -3220,6 +3235,18 @@ func TestValidateColumnMetadata(t *testing.T) {
 			wantDescs: []string{
 				"Column 'customer_id' has a foreign key without a referenced table",
 				"Column 'customer_id' has a foreign key without a referenced column",
+			},
+		},
+		{
+			name: "relationships check requires foreign key metadata",
+			asset: &pipeline.Asset{
+				Name: "orders",
+				Columns: []pipeline.Column{
+					{Name: "customer_id", Checks: []pipeline.ColumnCheck{{Name: "relationships"}}},
+				},
+			},
+			wantDescs: []string{
+				"Column 'customer_id' has a relationships check without foreign_key metadata",
 			},
 		},
 		{
@@ -3293,6 +3320,168 @@ func TestValidateColumnMetadata(t *testing.T) {
 			assert.ElementsMatch(t, tt.wantDescs, gotDescs)
 		})
 	}
+}
+
+func TestWarnBlockingRelationshipsCheckReferencesDownstream(t *testing.T) {
+	t.Parallel()
+
+	blocking := false
+	orders := &pipeline.Asset{
+		Name: "orders",
+		Columns: []pipeline.Column{
+			{
+				Name:       "customer_id",
+				ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"},
+				Checks:     []pipeline.ColumnCheck{{Name: "relationships"}},
+			},
+		},
+	}
+	nonBlockingOrders := &pipeline.Asset{
+		Name: "orders",
+		Columns: []pipeline.Column{
+			{
+				Name:       "customer_id",
+				ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"},
+				Checks: []pipeline.ColumnCheck{
+					{Name: "relationships", Blocking: pipeline.DefaultTrueBool{Value: &blocking}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		orders           *pipeline.Asset
+		customers        *pipeline.Asset
+		extraAsset       *pipeline.Asset
+		additionalAssets []*pipeline.Asset
+		want             string
+	}{
+		{
+			name:   "warns when referenced asset directly depends on checked asset",
+			orders: orders,
+			customers: &pipeline.Asset{
+				Name:      "customers",
+				Columns:   []pipeline.Column{{Name: "id"}},
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
+			},
+			want: "Column 'customer_id' has a blocking relationships check referencing downstream asset 'customers'; the check runs before that asset is refreshed. Set blocking to false or restructure the dependencies",
+		},
+		{
+			name:   "warns for transitive downstream dependency",
+			orders: orders,
+			customers: &pipeline.Asset{
+				Name:      "customers",
+				Columns:   []pipeline.Column{{Name: "id"}},
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "customer_staging"}},
+			},
+			extraAsset: &pipeline.Asset{
+				Name:      "customer_staging",
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
+			},
+			want: "Column 'customer_id' has a blocking relationships check referencing downstream asset 'customers'; the check runs before that asset is refreshed. Set blocking to false or restructure the dependencies",
+		},
+		{
+			name:   "does not warn for non-blocking check",
+			orders: nonBlockingOrders,
+			customers: &pipeline.Asset{
+				Name:      "customers",
+				Columns:   []pipeline.Column{{Name: "id"}},
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
+			},
+		},
+		{
+			name:   "does not warn for symbolic dependency",
+			orders: orders,
+			customers: &pipeline.Asset{
+				Name:      "customers",
+				Columns:   []pipeline.Column{{Name: "id"}},
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders", Mode: pipeline.UpstreamModeSymbolic}},
+			},
+		},
+		{
+			name:   "does not warn when referenced asset is independent",
+			orders: orders,
+			customers: &pipeline.Asset{
+				Name:    "customers",
+				Columns: []pipeline.Column{{Name: "id"}},
+			},
+		},
+		{
+			name:   "warns when multiple blocking relationships complete a dependency cycle",
+			orders: orders,
+			customers: &pipeline.Asset{
+				Name:      "customers",
+				Columns:   []pipeline.Column{{Name: "id"}},
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "customer_quality"}},
+			},
+			extraAsset: &pipeline.Asset{
+				Name: "customer_quality",
+				Columns: []pipeline.Column{
+					{
+						Name:       "order_id",
+						ForeignKey: &pipeline.ColumnReference{Table: "order_reporting", Column: "id"},
+						Checks:     []pipeline.ColumnCheck{{Name: "relationships"}},
+					},
+				},
+			},
+			additionalAssets: []*pipeline.Asset{
+				{
+					Name:      "order_reporting",
+					Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
+				},
+			},
+			want: "Column 'customer_id' has a blocking relationships check referencing downstream asset 'customers'; the check runs before that asset is refreshed. Set blocking to false or restructure the dependencies",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assets := []*pipeline.Asset{tt.orders, tt.customers}
+			if tt.extraAsset != nil {
+				assets = append(assets, tt.extraAsset)
+			}
+			assets = append(assets, tt.additionalAssets...)
+			p := &pipeline.Pipeline{Assets: assets}
+
+			issues, err := WarnBlockingRelationshipsCheckReferencesDownstream(t.Context(), p, tt.orders)
+			require.NoError(t, err)
+			if tt.want == "" {
+				assert.Empty(t, issues)
+				return
+			}
+			require.Len(t, issues, 1)
+			assert.Same(t, tt.orders, issues[0].Task)
+			assert.Equal(t, tt.want, issues[0].Description)
+		})
+	}
+}
+
+func TestBlockingRelationshipsCheckReferencesDownstreamRuleIsWarning(t *testing.T) {
+	t.Parallel()
+
+	const ruleName = "blocking-relationships-check-references-downstream"
+	findRule := func(rules []Rule) Rule {
+		for _, rule := range rules {
+			if rule.Name() == ruleName {
+				return rule
+			}
+		}
+		return nil
+	}
+
+	rules, err := GetRules(afero.NewMemMapFs(), nil, false, nil, false)
+	require.NoError(t, err)
+	rule := findRule(rules)
+	require.NotNil(t, rule)
+	assert.Equal(t, ValidatorSeverityWarning, rule.GetSeverity())
+	assert.Contains(t, rule.GetApplicableLevels(), LevelAsset)
+
+	rulesWithoutWarnings, err := GetRules(afero.NewMemMapFs(), nil, true, nil, false)
+	require.NoError(t, err)
+	assert.Nil(t, findRule(rulesWithoutWarnings))
 }
 
 func TestValidateDuplicateTags(t *testing.T) {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -3408,7 +3408,22 @@ func TestWarnBlockingRelationshipsCheckReferencesDownstream(t *testing.T) {
 			},
 		},
 		{
-			name:   "warns when multiple blocking relationships complete a dependency cycle",
+			name:   "does not warn for independent assets with reciprocal relationships checks",
+			orders: orders,
+			customers: &pipeline.Asset{
+				Name: "customers",
+				Columns: []pipeline.Column{
+					{Name: "id"},
+					{
+						Name:       "order_id",
+						ForeignKey: &pipeline.ColumnReference{Table: "orders", Column: "id"},
+						Checks:     []pipeline.ColumnCheck{{Name: "relationships"}},
+					},
+				},
+			},
+		},
+		{
+			name:   "does not warn when assets are connected only through relationships checks",
 			orders: orders,
 			customers: &pipeline.Asset{
 				Name:      "customers",
@@ -3431,7 +3446,6 @@ func TestWarnBlockingRelationshipsCheckReferencesDownstream(t *testing.T) {
 					Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
 				},
 			},
-			want: "Column 'customer_id' has a blocking relationships check referencing downstream asset 'customers'; the check runs before that asset is refreshed. Set blocking to false or restructure the dependencies",
 		},
 	}
 

--- a/pkg/mssql/operator.go
+++ b/pkg/mssql/operator.go
@@ -136,6 +136,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          &UniqueCheck{conn: manager},
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/mssql/operator.go
+++ b/pkg/mssql/operator.go
@@ -136,7 +136,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          &UniqueCheck{conn: manager},
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBrackets),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/mysql/operator.go
+++ b/pkg/mysql/operator.go
@@ -157,6 +157,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/mysql/operator.go
+++ b/pkg/mysql/operator.go
@@ -157,7 +157,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/oracle/operator.go
+++ b/pkg/oracle/operator.go
@@ -155,7 +155,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithDoubleQuotesWhenNeeded),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/oracle/operator.go
+++ b/pkg/oracle/operator.go
@@ -155,6 +155,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1504,6 +1504,12 @@ func (a *Asset) PrefixSchema(prefix string) {
 	}
 
 	a.Name = prefixSchemaComponent(a.Name, prefix)
+	for i := range a.Columns {
+		if a.Columns[i].ForeignKey == nil {
+			continue
+		}
+		a.Columns[i].ForeignKey.Table = prefixSchemaComponent(a.Columns[i].ForeignKey.Table, prefix)
+	}
 }
 
 func (a *Asset) PrefixUpstreams(prefix string) {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3535,6 +3535,16 @@ func TestAsset_PrefixSchema(t *testing.T) {
 			assert.Equal(t, tt.want, a.Name)
 		})
 	}
+
+	a := &pipeline.Asset{
+		Name: "analytics.orders",
+		Columns: []pipeline.Column{
+			{Name: "customer_id", ForeignKey: &pipeline.ColumnReference{Table: "analytics.customers", Column: "id"}},
+		},
+	}
+	a.PrefixSchema("dev_")
+	assert.Equal(t, "dev_analytics.orders", a.Name)
+	assert.Equal(t, "dev_analytics.customers", a.Columns[0].ForeignKey.Table)
 }
 
 func TestAsset_PrefixUpstreams(t *testing.T) {

--- a/pkg/pipeline/yaml.go
+++ b/pkg/pipeline/yaml.go
@@ -20,6 +20,7 @@ var ValidQualityChecks = map[string]bool{
 	"min":             true,
 	"max":             true,
 	"accepted_values": true,
+	"relationships":   true,
 	"negative":        true,
 	"non_negative":    true,
 	"pattern":         true,

--- a/pkg/pipeline/yaml_test.go
+++ b/pkg/pipeline/yaml_test.go
@@ -507,6 +507,8 @@ columns:
     foreign_key:
       table: customers
       column: id
+    checks:
+      - name: relationships
   - name: amount
     type: numeric
     precision: 10
@@ -523,6 +525,8 @@ columns:
 	require.Nil(t, task.Columns[0].ForeignKey)
 
 	require.Equal(t, &pipeline.ColumnReference{Table: "customers", Column: "id"}, task.Columns[1].ForeignKey)
+	require.Len(t, task.Columns[1].Checks, 1)
+	require.Equal(t, "relationships", task.Columns[1].Checks[0].Name)
 
 	require.Equal(t, 10, *task.Columns[2].Precision)
 	require.Equal(t, 2, *task.Columns[2].Scale)

--- a/pkg/postgres/operator.go
+++ b/pkg/postgres/operator.go
@@ -161,7 +161,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithDoubleQuotes),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/postgres/operator.go
+++ b/pkg/postgres/operator.go
@@ -161,6 +161,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/sail/checks.go
+++ b/pkg/sail/checks.go
@@ -21,6 +21,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/sail/checks.go
+++ b/pkg/sail/checks.go
@@ -21,7 +21,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -831,52 +831,6 @@ func (s *Scheduler) constructInstanceRelationships() {
 			}
 		}
 	}
-
-	// A relationships check reads both its child asset and the table referenced
-	// by the column's foreign_key metadata. Make the referenced asset an explicit
-	// prerequisite so independently scheduled assets cannot race the check.
-	for _, ti := range s.taskInstances {
-		check, ok := ti.(*ColumnCheckInstance)
-		if !ok || check.Check.Name != "relationships" || check.Column.ForeignKey == nil {
-			continue
-		}
-
-		parentAssetName := check.Column.ForeignKey.Table
-		if parentAssetName == "" || parentAssetName == check.GetAsset().Name {
-			continue
-		}
-
-		parentInstances, ok := s.taskNameMap[parentAssetName]
-		if !ok {
-			continue
-		}
-
-		for _, parent := range parentInstances[TaskInstanceTypeMain] {
-			if taskHasDownstreamPath(check, parent, make(map[TaskInstance]bool)) {
-				continue
-			}
-			check.AddUpstream(parent)
-			parent.AddDownstream(check)
-		}
-	}
-}
-
-func taskHasDownstreamPath(current, target TaskInstance, visited map[TaskInstance]bool) bool {
-	if current == target {
-		return true
-	}
-	if visited[current] {
-		return false
-	}
-	visited[current] = true
-
-	for _, downstream := range current.GetDownstream() {
-		if taskHasDownstreamPath(downstream, target, visited) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (s *Scheduler) Run(ctx context.Context) []*TaskExecutionResult {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -831,6 +831,52 @@ func (s *Scheduler) constructInstanceRelationships() {
 			}
 		}
 	}
+
+	// A relationships check reads both its child asset and the table referenced
+	// by the column's foreign_key metadata. Make the referenced asset an explicit
+	// prerequisite so independently scheduled assets cannot race the check.
+	for _, ti := range s.taskInstances {
+		check, ok := ti.(*ColumnCheckInstance)
+		if !ok || check.Check.Name != "relationships" || check.Column.ForeignKey == nil {
+			continue
+		}
+
+		parentAssetName := check.Column.ForeignKey.Table
+		if parentAssetName == "" || parentAssetName == check.GetAsset().Name {
+			continue
+		}
+
+		parentInstances, ok := s.taskNameMap[parentAssetName]
+		if !ok {
+			continue
+		}
+
+		for _, parent := range parentInstances[TaskInstanceTypeMain] {
+			if taskHasDownstreamPath(check, parent, make(map[TaskInstance]bool)) {
+				continue
+			}
+			check.AddUpstream(parent)
+			parent.AddDownstream(check)
+		}
+	}
+}
+
+func taskHasDownstreamPath(current, target TaskInstance, visited map[TaskInstance]bool) bool {
+	if current == target {
+		return true
+	}
+	if visited[current] {
+		return false
+	}
+	visited[current] = true
+
+	for _, downstream := range current.GetDownstream() {
+		if taskHasDownstreamPath(downstream, target, visited) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *Scheduler) Run(ctx context.Context) []*TaskExecutionResult {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -786,7 +786,7 @@ func TestScheduler_Run(t *testing.T) {
 	assert.True(t, finished)
 }
 
-func TestScheduler_RelationshipsCheckWaitsForReferencedAsset(t *testing.T) {
+func TestScheduler_RelationshipsCheckDoesNotWaitForReferencedAsset(t *testing.T) {
 	t.Parallel()
 
 	p := &pipeline.Pipeline{
@@ -808,20 +808,14 @@ func TestScheduler_RelationshipsCheckWaitsForReferencedAsset(t *testing.T) {
 	s := NewScheduler(zap.NewNop().Sugar(), p, "test")
 	check := s.taskNameMap["orders"][TaskInstanceTypeColumnCheck][0]
 
-	require.Len(t, check.GetUpstream(), 2)
-	assert.ElementsMatch(t, []string{"orders", "customers"}, []string{
-		check.GetUpstream()[0].GetHumanID(),
-		check.GetUpstream()[1].GetHumanID(),
-	})
+	require.Len(t, check.GetUpstream(), 1)
+	assert.Equal(t, "orders", check.GetUpstream()[0].GetHumanID())
 
 	markMainTaskStatus(s, "orders", Succeeded)
-	assert.NotContains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
-
-	markMainTaskStatus(s, "customers", Succeeded)
 	assert.Contains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
 }
 
-func TestScheduler_RelationshipsCheckDoesNotCreateDependencyCycle(t *testing.T) {
+func TestScheduler_BlockingRelationshipsCheckRunsBeforeReferencedDownstreamAsset(t *testing.T) {
 	t.Parallel()
 
 	p := &pipeline.Pipeline{
@@ -845,12 +839,25 @@ func TestScheduler_RelationshipsCheckDoesNotCreateDependencyCycle(t *testing.T) 
 
 	s := NewScheduler(zap.NewNop().Sugar(), p, "test")
 	check := s.taskNameMap["orders"][TaskInstanceTypeColumnCheck][0]
+	customers := s.taskNameMap["customers"][TaskInstanceTypeMain][0]
 
 	require.Len(t, check.GetUpstream(), 1)
 	assert.Equal(t, "orders", check.GetUpstream()[0].GetHumanID())
+	require.Len(t, customers.GetUpstream(), 2)
+	assert.ElementsMatch(t, []string{"orders", "orders:customer_id:relationships"}, []string{
+		customers.GetUpstream()[0].GetHumanID(),
+		customers.GetUpstream()[1].GetHumanID(),
+	})
+
+	markMainTaskStatus(s, "orders", Succeeded)
+	assert.Contains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
+	assert.NotContains(t, scheduleableHumanIDs(s), "customers")
+
+	s.MarkTaskInstance(check, Succeeded, false)
+	assert.Contains(t, scheduleableHumanIDs(s), "customers")
 }
 
-func TestScheduler_NonBlockingRelationshipsCheckWaitsForReverseDependentAsset(t *testing.T) {
+func TestScheduler_NonBlockingRelationshipsCheckDoesNotWaitForReferencedAsset(t *testing.T) {
 	t.Parallel()
 
 	blocking := false
@@ -877,18 +884,15 @@ func TestScheduler_NonBlockingRelationshipsCheckWaitsForReverseDependentAsset(t 
 
 	s := NewScheduler(zap.NewNop().Sugar(), p, "test")
 	check := s.taskNameMap["orders"][TaskInstanceTypeColumnCheck][0]
+	customers := s.taskNameMap["customers"][TaskInstanceTypeMain][0]
 
-	require.Len(t, check.GetUpstream(), 2)
-	assert.ElementsMatch(t, []string{"orders", "customers"}, []string{
-		check.GetUpstream()[0].GetHumanID(),
-		check.GetUpstream()[1].GetHumanID(),
-	})
+	require.Len(t, check.GetUpstream(), 1)
+	assert.Equal(t, "orders", check.GetUpstream()[0].GetHumanID())
+	require.Len(t, customers.GetUpstream(), 1)
+	assert.Equal(t, "orders", customers.GetUpstream()[0].GetHumanID())
 
 	markMainTaskStatus(s, "orders", Succeeded)
 	assert.Contains(t, scheduleableHumanIDs(s), "customers")
-	assert.NotContains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
-
-	markMainTaskStatus(s, "customers", Succeeded)
 	assert.Contains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -786,6 +786,112 @@ func TestScheduler_Run(t *testing.T) {
 	assert.True(t, finished)
 }
 
+func TestScheduler_RelationshipsCheckWaitsForReferencedAsset(t *testing.T) {
+	t.Parallel()
+
+	p := &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{Name: "customers"},
+			{
+				Name: "orders",
+				Columns: []pipeline.Column{
+					{
+						Name:       "customer_id",
+						ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"},
+						Checks:     []pipeline.ColumnCheck{{Name: "relationships"}},
+					},
+				},
+			},
+		},
+	}
+
+	s := NewScheduler(zap.NewNop().Sugar(), p, "test")
+	check := s.taskNameMap["orders"][TaskInstanceTypeColumnCheck][0]
+
+	require.Len(t, check.GetUpstream(), 2)
+	assert.ElementsMatch(t, []string{"orders", "customers"}, []string{
+		check.GetUpstream()[0].GetHumanID(),
+		check.GetUpstream()[1].GetHumanID(),
+	})
+
+	markMainTaskStatus(s, "orders", Succeeded)
+	assert.NotContains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
+
+	markMainTaskStatus(s, "customers", Succeeded)
+	assert.Contains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
+}
+
+func TestScheduler_RelationshipsCheckDoesNotCreateDependencyCycle(t *testing.T) {
+	t.Parallel()
+
+	p := &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{
+				Name:      "customers",
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
+			},
+			{
+				Name: "orders",
+				Columns: []pipeline.Column{
+					{
+						Name:       "customer_id",
+						ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"},
+						Checks:     []pipeline.ColumnCheck{{Name: "relationships"}},
+					},
+				},
+			},
+		},
+	}
+
+	s := NewScheduler(zap.NewNop().Sugar(), p, "test")
+	check := s.taskNameMap["orders"][TaskInstanceTypeColumnCheck][0]
+
+	require.Len(t, check.GetUpstream(), 1)
+	assert.Equal(t, "orders", check.GetUpstream()[0].GetHumanID())
+}
+
+func TestScheduler_NonBlockingRelationshipsCheckWaitsForReverseDependentAsset(t *testing.T) {
+	t.Parallel()
+
+	blocking := false
+	p := &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{
+				Name:      "customers",
+				Upstreams: []pipeline.Upstream{{Type: "asset", Value: "orders"}},
+			},
+			{
+				Name: "orders",
+				Columns: []pipeline.Column{
+					{
+						Name:       "customer_id",
+						ForeignKey: &pipeline.ColumnReference{Table: "customers", Column: "id"},
+						Checks: []pipeline.ColumnCheck{
+							{Name: "relationships", Blocking: pipeline.DefaultTrueBool{Value: &blocking}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := NewScheduler(zap.NewNop().Sugar(), p, "test")
+	check := s.taskNameMap["orders"][TaskInstanceTypeColumnCheck][0]
+
+	require.Len(t, check.GetUpstream(), 2)
+	assert.ElementsMatch(t, []string{"orders", "customers"}, []string{
+		check.GetUpstream()[0].GetHumanID(),
+		check.GetUpstream()[1].GetHumanID(),
+	})
+
+	markMainTaskStatus(s, "orders", Succeeded)
+	assert.Contains(t, scheduleableHumanIDs(s), "customers")
+	assert.NotContains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
+
+	markMainTaskStatus(s, "customers", Succeeded)
+	assert.Contains(t, scheduleableHumanIDs(s), "orders:customer_id:relationships")
+}
+
 func TestScheduler_MarkTasksAndDownstream(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -231,7 +231,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithDoubleQuotesWhenNeeded),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -231,6 +231,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/starrocks/checks.go
+++ b/pkg/starrocks/checks.go
@@ -17,7 +17,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBackticks),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/starrocks/checks.go
+++ b/pkg/starrocks/checks.go
@@ -17,6 +17,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/synapse/operator.go
+++ b/pkg/synapse/operator.go
@@ -134,7 +134,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithBrackets),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/synapse/operator.go
+++ b/pkg/synapse/operator.go
@@ -134,6 +134,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/vertica/operator.go
+++ b/pkg/vertica/operator.go
@@ -129,6 +129,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),

--- a/pkg/vertica/operator.go
+++ b/pkg/vertica/operator.go
@@ -129,7 +129,7 @@ func NewColumnCheckOperator(manager config.ConnectionGetter) *ansisql.ColumnChec
 	return ansisql.NewColumnCheckOperator(map[string]ansisql.CheckRunner{
 		"not_null":        ansisql.NewNotNullCheck(manager),
 		"unique":          ansisql.NewUniqueCheck(manager),
-		"relationships":   ansisql.NewRelationshipsCheck(manager),
+		"relationships":   ansisql.NewRelationshipsCheck(manager, ansisql.QuoteIdentifierWithDoubleQuotes),
 		"positive":        ansisql.NewPositiveCheck(manager),
 		"non_negative":    ansisql.NewNonNegativeCheck(manager),
 		"negative":        ansisql.NewNegativeCheck(manager),


### PR DESCRIPTION
## What
Adds a relationships column quality check backed by foreign key metadata.

## Changes
- Runs relationship checks across supported SQL platforms with scheduler ordering and cycle warnings.
- Adds documentation, unit coverage, and DuckDB integration fixtures.

## How to test
1. Run `make format`, `make test`, and the DuckDB relationship integration cases.

## Risk & rollback
- **Risk:** Low; the feature is opt-in and covered across parsing, scheduling, linting, and execution.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.