### PR TITLE
feat(okta): add Okta as an ingestr source connection

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -347,6 +347,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "MongoDB", link: "/ingestion/mongo"},
                                     {text: "MySQL", link: "/ingestion/mysql"},
                                     {text: "Notion", link: "/ingestion/notion"},
+                                    {text: "Okta", link: "/ingestion/okta"},
                                     {text: "Paddle", link: "/ingestion/paddle"},
                                     {text: "Payrails", link: "/ingestion/payrails"},
                                     {text: "Personio", link: "/ingestion/personio"},

--- a/docs/ingestion/okta.md
+++ b/docs/ingestion/okta.md
@@ -1,0 +1,79 @@
+# Okta
+
+[Okta](https://www.okta.com/) is an identity and access management platform for managing users, groups, applications, and authentication policies.
+
+Bruin supports Okta as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Okta into your data warehouse.
+
+> [!WARNING]
+> Okta support requires an ingestr release that includes the Okta source ([bruin-data/ingestr#1088](https://github.com/bruin-data/ingestr/pull/1088)). If that PR hasn't been released yet, this connection type won't be usable until Bruin's pinned ingestr version is bumped past it.
+
+In order to set up an Okta connection, you need to add a configuration item to `connections` in the `.bruin.yml` file and in the `asset` file.
+
+Follow the steps below to correctly set up Okta as a data source and run ingestion.
+
+## Configuration
+
+### Step 1: Add a connection to .bruin.yml file
+
+To connect to Okta, you need to add a configuration item to the connections section of the `.bruin.yml` file. This configuration must comply with the following schema:
+
+```yaml
+connections:
+  okta:
+    - name: "my_okta"
+      domain: "dev-123456.okta.com"
+      api_key: "your_api_token"
+```
+
+- `domain`: Your Okta org domain, for example `dev-123456.okta.com` or `mycompany.okta.com`.
+- `api_key`: An Okta API token used to authenticate requests. Create one in the Okta Admin Console under **Security → API → Tokens → Create Token**. The token inherits the permissions of the admin who creates it, so use an account that can read the resources you want to ingest.
+
+### Step 2: Create an asset file for data ingestion
+
+To ingest data from Okta, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., okta_ingestion.yml) inside the assets folder and add the following content:
+
+```yaml
+name: public.okta_users
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: my_okta
+  source_table: 'users'
+
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Specifies the type of the asset. Set this to `ingestr` to use the ingestr data pipeline.
+- `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
+- `source_connection`: The name of the Okta connection defined in `.bruin.yml`.
+- `source_table`: The name of the data table in Okta that you want to ingest.
+
+## Available Source Tables
+
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------|---------|
+| `users` | id | lastUpdated | merge | All users in the org |
+| `groups` | id | lastUpdated | merge | All groups in the org |
+| `group_members` | group_id, id | – | replace | Members of each group (one row per user per group); full snapshot each run |
+| `applications` | id | lastUpdated | merge | All applications configured in the org |
+| `application_users` | app_id, id | – | replace | Users assigned to each application; full snapshot each run |
+| `application_groups` | app_id, id | – | replace | Groups assigned to each application; full snapshot each run |
+| `system_log_events` | uuid | published | merge | System log events (Okta retains roughly the last 90 days) |
+| `devices` | id | lastUpdated | merge | Devices enrolled in the org |
+| `policies` | id | lastUpdated | merge | Policies across all policy types |
+| `policy_rules` | id | lastUpdated | merge | Rules belonging to each policy |
+| `roles` | id | – | replace | Custom admin role definitions |
+
+Nested objects (such as a user's `profile` and `credentials`) are preserved as JSON columns.
+
+Tables with an incremental key support incremental loading. When no interval is provided, ingestr performs a full load. The System Log can only be backfilled as far as Okta's retention window (about 90 days).
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/okta_ingestion.yml
+```
+
+As a result of this command, Bruin will ingest data from the given Okta table into your Postgres database.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1542,6 +1542,12 @@
           },
           "type": "array"
         },
+        "okta": {
+          "items": {
+            "$ref": "#/$defs/OktaConnection"
+          },
+          "type": "array"
+        },
         "fundraiseup": {
           "items": {
             "$ref": "#/$defs/FundraiseUpConnection"
@@ -3719,6 +3725,29 @@
       "type": "object",
       "required": [
         "name",
+        "api_key"
+      ]
+    },
+    "OktaConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "api_key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "domain",
         "api_key"
       ]
     },

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1922,6 +1922,16 @@ func (c FreshdeskConnection) GetName() string {
 	return c.Name
 }
 
+type OktaConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	Domain             string `yaml:"domain,omitempty" json:"domain" mapstructure:"domain"`
+	APIKey             string `yaml:"api_key,omitempty" json:"api_key" mapstructure:"api_key" sensitive:"true"`
+}
+
+func (c OktaConnection) GetName() string {
+	return c.Name
+}
+
 type RedditAdsConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	AccessToken        string `yaml:"access_token,omitempty" json:"access_token,omitempty" mapstructure:"access_token" sensitive:"true"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -149,6 +149,7 @@ type Connections struct {
 	Spark               []SparkConnection               `yaml:"spark,omitempty" json:"spark,omitempty" mapstructure:"spark"`
 	Fluxx               []FluxxConnection               `yaml:"fluxx,omitempty" json:"fluxx,omitempty" mapstructure:"fluxx"`
 	Freshdesk           []FreshdeskConnection           `yaml:"freshdesk,omitempty" json:"freshdesk,omitempty" mapstructure:"freshdesk"`
+	Okta                []OktaConnection                `yaml:"okta,omitempty" json:"okta,omitempty" mapstructure:"okta"`
 	FundraiseUp         []FundraiseUpConnection         `yaml:"fundraiseup,omitempty" json:"fundraiseup,omitempty" mapstructure:"fundraiseup"`
 	Fireflies           []FirefliesConnection           `yaml:"fireflies,omitempty" json:"fireflies,omitempty" mapstructure:"fireflies"`
 	Trello              []TrelloConnection              `yaml:"trello,omitempty" json:"trello,omitempty" mapstructure:"trello"`
@@ -1538,6 +1539,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Freshdesk = append(env.Connections.Freshdesk, conn)
+	case "okta":
+		var conn OktaConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.Okta = append(env.Connections.Okta, conn)
 	case "frankfurter":
 		var conn FrankfurterConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -2104,6 +2112,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.AppLovin = removeConnection(env.Connections.AppLovin, connectionName)
 	case "freshdesk":
 		env.Connections.Freshdesk = removeConnection(env.Connections.Freshdesk, connectionName)
+	case "okta":
+		env.Connections.Okta = removeConnection(env.Connections.Okta, connectionName)
 	case "frankfurter":
 		env.Connections.Frankfurter = removeConnection(env.Connections.Frankfurter, connectionName)
 	case "salesforce":
@@ -2406,6 +2416,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Spark, source.Spark)
 	mergeConnectionList(&c.Fluxx, source.Fluxx)
 	mergeConnectionList(&c.Freshdesk, source.Freshdesk)
+	mergeConnectionList(&c.Okta, source.Okta)
 	mergeConnectionList(&c.FundraiseUp, source.FundraiseUp)
 	mergeConnectionList(&c.Fireflies, source.Fireflies)
 	mergeConnectionList(&c.Trello, source.Trello)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -927,6 +927,13 @@ func TestLoadFromFile(t *testing.T) {
 					Timezone:           "Asia/Kolkata",
 				},
 			},
+			Okta: []OktaConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "okta-1"},
+					Domain:             "dev-123456.okta.com",
+					APIKey:             "test-api-key",
+				},
+			},
 			Sendgrid: []SendgridConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "sendgrid-1"},
@@ -2872,6 +2879,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Indeed:              []IndeedConnection{{ConnectionMetadata: ConnectionMetadata{Name: "indeed1"}}},
 				CustomerIo:          []CustomerIoConnection{{ConnectionMetadata: ConnectionMetadata{Name: "customerio1"}}},
 				CleverTap:           []CleverTapConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clevertap1"}}},
+				Okta:                []OktaConnection{{ConnectionMetadata: ConnectionMetadata{Name: "okta1"}}},
 				Sendgrid:            []SendgridConnection{{ConnectionMetadata: ConnectionMetadata{Name: "sendgrid1"}}},
 				Twilio:              []TwilioConnection{{ConnectionMetadata: ConnectionMetadata{Name: "twilio1"}}},
 				Braze:               []BrazeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "braze1"}}},
@@ -3011,6 +3019,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Indeed:              []IndeedConnection{{ConnectionMetadata: ConnectionMetadata{Name: "indeed1"}}},
 				CustomerIo:          []CustomerIoConnection{{ConnectionMetadata: ConnectionMetadata{Name: "customerio1"}}},
 				CleverTap:           []CleverTapConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clevertap1"}}},
+				Okta:                []OktaConnection{{ConnectionMetadata: ConnectionMetadata{Name: "okta1"}}},
 				Sendgrid:            []SendgridConnection{{ConnectionMetadata: ConnectionMetadata{Name: "sendgrid1"}}},
 				Twilio:              []TwilioConnection{{ConnectionMetadata: ConnectionMetadata{Name: "twilio1"}}},
 				Braze:               []BrazeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "braze1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -585,6 +585,10 @@ environments:
           passcode: "test-passcode"
           region: "eu1"
           timezone: "Asia/Kolkata"
+      okta:
+        - name: "okta-1"
+          domain: "dev-123456.okta.com"
+          api_key: "test-api-key"
       sendgrid:
         - name: "sendgrid-1"
           api_key: "test-api-key"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -586,6 +586,10 @@ environments:
           passcode: "test-passcode"
           region: "eu1"
           timezone: "Asia/Kolkata"
+      okta:
+        - name: "okta-1"
+          domain: "dev-123456.okta.com"
+          api_key: "test-api-key"
       sendgrid:
         - name: "sendgrid-1"
           api_key: "test-api-key"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -99,6 +99,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/mysql"
 	"github.com/bruin-data/bruin/pkg/notion"
+	"github.com/bruin-data/bruin/pkg/okta"
 	"github.com/bruin-data/bruin/pkg/onelake"
 	"github.com/bruin-data/bruin/pkg/oracle"
 	"github.com/bruin-data/bruin/pkg/paddle"
@@ -255,6 +256,7 @@ type Manager struct {
 	Frankfurter          map[string]*frankfurter.Client
 	Fluxx                map[string]*fluxx.Client
 	Freshdesk            map[string]*freshdesk.Client
+	Okta                 map[string]*okta.Client
 	FundraiseUp          map[string]*fundraiseup.Client
 	Fireflies            map[string]*fireflies.Client
 	Trello               map[string]*trello.Client
@@ -3410,6 +3412,28 @@ func (m *Manager) AddFreshdeskConnectionFromConfig(connection *config.FreshdeskC
 	return nil
 }
 
+func (m *Manager) AddOktaConnectionFromConfig(connection *config.OktaConnection) error {
+	m.mutex.Lock()
+	if m.Okta == nil {
+		m.Okta = make(map[string]*okta.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := okta.NewClient(okta.Config{
+		Domain: connection.Domain,
+		APIKey: connection.APIKey,
+	})
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.Okta[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddFundraiseUpConnectionFromConfig(connection *config.FundraiseUpConnection) error {
 	m.mutex.Lock()
 	if m.FundraiseUp == nil {
@@ -4287,6 +4311,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Frankfurter, connectionManager.AddFrankfurterConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Fluxx, connectionManager.AddFluxxConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Freshdesk, connectionManager.AddFreshdeskConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.Okta, connectionManager.AddOktaConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.FundraiseUp, connectionManager.AddFundraiseUpConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Fireflies, connectionManager.AddFirefliesConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Trello, connectionManager.AddTrelloConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/mssql"
 	"github.com/bruin-data/bruin/pkg/mysql"
 	"github.com/bruin-data/bruin/pkg/notion"
+	"github.com/bruin-data/bruin/pkg/okta"
 	"github.com/bruin-data/bruin/pkg/personio"
 	"github.com/bruin-data/bruin/pkg/postgres"
 	"github.com/bruin-data/bruin/pkg/sharepoint"
@@ -549,6 +550,33 @@ func Test_AddCleverTapConnectionFromConfig(t *testing.T) {
 	assert.Contains(t, uri, "passcode=test-passcode")
 	assert.Contains(t, uri, "region=in1")
 	assert.Contains(t, uri, "timezone=Asia%2FKolkata")
+	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
+}
+
+func Test_AddOktaConnectionFromConfig(t *testing.T) {
+	t.Parallel()
+
+	m := Manager{
+		AllConnectionDetails: map[string]any{},
+		availableConnections: make(map[string]any),
+	}
+
+	configuration := &config.OktaConnection{
+		ConnectionMetadata: config.ConnectionMetadata{Name: "test"},
+		Domain:             "dev-123456.okta.com",
+		APIKey:             "test-api-key",
+	}
+
+	err := m.AddOktaConnectionFromConfig(configuration)
+	require.NoError(t, err)
+
+	res, ok := m.GetConnection("test").(*okta.Client)
+	require.True(t, ok)
+	require.NotNil(t, res)
+
+	uri, err := res.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "okta://dev-123456.okta.com?api_key=test-api-key", uri)
 	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
 }
 

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -753,6 +753,21 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "<database_id>", PrimaryKey: "", IncKey: "", IncStrategy: "replace"},
 	},
 
+	// Okta - Identity and access management platform
+	"okta": {
+		{Name: "users", PrimaryKey: "id", IncKey: "lastUpdated", IncStrategy: "merge"},
+		{Name: "groups", PrimaryKey: "id", IncKey: "lastUpdated", IncStrategy: "merge"},
+		{Name: "group_members", PrimaryKey: "group_id,id", IncKey: "", IncStrategy: "replace"},
+		{Name: "applications", PrimaryKey: "id", IncKey: "lastUpdated", IncStrategy: "merge"},
+		{Name: "application_users", PrimaryKey: "app_id,id", IncKey: "", IncStrategy: "replace"},
+		{Name: "application_groups", PrimaryKey: "app_id,id", IncKey: "", IncStrategy: "replace"},
+		{Name: "system_log_events", PrimaryKey: "uuid", IncKey: "published", IncStrategy: "merge"},
+		{Name: "devices", PrimaryKey: "id", IncKey: "lastUpdated", IncStrategy: "merge"},
+		{Name: "policies", PrimaryKey: "id", IncKey: "lastUpdated", IncStrategy: "merge"},
+		{Name: "policy_rules", PrimaryKey: "id", IncKey: "lastUpdated", IncStrategy: "merge"},
+		{Name: "roles", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+	},
+
 	// Personio - HR platform
 	"personio": {
 		{Name: "employees", PrimaryKey: "id", IncKey: "last_modified_at", IncStrategy: "merge"},

--- a/pkg/ingestr/sources_test.go
+++ b/pkg/ingestr/sources_test.go
@@ -65,6 +65,49 @@ func TestCleverTapSourceTables(t *testing.T) {
 	require.True(t, hasContentBlocks)
 }
 
+func TestOktaSourceTables(t *testing.T) {
+	t.Parallel()
+
+	source, err := GetSourceTables("okta")
+	require.NoError(t, err)
+	require.Equal(t, "okta", source.Name)
+	require.NotEmpty(t, source.Tables)
+
+	var hasUsers, hasGroupMembers, hasApplicationUsers, hasSystemLogEvents, hasRoles bool
+	for _, table := range source.Tables {
+		switch table.Name {
+		case "users":
+			hasUsers = true
+			require.Equal(t, "id", table.PrimaryKey)
+			require.Equal(t, "lastUpdated", table.IncKey)
+			require.Equal(t, "merge", table.IncStrategy)
+		case "group_members":
+			hasGroupMembers = true
+			require.Equal(t, "group_id,id", table.PrimaryKey)
+			require.Equal(t, "replace", table.IncStrategy)
+		case "application_users":
+			hasApplicationUsers = true
+			require.Equal(t, "app_id,id", table.PrimaryKey)
+			require.Equal(t, "replace", table.IncStrategy)
+		case "system_log_events":
+			hasSystemLogEvents = true
+			require.Equal(t, "uuid", table.PrimaryKey)
+			require.Equal(t, "published", table.IncKey)
+			require.Equal(t, "merge", table.IncStrategy)
+		case "roles":
+			hasRoles = true
+			require.Equal(t, "id", table.PrimaryKey)
+			require.Equal(t, "replace", table.IncStrategy)
+		}
+	}
+
+	require.True(t, hasUsers)
+	require.True(t, hasGroupMembers)
+	require.True(t, hasApplicationUsers)
+	require.True(t, hasSystemLogEvents)
+	require.True(t, hasRoles)
+}
+
 func TestSharePointSourceTables(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/okta/config.go
+++ b/pkg/okta/config.go
@@ -1,0 +1,42 @@
+package okta
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Config describes credentials for an Okta connection.
+type Config struct {
+	Domain string `yaml:"domain" json:"domain" mapstructure:"domain"`
+	APIKey string `yaml:"api_key" json:"api_key" mapstructure:"api_key"`
+}
+
+type requiredField struct {
+	key   string
+	value string
+}
+
+// GetIngestrURI builds the Okta ingestr URI.
+func (c *Config) GetIngestrURI() (string, error) {
+	requiredFields := []requiredField{
+		{"domain", c.Domain},
+		{"api_key", c.APIKey},
+	}
+
+	values := make(map[string]string, len(requiredFields))
+	for _, field := range requiredFields {
+		value := strings.TrimSpace(field.value)
+		if value == "" {
+			return "", fmt.Errorf("okta: %s must be provided", field.key)
+		}
+		values[field.key] = value
+	}
+
+	u := &url.URL{
+		Scheme:   "okta",
+		Host:     values["domain"],
+		RawQuery: url.Values{"api_key": {values["api_key"]}}.Encode(),
+	}
+	return u.String(), nil
+}

--- a/pkg/okta/config_test.go
+++ b/pkg/okta/config_test.go
@@ -1,0 +1,59 @@
+package okta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "all fields set",
+			config: Config{Domain: "dev-123456.okta.com", APIKey: "test-api-key"},
+			want:   "okta://dev-123456.okta.com?api_key=test-api-key",
+		},
+		{
+			name:    "missing domain",
+			config:  Config{APIKey: "test-api-key"},
+			wantErr: true,
+		},
+		{
+			name:    "missing api key",
+			config:  Config{Domain: "dev-123456.okta.com"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.config.GetIngestrURI()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{Domain: "dev-123456.okta.com", APIKey: "test-api-key"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "okta://dev-123456.okta.com?api_key=test-api-key", uri)
+}

--- a/pkg/okta/db.go
+++ b/pkg/okta/db.go
@@ -1,0 +1,13 @@
+package okta
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{config: c}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -263,6 +263,7 @@ var defaultMapping = map[string]string{
 	"footballdata":          "footballdata-default",
 	"frankfurter":           "frankfurter-default",
 	"freshdesk":             "freshdesk-default",
+	"okta":                  "okta-default",
 	"fundraiseup":           "fundraiseup-default",
 	"g2":                    "g2-default",
 	"github":                "github-default",


### PR DESCRIPTION
## Summary
- Wires the new ingestr Okta source ([bruin-data/ingestr#1088](https://github.com/bruin-data/ingestr/pull/1088)) into Bruin as a connection type
- Adds `pkg/okta/` (Config/Client, mirrors the `freshdesk` domain+api_key URI shape: `okta://<domain>?api_key=...`)
- Wires connection config (add/delete/merge), connection manager, default incremental mapping, and the source table registry for all 11 Okta tables (users, groups, group_members, applications, application_users, application_groups, system_log_events, devices, policies, policy_rules, roles)
- Adds docs (`docs/ingestion/okta.md` + sidebar entry) and regenerates the connection schema expectations