### PR TITLE
Add agent thread management to the cloud CLI

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3042,14 +3042,26 @@ func cloudAgentsStatus() *cli.Command {
 func cloudAgentsThreads() *cli.Command {
 	return &cli.Command{
 		Name:  "threads",
-		Usage: "List threads for an agent",
+		Usage: "List an agent's threads, or manage one with the 'rename'/'archive'/'unarchive'/'delete' subcommands",
+		// Backward compatible: the bare command still lists (its Action below); the
+		// subcommands manage a thread. --agent-id is therefore not Required on the
+		// parent (that would also demand it for the subcommands); the Action validates it.
+		Commands: []*cli.Command{
+			cloudAgentsThreadsRename(),
+			cloudAgentsThreadsArchive(),
+			cloudAgentsThreadsUnarchive(),
+			cloudAgentsThreadsDelete(),
+		},
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
 			&cli.IntFlag{
-				Name:     "agent-id",
-				Usage:    "agent ID",
-				Required: true,
+				Name:  "agent-id",
+				Usage: "agent ID",
+			},
+			&cli.BoolFlag{
+				Name:  "archived",
+				Usage: "list archived threads instead of active ones",
 			},
 			limitFlag(),
 			offsetFlag(),
@@ -3058,13 +3070,18 @@ func cloudAgentsThreads() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
+			if c.Int("agent-id") <= 0 {
+				printError(fmt.Errorf("--agent-id must be a positive integer, got %d", c.Int("agent-id")), output, "Invalid --agent-id")
+				return cli.Exit("", 1)
+			}
+
 			client, err := newCloudClient(c)
 			if err != nil {
 				printError(err, output, "Failed to create API client")
 				return cli.Exit("", 1)
 			}
 
-			threads, err := client.ListAgentThreads(ctx, c.Int("agent-id"), c.Int("limit"), c.Int("offset"))
+			threads, err := client.ListAgentThreads(ctx, c.Int("agent-id"), c.Int("limit"), c.Int("offset"), c.Bool("archived"))
 			if err != nil {
 				printError(err, output, "Failed to list threads")
 				return cli.Exit("", 1)
@@ -3078,11 +3095,152 @@ func cloudAgentsThreads() *cli.Command {
 
 			t := table.NewWriter()
 			t.SetOutputMirror(os.Stdout)
-			t.AppendHeader(table.Row{"ID", "Agent ID", "Created At", "Updated At"})
+			t.AppendHeader(table.Row{"ID", "Agent ID", "Title", "Created At", "Updated At", "Archived At"})
 			for _, th := range threads {
-				t.AppendRow(table.Row{th.ID, th.AgentID, th.CreatedAt, th.UpdatedAt})
+				t.AppendRow(table.Row{th.ID, th.AgentID, derefString(th.Title), th.CreatedAt, th.UpdatedAt, derefString(th.ArchivedAt)})
 			}
 			t.Render()
+			return nil
+		},
+	}
+}
+
+// threadIDFlags are the required agent-id + thread-id flags shared by the thread
+// management subcommands.
+func threadIDFlags() []cli.Flag {
+	return []cli.Flag{
+		apiKeyFlag(),
+		outputFlag(),
+		&cli.IntFlag{Name: "agent-id", Usage: "agent ID", Required: true},
+		&cli.IntFlag{Name: "thread-id", Usage: "thread ID", Required: true},
+	}
+}
+
+func cloudAgentsThreadsRename() *cli.Command {
+	return &cli.Command{
+		Name:  "rename",
+		Usage: "Rename a thread",
+		Flags: append(threadIDFlags(), &cli.StringFlag{
+			Name:     "title",
+			Usage:    "the new thread title",
+			Required: true,
+		}),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			thread, err := client.UpdateAgentThread(ctx, c.Int("agent-id"), c.Int("thread-id"), map[string]any{"title": c.String("title")})
+			if err != nil {
+				printError(err, output, "Failed to rename thread")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(thread, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Renamed thread %d to %q.\n", thread.ID, derefString(thread.Title))
+			return nil
+		},
+	}
+}
+
+func cloudAgentsThreadsArchive() *cli.Command {
+	return &cli.Command{
+		Name:  "archive",
+		Usage: "Archive a thread",
+		Flags: threadIDFlags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if _, err := client.UpdateAgentThread(ctx, c.Int("agent-id"), c.Int("thread-id"), map[string]any{"archived": true}); err != nil {
+				printError(err, output, "Failed to archive thread")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Archived thread %d.\n", c.Int("thread-id"))
+			return nil
+		},
+	}
+}
+
+func cloudAgentsThreadsUnarchive() *cli.Command {
+	return &cli.Command{
+		Name:  "unarchive",
+		Usage: "Restore an archived thread",
+		Flags: threadIDFlags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if _, err := client.UpdateAgentThread(ctx, c.Int("agent-id"), c.Int("thread-id"), map[string]any{"archived": false}); err != nil {
+				printError(err, output, "Failed to unarchive thread")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Unarchived thread %d.\n", c.Int("thread-id"))
+			return nil
+		},
+	}
+}
+
+func cloudAgentsThreadsDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a thread",
+		Flags: threadIDFlags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteAgentThread(ctx, c.Int("agent-id"), c.Int("thread-id")); err != nil {
+				printError(err, output, "Failed to delete thread")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted thread %d.\n", c.Int("thread-id"))
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -343,6 +343,25 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "export-thread")
 }
 
+func TestCloudAgentsThreadsCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := cloudAgentsThreads()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "threads", cmd.Name)
+	// The bare command still lists (default Action); management verbs are subcommands.
+	require.NotNil(t, cmd.Action)
+	require.Len(t, cmd.Commands, 4)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "rename")
+	assert.Contains(t, subNames, "archive")
+	assert.Contains(t, subNames, "unarchive")
+	assert.Contains(t, subNames, "delete")
+}
+
 func TestCloudDashboardsCommand_Help(t *testing.T) {
 	t.Parallel()
 	cmd := CloudDashboards()

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -643,10 +643,25 @@ bruin cloud agents status \
 
 #### `threads`
 
-List all threads for an agent:
+List an agent's threads (active by default; pass `--archived` for archived ones):
 
 ```bash
 bruin cloud agents threads --agent-id <agent-id>
+bruin cloud agents threads --agent-id <agent-id> --archived
+```
+
+Manage a thread with the subcommands:
+
+```bash
+# Rename
+bruin cloud agents threads rename --agent-id <agent-id> --thread-id <thread-id> --title "New title"
+
+# Archive / restore (archiving also unpins)
+bruin cloud agents threads archive   --agent-id <agent-id> --thread-id <thread-id>
+bruin cloud agents threads unarchive --agent-id <agent-id> --thread-id <thread-id>
+
+# Delete
+bruin cloud agents threads delete --agent-id <agent-id> --thread-id <thread-id>
 ```
 
 #### `messages`

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -607,13 +607,16 @@ func (c *APIClient) GetAgentMessageStatus(ctx context.Context, agentID, threadID
 	return &resp.Data, nil
 }
 
-func (c *APIClient) ListAgentThreads(ctx context.Context, agentID int, limit, offset int) ([]AgentThread, error) {
+func (c *APIClient) ListAgentThreads(ctx context.Context, agentID int, limit, offset int, archived bool) ([]AgentThread, error) {
 	params := url.Values{}
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
 	}
 	if offset > 0 {
 		params.Set("offset", strconv.Itoa(offset))
+	}
+	if archived {
+		params.Set("archived", "true")
 	}
 	path := fmt.Sprintf("/agents/%d/threads", agentID)
 	if len(params) > 0 {
@@ -624,6 +627,22 @@ func (c *APIClient) ListAgentThreads(ctx context.Context, agentID int, limit, of
 	}
 	err := c.doRequest(ctx, http.MethodGet, path, nil, &resp)
 	return resp.Threads, err
+}
+
+// UpdateAgentThread renames a thread (title) and/or archives it (archived); the
+// server also unpins an archived thread.
+func (c *APIClient) UpdateAgentThread(ctx context.Context, agentID, threadID int, fields map[string]any) (*AgentThread, error) {
+	var result AgentThread
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/agents/%d/threads/%d", agentID, threadID), fields, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteAgentThread soft-deletes a chat thread (mirroring the UI).
+func (c *APIClient) DeleteAgentThread(ctx context.Context, agentID, threadID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/agents/%d/threads/%d", agentID, threadID), nil, nil)
 }
 
 func (c *APIClient) GetAgentPrompt(ctx context.Context, agentID int) (*AgentPrompt, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -885,10 +885,54 @@ func TestListAgentThreads(t *testing.T) {
 		})
 	})
 
-	threads, err := client.ListAgentThreads(t.Context(), 1, 0, 0)
+	threads, err := client.ListAgentThreads(t.Context(), 1, 0, 0, false)
 	require.NoError(t, err)
 	require.Len(t, threads, 1)
 	assert.Equal(t, 10, threads[0].ID)
+}
+
+func TestListAgentThreadsArchived(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/agents/1/threads", r.URL.Path)
+		assert.Equal(t, "true", r.URL.Query().Get("archived"))
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"threads": []AgentThread{}})
+	})
+
+	_, err := client.ListAgentThreads(t.Context(), 1, 0, 0, true)
+	require.NoError(t, err)
+}
+
+func TestUpdateAgentThread(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/agents/1/threads/10", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "Renamed", body["title"])
+
+		w.WriteHeader(http.StatusOK)
+		title := "Renamed"
+		writeJSON(t, w, AgentThread{ID: 10, AgentID: 1, Title: &title})
+	})
+
+	thread, err := client.UpdateAgentThread(t.Context(), 1, 10, map[string]any{"title": "Renamed"})
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed", *thread.Title)
+}
+
+func TestDeleteAgentThread(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/agents/1/threads/10", r.URL.Path)
+		writeJSON(t, w, map[string]bool{"success": true})
+	})
+
+	require.NoError(t, client.DeleteAgentThread(t.Context(), 1, 10))
 }
 
 func TestListAgentMessages(t *testing.T) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -163,10 +163,12 @@ type AgentConnection struct {
 
 // AgentThread represents a thread for an agent.
 type AgentThread struct {
-	ID        int    `json:"id"`
-	AgentID   int    `json:"agent_id"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID         int     `json:"id"`
+	AgentID    int     `json:"agent_id"`
+	Title      *string `json:"title"`
+	CreatedAt  string  `json:"created_at"`
+	UpdatedAt  string  `json:"updated_at"`
+	ArchivedAt *string `json:"archived_at"`
 }
 
 // AgentPrompt represents an agent's system prompt.


### PR DESCRIPTION
The client half of the new agent thread-management endpoints (bruin-data/cloud#3010).

`bruin cloud agents threads` gains subcommands:
```
bruin cloud agents threads --agent-id <id> [--archived]     # list active (or archived)
bruin cloud agents threads rename    --agent-id <id> --thread-id <tid> --title "..."
bruin cloud agents threads archive   --agent-id <id> --thread-id <tid>
bruin cloud agents threads unarchive --agent-id <id> --thread-id <tid>
bruin cloud agents threads delete    --agent-id <id> --thread-id <tid>
```

The bare `threads` command still lists (default action + nested subcommands, like `agents connections`). Client methods `UpdateAgentThread`/`DeleteAgentThread` + `--archived` on `ListAgentThreads`; `AgentThread` gains `title`/`archived_at`. Depends on the cloud PR.