### PR TITLE
docs(chess,frankfurter): document source params in table names

### DIFF
--- a/docs/ingestion/chess.md
+++ b/docs/ingestion/chess.md
@@ -33,6 +33,10 @@ To connect to Chess, you need to add a configuration item to the connections sec
 
 - `players`: A list of players usernames for which you want to fetch data.
 
+::: warning DEPRECATED
+Specifying `players` on the connection is deprecated and will be removed in a future release. Provide the players in the `source_table` instead (see [Specifying players in the source table](#specifying-players-in-the-source-table)). If both are set, the players in the `source_table` take precedence.
+:::
+
 ### Step 2: Create an asset file for data ingestion
 
 To ingest data from Chess, you need to create an [asset configuration](/assets/ingestr#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., chess_ingestion.yml) inside the assets folder and add the following content:
@@ -54,6 +58,20 @@ parameters:
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
 - `source_connection`: The name of the Chess connection defined in .bruin.yml.
 - `source_table`: The name of the data table in Chess that you want to ingest. For example, `profiles` is the table of Chess that you want to ingest.
+
+### Specifying players in the source table
+
+Instead of listing players on the connection, you can pass them directly in the `source_table` value, appended after a colon as a comma-separated list:
+
+```yaml
+parameters:
+  source_connection: my-chess
+  source_table: 'profiles:MagnusCarlsen,Hikaru'
+
+  destination: postgres
+```
+
+Players given this way take precedence over the connection's `players`, so a single connection can feed different players into different tables. This is the recommended approach; the connection-level `players` field is deprecated.
 
 ## Available Source Tables
 

--- a/docs/ingestion/frankfurter.md
+++ b/docs/ingestion/frankfurter.md
@@ -41,6 +41,20 @@ parameters:
 - `source_connection`: The name of the Frankfurter connection defined in `.bruin.yml`.
 - `source_table`: The name of the Frankfurter table you want to ingest.
 
+### Setting the base currency
+
+Exchange rates are calculated against a base currency (default `EUR`). You can override it per table by appending the currency code to the `source_table` value after a colon:
+
+```yaml
+parameters:
+  source_connection: frankfurter
+  source_table: 'latest:USD'
+
+  destination: duckdb
+```
+
+This fetches the `latest` rates with `USD` as the base currency. It applies to the `latest` and `exchange_rates` tables.
+
 ## Available Source Tables
 
 Frankfurter source allows ingesting the following sources into separate tables:


### PR DESCRIPTION
## What

Documents the new table-name parameter syntax for the **chess** and **frankfurter** ingestr sources, now that the [ingestr side](https://github.com/bruin-data/ingestr/pull/1091) supports it.

- **chess** — players can be given in `source_table`, e.g. `source_table: 'profiles:MagnusCarlsen,Hikaru'`. Added a "Specifying players in the source table" section and a deprecation note on the connection-level `players` field.
- **frankfurter** — the base currency can be given in `source_table`, e.g. `source_table: 'latest:USD'`. Added a "Setting the base currency" section.