### PR TITLE
Point --team flag help at 'bruin cloud teams list'

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -69,7 +69,7 @@ func addTeamFlag(cmd *cli.Command) {
 func teamFlag() *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:    "team",
-		Usage:   "act on this team (company prefix) instead of your current team",
+		Usage:   "act on this team instead of your current one, given as its company prefix (see 'bruin cloud teams list' for available prefixes)",
 		Sources: cli.EnvVars("BRUIN_CLOUD_TEAM"),
 	}
 }


### PR DESCRIPTION
The `--team` flag names a team by its company prefix, but nothing told users what a company prefix is or where to find it. Point the flag help at `bruin cloud teams list`, matching the existing `--project-id` pattern. Shows up in `--help` for every cloud command, including where the "you belong to multiple teams" error fires.