### PR TITLE
feat(cloud): add agents memory commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2249,6 +2249,9 @@ func CloudAgents() *cli.Command {
 			cloudAgentsMessages(),
 			cloudAgentsGetPrompt(),
 			cloudAgentsSetPrompt(),
+			cloudAgentsGetMemory(),
+			cloudAgentsSetMemory(),
+			cloudAgentsClearMemory(),
 			cloudAgentsConnections(),
 			cloudAgentsMcp(),
 		},
@@ -3154,6 +3157,159 @@ func cloudAgentsSetPrompt() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func cloudAgentsGetMemory() *cli.Command {
+	return &cli.Command{
+		Name:  "get-memory",
+		Usage: "Get an agent's long-term memory",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			memory, err := client.GetAgentMemory(ctx, c.Int("agent-id"))
+			if err != nil {
+				printError(err, output, "Failed to get agent memory")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(memory, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if memory.Memory == nil {
+				fmt.Println("(none)")
+				return nil
+			}
+			fmt.Println(*memory.Memory)
+			return nil
+		},
+	}
+}
+
+func cloudAgentsSetMemory() *cli.Command {
+	return &cli.Command{
+		Name:  "set-memory",
+		Usage: "Replace an agent's long-term memory from --memory or --memory-file",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+			&cli.StringFlag{Name: "memory", Usage: "the new memory content"},
+			&cli.StringFlag{Name: "memory-file", Usage: "path to a file whose contents become the memory"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			content, err := resolveMemoryContent(c)
+			if err != nil {
+				printError(err, output, "Invalid memory")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			memory, err := client.SetAgentMemory(ctx, c.Int("agent-id"), &content)
+			if err != nil {
+				printError(err, output, "Failed to set agent memory")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(memory, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Updated memory for agent %d (%s)\n", memory.ID, memory.Name)
+			return nil
+		},
+	}
+}
+
+func cloudAgentsClearMemory() *cli.Command {
+	return &cli.Command{
+		Name:  "clear-memory",
+		Usage: "Clear an agent's long-term memory",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			memory, err := client.SetAgentMemory(ctx, c.Int("agent-id"), nil)
+			if err != nil {
+				printError(err, output, "Failed to clear agent memory")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(memory, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Cleared memory for agent %d (%s)\n", memory.ID, memory.Name)
+			return nil
+		},
+	}
+}
+
+// resolveMemoryContent reads the memory body from --memory or --memory-file.
+func resolveMemoryContent(c *cli.Command) (string, error) {
+	if c.IsSet("memory") && c.IsSet("memory-file") {
+		return "", errors.New("pass only one of --memory or --memory-file")
+	}
+	if c.IsSet("memory-file") {
+		data, err := os.ReadFile(c.String("memory-file"))
+		if err != nil {
+			return "", fmt.Errorf("failed to read --memory-file: %w", err)
+		}
+		return string(data), nil
+	}
+	if c.IsSet("memory") {
+		return c.String("memory"), nil
+	}
+	return "", errors.New("provide the memory with --memory or --memory-file")
 }
 
 func cloudAgentsMessages() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -310,7 +310,7 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 12)
+	require.Len(t, cmd.Commands, 15)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -318,6 +318,9 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	}
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "mcp")
+	assert.Contains(t, subNames, "get-memory")
+	assert.Contains(t, subNames, "set-memory")
+	assert.Contains(t, subNames, "clear-memory")
 }
 
 func TestCloudDashboardsCommand_Help(t *testing.T) {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -645,6 +645,26 @@ func (c *APIClient) SetAgentPrompt(ctx context.Context, agentID int, systemPromp
 	return &result, nil
 }
 
+func (c *APIClient) GetAgentMemory(ctx context.Context, agentID int) (*AgentMemory, error) {
+	var result AgentMemory
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%d/memory", agentID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// SetAgentMemory replaces the agent's memory. A nil memory clears it (sends JSON null).
+func (c *APIClient) SetAgentMemory(ctx context.Context, agentID int, memory *string) (*AgentMemory, error) {
+	body := map[string]any{"memory": memory}
+	var result AgentMemory
+	err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf("/agents/%d/memory", agentID), body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *APIClient) ListAgentMessages(ctx context.Context, agentID, threadID int, limit, offset int) ([]AgentMessage, error) {
 	params := url.Values{}
 	if limit > 0 {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -648,6 +648,66 @@ func TestUpdateAgent(t *testing.T) {
 	assert.Equal(t, "renamed", agent.Name)
 }
 
+func TestGetAgentMemory(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/agents/7/memory", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		mem := "remembered thing"
+		writeJSON(t, w, AgentMemory{ID: 7, Name: "an-agent", Memory: &mem})
+	})
+
+	memory, err := client.GetAgentMemory(t.Context(), 7)
+	require.NoError(t, err)
+	require.NotNil(t, memory.Memory)
+	assert.Equal(t, "remembered thing", *memory.Memory)
+}
+
+func TestSetAgentMemory(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/agents/7/memory", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "new memory", body["memory"])
+
+		w.WriteHeader(http.StatusOK)
+		mem := "new memory"
+		writeJSON(t, w, AgentMemory{ID: 7, Name: "an-agent", Memory: &mem})
+	})
+
+	mem := "new memory"
+	memory, err := client.SetAgentMemory(t.Context(), 7, &mem)
+	require.NoError(t, err)
+	require.NotNil(t, memory.Memory)
+	assert.Equal(t, "new memory", *memory.Memory)
+}
+
+func TestSetAgentMemoryClear(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/agents/7/memory", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		// A nil memory clears it: the field is present and JSON null.
+		val, present := body["memory"]
+		assert.True(t, present)
+		assert.Nil(t, val)
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, AgentMemory{ID: 7, Name: "an-agent", Memory: nil})
+	})
+
+	memory, err := client.SetAgentMemory(t.Context(), 7, nil)
+	require.NoError(t, err)
+	assert.Nil(t, memory.Memory)
+}
+
 func TestListAgentMcpServers(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -176,6 +176,13 @@ type AgentPrompt struct {
 	SystemPrompt *string `json:"system_prompt"`
 }
 
+// AgentMemory represents an agent's long-term memory blob.
+type AgentMemory struct {
+	ID     int     `json:"id"`
+	Name   string  `json:"name"`
+	Memory *string `json:"memory"`
+}
+
 // AgentMessage represents a message in an agent thread.
 type AgentMessage struct {
 	ID                int             `json:"id"`


### PR DESCRIPTION
Adds `bruin cloud agents get-memory`, `set-memory` (`--memory` / `--memory-file`), and `clear-memory` so an agent can read, rewrite, and clear its own long-term memory. Mirrors the existing `get-prompt`/`set-prompt` commands.

Pairs with the cloud-side endpoints in bruin-data/cloud#2978 (`agent:memory:manage`, opt-in per agent).