### PR TITLE
Resolve column lineage for database-qualified upstream references

### DIFF
--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -396,10 +396,7 @@ type ParseCommand struct {
 }
 
 // buildAssetDatabaseMap best-effort maps each asset name to its connection's
-// configured database (from .bruin.yml). Column-lineage resolution uses it to
-// match a table reference that is qualified with its database (e.g.
-// prod.schema.table) back to the two-part asset. Returns an empty map when no
-// config is available, in which case resolution falls back to exact matching.
+// database from .bruin.yml. Empty when no config is available.
 func buildAssetDatabaseMap(inputPath string, foundPipeline *pipeline.Pipeline) map[string]string {
 	result := map[string]string{}
 	fs := afero.NewOsFs()
@@ -427,9 +424,8 @@ func buildAssetDatabaseMap(inputPath string, foundPipeline *pipeline.Pipeline) m
 	return result
 }
 
-// connectionDatabase reads the "Database" field from a connection config of any
-// type. Most SQL connections (Fabric, MSSQL, Snowflake, Postgres, ...) expose
-// it; those that don't yield "".
+// connectionDatabase returns a connection's leading namespace: Database, or
+// Catalog (Databricks/Trino/Spark/StarRocks), or ProjectID (BigQuery). "" if none.
 func connectionDatabase(conn any) string {
 	if conn == nil {
 		return ""
@@ -444,8 +440,10 @@ func connectionDatabase(conn any) string {
 	if v.Kind() != reflect.Struct {
 		return ""
 	}
-	if f := v.FieldByName("Database"); f.IsValid() && f.Kind() == reflect.String {
-		return f.String()
+	for _, field := range []string{"Database", "Catalog", "ProjectID"} {
+		if f := v.FieldByName(field); f.IsValid() && f.Kind() == reflect.String && f.String() != "" {
+			return f.String()
+		}
 	}
 	return ""
 }

--- a/cmd/internal.go
+++ b/cmd/internal.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -394,6 +395,61 @@ type ParseCommand struct {
 	errorPrinter *color2.Color
 }
 
+// buildAssetDatabaseMap best-effort maps each asset name to its connection's
+// configured database (from .bruin.yml). Column-lineage resolution uses it to
+// match a table reference that is qualified with its database (e.g.
+// prod.schema.table) back to the two-part asset. Returns an empty map when no
+// config is available, in which case resolution falls back to exact matching.
+func buildAssetDatabaseMap(inputPath string, foundPipeline *pipeline.Pipeline) map[string]string {
+	result := map[string]string{}
+	fs := afero.NewOsFs()
+	repoRoot, err := git.FindRepoFromPath(inputPath)
+	if err != nil {
+		return result
+	}
+	configPath := filepath.Join(repoRoot.Path, ".bruin.yml")
+	if exists, _ := afero.Exists(fs, configPath); !exists {
+		return result
+	}
+	cm, err := config.LoadOrCreate(fs, configPath)
+	if err != nil || cm.SelectedEnvironment == nil {
+		return result
+	}
+	for _, asset := range foundPipeline.Assets {
+		connName, err := foundPipeline.GetConnectionNameForAsset(asset)
+		if err != nil || connName == "" {
+			continue
+		}
+		if db := connectionDatabase(cm.SelectedEnvironment.Connections.GetConnection(connName)); db != "" {
+			result[asset.Name] = db
+		}
+	}
+	return result
+}
+
+// connectionDatabase reads the "Database" field from a connection config of any
+// type. Most SQL connections (Fabric, MSSQL, Snowflake, Postgres, ...) expose
+// it; those that don't yield "".
+func connectionDatabase(conn any) string {
+	if conn == nil {
+		return ""
+	}
+	v := reflect.ValueOf(conn)
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return ""
+	}
+	if f := v.FieldByName("Database"); f.IsValid() && f.Kind() == reflect.String {
+		return f.String()
+	}
+	return ""
+}
+
 func (r *ParseCommand) ParsePipeline(ctx context.Context, assetPath string, lineage bool, slimResponse bool, variantName string) error {
 	// defer RecoverFromPanic()
 	var lineageWg conc.WaitGroup
@@ -465,7 +521,8 @@ func (r *ParseCommand) ParsePipeline(ctx context.Context, assetPath string, line
 
 		defer sqlParser.Close()
 		processedAssets := make(map[string]bool)
-		lineage := lineagepackage.NewLineageExtractor(sqlParser)
+		lineage := lineagepackage.NewLineageExtractor(sqlParser).
+			WithAssetDatabases(buildAssetDatabaseMap(assetPath, foundPipeline))
 		for _, asset := range foundPipeline.Assets {
 			errIssues := lineage.ColumnLineage(foundPipeline, asset, processedAssets)
 			if errIssues != nil {
@@ -662,7 +719,8 @@ func (r *ParseCommand) Run(ctx context.Context, assetPath string, lineage bool, 
 		defer sqlParser.Close()
 
 		processedAssets := make(map[string]bool)
-		lineageExtractor := lineagepackage.NewLineageExtractor(sqlParser)
+		lineageExtractor := lineagepackage.NewLineageExtractor(sqlParser).
+			WithAssetDatabases(buildAssetDatabaseMap(assetPath, foundPipeline))
 		lineageErrors := lineageExtractor.ColumnLineage(foundPipeline, asset, processedAssets)
 		if lineageErrors != nil {
 			for _, issue := range lineageErrors.Issues {

--- a/cmd/internal_test.go
+++ b/cmd/internal_test.go
@@ -7,8 +7,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/spf13/afero"
 )
+
+func TestConnectionDatabase(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		conn any
+		want string
+	}{
+		{"fabric database", &config.FabricConnection{Database: "prod"}, "prod"},
+		{"mssql database", &config.MsSQLConnection{Database: "wh"}, "wh"},
+		{"databricks catalog", &config.DatabricksConnection{Catalog: "main"}, "main"},
+		{"trino catalog", &config.TrinoConnection{Catalog: "hive"}, "hive"},
+		{"bigquery project", &config.GoogleCloudPlatformConnection{ProjectID: "my-proj"}, "my-proj"},
+		{"no namespace field", struct{}{}, ""},
+		{"nil", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := connectionDatabase(tt.conn); got != tt.want {
+				t.Errorf("connectionDatabase() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func BenchmarkInternalParsePipeline(b *testing.B) {
 	r := ParseCommand{

--- a/pkg/lineage/lineage.go
+++ b/pkg/lineage/lineage.go
@@ -16,8 +16,9 @@ type sqlParser interface {
 }
 
 type LineageExtractor struct {
-	sqlParser sqlParser
-	renderer  *jinja.Renderer
+	sqlParser      sqlParser
+	renderer       *jinja.Renderer
+	assetDatabases map[string]string
 }
 
 type LineageError struct {
@@ -37,6 +38,39 @@ func NewLineageExtractor(parser sqlParser) *LineageExtractor {
 		sqlParser: parser,
 		renderer:  jinja.NewRendererWithYesterday("lineage-parser", "lineage-parser"),
 	}
+}
+
+// WithAssetDatabases attaches an asset-name -> database map (from .bruin.yml) so
+// column-lineage resolution can match a table reference that is qualified with
+// its database (e.g. prod.schema.table) back to the two-part asset schema.table.
+// Optional; when unset, resolution falls back to exact name matching.
+func (p *LineageExtractor) WithAssetDatabases(assetDatabases map[string]string) *LineageExtractor {
+	p.assetDatabases = assetDatabases
+	return p
+}
+
+// resolveUpstreamAsset finds the asset a column-lineage table reference points
+// to. It first tries an exact, case-insensitive match on the asset name. If that
+// fails and the reference is qualified with a leading database (e.g.
+// prod.schema.table against the asset schema.table), it qualifies each candidate
+// asset with its own connection's database and matches on the fully-qualified
+// name. Matching is case-insensitive and returns the canonical asset; a
+// genuinely external table (whose database does not match any asset's) resolves
+// to nil so no false edge is drawn.
+func (p *LineageExtractor) resolveUpstreamAsset(foundPipeline *pipeline.Pipeline, table string) *pipeline.Asset {
+	if asset := foundPipeline.GetAssetByNameCaseInsensitive(table); asset != nil {
+		return asset
+	}
+	for _, asset := range foundPipeline.Assets {
+		db := p.assetDatabases[asset.Name]
+		if db == "" {
+			continue
+		}
+		if strings.EqualFold(db+"."+asset.Name, table) {
+			return asset
+		}
+	}
+	return nil
 }
 
 // TableSchema extracts the table schema from the assets and stores it in the columnMetadata map.
@@ -164,7 +198,7 @@ func (p *LineageExtractor) parseLineage(foundPipeline *pipeline.Pipeline, asset 
 
 func (p *LineageExtractor) mergeAsteriskColumns(foundPipeline *pipeline.Pipeline, asset *pipeline.Asset, lineageCol sqlparser.ColumnLineage) error {
 	for _, upstream := range lineageCol.Upstream {
-		upstreamAsset := foundPipeline.GetAssetByNameCaseInsensitive(upstream.Table)
+		upstreamAsset := p.resolveUpstreamAsset(foundPipeline, upstream.Table)
 		if upstreamAsset == nil {
 			return nil
 		}
@@ -277,7 +311,7 @@ func (p *LineageExtractor) processLineageColumns(foundPipeline *pipeline.Pipelin
 				continue
 			}
 
-			upstreamAsset := foundPipeline.GetAssetByNameCaseInsensitive(upstream.Table)
+			upstreamAsset := p.resolveUpstreamAsset(foundPipeline, upstream.Table)
 			if upstreamAsset == nil {
 				if err := p.addColumnToAsset(asset, lineageCol.Name, &pipeline.Column{
 					Name:       lineageCol.Name,

--- a/pkg/lineage/lineage.go
+++ b/pkg/lineage/lineage.go
@@ -40,23 +40,16 @@ func NewLineageExtractor(parser sqlParser) *LineageExtractor {
 	}
 }
 
-// WithAssetDatabases attaches an asset-name -> database map (from .bruin.yml) so
-// column-lineage resolution can match a table reference that is qualified with
-// its database (e.g. prod.schema.table) back to the two-part asset schema.table.
-// Optional; when unset, resolution falls back to exact name matching.
+// WithAssetDatabases attaches an asset-name -> database map used to resolve
+// database-qualified table references. Optional.
 func (p *LineageExtractor) WithAssetDatabases(assetDatabases map[string]string) *LineageExtractor {
 	p.assetDatabases = assetDatabases
 	return p
 }
 
-// resolveUpstreamAsset finds the asset a column-lineage table reference points
-// to. It first tries an exact, case-insensitive match on the asset name. If that
-// fails and the reference is qualified with a leading database (e.g.
-// prod.schema.table against the asset schema.table), it qualifies each candidate
-// asset with its own connection's database and matches on the fully-qualified
-// name. Matching is case-insensitive and returns the canonical asset; a
-// genuinely external table (whose database does not match any asset's) resolves
-// to nil so no false edge is drawn.
+// resolveUpstreamAsset matches a table reference to an asset, falling back to a
+// database-qualified match (<database>.<name>) when the reference carries a
+// leading database the asset name omits. Unmatched references stay external.
 func (p *LineageExtractor) resolveUpstreamAsset(foundPipeline *pipeline.Pipeline, table string) *pipeline.Asset {
 	if asset := foundPipeline.GetAssetByNameCaseInsensitive(table); asset != nil {
 		return asset

--- a/pkg/lineage/lineage_test.go
+++ b/pkg/lineage/lineage_test.go
@@ -1882,3 +1882,46 @@ func TestLineageError(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveUpstreamAsset(t *testing.T) {
+	t.Parallel()
+
+	foundPipeline := &pipeline.Pipeline{
+		Assets: []*pipeline.Asset{
+			{Name: "raw.users"},
+			{Name: "Core.Orders"},
+		},
+	}
+	// Trigger the internal name index that GetAssetByNameCaseInsensitive reads;
+	// CreatePipelineFromPath does this in the real parse flow.
+	foundPipeline.GetAssetByName("raw.users")
+	extractor := NewLineageExtractor(nil).WithAssetDatabases(map[string]string{
+		"raw.users":   "prod",
+		"Core.Orders": "prod",
+	})
+
+	tests := []struct {
+		name  string
+		table string
+		want  string // "" means external (nil)
+	}{
+		{"exact two-part", "raw.users", "raw.users"},
+		{"case-insensitive two-part", "core.orders", "Core.Orders"},
+		{"database-qualified resolves to canonical", "prod.raw.users", "raw.users"},
+		{"database-qualified plus mixed case", "PROD.core.Orders", "Core.Orders"},
+		{"wrong database stays external", "staging.raw.users", ""},
+		{"unknown table stays external", "prod.raw.missing", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractor.resolveUpstreamAsset(foundPipeline, tt.table)
+			if tt.want == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.Name)
+		})
+	}
+}


### PR DESCRIPTION
## What

Column lineage matched a query's `FROM` table to an asset by exact name only. When a query qualifies a table with its database (e.g. `prod.schema.table`) but the asset is named `schema.table`, the match failed — the source was stored as the raw string, so the VS Code lineage graph couldn't connect it to the asset and drew no column edges. Users on Fabric/MSSQL/Snowflake/etc. who fully-qualify tables in their SQL saw empty column lineage.

## How

When the exact match fails, qualify each candidate asset as `<database>.<name>` (database from the connection in `.bruin.yml`) and compare case-insensitively, returning the canonical asset name on a match. A reference whose database doesn't match any asset stays unresolved (external), so no false edge is drawn. Falls back to exact matching when no config is available, so nothing changes for pipelines that already work.

## Test

- New `TestResolveUpstreamAsset` covering exact, case-insensitive, database-qualified, mixed-case, wrong-database, and unknown-table cases.
- Verified end-to-end with `internal parse-pipeline -c` on a sample pipeline: `prod.raw.users` → `raw.users`, `PROD.core.Orders` → `Core.Orders` (canonical case kept), `staging.raw.users` → stays external.