### PR TITLE
Add dashboards delete to the cloud CLI

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4430,6 +4430,11 @@ func cloudDashboardsDelete() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
+			if c.Int("dashboard-id") <= 0 {
+				printError(fmt.Errorf("--dashboard-id must be a positive integer, got %d", c.Int("dashboard-id")), output, "Invalid --dashboard-id")
+				return cli.Exit("", 1)
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3993,6 +3993,7 @@ func CloudDashboards() *cli.Command {
 			cloudDashboardsGet(),
 			cloudDashboardsCreate(),
 			cloudDashboardsUpdate(),
+			cloudDashboardsDelete(),
 		},
 	}
 }
@@ -4407,6 +4408,45 @@ func cloudDashboardsUpdate() *cli.Command {
 			} else {
 				infoPrinter.Printf("Updated dashboard %d (%s).\n", dashboard.ID, title)
 			}
+			return nil
+		},
+	}
+}
+
+func cloudDashboardsDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a dashboard so it stops appearing",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "dashboard-id",
+				Usage:    "dashboard ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteDashboard(ctx, c.Int("dashboard-id")); err != nil {
+				printError(err, output, "Failed to delete dashboard")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted dashboard %d.\n", c.Int("dashboard-id"))
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -348,7 +348,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	cmd := CloudDashboards()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "dashboards", cmd.Name)
-	require.Len(t, cmd.Commands, 4)
+	require.Len(t, cmd.Commands, 5)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -358,6 +358,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "get")
 	assert.Contains(t, subNames, "create")
 	assert.Contains(t, subNames, "update")
+	assert.Contains(t, subNames, "delete")
 }
 
 // cliRunMu serializes cli.Command.Run: urfave/cli's ensureHelp resets the

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -947,6 +947,16 @@ bruin cloud dashboards update --dashboard-id 42 --state-file ./dashboard.json
 bruin cloud dashboards update --dashboard-id 42 --visibility team
 ```
 
+#### `delete`
+
+Delete a dashboard so it stops appearing. Requires manage-access (the dashboard
+creator or a team admin); repo (DAC) dashboards are managed in the repo and can't
+be deleted here.
+
+```bash
+bruin cloud dashboards delete --dashboard-id 42
+```
+
 ---
 
 ### `scheduled-agents`

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -823,6 +823,12 @@ func (c *APIClient) UpdateDashboard(ctx context.Context, dashboardID int, fields
 	return &result, nil
 }
 
+// DeleteDashboard deletes a dashboard so it stops appearing (soft-deleted
+// server-side, mirroring the UI). Requires an owner or team admin.
+func (c *APIClient) DeleteDashboard(ctx context.Context, dashboardID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/dashboards/%d", dashboardID), nil, nil)
+}
+
 func (c *APIClient) ListScheduledAgents(ctx context.Context) ([]ScheduledAgent, error) {
 	var resp struct {
 		ScheduledAgents []ScheduledAgent `json:"scheduled_agents"`

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1249,6 +1249,18 @@ func TestUpdateDashboard(t *testing.T) {
 	assert.Equal(t, "Renamed", *dashboard.Title)
 }
 
+func TestDeleteDashboard(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/dashboards/9", r.URL.Path)
+
+		writeJSON(t, w, map[string]bool{"success": true})
+	})
+
+	require.NoError(t, client.DeleteDashboard(t.Context(), 9))
+}
+
 func TestListScheduledAgents(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`bruin cloud dashboards delete --dashboard-id <id>` — the client half of the new `DELETE /api/v1/dashboards/{id}` endpoint (bruin-data/cloud#3006, merged).

Client method `DeleteDashboard`, plus the help-count bump and a client test. Requires manage-access (creator/team admin) server-side; repo dashboards are rejected.