### PR TITLE
Add agents delete to the cloud CLI

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2245,6 +2245,7 @@ func CloudAgents() *cli.Command {
 			cloudAgentsCreate(),
 			cloudAgentsGet(),
 			cloudAgentsUpdate(),
+			cloudAgentsDelete(),
 			cloudAgentsSend(),
 			cloudAgentsStatus(),
 			cloudAgentsThreads(),
@@ -2561,6 +2562,45 @@ func cloudAgentsUpdate() *cli.Command {
 			}
 
 			infoPrinter.Printf("Updated agent %d (%s)\n", agent.ID, agent.Name)
+			return nil
+		},
+	}
+}
+
+func cloudAgentsDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete an agent (cascades to its scheduled agents, dashboards and threads)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "agent-id",
+				Usage:    "agent ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteAgent(ctx, c.Int("agent-id")); err != nil {
+				printError(err, output, "Failed to delete agent")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted agent %d.\n", c.Int("agent-id"))
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -329,12 +329,13 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 16)
+	require.Len(t, cmd.Commands, 17)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
 		subNames[i] = sub.Name
 	}
+	assert.Contains(t, subNames, "delete")
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "mcp")
 	assert.Contains(t, subNames, "get-memory")

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -557,6 +557,15 @@ List available agents:
 bruin cloud agents list
 ```
 
+#### `delete`
+
+Delete an agent. Cascades to its scheduled agents, dashboards and chat threads,
+and revokes its Cloud-CLI token. Requires an owner or team admin.
+
+```bash
+bruin cloud agents delete --agent-id <agent-id>
+```
+
 #### `connections`
 
 List the connections available to an agent — names and types only (never

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -567,6 +567,12 @@ func (c *APIClient) UpdateAgent(ctx context.Context, agentID int, fields map[str
 	return &result, nil
 }
 
+// DeleteAgent deletes an agent and cascades to what it owns (scheduled agents,
+// dashboards, threads), revoking its Cloud-CLI token. Requires an owner or team admin.
+func (c *APIClient) DeleteAgent(ctx context.Context, agentID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/agents/%d", agentID), nil, nil)
+}
+
 // ListAgentMcpServers returns the agent's current external MCP server picks
 // along with the supported kinds and the connections eligible for each.
 func (c *APIClient) ListAgentMcpServers(ctx context.Context, agentID int) (*AgentMcpServersResponse, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -746,6 +746,17 @@ func TestUpdateAgent(t *testing.T) {
 	assert.Equal(t, "renamed", agent.Name)
 }
 
+func TestDeleteAgent(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/agents/7", r.URL.Path)
+		writeJSON(t, w, map[string]bool{"success": true})
+	})
+
+	require.NoError(t, client.DeleteAgent(t.Context(), 7))
+}
+
 func TestGetAgentMemory(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`bruin cloud agents delete --agent-id <id>` — the client half of the new `DELETE /api/v1/agents/{id}` endpoint (bruin-data/cloud#3016).

Client method `DeleteAgent`, help-count bump, and a client test. Server-side it cascades (scheduled agents, dashboards, threads) and requires an owner or team admin.