### PR TITLE
Add 'bruin cloud connection-sets' commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2525,11 +2525,16 @@ func cloudAgentsUpdate() *cli.Command {
 				fields["visibility"] = visibility
 			}
 			if c.IsSet("connection-set-id") {
-				// 0 (or negative) detaches — send an explicit null; a positive id assigns.
-				if id := c.Int("connection-set-id"); id > 0 {
+				// >0 assigns, 0 detaches (explicit null); a negative id is a typo,
+				// not a detach — reject it rather than silently wiping the set.
+				switch id := c.Int("connection-set-id"); {
+				case id > 0:
 					fields["connection_set_id"] = id
-				} else {
+				case id == 0:
 					fields["connection_set_id"] = nil
+				default:
+					printError(fmt.Errorf("--connection-set-id must be >= 0 (0 detaches), got %d", id), output, "Invalid --connection-set-id")
+					return cli.Exit("", 1)
 				}
 			}
 			if len(fields) == 0 {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -40,6 +40,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudGlossary(),
 			CloudAgents(),
 			CloudConnections(),
+			CloudConnectionSets(),
 			CloudDashboards(),
 			CloudScheduledAgents(),
 			CloudAuditLogs(),
@@ -2476,7 +2477,7 @@ func cloudAgentsGet() *cli.Command {
 func cloudAgentsUpdate() *cli.Command {
 	return &cli.Command{
 		Name:  "update",
-		Usage: "Update an agent's name, description or visibility",
+		Usage: "Update an agent's name, description, visibility or connection set",
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
@@ -2496,6 +2497,10 @@ func cloudAgentsUpdate() *cli.Command {
 			&cli.StringFlag{
 				Name:  "visibility",
 				Usage: "agent visibility: team or private",
+			},
+			&cli.IntFlag{
+				Name:  "connection-set-id",
+				Usage: "assign a connection set to the agent (0 to detach); see 'bruin cloud connection-sets list'",
 			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
@@ -2519,8 +2524,16 @@ func cloudAgentsUpdate() *cli.Command {
 				}
 				fields["visibility"] = visibility
 			}
+			if c.IsSet("connection-set-id") {
+				// 0 (or negative) detaches — send an explicit null; a positive id assigns.
+				if id := c.Int("connection-set-id"); id > 0 {
+					fields["connection_set_id"] = id
+				} else {
+					fields["connection_set_id"] = nil
+				}
+			}
 			if len(fields) == 0 {
-				printError(errors.New("provide at least one of --name, --description or --visibility"), output, "Nothing to update")
+				printError(errors.New("provide at least one of --name, --description, --visibility or --connection-set-id"), output, "Nothing to update")
 				return cli.Exit("", 1)
 			}
 
@@ -3696,6 +3709,274 @@ func cloudConnectionsDelete() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func CloudConnectionSets() *cli.Command {
+	return &cli.Command{
+		Name:  "connection-sets",
+		Usage: "Manage Bruin Cloud connection sets (named bundles of connections an agent runs against)",
+		Commands: []*cli.Command{
+			cloudConnectionSetsList(),
+			cloudConnectionSetsGet(),
+			cloudConnectionSetsCreate(),
+			cloudConnectionSetsUpdate(),
+			cloudConnectionSetsDelete(),
+		},
+	}
+}
+
+func cloudConnectionSetsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List connection sets",
+		Flags: []cli.Flag{apiKeyFlag(), outputFlag()},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			sets, err := client.ListConnectionSets(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list connection sets")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(sets, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(sets) == 0 {
+				infoPrinter.Println("No connection sets found.")
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Name", "Created", "Updated"})
+			for _, s := range sets {
+				t.AppendRow(table.Row{s.ID, s.Name, s.CreatedAt, s.UpdatedAt})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudConnectionSetsGet() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "List the connections in a connection set (names and types only)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "set-id", Usage: "connection set ID", Required: true},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("set-id") <= 0 {
+				printError(fmt.Errorf("--set-id must be a positive integer, got %d", c.Int("set-id")), output, "Invalid --set-id")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			conns, err := client.ListConnectionSetConnections(ctx, c.Int("set-id"))
+			if err != nil {
+				printError(err, output, "Failed to get connection set")
+				return cli.Exit("", 1)
+			}
+			if conns == nil {
+				conns = []bruincloud.Connection{}
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(conns, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(conns) == 0 {
+				infoPrinter.Println("This connection set has no connections.")
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Name", "Type"})
+			for _, conn := range conns {
+				t.AppendRow(table.Row{conn.Name, conn.Type})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudConnectionSetsCreate() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a connection set from connections in the local .bruin.yml",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.StringFlag{Name: "name", Usage: "the connection set name", Required: true},
+			&cli.StringSliceFlag{Name: "connection", Usage: "a connection name to include, read from the local .bruin.yml; repeat for multiple", Required: true},
+			&cli.StringFlag{Name: "environment", Usage: "the .bruin.yml environment to read from (default: selected environment)"},
+			&cli.StringFlag{Name: "config-file", Usage: "path to the .bruin.yml file"},
+			&cli.BoolFlag{Name: "skip-validation", Usage: "skip the live connection test"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			inputs, err := connectionSetInputsFromConfig(ctx, c.StringSlice("connection"), c.String("environment"), c.String("config-file"))
+			if err != nil {
+				printError(err, output, "Failed to read connections")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			set, err := client.CreateConnectionSet(ctx, c.String("name"), inputs, c.Bool("skip-validation"))
+			if err != nil {
+				printError(err, output, "Failed to create connection set")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(set, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			printSuccessForOutput(output, fmt.Sprintf("Created connection set '%s' (ID %d) with %d connection(s)", set.Name, set.ID, len(inputs)))
+			return nil
+		},
+	}
+}
+
+func cloudConnectionSetsUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Replace a connection set's connections with ones from the local .bruin.yml",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "set-id", Usage: "connection set ID", Required: true},
+			&cli.StringSliceFlag{Name: "connection", Usage: "a connection name to include, read from the local .bruin.yml; repeat for multiple. The set becomes exactly these connections.", Required: true},
+			&cli.StringFlag{Name: "environment", Usage: "the .bruin.yml environment to read from (default: selected environment)"},
+			&cli.StringFlag{Name: "config-file", Usage: "path to the .bruin.yml file"},
+			&cli.BoolFlag{Name: "skip-validation", Usage: "skip the live connection test"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("set-id") <= 0 {
+				printError(fmt.Errorf("--set-id must be a positive integer, got %d", c.Int("set-id")), output, "Invalid --set-id")
+				return cli.Exit("", 1)
+			}
+
+			inputs, err := connectionSetInputsFromConfig(ctx, c.StringSlice("connection"), c.String("environment"), c.String("config-file"))
+			if err != nil {
+				printError(err, output, "Failed to read connections")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.UpdateConnectionSet(ctx, c.Int("set-id"), inputs, c.Bool("skip-validation")); err != nil {
+				printError(err, output, "Failed to update connection set")
+				return cli.Exit("", 1)
+			}
+
+			printSuccessForOutput(output, fmt.Sprintf("Updated connection set %d (%d connection(s))", c.Int("set-id"), len(inputs)))
+			return nil
+		},
+	}
+}
+
+func cloudConnectionSetsDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a connection set",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "set-id", Usage: "connection set ID", Required: true},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("set-id") <= 0 {
+				printError(fmt.Errorf("--set-id must be a positive integer, got %d", c.Int("set-id")), output, "Invalid --set-id")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteConnectionSet(ctx, c.Int("set-id")); err != nil {
+				printError(err, output, "Failed to delete connection set")
+				return cli.Exit("", 1)
+			}
+
+			printSuccessForOutput(output, fmt.Sprintf("Deleted connection set %d", c.Int("set-id")))
+			return nil
+		},
+	}
+}
+
+// connectionSetInputsFromConfig reads each named connection from the local
+// .bruin.yml and returns them as {type, name, config} inputs, inlining any
+// service_account_file into service_account_json (the cloud runner can't read
+// local files). Every connection is sent with a full config — the API takes no
+// partial edits.
+func connectionSetInputsFromConfig(ctx context.Context, names []string, environment, configFile string) ([]bruincloud.ConnectionSetInput, error) {
+	inputs := make([]bruincloud.ConnectionSetInput, 0, len(names))
+	for _, name := range names {
+		connType, credentials, err := connectionFromConfig(ctx, name, environment, configFile)
+		if err != nil {
+			return nil, fmt.Errorf("connection %q: %w", name, err)
+		}
+
+		if path, ok := credentials["service_account_file"].(string); ok && path != "" {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("connection %q: failed to read service_account_file: %w", name, err)
+			}
+			credentials["service_account_json"] = string(data)
+			delete(credentials, "service_account_file")
+		}
+
+		inputs = append(inputs, bruincloud.ConnectionSetInput{Type: connType, Name: name, Config: credentials})
+	}
+	return inputs, nil
 }
 
 func CloudDashboards() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -149,7 +149,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 14)
+	assert.Len(t, cmd.Commands, 15)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -166,9 +166,28 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "glossary")
 	assert.Contains(t, subNames, "agents")
 	assert.Contains(t, subNames, "connections")
+	assert.Contains(t, subNames, "connection-sets")
 	assert.Contains(t, subNames, "dashboards")
 	assert.Contains(t, subNames, "scheduled-agents")
 	assert.Contains(t, subNames, "audit-logs")
+}
+
+func TestCloudConnectionSetsCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := CloudConnectionSets()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "connection-sets", cmd.Name)
+	require.Len(t, cmd.Commands, 5)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "list")
+	assert.Contains(t, subNames, "get")
+	assert.Contains(t, subNames, "create")
+	assert.Contains(t, subNames, "update")
+	assert.Contains(t, subNames, "delete")
 }
 
 func TestCloudLeafCommandsHaveTeamFlag(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -734,6 +734,60 @@ Delete a connection by name:
 bruin cloud connections delete --name my_pg
 ```
 
+### `connection-sets`
+
+Manage connection **sets** — named bundles of connections an agent runs against
+(assigned to an agent via its connection set). Distinct from individual
+connections. Credentials are write-only: reads never return config values, and
+create/update always send a full config per connection (read from the local
+`.bruin.yml`).
+
+#### `list`
+
+List the team's connection sets:
+
+```bash
+bruin cloud connection-sets list
+```
+
+#### `get`
+
+List the connections in a set (names and types only — never secret values):
+
+```bash
+bruin cloud connection-sets get --set-id 7
+```
+
+#### `create`
+
+Create a set from connections in the local `.bruin.yml` (repeat `--connection`):
+
+```bash
+bruin cloud connection-sets create --name prod \
+  --connection my_pg --connection my_bq
+```
+
+Use `--skip-validation` to skip the live connection test, and `--environment` /
+`--config-file` to pick a specific `.bruin.yml` / environment.
+
+#### `update`
+
+Replace a set's connections — the set becomes exactly the connections you pass:
+
+```bash
+bruin cloud connection-sets update --set-id 7 --connection my_pg
+```
+
+#### `delete`
+
+Delete a set (refused while an agent is still assigned to it):
+
+```bash
+bruin cloud connection-sets delete --set-id 7
+```
+
+To assign a set to an agent, use `bruin cloud agents update --agent-id <id> --connection-set-id <set-id>` (or `--connection-set-id 0` to detach).
+
 ### `dashboards`
 
 Read the dashboards in your Bruin Cloud team — useful for inspecting or

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -716,6 +716,57 @@ func (c *APIClient) DeleteConnection(ctx context.Context, name string) error {
 	return c.doRequest(ctx, http.MethodDelete, "/connections/"+url.PathEscape(name), nil, nil)
 }
 
+// --- Connection sets ---
+
+func (c *APIClient) ListConnectionSets(ctx context.Context) ([]ConnectionSet, error) {
+	var resp struct {
+		ConnectionSets []ConnectionSet `json:"connection_sets"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/connection-sets", nil, &resp)
+	return resp.ConnectionSets, err
+}
+
+func (c *APIClient) ListConnectionSetConnections(ctx context.Context, setID int) ([]Connection, error) {
+	var resp struct {
+		Connections []Connection `json:"connections"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/connection-sets/%d/connections", setID), nil, &resp)
+	return resp.Connections, err
+}
+
+// ConnectionSetInput is one connection in a create/update payload: a name, its
+// type, and its full credentials (the API requires full config, never partial).
+type ConnectionSetInput struct {
+	Type   string         `json:"type"`
+	Name   string         `json:"name"`
+	Config map[string]any `json:"config"`
+}
+
+func (c *APIClient) CreateConnectionSet(ctx context.Context, name string, connections []ConnectionSetInput, skipValidation bool) (*ConnectionSet, error) {
+	body := map[string]any{
+		"name":            name,
+		"connections":     connections,
+		"skip_validation": skipValidation,
+	}
+	var result ConnectionSet
+	if err := c.doRequest(ctx, http.MethodPost, "/connection-sets", body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *APIClient) UpdateConnectionSet(ctx context.Context, setID int, connections []ConnectionSetInput, skipValidation bool) error {
+	body := map[string]any{
+		"connections":     connections,
+		"skip_validation": skipValidation,
+	}
+	return c.doRequest(ctx, http.MethodPut, fmt.Sprintf("/connection-sets/%d", setID), body, nil)
+}
+
+func (c *APIClient) DeleteConnectionSet(ctx context.Context, setID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/connection-sets/%d", setID), nil, nil)
+}
+
 // --- Dashboards ---
 
 func (c *APIClient) ListDashboards(ctx context.Context) ([]Dashboard, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -588,6 +588,104 @@ func TestAddAgentConnection(t *testing.T) {
 	assert.Equal(t, "postgres", connections[0].Type)
 }
 
+func TestListConnectionSets(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/connection-sets", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"connection_sets": []ConnectionSet{{ID: 1, Name: "prod"}, {ID: 2, Name: "dev"}},
+		})
+	})
+
+	sets, err := client.ListConnectionSets(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sets, 2)
+	assert.Equal(t, "prod", sets[0].Name)
+	assert.Equal(t, 2, sets[1].ID)
+}
+
+func TestListConnectionSetConnections(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/connection-sets/5/connections", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"connections": []Connection{{Name: "pg", Type: "postgres"}},
+		})
+	})
+
+	conns, err := client.ListConnectionSetConnections(t.Context(), 5)
+	require.NoError(t, err)
+	require.Len(t, conns, 1)
+	assert.Equal(t, "pg", conns[0].Name)
+	assert.Equal(t, "postgres", conns[0].Type)
+}
+
+func TestCreateConnectionSet(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/connection-sets", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "prod", body["name"])
+		assert.Equal(t, true, body["skip_validation"])
+		conns, _ := body["connections"].([]any)
+		assert.Len(t, conns, 1)
+		first, _ := conns[0].(map[string]any)
+		assert.Equal(t, "postgres", first["type"])
+		cfg, _ := first["config"].(map[string]any)
+		assert.Equal(t, "secret", cfg["password"])
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, ConnectionSet{ID: 9, Name: "prod"})
+	})
+
+	set, err := client.CreateConnectionSet(t.Context(), "prod", []ConnectionSetInput{
+		{Type: "postgres", Name: "pg", Config: map[string]any{"password": "secret"}},
+	}, true)
+	require.NoError(t, err)
+	assert.Equal(t, 9, set.ID)
+	assert.Equal(t, "prod", set.Name)
+}
+
+func TestUpdateConnectionSet(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/connection-sets/9", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		conns, _ := body["connections"].([]any)
+		assert.Len(t, conns, 1)
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"success": true})
+	})
+
+	err := client.UpdateConnectionSet(t.Context(), 9, []ConnectionSetInput{
+		{Type: "postgres", Name: "pg", Config: map[string]any{"password": "secret"}},
+	}, false)
+	require.NoError(t, err)
+}
+
+func TestDeleteConnectionSet(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/connection-sets/9", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"success": true})
+	})
+
+	require.NoError(t, client.DeleteConnectionSet(t.Context(), 9))
+}
+
 func TestCreateAgent(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -308,6 +308,15 @@ type Connection struct {
 	Type string `json:"type"`
 }
 
+// ConnectionSet represents a Bruin Cloud connection set (dev-env secret): a named
+// bundle of connections an agent runs against via its connection_set_id.
+type ConnectionSet struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
 // Dashboard represents a Bruin Cloud dashboard. State is only populated by the
 // single-dashboard endpoint and carries the published definition as raw JSON.
 type Dashboard struct {


### PR DESCRIPTION
Adds `bruin cloud connection-sets list/get/create/update/delete` and a `--connection-set-id` flag on `bruin cloud agents update`, for managing connection sets (named bundles of connections an agent runs against) from local.

- `list` — the team's sets. `get --set-id` — a set's connections (names/types only).
- `create --name --connection … [--skip-validation]` / `update --set-id --connection …` — read each connection from the local `.bruin.yml` (inlining `service_account_file`), send full config per connection (the API takes no partial edits).
- `delete --set-id` — refused while an agent is still assigned.
- `agents update --connection-set-id <id>` assigns a set to an agent (`0` detaches).

New client methods `List/Get/Create/Update/DeleteConnectionSet` + `ConnectionSet`/`ConnectionSetInput` types. Tests + docs included.

Cloud API: bruin-data/cloud #2992 (read/lifecycle/assign, merged) + #2996 (create/update).