### PR TITLE
feat(ingestr): forward decimal precision/scale in --columns hints

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -378,3 +378,22 @@ columns:
 ```
 
 If you set both, the inline length wins. A string type without a length creates an unbounded column.
+
+#### Sized decimal types
+
+You can give a `decimal`/`numeric` column a precision and an optional scale. Set them inline in the `type` or with the `precision` and `scale` fields (requires `enforce_schema: true`):
+
+```yaml
+parameters:
+  enforce_schema: "true"
+
+columns:
+  - name: amount
+    type: decimal(10,2)
+  - name: rate
+    type: decimal
+    precision: 18
+    scale: 4
+```
+
+If you set both, the inline parameters win. `decimal(10)` (or `precision` without `scale`) sets only the precision; a `decimal` without either creates a decimal with the destination's default precision and scale.

--- a/pkg/clickhouse/ingestr_types_test.go
+++ b/pkg/clickhouse/ingestr_types_test.go
@@ -57,8 +57,8 @@ func TestIngestrTypeHints_CoversClickHouseTypes(t *testing.T) {
 		{"Decimal64", "decimal"},
 		{"Decimal128", "decimal"},
 		{"Decimal256", "decimal"},
-		{"Decimal64(2)", "decimal"},
-		{"Decimal(18, 4)", "decimal"},
+		{"Decimal64(2)", "decimal"}, // bit-width forms carry a scale, not a precision — keep bare
+		{"Decimal(18, 4)", "decimal(18,4)"},
 		// bool / string / uuid
 		{"Bool", "bool"},
 		{"String", "text"},

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -384,7 +384,7 @@ func decimalParams(inlineParams string, precision, scale *int) string {
 }
 
 // normaliseDecimalParams validates an inline "p" or "p,s" spec, returning its
-// canonical form or "" when the precision is not a positive integer.
+// canonical form or "" when any parameter is malformed (treated as unbounded).
 func normaliseDecimalParams(inner string) string {
 	parts := strings.Split(inner, ",")
 	if len(parts) > 2 {
@@ -399,7 +399,7 @@ func normaliseDecimalParams(inner string) string {
 	}
 	s, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 	if err != nil || s < 0 {
-		return strconv.Itoa(p)
+		return ""
 	}
 	return fmt.Sprintf("%d,%d", p, s)
 }

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -215,13 +215,29 @@ var TypeHintMapping = map[string]string{
 
 var multipleSpacePattern = regexp.MustCompile(`\s+`)
 
+// decimalHint is the ingestr type name for fixed-point decimals.
+const decimalHint = "decimal"
+
 // ingestrSizedTypes are the ingestr types that accept size parameters: a single
 // length (e.g. text(50)) or, for decimal, precision and optional scale (e.g.
 // decimal(10,2)). Add an entry if a source type starts mapping to another sized type.
 var ingestrSizedTypes = map[string]bool{
-	"text":    true,
-	"decimal": true,
+	"text":      true,
+	decimalHint: true,
 }
+
+// precisionScaleDecimalBases are base names using decimal(P,S) semantics, derived
+// from the shared mapping. ClickHouse Decimal32/64/128/256 (lone arg = scale) live
+// only in the overlay and are excluded, so their scale is not misread as precision.
+var precisionScaleDecimalBases = func() map[string]bool {
+	bases := make(map[string]bool)
+	for name, hint := range TypeHintMapping {
+		if hint == decimalHint {
+			bases[name] = true
+		}
+	}
+	return bases
+}()
 
 // TypeHintOverlayForConnection returns DB-specific type aliases when the
 // connection implements IngestrTypeHintProvider; otherwise nil.
@@ -280,7 +296,7 @@ func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[s
 			continue
 		}
 		if h, ok := mapping[base]; ok {
-			if ingestrSizedTypes[h] {
+			if ingestrSizedTypes[h] && (h != decimalHint || precisionScaleDecimalBases[base]) {
 				return h, true, inner
 			}
 			return h, true, ""
@@ -307,7 +323,7 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string
 		// over the length/precision/scale fields, and an invalid size is treated as
 		// unbounded. decimal is the only precision/scale type; the rest take a length.
 		if typeKnown && ingestrSizedTypes[hint] {
-			if hint == "decimal" {
+			if hint == decimalHint {
 				if params := decimalParams(inlineParams, col.Precision, col.Scale); params != "" {
 					hint = fmt.Sprintf("%s(%s)", hint, params)
 				}

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -218,6 +218,11 @@ var multipleSpacePattern = regexp.MustCompile(`\s+`)
 // decimalHint is the ingestr type name for fixed-point decimals.
 const decimalHint = "decimal"
 
+// maxDecimalPrecision is the largest precision ingestr accepts (its Decimal128
+// ceiling). A larger precision is emitted as an unbounded decimal instead of a
+// hint ingestr would reject.
+const maxDecimalPrecision = 38
+
 // ingestrSizedTypes are the ingestr types that accept size parameters: a single
 // length (e.g. text(50)) or, for decimal, precision and optional scale (e.g.
 // decimal(10,2)). Add an entry if a source type starts mapping to another sized type.
@@ -383,7 +388,7 @@ func decimalParams(inlineParams string, precision, scale *int) string {
 	if inlineParams != "" {
 		return normaliseDecimalParams(inlineParams)
 	}
-	if precision == nil || *precision <= 0 {
+	if precision == nil || *precision <= 0 || *precision > maxDecimalPrecision {
 		return ""
 	}
 	if scale != nil {
@@ -396,15 +401,15 @@ func decimalParams(inlineParams string, precision, scale *int) string {
 }
 
 // normaliseDecimalParams validates an inline "p" or "p,s" spec, returning its
-// canonical form or "" when any parameter is malformed or the scale exceeds the
-// precision (treated as unbounded).
+// canonical form or "" (treated as unbounded) when any parameter is malformed,
+// the precision is out of range, or the scale exceeds the precision.
 func normaliseDecimalParams(inner string) string {
 	parts := strings.Split(inner, ",")
 	if len(parts) > 2 {
 		return ""
 	}
 	p, err := strconv.Atoi(strings.TrimSpace(parts[0]))
-	if err != nil || p <= 0 {
+	if err != nil || p <= 0 || p > maxDecimalPrecision {
 		return ""
 	}
 	if len(parts) == 1 {

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -221,6 +221,12 @@ var ingestrSizedTypes = map[string]bool{
 	"text": true,
 }
 
+// ingestrPrecisionScaleTypes are the ingestr types that accept a precision and an
+// optional scale parameter, e.g. decimal(10,2).
+var ingestrPrecisionScaleTypes = map[string]bool{
+	"decimal": true,
+}
+
 // TypeHintOverlayForConnection returns DB-specific type aliases when the
 // connection implements IngestrTypeHintProvider; otherwise nil.
 func TypeHintOverlayForConnection(conn any) map[string]string {
@@ -262,7 +268,7 @@ func MergeTypeHints(base, overlay map[string]string) map[string]string {
 // resolveColumnTypeHint maps a declared column type to an ingestr hint, peeling
 // destination-specific transparent wrappers and resolving parameterized bases
 // (e.g. DateTime64(3)).
-func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[string]bool) (hint string, known bool, inlineLength string) {
+func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[string]bool) (hint string, known bool, inlineParams string) {
 	typ = NormaliseColumnType(typ)
 	for {
 		if h, ok := mapping[typ]; ok {
@@ -278,7 +284,7 @@ func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[s
 			continue
 		}
 		if h, ok := mapping[base]; ok {
-			if ingestrSizedTypes[h] {
+			if ingestrSizedTypes[h] || ingestrPrecisionScaleTypes[h] {
 				return h, true, inner
 			}
 			return h, true, ""
@@ -295,17 +301,25 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string
 	mapping := MergeTypeHints(TypeHintMapping, overlay)
 	hints := make([]string, 0)
 	for _, col := range cols {
-		hint, typeKnown, inlineLength := resolveColumnTypeHint(col.Type, mapping, wrappers)
+		hint, typeKnown, inlineParams := resolveColumnTypeHint(col.Type, mapping, wrappers)
 
 		if !typeKnown && col.SourceColumn == "" {
 			continue
 		}
 
-		// Append a length to sized types; an inline length takes precedence over the
-		// length field, and a non-numeric size is treated as unbounded.
-		if typeKnown && ingestrSizedTypes[hint] {
-			if length := sizedStringLength(inlineLength, col.Length); length != "" {
-				hint = fmt.Sprintf("%s(%s)", hint, length)
+		// Append size parameters to sized types. Inline parameters take precedence
+		// over the length/precision/scale fields, and an invalid size is treated as
+		// unbounded.
+		if typeKnown {
+			switch {
+			case ingestrSizedTypes[hint]:
+				if length := sizedStringLength(inlineParams, col.Length); length != "" {
+					hint = fmt.Sprintf("%s(%s)", hint, length)
+				}
+			case ingestrPrecisionScaleTypes[hint]:
+				if params := decimalParams(inlineParams, col.Precision, col.Scale); params != "" {
+					hint = fmt.Sprintf("%s(%s)", hint, params)
+				}
 			}
 		}
 
@@ -351,6 +365,43 @@ func sizedStringLength(inlineLength string, lengthField *int) string {
 		return strconv.Itoa(*lengthField)
 	}
 	return ""
+}
+
+// decimalParams resolves the precision/scale for a decimal type, preferring inline
+// "p" or "p,s" parameters over the precision/scale fields. Returns "" when no
+// positive precision is available.
+func decimalParams(inlineParams string, precision, scale *int) string {
+	if inlineParams != "" {
+		return normaliseDecimalParams(inlineParams)
+	}
+	if precision == nil || *precision <= 0 {
+		return ""
+	}
+	if scale != nil && *scale >= 0 {
+		return fmt.Sprintf("%d,%d", *precision, *scale)
+	}
+	return strconv.Itoa(*precision)
+}
+
+// normaliseDecimalParams validates an inline "p" or "p,s" spec, returning its
+// canonical form or "" when the precision is not a positive integer.
+func normaliseDecimalParams(inner string) string {
+	parts := strings.Split(inner, ",")
+	if len(parts) > 2 {
+		return ""
+	}
+	p, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || p <= 0 {
+		return ""
+	}
+	if len(parts) == 1 {
+		return strconv.Itoa(p)
+	}
+	s, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil || s < 0 {
+		return strconv.Itoa(p)
+	}
+	return fmt.Sprintf("%d,%d", p, s)
 }
 
 func NormaliseColumnType(typ string) string {

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -219,21 +219,18 @@ var multipleSpacePattern = regexp.MustCompile(`\s+`)
 const decimalHint = "decimal"
 
 // maxDecimalPrecision is the largest precision ingestr accepts (its Decimal128
-// ceiling). A larger precision is emitted as an unbounded decimal instead of a
-// hint ingestr would reject.
+// ceiling); a larger precision is emitted as an unbounded decimal.
 const maxDecimalPrecision = 38
 
-// ingestrSizedTypes are the ingestr types that accept size parameters: a single
-// length (e.g. text(50)) or, for decimal, precision and optional scale (e.g.
-// decimal(10,2)). Add an entry if a source type starts mapping to another sized type.
+// ingestrSizedTypes accept size parameters: a length (text(50)) or, for decimal,
+// precision and optional scale (decimal(10,2)). Add an entry for new sized types.
 var ingestrSizedTypes = map[string]bool{
 	"text":      true,
 	decimalHint: true,
 }
 
-// precisionScaleDecimalBases are base names using decimal(P,S) semantics, derived
-// from the shared mapping. ClickHouse Decimal32/64/128/256 (lone arg = scale) live
-// only in the overlay and are excluded, so their scale is not misread as precision.
+// precisionScaleDecimalBases are base names with decimal(P,S) semantics, derived from
+// the shared mapping (excludes ClickHouse DecimalN, whose lone arg is a scale).
 var precisionScaleDecimalBases = func() map[string]bool {
 	bases := make(map[string]bool)
 	for name, hint := range TypeHintMapping {
@@ -324,9 +321,8 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string
 			continue
 		}
 
-		// Append size parameters to sized types. Inline parameters take precedence
-		// over the length/precision/scale fields, and an invalid size is treated as
-		// unbounded. decimal is the only precision/scale type; the rest take a length.
+		// Append size params (inline wins over length/precision/scale fields; invalid
+		// sizes stay unbounded). Only decimal uses precision/scale; the rest take a length.
 		if typeKnown && ingestrSizedTypes[hint] {
 			if hint == decimalHint {
 				if params := decimalParams(inlineParams, col.Precision, col.Scale); params != "" {
@@ -381,9 +377,8 @@ func sizedStringLength(inlineLength string, lengthField *int) string {
 	return ""
 }
 
-// decimalParams resolves the precision/scale for a decimal type, preferring inline
-// "p" or "p,s" parameters over the precision/scale fields. Returns "" when no
-// positive precision is available.
+// decimalParams resolves a decimal's precision/scale, preferring inline "p"/"p,s"
+// over the fields. Returns "" (unbounded) when no positive in-range precision exists.
 func decimalParams(inlineParams string, precision, scale *int) string {
 	if inlineParams != "" {
 		return normaliseDecimalParams(inlineParams)
@@ -400,9 +395,8 @@ func decimalParams(inlineParams string, precision, scale *int) string {
 	return strconv.Itoa(*precision)
 }
 
-// normaliseDecimalParams validates an inline "p" or "p,s" spec, returning its
-// canonical form or "" (treated as unbounded) when any parameter is malformed,
-// the precision is out of range, or the scale exceeds the precision.
+// normaliseDecimalParams returns the canonical "p"/"p,s" form, or "" (unbounded) when
+// a param is malformed, the precision is out of range, or the scale exceeds precision.
 func normaliseDecimalParams(inner string) string {
 	parts := strings.Split(inner, ",")
 	if len(parts) > 2 {

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -370,14 +370,18 @@ func decimalParams(inlineParams string, precision, scale *int) string {
 	if precision == nil || *precision <= 0 {
 		return ""
 	}
-	if scale != nil && *scale >= 0 {
+	if scale != nil {
+		if *scale < 0 || *scale > *precision {
+			return ""
+		}
 		return fmt.Sprintf("%d,%d", *precision, *scale)
 	}
 	return strconv.Itoa(*precision)
 }
 
 // normaliseDecimalParams validates an inline "p" or "p,s" spec, returning its
-// canonical form or "" when any parameter is malformed (treated as unbounded).
+// canonical form or "" when any parameter is malformed or the scale exceeds the
+// precision (treated as unbounded).
 func normaliseDecimalParams(inner string) string {
 	parts := strings.Split(inner, ",")
 	if len(parts) > 2 {
@@ -391,7 +395,7 @@ func normaliseDecimalParams(inner string) string {
 		return strconv.Itoa(p)
 	}
 	s, err := strconv.Atoi(strings.TrimSpace(parts[1]))
-	if err != nil || s < 0 {
+	if err != nil || s < 0 || s > p {
 		return ""
 	}
 	return fmt.Sprintf("%d,%d", p, s)

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -215,20 +215,12 @@ var TypeHintMapping = map[string]string{
 
 var multipleSpacePattern = regexp.MustCompile(`\s+`)
 
-// sizeKind describes how a sized ingestr type is parameterized.
-type sizeKind int
-
-const (
-	sizeLength         sizeKind = iota // single length, e.g. text(50)
-	sizePrecisionScale                 // precision and optional scale, e.g. decimal(10,2)
-)
-
-// ingestrSizedTypes maps the ingestr types that accept size parameters to the
-// shape of those parameters. Add an entry if a source type starts mapping to
-// another sized ingestr type.
-var ingestrSizedTypes = map[string]sizeKind{
-	"text":    sizeLength,
-	"decimal": sizePrecisionScale,
+// ingestrSizedTypes are the ingestr types that accept size parameters: a single
+// length (e.g. text(50)) or, for decimal, precision and optional scale (e.g.
+// decimal(10,2)). Add an entry if a source type starts mapping to another sized type.
+var ingestrSizedTypes = map[string]bool{
+	"text":    true,
+	"decimal": true,
 }
 
 // TypeHintOverlayForConnection returns DB-specific type aliases when the
@@ -288,7 +280,7 @@ func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[s
 			continue
 		}
 		if h, ok := mapping[base]; ok {
-			if _, sized := ingestrSizedTypes[h]; sized {
+			if ingestrSizedTypes[h] {
 				return h, true, inner
 			}
 			return h, true, ""
@@ -313,17 +305,14 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string
 
 		// Append size parameters to sized types. Inline parameters take precedence
 		// over the length/precision/scale fields, and an invalid size is treated as
-		// unbounded.
-		if kind, sized := ingestrSizedTypes[hint]; typeKnown && sized {
-			switch kind {
-			case sizeLength:
-				if length := sizedStringLength(inlineParams, col.Length); length != "" {
-					hint = fmt.Sprintf("%s(%s)", hint, length)
-				}
-			case sizePrecisionScale:
+		// unbounded. decimal is the only precision/scale type; the rest take a length.
+		if typeKnown && ingestrSizedTypes[hint] {
+			if hint == "decimal" {
 				if params := decimalParams(inlineParams, col.Precision, col.Scale); params != "" {
 					hint = fmt.Sprintf("%s(%s)", hint, params)
 				}
+			} else if length := sizedStringLength(inlineParams, col.Length); length != "" {
+				hint = fmt.Sprintf("%s(%s)", hint, length)
 			}
 		}
 

--- a/pkg/python/columns.go
+++ b/pkg/python/columns.go
@@ -215,16 +215,20 @@ var TypeHintMapping = map[string]string{
 
 var multipleSpacePattern = regexp.MustCompile(`\s+`)
 
-// ingestrSizedTypes are the ingestr types that accept a single length parameter, e.g.
-// text(50). Add an entry if a source type starts mapping to another sized type.
-var ingestrSizedTypes = map[string]bool{
-	"text": true,
-}
+// sizeKind describes how a sized ingestr type is parameterized.
+type sizeKind int
 
-// ingestrPrecisionScaleTypes are the ingestr types that accept a precision and an
-// optional scale parameter, e.g. decimal(10,2).
-var ingestrPrecisionScaleTypes = map[string]bool{
-	"decimal": true,
+const (
+	sizeLength         sizeKind = iota // single length, e.g. text(50)
+	sizePrecisionScale                 // precision and optional scale, e.g. decimal(10,2)
+)
+
+// ingestrSizedTypes maps the ingestr types that accept size parameters to the
+// shape of those parameters. Add an entry if a source type starts mapping to
+// another sized ingestr type.
+var ingestrSizedTypes = map[string]sizeKind{
+	"text":    sizeLength,
+	"decimal": sizePrecisionScale,
 }
 
 // TypeHintOverlayForConnection returns DB-specific type aliases when the
@@ -284,7 +288,7 @@ func resolveColumnTypeHint(typ string, mapping map[string]string, wrappers map[s
 			continue
 		}
 		if h, ok := mapping[base]; ok {
-			if ingestrSizedTypes[h] || ingestrPrecisionScaleTypes[h] {
+			if _, sized := ingestrSizedTypes[h]; sized {
 				return h, true, inner
 			}
 			return h, true, ""
@@ -310,13 +314,13 @@ func ColumnHints(cols []pipeline.Column, normaliseNames bool, overlay map[string
 		// Append size parameters to sized types. Inline parameters take precedence
 		// over the length/precision/scale fields, and an invalid size is treated as
 		// unbounded.
-		if typeKnown {
-			switch {
-			case ingestrSizedTypes[hint]:
+		if kind, sized := ingestrSizedTypes[hint]; typeKnown && sized {
+			switch kind {
+			case sizeLength:
 				if length := sizedStringLength(inlineParams, col.Length); length != "" {
 					hint = fmt.Sprintf("%s(%s)", hint, length)
 				}
-			case ingestrPrecisionScaleTypes[hint]:
+			case sizePrecisionScale:
 				if params := decimalParams(inlineParams, col.Precision, col.Scale); params != "" {
 					hint = fmt.Sprintf("%s(%s)", hint, params)
 				}

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -540,6 +540,19 @@ func TestColumnHints(t *testing.T) {
 			expected:       "bare:text,inline:text(100),field:text(50),renamed:text(255):src",
 		},
 		{
+			name: "overlay decimal alias with a lone scale arg is not forwarded as precision",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "Decimal64(2)"},
+				{Name: "b", Type: "Decimal(18, 4)"},
+			},
+			normalizeNames: false,
+			overlay: map[string]string{
+				"decimal64": "decimal",
+				"decimal":   "decimal",
+			},
+			expected: "a:decimal,b:decimal(18,4)",
+		},
+		{
 			name: "destination overlay aliases are applied",
 			columns: []pipeline.Column{
 				{Name: "id", Type: "uint64"},
@@ -614,7 +627,7 @@ func TestColumnHints_SizedTypes(t *testing.T) {
 
 	sized := make(map[string]string) // source alias -> expected hint
 	for typ, hint := range TypeHintMapping {
-		if ingestrSizedTypes[hint] && hint != "decimal" {
+		if ingestrSizedTypes[hint] && hint != decimalHint {
 			sized[typ] = hint
 		}
 	}
@@ -641,7 +654,7 @@ func TestColumnHints_PrecisionScaleTypes(t *testing.T) {
 
 	sized := make(map[string]string) // source alias -> expected hint
 	for typ, hint := range TypeHintMapping {
-		if ingestrSizedTypes[hint] && hint == "decimal" {
+		if ingestrSizedTypes[hint] && hint == decimalHint {
 			sized[typ] = hint
 		}
 	}

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -504,9 +504,11 @@ func TestColumnHints(t *testing.T) {
 			columns: []pipeline.Column{
 				{Name: "a", Type: "decimal(abc)"},
 				{Name: "b", Type: "decimal(0)"},
+				{Name: "c", Type: "decimal(10,abc)"},
+				{Name: "d", Type: "decimal(10,-1)"},
 			},
 			normalizeNames: false,
-			expected:       "a:decimal,b:decimal",
+			expected:       "a:decimal,b:decimal,c:decimal,d:decimal",
 		},
 		{
 			name: "sized string with source_column emits dest:text(n):source",

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -521,6 +521,16 @@ func TestColumnHints(t *testing.T) {
 			expected:       "a:decimal,b:decimal",
 		},
 		{
+			name: "decimal precision above ingestr max stays unparameterized",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "decimal(50,2)"},
+				{Name: "b", Type: "decimal", Precision: intPtr(76), Scale: intPtr(38)},
+				{Name: "c", Type: "decimal(38,2)"},
+			},
+			normalizeNames: false,
+			expected:       "a:decimal,b:decimal,c:decimal(38,2)",
+		},
+		{
 			name: "sized string with source_column emits dest:text(n):source",
 			columns: []pipeline.Column{
 				{Name: "email", SourceColumn: "eml", Type: "varchar(255)"},

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -604,7 +604,7 @@ func TestColumnHints_SizedTypes(t *testing.T) {
 
 	sized := make(map[string]string) // source alias -> expected hint
 	for typ, hint := range TypeHintMapping {
-		if ingestrSizedTypes[hint] {
+		if kind, ok := ingestrSizedTypes[hint]; ok && kind == sizeLength {
 			sized[typ] = hint
 		}
 	}
@@ -631,7 +631,7 @@ func TestColumnHints_PrecisionScaleTypes(t *testing.T) {
 
 	sized := make(map[string]string) // source alias -> expected hint
 	for typ, hint := range TypeHintMapping {
-		if ingestrPrecisionScaleTypes[hint] {
+		if kind, ok := ingestrSizedTypes[hint]; ok && kind == sizePrecisionScale {
 			sized[typ] = hint
 		}
 	}

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -506,9 +506,19 @@ func TestColumnHints(t *testing.T) {
 				{Name: "b", Type: "decimal(0)"},
 				{Name: "c", Type: "decimal(10,abc)"},
 				{Name: "d", Type: "decimal(10,-1)"},
+				{Name: "e", Type: "decimal(2,5)"},
 			},
 			normalizeNames: false,
-			expected:       "a:decimal,b:decimal,c:decimal,d:decimal",
+			expected:       "a:decimal,b:decimal,c:decimal,d:decimal,e:decimal",
+		},
+		{
+			name: "decimal fields with out-of-range scale stay unparameterized",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "decimal", Precision: intPtr(2), Scale: intPtr(5)},
+				{Name: "b", Type: "decimal", Precision: intPtr(10), Scale: intPtr(-1)},
+			},
+			normalizeNames: false,
+			expected:       "a:decimal,b:decimal",
 		},
 		{
 			name: "sized string with source_column emits dest:text(n):source",

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -604,7 +604,7 @@ func TestColumnHints_SizedTypes(t *testing.T) {
 
 	sized := make(map[string]string) // source alias -> expected hint
 	for typ, hint := range TypeHintMapping {
-		if kind, ok := ingestrSizedTypes[hint]; ok && kind == sizeLength {
+		if ingestrSizedTypes[hint] && hint != "decimal" {
 			sized[typ] = hint
 		}
 	}
@@ -631,7 +631,7 @@ func TestColumnHints_PrecisionScaleTypes(t *testing.T) {
 
 	sized := make(map[string]string) // source alias -> expected hint
 	for typ, hint := range TypeHintMapping {
-		if kind, ok := ingestrSizedTypes[hint]; ok && kind == sizePrecisionScale {
+		if ingestrSizedTypes[hint] && hint == "decimal" {
 			sized[typ] = hint
 		}
 	}

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -454,14 +454,59 @@ func TestColumnHints(t *testing.T) {
 			expected:       "a:text,b:text,c:text",
 		},
 		{
-			name: "non-string parameterized types use base mapping without length",
+			name: "unsizable parameterized types use base mapping without params",
 			columns: []pipeline.Column{
 				{Name: "kept", Type: "int"},
 				{Name: "sized_int", Type: "int(11)"},
-				{Name: "sized_dec", Type: "decimal(10,2)"},
 			},
 			normalizeNames: false,
-			expected:       "kept:int,sized_int:int,sized_dec:decimal",
+			expected:       "kept:int,sized_int:int",
+		},
+		{
+			name: "inline decimal precision and scale are preserved",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "decimal(10,2)"},
+				{Name: "b", Type: "numeric(18)"},
+				{Name: "c", Type: "money(12, 4)"},
+			},
+			normalizeNames: false,
+			expected:       "a:decimal(10,2),b:decimal(18),c:decimal(12,4)",
+		},
+		{
+			name: "decimal precision and scale fields are emitted",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "decimal", Precision: intPtr(10), Scale: intPtr(2)},
+				{Name: "b", Type: "decimal", Precision: intPtr(18)},
+				{Name: "c", Type: "decimal", Scale: intPtr(2)},
+				{Name: "d", Type: "decimal"},
+			},
+			normalizeNames: false,
+			expected:       "a:decimal(10,2),b:decimal(18),c:decimal,d:decimal",
+		},
+		{
+			name: "inline decimal params take precedence over fields",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "decimal(10,2)", Precision: intPtr(5), Scale: intPtr(1)},
+			},
+			normalizeNames: false,
+			expected:       "a:decimal(10,2)",
+		},
+		{
+			name: "decimal with source_column emits dest:decimal(p,s):source",
+			columns: []pipeline.Column{
+				{Name: "amount", SourceColumn: "amt", Type: "decimal", Precision: intPtr(12), Scale: intPtr(2)},
+			},
+			normalizeNames: false,
+			expected:       "amount:decimal(12,2):amt",
+		},
+		{
+			name: "invalid inline decimal params stay unparameterized",
+			columns: []pipeline.Column{
+				{Name: "a", Type: "decimal(abc)"},
+				{Name: "b", Type: "decimal(0)"},
+			},
+			normalizeNames: false,
+			expected:       "a:decimal,b:decimal",
 		},
 		{
 			name: "sized string with source_column emits dest:text(n):source",
@@ -572,6 +617,33 @@ func TestColumnHints_SizedTypes(t *testing.T) {
 
 			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Length: intPtr(50)}}, false, nil, nil)
 			assert.Equal(t, want, field, "length field for %q", typ)
+		})
+	}
+}
+
+// TestColumnHints_PrecisionScaleTypes guards that every alias mapping to a
+// precision/scale ingestr type emits precision and scale, both via inline
+// parameters and via the precision/scale fields.
+func TestColumnHints_PrecisionScaleTypes(t *testing.T) {
+	t.Parallel()
+
+	sized := make(map[string]string) // source alias -> expected hint
+	for typ, hint := range TypeHintMapping {
+		if ingestrPrecisionScaleTypes[hint] {
+			sized[typ] = hint
+		}
+	}
+	require.NotEmpty(t, sized)
+
+	for typ, hint := range sized {
+		want := fmt.Sprintf("c:%s(10,2)", hint)
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
+			inline := ColumnHints([]pipeline.Column{{Name: "c", Type: typ + "(10,2)"}}, false, nil, nil)
+			assert.Equal(t, want, inline, "inline params for %q", typ)
+
+			field := ColumnHints([]pipeline.Column{{Name: "c", Type: typ, Precision: intPtr(10), Scale: intPtr(2)}}, false, nil, nil)
+			assert.Equal(t, want, field, "precision/scale fields for %q", typ)
 		})
 	}
 }
@@ -787,6 +859,48 @@ func TestConsolidatedParameters_SourceColumn(t *testing.T) {
 		for _, arg := range result {
 			assert.NotEqual(t, "--columns", arg)
 		}
+	})
+}
+
+func TestConsolidatedParameters_DecimalPrecisionScale(t *testing.T) {
+	t.Parallel()
+
+	columnsValue := func(t *testing.T, cols []pipeline.Column) string {
+		t.Helper()
+		asset := &pipeline.Asset{
+			Parameters: pipeline.ParameterMap{"enforce_schema": "true"},
+			Columns:    cols,
+		}
+		result, err := ConsolidatedParameters(t.Context(), asset, []string{"--existing"}, &ColumnHintOptions{})
+		require.NoError(t, err)
+		for i, arg := range result {
+			if arg == "--columns" && i+1 < len(result) {
+				return result[i+1]
+			}
+		}
+		return ""
+	}
+
+	t.Run("inline precision and scale flow through to --columns", func(t *testing.T) {
+		t.Parallel()
+		got := columnsValue(t, []pipeline.Column{{Name: "amount", Type: "decimal(10,2)"}})
+		assert.Equal(t, "amount:decimal(10,2)", got)
+	})
+
+	t.Run("precision and scale fields flow through to --columns", func(t *testing.T) {
+		t.Parallel()
+		got := columnsValue(t, []pipeline.Column{
+			{Name: "amount", Type: "decimal", Precision: intPtr(18), Scale: intPtr(4)},
+		})
+		assert.Equal(t, "amount:decimal(18,4)", got)
+	})
+
+	t.Run("numeric alias and source_column rename keep the precision", func(t *testing.T) {
+		t.Parallel()
+		got := columnsValue(t, []pipeline.Column{
+			{Name: "amount", SourceColumn: "amt", Type: "numeric", Precision: intPtr(12), Scale: intPtr(2)},
+		})
+		assert.Equal(t, "amount:decimal(12,2):amt", got)
 	})
 }
 


### PR DESCRIPTION
Closes BRU-5249.

## Problem

Bruin lets you size a **string** column when forwarding a schema to ingestr (inline `varchar(100)` or the `length` field, both emitted as `text(100)`). But **decimal precision/scale were silently dropped** on the ingestr path.

Even with:

```yaml
parameters:
  enforce_schema: "true"
columns:
  - name: amount
    type: decimal
    precision: 10
    scale: 2
```

…or inline `type: decimal(10,2)`, `ColumnHints()` mapped `decimal → decimal`, saw it wasn't a "sized type", and threw the `(10,2)` away — never reading `col.Precision`/`col.Scale`. The destination got an unscaled decimal.

(`Column.SQLType()` does produce `decimal(10, 2)`, but that only feeds the native DDL asset path, not the ingestr `--columns` path.)

## Behavior

| Bruin column | `--columns` hint |
|---|---|
| `type: decimal(10,2)` | `amount:decimal(10,2)` |
| `type: decimal` + `precision: 10, scale: 2` | `amount:decimal(10,2)` |
| `type: numeric` + `precision: 18` | `amount:decimal(18)` |
| `type: decimal` (no size) | `amount:decimal` (unchanged) |