### PR TITLE
Add agents usage-stats to the cloud CLI

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2242,6 +2242,7 @@ func CloudAgents() *cli.Command {
 		Usage: "Manage Bruin Cloud agents",
 		Commands: []*cli.Command{
 			cloudAgentsList(),
+			cloudAgentsUsageStats(),
 			cloudAgentsCreate(),
 			cloudAgentsGet(),
 			cloudAgentsUpdate(),
@@ -3244,6 +3245,92 @@ func cloudAgentsThreadsDelete() *cli.Command {
 			return nil
 		},
 	}
+}
+
+func cloudAgentsUsageStats() *cli.Command {
+	return &cli.Command{
+		Name:  "usage-stats",
+		Usage: "Show AI usage across the agents you can see (messages, threads, per-agent breakdown)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "days", Usage: "window size in days (default 30); ignored if --start-date and --end-date are set"},
+			&cli.StringFlag{Name: "start-date", Usage: "range start (YYYY-MM-DD); use with --end-date"},
+			&cli.StringFlag{Name: "end-date", Usage: "range end (YYYY-MM-DD); use with --start-date"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			raw, err := client.GetAgentUsageStats(ctx, c.String("start-date"), c.String("end-date"), c.Int("days"))
+			if err != nil {
+				printError(err, output, "Failed to get usage stats")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				var pretty bytes.Buffer
+				if json.Indent(&pretty, raw, "", "  ") == nil {
+					fmt.Println(pretty.String())
+				} else {
+					fmt.Println(string(raw))
+				}
+				return nil
+			}
+
+			var s struct {
+				Totals struct {
+					TotalMessages json.Number `json:"total_messages"`
+					TotalThreads  json.Number `json:"total_threads"`
+				} `json:"totals"`
+				CurrentMonth struct {
+					Messages int `json:"messages"`
+					Threads  int `json:"threads"`
+				} `json:"currentMonth"`
+				PerAgent []struct {
+					AgentName    string      `json:"agent_name"`
+					MessageCount json.Number `json:"message_count"`
+					ThreadCount  json.Number `json:"thread_count"`
+				} `json:"perAgent"`
+			}
+			if err := json.Unmarshal(raw, &s); err != nil {
+				// Fall back to the raw payload if the shape is unexpected.
+				fmt.Println(string(raw))
+				return nil
+			}
+
+			infoPrinter.Printf("Totals: %s messages across %s threads. This month: %d messages, %d threads.\n",
+				numOrZero(s.Totals.TotalMessages), numOrZero(s.Totals.TotalThreads), s.CurrentMonth.Messages, s.CurrentMonth.Threads)
+
+			if len(s.PerAgent) == 0 {
+				infoPrinter.Println("No per-agent activity in the selected range.")
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"Agent", "Messages", "Threads"})
+			for _, a := range s.PerAgent {
+				t.AppendRow(table.Row{a.AgentName, numOrZero(a.MessageCount), numOrZero(a.ThreadCount)})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+// numOrZero renders a json.Number, defaulting a blank to "0".
+func numOrZero(n json.Number) string {
+	if n == "" {
+		return "0"
+	}
+	return n.String()
 }
 
 func cloudAgentsGetPrompt() *cli.Command {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3268,7 +3268,13 @@ func cloudAgentsUsageStats() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			raw, err := client.GetAgentUsageStats(ctx, c.String("start-date"), c.String("end-date"), c.Int("days"))
+			// An explicit start/end range wins server-side, so don't also send a
+			// contradictory --days alongside it.
+			days := c.Int("days")
+			if c.String("start-date") != "" && c.String("end-date") != "" {
+				days = 0
+			}
+			raw, err := client.GetAgentUsageStats(ctx, c.String("start-date"), c.String("end-date"), days)
 			if err != nil {
 				printError(err, output, "Failed to get usage stats")
 				return cli.Exit("", 1)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -329,12 +329,13 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 16)
+	require.Len(t, cmd.Commands, 17)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
 		subNames[i] = sub.Name
 	}
+	assert.Contains(t, subNames, "usage-stats")
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "mcp")
 	assert.Contains(t, subNames, "get-memory")

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -557,6 +557,20 @@ List available agents:
 bruin cloud agents list
 ```
 
+#### `usage-stats`
+
+Show AI usage across the agents you can see — total messages/threads, the
+current month's counters, and a per-agent breakdown. Defaults to the last 30
+days; pass `--days`, or an explicit `--start-date`/`--end-date` window. Use
+`--output json` for the full payload (per-day/per-month/per-user series).
+
+```bash
+bruin cloud agents usage-stats
+bruin cloud agents usage-stats --days 7
+bruin cloud agents usage-stats --start-date 2026-01-01 --end-date 2026-01-31
+bruin cloud agents usage-stats --output json
+```
+
 #### `connections`
 
 List the connections available to an agent — names and types only (never

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -500,6 +500,29 @@ func (c *APIClient) ListAgents(ctx context.Context) ([]Agent, error) {
 	return resp.Agents, err
 }
 
+// GetAgentUsageStats returns AI-usage aggregates across the agents the token can
+// see. Pass startDate+endDate (YYYY-MM-DD) for an explicit window, else the last
+// days (0 = server default). The payload is nested and returned raw.
+func (c *APIClient) GetAgentUsageStats(ctx context.Context, startDate, endDate string, days int) (json.RawMessage, error) {
+	params := url.Values{}
+	if startDate != "" {
+		params.Set("startDate", startDate)
+	}
+	if endDate != "" {
+		params.Set("endDate", endDate)
+	}
+	if days > 0 {
+		params.Set("days", strconv.Itoa(days))
+	}
+	path := "/agents/usage-stats"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	var result json.RawMessage
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &result)
+	return result, err
+}
+
 // ListAgentConnections returns the connection names and types available to the
 // agent (from its dev-env secret) — names/types only, never credentials. Use it
 // to pick a connection the agent can actually query.

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -541,6 +541,21 @@ func TestListAgents(t *testing.T) {
 	assert.Equal(t, "test-agent", agents[0].Name)
 }
 
+func TestGetAgentUsageStats(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/agents/usage-stats", r.URL.Path)
+		assert.Equal(t, "2026-01-01", r.URL.Query().Get("startDate"))
+		assert.Equal(t, "2026-01-31", r.URL.Query().Get("endDate"))
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"totals": map[string]any{"total_messages": 3, "total_threads": 1}})
+	})
+
+	raw, err := client.GetAgentUsageStats(t.Context(), "2026-01-01", "2026-01-31", 0)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "total_messages")
+}
+
 func TestListAgentConnections(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`bruin cloud agents usage-stats` — the client half of the new `GET /api/v1/agents/usage-stats` endpoint (bruin-data/cloud#3018).

Prints totals + current-month + a per-agent table by default; `--output json` returns the full nested payload (per-day/per-month/per-user series). Window via `--days` (default 30) or `--start-date`/`--end-date`. Client method `GetAgentUsageStats`, help-count bump, client test.