### PR TITLE
Fix Fabric truncate+insert for CTE queries

### DIFF
--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bruin-data/bruin/pkg/helpers"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 )
 
@@ -111,11 +112,15 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 
 func buildTruncateInsertQuery(asset *pipeline.Asset, query string) (string, error) {
 	tableName := QuoteIdentifier(asset.Name)
-	tempName := QuoteIdentifier(asset.Name + "__bruin_tmp")
+	schemaName, _ := splitSchemaName(asset.Name)
+	tempFullName := "__bruin_tmp_" + helpers.PrefixGenerator()
+	if schemaName != "" {
+		tempFullName = schemaName + "." + tempFullName
+	}
+	tempName := QuoteIdentifier(tempFullName)
 	query = strings.TrimSuffix(query, ";")
 
 	queries := []string{
-		"DROP TABLE IF EXISTS " + tempName,
 		"CREATE TABLE " + tempName + " AS\n" + query,
 		"TRUNCATE TABLE " + tableName,
 		"INSERT INTO " + tableName + " SELECT * FROM " + tempName,

--- a/pkg/fabric/materialization.go
+++ b/pkg/fabric/materialization.go
@@ -110,9 +110,16 @@ func buildMergeQuery(asset *pipeline.Asset, query string) (string, error) {
 }
 
 func buildTruncateInsertQuery(asset *pipeline.Asset, query string) (string, error) {
+	tableName := QuoteIdentifier(asset.Name)
+	tempName := QuoteIdentifier(asset.Name + "__bruin_tmp")
+	query = strings.TrimSuffix(query, ";")
+
 	queries := []string{
-		"TRUNCATE TABLE " + QuoteIdentifier(asset.Name),
-		"INSERT INTO " + QuoteIdentifier(asset.Name) + "\n" + strings.TrimSuffix(query, ";"),
+		"DROP TABLE IF EXISTS " + tempName,
+		"CREATE TABLE " + tempName + " AS\n" + query,
+		"TRUNCATE TABLE " + tableName,
+		"INSERT INTO " + tableName + " SELECT * FROM " + tempName,
+		"DROP TABLE IF EXISTS " + tempName,
 	}
 	return strings.Join(queries, ";\n") + ";", nil
 }

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -138,12 +138,11 @@ func TestBuildTruncateInsertQuery(t *testing.T) {
 			asset := &pipeline.Asset{Name: "dbo.Table"}
 			result, err := buildTruncateInsertQuery(asset, tt.query)
 			require.NoError(t, err)
-			expected := "DROP TABLE IF EXISTS [dbo].[Table__bruin_tmp];\n" +
-				"CREATE TABLE [dbo].[Table__bruin_tmp] AS\n" +
+			expected := "CREATE TABLE [dbo].[__bruin_tmp_abcefghi] AS\n" +
 				strings.TrimSuffix(tt.query, ";") + ";\n" +
 				"TRUNCATE TABLE [dbo].[Table];\n" +
-				"INSERT INTO [dbo].[Table] SELECT * FROM [dbo].[Table__bruin_tmp];\n" +
-				"DROP TABLE IF EXISTS [dbo].[Table__bruin_tmp];"
+				"INSERT INTO [dbo].[Table] SELECT * FROM [dbo].[__bruin_tmp_abcefghi];\n" +
+				"DROP TABLE IF EXISTS [dbo].[__bruin_tmp_abcefghi];"
 			assert.Equal(t, expected, result)
 		})
 	}

--- a/pkg/fabric/materialization_test.go
+++ b/pkg/fabric/materialization_test.go
@@ -1,6 +1,7 @@
 package fabric
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
@@ -112,6 +113,40 @@ func TestBuildMergeQueryRejectsIncrementalPredicate(t *testing.T) {
 	}
 	_, err := buildMergeQuery(asset, "SELECT 1")
 	require.ErrorContains(t, err, "incremental_predicate is not supported for Fabric merge materialization")
+}
+
+func TestBuildTruncateInsertQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "simple query",
+			query: "SELECT id, val FROM src;",
+		},
+		{
+			name:  "query with CTE",
+			query: "WITH cte AS (SELECT id, val FROM src) SELECT * FROM cte;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			asset := &pipeline.Asset{Name: "dbo.Table"}
+			result, err := buildTruncateInsertQuery(asset, tt.query)
+			require.NoError(t, err)
+			expected := "DROP TABLE IF EXISTS [dbo].[Table__bruin_tmp];\n" +
+				"CREATE TABLE [dbo].[Table__bruin_tmp] AS\n" +
+				strings.TrimSuffix(tt.query, ";") + ";\n" +
+				"TRUNCATE TABLE [dbo].[Table];\n" +
+				"INSERT INTO [dbo].[Table] SELECT * FROM [dbo].[Table__bruin_tmp];\n" +
+				"DROP TABLE IF EXISTS [dbo].[Table__bruin_tmp];"
+			assert.Equal(t, expected, result)
+		})
+	}
 }
 
 func TestBuildDDLQuery(t *testing.T) {


### PR DESCRIPTION
## What

Fix Fabric SQL `truncate+insert` assets whose query starts with a CTE.

## Changes

- Stage the asset query in a unique CTAS table before truncating and inserting into the target.
- Add regression coverage for simple and CTE queries.

## How to test

1. Run `make test`.

## Risk & rollback

- **Risk:** Low; this only changes Fabric `truncate+insert` SQL generation.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues

N/A
