### PR TITLE
docs: correct pipeline & asset start_date behavior

### DIFF
--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -238,7 +238,7 @@ The items of this list can be just a `String` with the name of the asset in the 
 
 ## `start_date`
 
-The start date for the asset, used when running with full refresh (`--full-refresh`). When specified, the asset will process data starting from this date during full refresh runs (overrides the pipeline's start_date).
+The start date for the asset, used when running with full refresh (`--full-refresh`). When specified, the asset ingests data starting from this date during full-refresh runs, overriding the run's `--start-date` for that asset.
 
 - **Type:** `String` (YYYY-MM-DD format)
 

--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -238,7 +238,7 @@ The items of this list can be just a `String` with the name of the asset in the 
 
 ## `start_date`
 
-The start date for the asset, used when running with full refresh (`--full-refresh`). When specified, the asset ingests data starting from this date during full-refresh runs, overriding the run's `--start-date` for that asset.
+The start date for an ingestr asset — or a Python asset materialized through ingestr — used when running with full refresh (`--full-refresh`). When specified, that asset ingests data starting from this date during full-refresh runs, overriding the run's `--start-date`. It has no effect on other asset types (such as plain SQL assets), whose full-refresh window still comes from `--start-date`.
 
 - **Type:** `String` (YYYY-MM-DD format)
 

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -171,7 +171,7 @@ schedule: "0 0 * * *"
 
 ### Start date
 
-Set the earliest date from which runs should be considered. Useful for controlled backfills and catchup runs. When running with full refresh (`--full-refresh`), the pipeline will process data starting from this date.
+The earliest date the pipeline has data for. Bruin Cloud uses it as the anchor for scheduled backfills and [catchup](#catchup) runs, filling in any missed intervals between `start_date` and now.
 
 Example:
 
@@ -179,7 +179,9 @@ Example:
 start_date: "2024-01-01"
 ```
 
-- **Type:** `String` (ISO 8601 date, e.g., YYYY-MM-DD)
+- **Type:** `String` (ISO 8601 date, `YYYY-MM-DD`). The linter rejects any other format.
+
+> Local ad-hoc runs (`bruin run`) take their run window from the `--start-date` / `--end-date` flags (both default to yesterday) and do not read this field. To make a single asset start from a fixed date on `--full-refresh`, set [`start_date` on the asset](/assets/definition-schema#start_date) instead.
 
 ### Default connections
 

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -171,7 +171,7 @@ schedule: "0 0 * * *"
 
 ### Start date
 
-The earliest date the pipeline has data for. Bruin Cloud uses it as the anchor for scheduled backfills and [catchup](#catchup) runs, filling in any missed intervals between `start_date` and now.
+The earliest date the pipeline has data for. Bruin Cloud uses it as the anchor for scheduled backfills and [catchup](#catchup) runs, with missed intervals filled according to the pipeline's catchup mode.
 
 Example:
 


### PR DESCRIPTION
## Summary

Reviewed the `start_date` documentation against the source code and corrected two inaccuracies about what the field actually does at runtime.

### What was wrong

**`docs/pipelines/definition.md` (pipeline-level `start_date`)** claimed:
> When running with full refresh (`--full-refresh`), the pipeline will process data starting from this date.

This is not what the code does. The top-level pipeline `start_date` (`pkg/pipeline/pipeline.go:2246`) is **never read by `bruin run`** to set the run interval. Its only consumers are:
- Bruin Cloud backfill/catchup scheduling and display (`cmd/cloud.go`)
- Metadata output (`cmd/internal.go:749`)
- Lint validation — must be `YYYY-MM-DD` (`pkg/lint/rules.go:608`) and the `pipeline-has-start-date` policy (`pkg/lint/policy_builtins.go:475`)

The local run window comes entirely from the `--start-date` / `--end-date` flags, which default to **yesterday (UTC)** and do not consult this field (`cmd/run.go:531`).

**`docs/assets/definition-schema.md` (asset-level `start_date`)** said the asset value "overrides the pipeline's start_date" during full refresh. The pipeline field is not involved at runtime. What actually happens (`pkg/python/helper.go` `ConsolidatedParameters`): on a `--full-refresh` run, if the asset has its own `start_date`, that value overrides the run's `--start-date` (i.e. the `--interval-start` passed to ingestr) for that asset. This applies to ingestr assets and Python assets materialized via ingestr.

### Changes
- Rewrote the pipeline `start_date` section to describe its real role (Cloud backfill/catchup anchor + lint format), and added a note that local runs use `--start-date`/`--end-date` (default yesterday), pointing to the asset-level field for the full-refresh override.
- Corrected the asset `start_date` wording: it overrides the run's `--start-date`, not the pipeline's `start_date`.

Docs-only change; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)