### PR TITLE
feat(cloud): add agents export-thread command

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2252,6 +2252,7 @@ func CloudAgents() *cli.Command {
 			cloudAgentsGetMemory(),
 			cloudAgentsSetMemory(),
 			cloudAgentsClearMemory(),
+			cloudAgentsExportThread(),
 			cloudAgentsConnections(),
 			cloudAgentsMcp(),
 		},
@@ -3310,6 +3311,67 @@ func resolveMemoryContent(c *cli.Command) (string, error) {
 		return c.String("memory"), nil
 	}
 	return "", errors.New("provide the memory with --memory or --memory-file")
+}
+
+func cloudAgentsExportThread() *cli.Command {
+	return &cli.Command{
+		Name:  "export-thread",
+		Usage: "Export a chat thread as JSON",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:     "thread-id",
+				Usage:    "thread ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "file",
+				Usage: "write the export to this file instead of stdout",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			export, err := client.ExportThread(ctx, c.Int("agent-id"), c.Int("thread-id"))
+			if err != nil {
+				printError(err, output, "Failed to export thread")
+				return cli.Exit("", 1)
+			}
+
+			// Re-indent the server's JSON for a readable file/stdout dump.
+			var obj any
+			if err := json.Unmarshal(export, &obj); err != nil {
+				printError(err, output, "Failed to parse export")
+				return cli.Exit("", 1)
+			}
+			pretty, _ := json.MarshalIndent(obj, "", "  ")
+
+			if file := c.String("file"); file != "" {
+				if err := os.WriteFile(file, pretty, 0o644); err != nil {
+					printError(err, output, "Failed to write file")
+					return cli.Exit("", 1)
+				}
+				infoPrinter.Printf("Exported thread %d to %s\n", c.Int("thread-id"), file)
+				return nil
+			}
+
+			fmt.Println(string(pretty))
+			return nil
+		},
+	}
 }
 
 func cloudAgentsMessages() *cli.Command {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3360,7 +3360,7 @@ func cloudAgentsExportThread() *cli.Command {
 			pretty, _ := json.MarshalIndent(obj, "", "  ")
 
 			if file := c.String("file"); file != "" {
-				if err := os.WriteFile(file, pretty, 0o644); err != nil {
+				if err := os.WriteFile(file, pretty, 0o600); err != nil {
 					printError(err, output, "Failed to write file")
 					return cli.Exit("", 1)
 				}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -3351,13 +3352,14 @@ func cloudAgentsExportThread() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			// Re-indent the server's JSON for a readable file/stdout dump.
-			var obj any
-			if err := json.Unmarshal(export, &obj); err != nil {
-				printError(err, output, "Failed to parse export")
+			// Indent the raw bytes rather than round-tripping through `any`, which
+			// would coerce large integers through float64 and silently corrupt them.
+			var buf bytes.Buffer
+			if err := json.Indent(&buf, export, "", "  "); err != nil {
+				printError(err, output, "Failed to format export")
 				return cli.Exit("", 1)
 			}
-			pretty, _ := json.MarshalIndent(obj, "", "  ")
+			pretty := buf.Bytes()
 
 			if file := c.String("file"); file != "" {
 				if err := os.WriteFile(file, pretty, 0o600); err != nil {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -310,7 +310,7 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 15)
+	require.Len(t, cmd.Commands, 16)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -321,6 +321,7 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "get-memory")
 	assert.Contains(t, subNames, "set-memory")
 	assert.Contains(t, subNames, "clear-memory")
+	assert.Contains(t, subNames, "export-thread")
 }
 
 func TestCloudDashboardsCommand_Help(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -659,6 +659,23 @@ bruin cloud agents messages \
   --thread-id <thread-id>
 ```
 
+#### `export-thread`
+
+Export a whole thread as JSON (thread, agent, and every message pair with
+input/output, agent logs, and query logs). Prints to stdout, or writes to a file
+with `--file`:
+
+```bash
+bruin cloud agents export-thread \
+  --agent-id <agent-id> \
+  --thread-id <thread-id>
+
+bruin cloud agents export-thread \
+  --agent-id <agent-id> \
+  --thread-id <thread-id> \
+  --file thread.json
+```
+
 ### `connections`
 
 Manage the connections stored in Bruin Cloud. Connections live in your team's

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -665,6 +665,17 @@ func (c *APIClient) SetAgentMemory(ctx context.Context, agentID int, memory *str
 	return &result, nil
 }
 
+// ExportThread returns a chat thread as the canonical versioned JSON export.
+// The shape is server-defined, so the raw JSON is returned verbatim.
+func (c *APIClient) ExportThread(ctx context.Context, agentID, threadID int) (json.RawMessage, error) {
+	var result json.RawMessage
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%d/threads/%d/export", agentID, threadID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (c *APIClient) ListAgentMessages(ctx context.Context, agentID, threadID int, limit, offset int) ([]AgentMessage, error) {
 	params := url.Values{}
 	if limit > 0 {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -708,6 +708,27 @@ func TestSetAgentMemoryClear(t *testing.T) {
 	assert.Nil(t, memory.Memory)
 }
 
+func TestExportThread(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/agents/7/threads/42/export", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"export_version": "1.0",
+			"thread":         map[string]any{"id": 42},
+			"messages":       []any{},
+		})
+	})
+
+	export, err := client.ExportThread(t.Context(), 7, 42)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(export, &parsed))
+	assert.Equal(t, "1.0", parsed["export_version"])
+}
+
 func TestListAgentMcpServers(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds `bruin cloud agents export-thread --agent-id <id> --thread-id <id> [--file <path>]` to pull a chat thread as JSON. Backed by the new `ExportThread` client method.

Pairs with the cloud endpoint in bruin-data/cloud#2979.