### PR TITLE
Add scheduled-agents trigger + delete to the cloud CLI

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4421,6 +4421,8 @@ func CloudScheduledAgents() *cli.Command {
 			cloudScheduledAgentsGet(),
 			cloudScheduledAgentsCreate(),
 			cloudScheduledAgentsUpdate(),
+			cloudScheduledAgentsTrigger(),
+			cloudScheduledAgentsDelete(),
 			cloudScheduledAgentsRunStates(),
 		},
 	}
@@ -4835,6 +4837,86 @@ func cloudScheduledAgentsUpdate() *cli.Command {
 			}
 
 			infoPrinter.Printf("Updated scheduled agent %d (%s).\n", run.ID, derefString(run.Title))
+			return nil
+		},
+	}
+}
+
+func cloudScheduledAgentsTrigger() *cli.Command {
+	return &cli.Command{
+		Name:  "trigger",
+		Usage: "Run a scheduled agent now, off its schedule (the schedule is untouched)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "scheduled-agent-id",
+				Usage:    "scheduled agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			execution, err := client.TriggerScheduledAgent(ctx, c.Int("scheduled-agent-id"))
+			if err != nil {
+				printError(err, output, "Failed to trigger scheduled agent")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(execution, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Triggered scheduled agent %d — execution %d is running in thread %d.\n", c.Int("scheduled-agent-id"), execution.ExecutionID, execution.ThreadID)
+			return nil
+		},
+	}
+}
+
+func cloudScheduledAgentsDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a scheduled agent so it stops firing",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "scheduled-agent-id",
+				Usage:    "scheduled agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteScheduledAgent(ctx, c.Int("scheduled-agent-id")); err != nil {
+				printError(err, output, "Failed to delete scheduled agent")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted scheduled agent %d.\n", c.Int("scheduled-agent-id"))
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -475,7 +475,7 @@ func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	cmd := CloudScheduledAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "scheduled-agents", cmd.Name)
-	require.Len(t, cmd.Commands, 5)
+	require.Len(t, cmd.Commands, 7)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -485,6 +485,8 @@ func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "get")
 	assert.Contains(t, subNames, "create")
 	assert.Contains(t, subNames, "update")
+	assert.Contains(t, subNames, "trigger")
+	assert.Contains(t, subNames, "delete")
 	assert.Contains(t, subNames, "run-states")
 }
 

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -985,6 +985,24 @@ bruin cloud scheduled-agents update --scheduled-agent-id 42 --cron "0 8 * * 1"
 bruin cloud scheduled-agents update --scheduled-agent-id 42 --state-file ./plan.yaml
 ```
 
+#### `trigger`
+
+Run a scheduled agent now, off its schedule — the "Run now" action. The schedule
+is untouched (the next scheduled run still fires as planned). Refused while a run
+is already in progress. Prints the execution and thread ids.
+
+```bash
+bruin cloud scheduled-agents trigger --scheduled-agent-id 42
+```
+
+#### `delete`
+
+Delete a scheduled agent so it stops firing.
+
+```bash
+bruin cloud scheduled-agents delete --scheduled-agent-id 42
+```
+
 #### `run-states`
 
 Manage a scheduled agent's **run-state** files — the markdown "memory" the agent

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -863,6 +863,23 @@ func (c *APIClient) UpdateScheduledAgent(ctx context.Context, scheduledAgentID i
 	return &result, nil
 }
 
+// DeleteScheduledAgent deletes a scheduled agent so it stops firing
+// (soft-deleted server-side, mirroring the UI).
+func (c *APIClient) DeleteScheduledAgent(ctx context.Context, scheduledAgentID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/scheduled-agents/%d", scheduledAgentID), nil, nil)
+}
+
+// TriggerScheduledAgent runs a scheduled agent immediately, off its schedule; the
+// schedule itself is untouched. Returns the execution that was stood up.
+func (c *APIClient) TriggerScheduledAgent(ctx context.Context, scheduledAgentID int) (*ScheduledAgentExecution, error) {
+	var result ScheduledAgentExecution
+	err := c.doRequest(ctx, http.MethodPost, fmt.Sprintf("/scheduled-agents/%d/trigger", scheduledAgentID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // --- Scheduled agent run state ---
 
 // ListRunStates returns the run-state ("memory") files persisted on a scheduled

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1344,6 +1344,34 @@ func TestUpdateScheduledAgent(t *testing.T) {
 	assert.Equal(t, "Renamed", *run.Title)
 }
 
+func TestTriggerScheduledAgent(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/scheduled-agents/11/trigger", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, ScheduledAgentExecution{ExecutionID: 42, ThreadID: 99})
+	})
+
+	execution, err := client.TriggerScheduledAgent(t.Context(), 11)
+	require.NoError(t, err)
+	assert.Equal(t, 42, execution.ExecutionID)
+	assert.Equal(t, 99, execution.ThreadID)
+}
+
+func TestDeleteScheduledAgent(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/scheduled-agents/11", r.URL.Path)
+
+		writeJSON(t, w, map[string]bool{"success": true})
+	})
+
+	require.NoError(t, client.DeleteScheduledAgent(t.Context(), 11))
+}
+
 func TestGetCostExplorerSchema(t *testing.T) {
 	t.Parallel()
 	var gotPath string

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -360,6 +360,13 @@ type ScheduledAgent struct {
 	RecentExecutions  json.RawMessage `json:"recent_executions,omitempty"`
 }
 
+// ScheduledAgentExecution is the execution a trigger stands up: the run that was
+// just kicked off, and the thread it runs in.
+type ScheduledAgentExecution struct {
+	ExecutionID int `json:"execution_id"`
+	ThreadID    int `json:"thread_id"`
+}
+
 // AuditLog is one entry in a team's audit trail as returned by GET /audit-logs.
 // Metadata is event-specific and left raw.
 type AuditLog struct {


### PR DESCRIPTION
Adds the two scheduled-agent commands matching the new cloud API endpoints:

```
bruin cloud scheduled-agents trigger --scheduled-agent-id <id>
bruin cloud scheduled-agents delete  --scheduled-agent-id <id>
```

- `trigger` runs the agent now, off its schedule (the schedule is left untouched), and prints the execution + thread ids.
- `delete` removes the scheduled agent so it stops firing.

Client methods `TriggerScheduledAgent`/`DeleteScheduledAgent` + a `ScheduledAgentExecution` type, with client tests and the help-count bump. Depends on the cloud API PR (bruin-data/cloud#3004).