### PR TITLE
fix(ingestr): push column metadata to the destination platform

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -312,26 +312,15 @@ func printExecutionSummary(results []*scheduler.TaskExecutionResult, s *schedule
 
 	// Metadata push
 	if summary.MetadataPush.HasAny() {
-		metadataExecuted := summary.MetadataPush.Succeeded + summary.MetadataPush.Failed
-		if summary.MetadataPush.Failed > 0 {
+		if summary.MetadataPush.Failed > 0 || summary.MetadataPush.Skipped > 0 || summary.MetadataPush.NotStarted > 0 {
 			summaryPrinter.Printf(" %s Metadata pushed      %s\n",
 				color.New(color.FgRed).Sprint("✗"),
-				formatCount(metadataExecuted, summary.MetadataPush.Failed))
+				formatCountWithSkipped(summary.MetadataPush.Total, summary.MetadataPush.Failed, 0, summary.MetadataPush.Skipped, summary.MetadataPush.NotStarted))
 		} else {
 			summaryPrinter.Printf(" %s Metadata pushed      %d\n",
-				color.New(color.FgGreen).Sprint("✓"), metadataExecuted)
+				color.New(color.FgGreen).Sprint("✓"), summary.MetadataPush.Succeeded)
 		}
 	}
-}
-
-func formatCount(total, failed int) string {
-	if failed == 0 {
-		return strconv.Itoa(total)
-	}
-	succeeded := total - failed
-	return fmt.Sprintf("%s / %s",
-		color.New(color.FgRed).Sprintf("%d failed", failed),
-		color.New(color.FgGreen).Sprintf("%d succeeded", succeeded))
 }
 
 func formatCountWithSkipped(total, failed, failedDueToChecks, skipped, notStarted int) string {
@@ -417,9 +406,12 @@ func analyzeResults(results []*scheduler.TaskExecutionResult, s *scheduler.Sched
 			}
 		case *scheduler.MetadataPushInstance:
 			summary.MetadataPush.Total++
-			if succeeded {
+			switch {
+			case instance.GetStatus() == scheduler.Skipped:
+				summary.MetadataPush.Skipped++
+			case succeeded:
 				summary.MetadataPush.Succeeded++
-			} else {
+			default:
 				summary.MetadataPush.Failed++
 			}
 		}
@@ -2456,10 +2448,12 @@ func SetupExecutors(
 		}
 		ingestrCheckRunner := ingestr.NewColumnCheckOperator(&mainExecutors)
 		ingestrCustomCheckRunner := ingestr.NewCustomCheckOperator(&mainExecutors)
+		ingestrMetadataPushRunner := ingestr.NewMetadataPushOperator(&mainExecutors, conn)
 
 		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeMain] = ingestrOperator
 		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeColumnCheck] = ingestrCheckRunner
 		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeCustomCheck] = ingestrCustomCheckRunner
+		mainExecutors[pipeline.AssetTypeIngestr][scheduler.TaskInstanceTypeMetadataPush] = ingestrMetadataPushRunner
 	}
 
 	//nolint:dupl

--- a/cmd/tui_summary.go
+++ b/cmd/tui_summary.go
@@ -82,14 +82,13 @@ func printTUISummary(w io.Writer, results []*scheduler.TaskExecutionResult, s *s
 
 	// Metadata push
 	if summary.MetadataPush.HasAny() {
-		metadataExecuted := summary.MetadataPush.Succeeded + summary.MetadataPush.Failed
-		if summary.MetadataPush.Failed > 0 {
+		if summary.MetadataPush.Failed > 0 || summary.MetadataPush.Skipped > 0 || summary.MetadataPush.NotStarted > 0 {
 			fmt.Fprintf(w, "  %s Metadata pushed      %s\n",
 				color.New(color.FgRed).Sprint("✗"),
-				formatCount(metadataExecuted, summary.MetadataPush.Failed))
+				formatCountWithSkipped(summary.MetadataPush.Total, summary.MetadataPush.Failed, 0, summary.MetadataPush.Skipped, summary.MetadataPush.NotStarted))
 		} else {
 			fmt.Fprintf(w, "  %s Metadata pushed      %d\n",
-				color.New(color.FgGreen).Sprint("✓"), metadataExecuted)
+				color.New(color.FgGreen).Sprint("✓"), summary.MetadataPush.Succeeded)
 		}
 	}
 

--- a/pkg/ingestr/checks.go
+++ b/pkg/ingestr/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -57,5 +58,42 @@ func (i IngestrCustomCheckOperator) Run(ctx context.Context, ti scheduler.TaskIn
 func NewCustomCheckOperator(configs *map[pipeline.AssetType]executor.Config) *IngestrCustomCheckOperator {
 	return &IngestrCustomCheckOperator{
 		configs: configs,
+	}
+}
+
+type IngestrMetadataPushOperator struct {
+	configs    *map[pipeline.AssetType]executor.Config
+	connection config.ConnectionGetter
+}
+
+func (i IngestrMetadataPushOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error {
+	asset := ti.GetAsset()
+	assetType, err := helpers.GetIngestrDestinationType(asset)
+	if err != nil {
+		return err
+	}
+
+	pusher, ok := (*i.configs)[assetType][scheduler.TaskInstanceTypeMetadataPush]
+	if _, isNoOp := pusher.(executor.NoOpOperator); !ok || isNoOp {
+		ti.MarkAs(scheduler.Skipped)
+		return nil
+	}
+
+	connName, err := ti.GetPipeline().GetConnectionNameForAsset(asset)
+	if err != nil {
+		return err
+	}
+	if i.connection.GetConnection(connName) == nil {
+		ti.MarkAs(scheduler.Skipped)
+		return nil
+	}
+
+	return pusher.Run(ctx, ti)
+}
+
+func NewMetadataPushOperator(configs *map[pipeline.AssetType]executor.Config, conn config.ConnectionGetter) *IngestrMetadataPushOperator {
+	return &IngestrMetadataPushOperator{
+		configs:    configs,
+		connection: conn,
 	}
 }

--- a/pkg/ingestr/metadata_test.go
+++ b/pkg/ingestr/metadata_test.go
@@ -1,0 +1,120 @@
+package ingestr
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/executor"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/scheduler"
+	"github.com/stretchr/testify/require"
+)
+
+type stubConn struct{ present bool }
+
+func (s stubConn) GetConnection(string) any {
+	if s.present {
+		return struct{}{}
+	}
+	return nil
+}
+
+func TestIngestrMetadataPushOperator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		wantError   bool
+		wantPushed  bool
+		wantSkipped bool
+		connPresent bool
+		destination string
+		configs     map[pipeline.AssetType]executor.Config
+	}{
+		{
+			name:        "delegates to destination metadata pusher",
+			destination: "bigquery",
+			connPresent: true,
+			wantPushed:  true,
+			configs: map[pipeline.AssetType]executor.Config{
+				pipeline.AssetTypeBigqueryQuery: {},
+			},
+		},
+		{
+			name:        "propagates destination pusher error",
+			destination: "bigquery",
+			connPresent: true,
+			wantError:   true,
+			wantPushed:  true,
+			configs: map[pipeline.AssetType]executor.Config{
+				pipeline.AssetTypeBigqueryQuery: {},
+			},
+		},
+		{
+			name:        "skips when destination connection is not configured",
+			destination: "bigquery",
+			wantSkipped: true,
+			configs: map[pipeline.AssetType]executor.Config{
+				pipeline.AssetTypeBigqueryQuery: {},
+			},
+		},
+		{
+			name:        "skips when destination has no metadata pusher",
+			destination: "duckdb",
+			wantSkipped: true,
+			configs:     map[pipeline.AssetType]executor.Config{},
+		},
+		{
+			name:        "skips when destination pusher is a no-op",
+			destination: "duckdb",
+			wantSkipped: true,
+			configs: map[pipeline.AssetType]executor.Config{
+				pipeline.AssetTypeDuckDBQuery: {
+					scheduler.TaskInstanceTypeMetadataPush: executor.NoOpOperator{},
+				},
+			},
+		},
+		{
+			name:        "errors on unknown destination",
+			destination: "not-a-real-destination",
+			wantError:   true,
+			configs:     map[pipeline.AssetType]executor.Config{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pushed := false
+			if cfg, ok := tt.configs[pipeline.AssetTypeBigqueryQuery]; ok {
+				cfg[scheduler.TaskInstanceTypeMetadataPush] = checker{fn: func() error {
+					pushed = true
+					if tt.wantError {
+						return errors.New("push failed")
+					}
+					return nil
+				}}
+			}
+
+			op := NewMetadataPushOperator(&tt.configs, stubConn{present: tt.connPresent})
+			asset := scheduler.AssetInstance{
+				Pipeline: &pipeline.Pipeline{},
+				Asset: &pipeline.Asset{
+					Type:       "ingestr",
+					Parameters: pipeline.ParameterMap{"destination": tt.destination},
+				},
+			}
+
+			err := op.Run(context.Background(), &asset)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantPushed, pushed)
+			require.Equal(t, tt.wantSkipped, asset.GetStatus() == scheduler.Skipped)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #2533. Pipeline-level `metadata_push` silently did nothing for `ingestr` assets. The run printed `✓ Metadata pushed 1`, but no column descriptions reached the destination.

Root cause: `SetupExecutors` seeds `mainExecutors` from `DefaultExecutorsV2` (where `AssetTypeIngestr` → metadata-push is a `NoOpOperator`) and only overrode `Main`/`ColumnCheck`/`CustomCheck` for ingestr — never `MetadataPush`. The no-op ran, succeeded, and got counted as a successful push.

## Fix

- **`pkg/ingestr/checks.go`** — add `IngestrMetadataPushOperator`, which resolves the destination platform via `GetIngestrDestinationType` and delegates to that platform's registered metadata pusher, mirroring the existing ingestr column/custom-check operators. It skips (marks the task `Skipped`) when:
  - the destination has no real metadata pusher (or only the default no-op, e.g. DuckDB), or
  - the destination connection isn't configured — metadata push is a best-effort add-on, so a missing connection is skipped rather than failing the run. In a normal run a genuinely missing connection is still caught by the main ingestion task, which needs the same connection.
- **`cmd/run.go`** — register the operator for `AssetTypeIngestr`, and count/print a skipped metadata push as **skipped** rather than a false success.
- **`cmd/tui_summary.go`** — render the skipped count in the TUI summary too.

## Reporting

| Case | Before | After |
| --- | --- | --- |
| Supported destination, connection configured (BigQuery/Snowflake/Postgres) | `✓ Metadata pushed 1` (nothing written) | `✓ Metadata pushed 1` (descriptions written) |
| Unsupported destination, or destination connection absent | `✓ Metadata pushed 1` (misleading) | `✗ Metadata pushed 1 skipped` |

A skip is not a failure — the run still exits 0.