### PR TITLE
Add the skills command group to the cloud CLI

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4248,6 +4248,32 @@ func skillFieldsFromFlags(c *cli.Command) (map[string]any, error) {
 	return fields, nil
 }
 
+// skillUpdateFields builds a partial update from only the flags that were set, so a
+// caller can change one field without resending the whole skill.
+func skillUpdateFields(c *cli.Command) (map[string]any, error) {
+	fields := map[string]any{}
+	if c.IsSet("name") {
+		fields["name"] = c.String("name")
+	}
+	if c.IsSet("description") {
+		fields["description"] = c.String("description")
+	}
+	if c.IsSet("body") || c.IsSet("body-file") {
+		body, err := resolveSkillBody(c)
+		if err != nil {
+			return nil, err
+		}
+		fields["body"] = body
+	}
+	if c.IsSet("all-agents") {
+		fields["all_agents"] = c.Bool("all-agents")
+	}
+	if len(fields) == 0 {
+		return nil, errors.New("provide at least one field to update (--name, --description, --body/--body-file or --all-agents)")
+	}
+	return fields, nil
+}
+
 func cloudSkillsList() *cli.Command {
 	return &cli.Command{
 		Name:  "list",
@@ -4337,15 +4363,24 @@ func cloudSkillsCreate() *cli.Command {
 func cloudSkillsUpdate() *cli.Command {
 	return &cli.Command{
 		Name:  "update",
-		Usage: "Update a skill (name, description and body are all replaced)",
-		Flags: append(skillContentFlags(), &cli.IntFlag{Name: "skill-id", Usage: "skill ID", Required: true}),
+		Usage: "Update a skill (only the fields you pass change)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "skill-id", Usage: "skill ID", Required: true},
+			&cli.StringFlag{Name: "name", Usage: "new skill name"},
+			&cli.StringFlag{Name: "description", Usage: "new description"},
+			&cli.StringFlag{Name: "body", Usage: "new skill instructions"},
+			&cli.StringFlag{Name: "body-file", Usage: "path to a file with the new skill instructions"},
+			&cli.BoolFlag{Name: "all-agents", Usage: "apply to every agent on the team (--all-agents=false to unset)"},
+		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
-			fields, err := skillFieldsFromFlags(c)
+			fields, err := skillUpdateFields(c)
 			if err != nil {
-				printError(err, output, "Invalid skill")
+				printError(err, output, "Invalid update")
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -43,6 +43,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudConnectionSets(),
 			CloudDashboards(),
 			CloudScheduledAgents(),
+			CloudSkills(),
 			CloudAuditLogs(),
 			CloudCost(),
 		},
@@ -4180,6 +4181,279 @@ func connectionSetInputsFromConfig(ctx context.Context, names []string, environm
 		inputs = append(inputs, bruincloud.ConnectionSetInput{Type: connType, Name: name, Config: credentials})
 	}
 	return inputs, nil
+}
+
+func CloudSkills() *cli.Command {
+	return &cli.Command{
+		Name:  "skills",
+		Usage: "Manage Bruin Cloud team skills (instruction snippets attached to agents)",
+		Commands: []*cli.Command{
+			cloudSkillsList(),
+			cloudSkillsCreate(),
+			cloudSkillsUpdate(),
+			cloudSkillsDelete(),
+			cloudSkillsSetAgents(),
+		},
+	}
+}
+
+// skillContentFlags are the create/update flags. The server requires name,
+// description and a body on both, so name/description are required here and the
+// body (via --body or --body-file) is validated in the action.
+func skillContentFlags() []cli.Flag {
+	return []cli.Flag{
+		apiKeyFlag(),
+		outputFlag(),
+		&cli.StringFlag{Name: "name", Usage: "skill name (letters, numbers, '_' and '-')", Required: true},
+		&cli.StringFlag{Name: "description", Usage: "short description", Required: true},
+		&cli.StringFlag{Name: "body", Usage: "the skill instructions"},
+		&cli.StringFlag{Name: "body-file", Usage: "path to a file with the skill instructions"},
+		&cli.BoolFlag{Name: "all-agents", Usage: "apply to every agent on the team"},
+	}
+}
+
+// resolveSkillBody reads the body from --body or --body-file (exactly one required).
+func resolveSkillBody(c *cli.Command) (string, error) {
+	body := c.String("body")
+	file := c.String("body-file")
+	if body != "" && file != "" {
+		return "", errors.New("pass only one of --body or --body-file")
+	}
+	if file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("failed to read --body-file: %w", err)
+		}
+		return string(data), nil
+	}
+	if body == "" {
+		return "", errors.New("provide the skill body via --body or --body-file")
+	}
+	return body, nil
+}
+
+func skillFieldsFromFlags(c *cli.Command) (map[string]any, error) {
+	body, err := resolveSkillBody(c)
+	if err != nil {
+		return nil, err
+	}
+	fields := map[string]any{
+		"name":        c.String("name"),
+		"description": c.String("description"),
+		"body":        body,
+	}
+	if c.IsSet("all-agents") {
+		fields["all_agents"] = c.Bool("all-agents")
+	}
+	return fields, nil
+}
+
+func cloudSkillsList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List the team's skills",
+		Flags: []cli.Flag{apiKeyFlag(), outputFlag()},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			skills, err := client.ListSkills(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list skills")
+				return cli.Exit("", 1)
+			}
+			if skills == nil {
+				skills = []bruincloud.Skill{}
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(skills, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(skills) == 0 {
+				infoPrinter.Println("No skills yet.")
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Name", "Description", "All Agents", "Agents"})
+			for _, s := range skills {
+				t.AppendRow(table.Row{s.ID, s.Name, s.Description, s.AllAgents, len(s.AgentIDs)})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudSkillsCreate() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a team skill",
+		Flags: skillContentFlags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			fields, err := skillFieldsFromFlags(c)
+			if err != nil {
+				printError(err, output, "Invalid skill")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			skill, err := client.CreateSkill(ctx, fields)
+			if err != nil {
+				printError(err, output, "Failed to create skill")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(skill, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Created skill %d (%s).\n", skill.ID, skill.Name)
+			return nil
+		},
+	}
+}
+
+func cloudSkillsUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Update a skill (name, description and body are all replaced)",
+		Flags: append(skillContentFlags(), &cli.IntFlag{Name: "skill-id", Usage: "skill ID", Required: true}),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			fields, err := skillFieldsFromFlags(c)
+			if err != nil {
+				printError(err, output, "Invalid skill")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			skill, err := client.UpdateSkill(ctx, c.Int("skill-id"), fields)
+			if err != nil {
+				printError(err, output, "Failed to update skill")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(skill, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Updated skill %d (%s).\n", skill.ID, skill.Name)
+			return nil
+		},
+	}
+}
+
+func cloudSkillsDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a skill",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "skill-id", Usage: "skill ID", Required: true},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteSkill(ctx, c.Int("skill-id")); err != nil {
+				printError(err, output, "Failed to delete skill")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"deleted": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted skill %d.\n", c.Int("skill-id"))
+			return nil
+		},
+	}
+}
+
+func cloudSkillsSetAgents() *cli.Command {
+	return &cli.Command{
+		Name:  "set-agents",
+		Usage: "Set which agents a skill is attached to (replaces the set; omit --agent-id to detach all)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{Name: "skill-id", Usage: "skill ID", Required: true},
+			&cli.StringSliceFlag{Name: "agent-id", Usage: "agent ID to attach (repeatable)"},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			agentIDs := make([]int, 0, len(c.StringSlice("agent-id")))
+			for _, raw := range c.StringSlice("agent-id") {
+				id, err := strconv.Atoi(raw)
+				if err != nil {
+					printError(fmt.Errorf("invalid --agent-id %q: must be an integer", raw), output, "Invalid --agent-id")
+					return cli.Exit("", 1)
+				}
+				agentIDs = append(agentIDs, id)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			attached, err := client.SetSkillAgents(ctx, c.Int("skill-id"), agentIDs)
+			if err != nil {
+				printError(err, output, "Failed to set skill agents")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(map[string]any{"agent_ids": attached}, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Skill %d is now attached to %d agent(s): %v\n", c.Int("skill-id"), len(attached), attached)
+			return nil
+		},
+	}
 }
 
 func CloudDashboards() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -149,7 +149,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 15)
+	assert.Len(t, cmd.Commands, 16)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -169,7 +169,26 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "connection-sets")
 	assert.Contains(t, subNames, "dashboards")
 	assert.Contains(t, subNames, "scheduled-agents")
+	assert.Contains(t, subNames, "skills")
 	assert.Contains(t, subNames, "audit-logs")
+}
+
+func TestCloudSkillsCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := CloudSkills()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "skills", cmd.Name)
+	require.Len(t, cmd.Commands, 5)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.Contains(t, subNames, "list")
+	assert.Contains(t, subNames, "create")
+	assert.Contains(t, subNames, "update")
+	assert.Contains(t, subNames, "delete")
+	assert.Contains(t, subNames, "set-agents")
 }
 
 func TestCloudConnectionSetsCommand_Help(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -1074,8 +1074,9 @@ bruin cloud skills list
 bruin cloud skills create --name reporting --description "How to write reports" --body "Be concise."
 bruin cloud skills create --name reporting --description "How to write reports" --body-file ./skill.md --all-agents
 
-# Update (name, description and body are all replaced)
-bruin cloud skills update --skill-id 7 --name reporting --description "..." --body-file ./skill.md
+# Update (only the fields you pass change)
+bruin cloud skills update --skill-id 7 --body-file ./skill.md
+bruin cloud skills update --skill-id 7 --all-agents=false
 
 # Delete
 bruin cloud skills delete --skill-id 7

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -1061,6 +1061,31 @@ bruin cloud scheduled-agents run-states delete --scheduled-agent-id 42 --name me
 
 ---
 
+### `skills`
+
+Manage the team **skill library** — named instruction snippets you attach to
+agents. Team-scoped (you only see your own team's skills).
+
+```bash
+# List
+bruin cloud skills list
+
+# Create (body inline or from a file; --all-agents applies it to every agent)
+bruin cloud skills create --name reporting --description "How to write reports" --body "Be concise."
+bruin cloud skills create --name reporting --description "How to write reports" --body-file ./skill.md --all-agents
+
+# Update (name, description and body are all replaced)
+bruin cloud skills update --skill-id 7 --name reporting --description "..." --body-file ./skill.md
+
+# Delete
+bruin cloud skills delete --skill-id 7
+
+# Set which agents have the skill (replaces the set; omit --agent-id to detach all)
+bruin cloud skills set-agents --skill-id 7 --agent-id 3 --agent-id 5
+```
+
+---
+
 ### `cost`
 
 Explore warehouse costs, mirroring the Cost Explorer in the Bruin Cloud UI.

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -814,8 +814,7 @@ func (c *APIClient) CreateSkill(ctx context.Context, fields map[string]any) (*Sk
 	return &resp.Skill, nil
 }
 
-// UpdateSkill replaces a skill's name, description, body and all_agents (the server
-// requires all of them).
+// UpdateSkill applies a partial update — only the fields present are changed.
 func (c *APIClient) UpdateSkill(ctx context.Context, skillID int, fields map[string]any) (*Skill, error) {
 	var resp struct {
 		Skill Skill `json:"skill"`

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -792,6 +792,58 @@ func (c *APIClient) DeleteConnectionSet(ctx context.Context, setID int) error {
 	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/connection-sets/%d", setID), nil, nil)
 }
 
+// --- Skills ---
+
+func (c *APIClient) ListSkills(ctx context.Context) ([]Skill, error) {
+	var resp struct {
+		Skills []Skill `json:"skills"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/skills", nil, &resp)
+	return resp.Skills, err
+}
+
+// CreateSkill creates a team skill. fields must include name, description and body.
+func (c *APIClient) CreateSkill(ctx context.Context, fields map[string]any) (*Skill, error) {
+	var resp struct {
+		Skill Skill `json:"skill"`
+	}
+	err := c.doRequest(ctx, http.MethodPost, "/skills", fields, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Skill, nil
+}
+
+// UpdateSkill replaces a skill's name, description, body and all_agents (the server
+// requires all of them).
+func (c *APIClient) UpdateSkill(ctx context.Context, skillID int, fields map[string]any) (*Skill, error) {
+	var resp struct {
+		Skill Skill `json:"skill"`
+	}
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/skills/%d", skillID), fields, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Skill, nil
+}
+
+func (c *APIClient) DeleteSkill(ctx context.Context, skillID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/skills/%d", skillID), nil, nil)
+}
+
+// SetSkillAgents replaces the agents a skill is attached to; ids outside the team
+// are dropped server-side. Returns the attached ids.
+func (c *APIClient) SetSkillAgents(ctx context.Context, skillID int, agentIDs []int) ([]int, error) {
+	if agentIDs == nil {
+		agentIDs = []int{}
+	}
+	var resp struct {
+		AgentIDs []int `json:"agent_ids"`
+	}
+	err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf("/skills/%d/agents", skillID), map[string]any{"agent_ids": agentIDs}, &resp)
+	return resp.AgentIDs, err
+}
+
 // --- Dashboards ---
 
 func (c *APIClient) ListDashboards(ctx context.Context) ([]Dashboard, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -686,6 +686,80 @@ func TestDeleteConnectionSet(t *testing.T) {
 	require.NoError(t, client.DeleteConnectionSet(t.Context(), 9))
 }
 
+func TestListSkills(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/skills", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"skills": []Skill{{ID: 1, Name: "reporting", AgentIDs: []int{5}}}})
+	})
+
+	skills, err := client.ListSkills(t.Context())
+	require.NoError(t, err)
+	require.Len(t, skills, 1)
+	assert.Equal(t, "reporting", skills[0].Name)
+	assert.Equal(t, []int{5}, skills[0].AgentIDs)
+}
+
+func TestCreateSkill(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/skills", r.URL.Path)
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "sql_helper", body["name"])
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, map[string]any{"skill": Skill{ID: 3, Name: "sql_helper"}})
+	})
+
+	skill, err := client.CreateSkill(t.Context(), map[string]any{"name": "sql_helper", "description": "d", "body": "b"})
+	require.NoError(t, err)
+	assert.Equal(t, 3, skill.ID)
+}
+
+func TestUpdateSkill(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/skills/3", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"skill": Skill{ID: 3, Name: "renamed"}})
+	})
+
+	skill, err := client.UpdateSkill(t.Context(), 3, map[string]any{"name": "renamed", "description": "d", "body": "b"})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", skill.Name)
+}
+
+func TestDeleteSkill(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/skills/3", r.URL.Path)
+		writeJSON(t, w, map[string]bool{"deleted": true})
+	})
+
+	require.NoError(t, client.DeleteSkill(t.Context(), 3))
+}
+
+func TestSetSkillAgents(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/skills/3/agents", r.URL.Path)
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, []any{float64(5), float64(7)}, body["agent_ids"])
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{"agent_ids": []int{5, 7}})
+	})
+
+	ids, err := client.SetSkillAgents(t.Context(), 3, []int{5, 7})
+	require.NoError(t, err)
+	assert.Equal(t, []int{5, 7}, ids)
+}
+
 func TestCreateAgent(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -319,6 +319,17 @@ type ConnectionSet struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
+// Skill is a team skill-library entry — a named instruction snippet attached to
+// agents. AgentIDs lists the agents it's attached to.
+type Skill struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Body        string `json:"body"`
+	AllAgents   bool   `json:"all_agents"`
+	AgentIDs    []int  `json:"agent_ids"`
+}
+
 // Dashboard represents a Bruin Cloud dashboard. State is only populated by the
 // single-dashboard endpoint and carries the published definition as raw JSON.
 type Dashboard struct {


### PR DESCRIPTION
`bruin cloud skills` — the client half of the new skill-library endpoints (bruin-data/cloud#3019).

```
bruin cloud skills list
bruin cloud skills create --name reporting --description "..." --body-file ./skill.md [--all-agents]
bruin cloud skills update --skill-id 7 --name ... --description ... --body ...
bruin cloud skills delete --skill-id 7
bruin cloud skills set-agents --skill-id 7 --agent-id 3 --agent-id 5
```

Client methods `ListSkills`/`CreateSkill`/`UpdateSkill`/`DeleteSkill`/`SetSkillAgents` + `Skill` type; help-count bumps + client tests + docs. Body via `--body` or `--body-file`; `set-agents` replaces the attached set (omit `--agent-id` to detach all).