### PR TITLE
feat(ingestr): allow public chess and frankfurter sources without a connection

### DIFF
--- a/docs/ingestion/chess.md
+++ b/docs/ingestion/chess.md
@@ -73,6 +73,24 @@ parameters:
 
 Players given this way take precedence over the connection's `players`, so a single connection can feed different players into different tables. This is the recommended approach; the connection-level `players` field is deprecated.
 
+### Using Chess without a connection
+
+Chess is a public API and needs no credentials, so you can skip the connection entirely. Set `source_connection: chess.com` and provide the players in the `source_table`; no `chess` entry is required in `.bruin.yml`:
+
+```yaml
+name: public.chess
+type: ingestr
+connection: postgres
+
+parameters:
+  source_connection: chess.com
+  source_table: 'profiles:MagnusCarlsen,Hikaru'
+
+  destination: postgres
+```
+
+If a connection with that same name is defined in `.bruin.yml`, it takes precedence and is used as before; the public source is only used when no such connection exists.
+
 ## Available Source Tables
 
 | Table     | PK | Inc Key | Inc Strategy | Details                                                          |

--- a/docs/ingestion/frankfurter.md
+++ b/docs/ingestion/frankfurter.md
@@ -55,6 +55,24 @@ parameters:
 
 This fetches the `latest` rates with `USD` as the base currency. It applies to the `latest` and `exchange_rates` tables.
 
+### Using Frankfurter without a connection
+
+Frankfurter is a public API and needs no credentials, so you can skip the connection entirely. Set `source_connection: frankfurter.dev`; no `frankfurter` entry is required in `.bruin.yml`:
+
+```yaml
+name: dataset.frankfurter
+type: ingestr
+connection: duckdb-default
+
+parameters:
+  source_connection: frankfurter.dev
+  source_table: 'latest:USD'
+
+  destination: duckdb
+```
+
+If a connection with that same name is defined in `.bruin.yml`, it takes precedence and is used as before; the public source is only used when no such connection exists.
+
 ## Available Source Tables
 
 Frankfurter source allows ingesting the following sources into separate tables:

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -213,9 +213,17 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		return errors.New("source connection not configured")
 	}
 
-	sourceURI, err := ingestruri.ForConnection(ctx, o.conn, "source", sourceConnectionName)
-	if err != nil {
-		return err
+	var sourceURI string
+	// A public source name with no matching connection is used directly; a
+	// defined connection always wins.
+	if uri, isPublic := pipeline.ConnectionlessIngestrSources[sourceConnectionName]; isPublic && o.conn.GetConnection(sourceConnectionName) == nil {
+		sourceURI = uri
+	} else {
+		resolved, err := ingestruri.ForConnection(ctx, o.conn, "source", sourceConnectionName)
+		if err != nil {
+			return err
+		}
+		sourceURI = resolved
 	}
 
 	sourceURI = ingestruri.Normalize(sourceURI)

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -639,6 +639,32 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 				"--full-refresh",
 			},
 		},
+		{
+			name: "public chess source via domain name (no connection defined)",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "chess.com",
+					"source_table":      "profiles:magnuscarlsen",
+					"destination":       "duckdb",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "chess://", "--source-table", "profiles:magnuscarlsen", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
+		{
+			name: "public frankfurter source via domain name (no connection defined)",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "duck",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "frankfurter.dev",
+					"source_table":      "latest:USD",
+					"destination":       "duckdb",
+				},
+			},
+			want: []string{"ingest", "--source-uri", "frankfurter://", "--source-table", "latest:USD", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -669,6 +695,52 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// A connection whose name matches a public source (e.g. "chess") is defined, so
+// it must be used instead of the public chess:// fallback.
+func TestBasicOperator_DefinedConnectionWinsOverPublicSource(t *testing.T) {
+	t.Parallel()
+
+	mockChess := new(mockConnection)
+	mockChess.On("GetIngestrURI").Return("chess://?players=hikaru", nil)
+	mockDuck := new(mockConnection)
+	mockDuck.On("GetIngestrURI").Return("duckdb:////some/path", nil)
+
+	fetcher := simpleConnectionFetcher{
+		connections: map[string]*mockConnection{
+			"chess": mockChess,
+			"duck":  mockDuck,
+		},
+	}
+
+	runner := new(mockRunner)
+	want := []string{"ingest", "--source-uri", "chess://?players=hikaru", "--source-table", "profiles", "--dest-uri", "duckdb:////some/path", "--dest-table", "asset-name", "--yes", "--progress", "log"}
+	runner.On("RunIngestr", mock.Anything, want, mock.Anything, repo).Return(nil)
+
+	o := &BasicOperator{
+		conn:          &fetcher,
+		finder:        new(mockFinder),
+		runner:        runner,
+		jinjaRenderer: jinja.NewRendererWithYesterday("ingestr-test", "ingestr-test"),
+	}
+
+	ti := scheduler.AssetInstance{
+		Pipeline: &pipeline.Pipeline{},
+		Asset: &pipeline.Asset{
+			Name:       "asset-name",
+			Connection: "duck",
+			Parameters: pipeline.ParameterMap{
+				"source_connection": "chess",
+				"source_table":      "profiles",
+				"destination":       "duckdb",
+			},
+		},
+	}
+
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigFullRefresh, false)
+	require.NoError(t, o.Run(ctx, &ti))
+	runner.AssertExpectations(t)
 }
 
 func TestBasicOperator_ConvertTaskInstanceToIngestrCommand_IntervalStartAndEnd(t *testing.T) {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -2290,6 +2290,19 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			wantErr:        assert.NoError,
 		},
 		{
+			name: "public source via source_connection is valid",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "chess.com",
+					"source_table":      "profiles:magnuscarlsen",
+					"destination":       "duckdb",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
 			name: "ingestr asset with merge strategy but no primary key",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -2454,6 +2454,12 @@ func (p *Pipeline) GetAllConnectionNamesForAsset(asset *Asset) ([]string, error)
 			return []string{}, err
 		}
 
+		// A public source (e.g. chess.com) is used connectionless, so it is not a
+		// real connection dependency.
+		if _, ok := ConnectionlessIngestrSources[ingestrSource]; ok {
+			return []string{ingestrDestination}, nil
+		}
+
 		return []string{ingestrDestination, ingestrSource}, nil
 	} else if assetMainTaskIsConnectionless(assetType) {
 		return nil, nil
@@ -2512,6 +2518,13 @@ func assetMainTaskIsConnectionless(assetType AssetType) bool {
 	default:
 		return false
 	}
+}
+
+// ConnectionlessIngestrSources maps public, credential-less ingestr sources to
+// their base URI, keyed by canonical domain name so short names stay connections.
+var ConnectionlessIngestrSources = map[string]string{
+	"chess.com":       "chess://",
+	"frankfurter.dev": "frankfurter://",
 }
 
 func assetSecretConnectionNames(asset *Asset) []string {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -3803,3 +3803,49 @@ func TestAsset_PrefixUpstreams(t *testing.T) {
 	assert.Equal(t, "raw.dev_analytics.events", a.Upstreams[1].Value)
 	assert.Equal(t, "raw.analytics.events", a.Upstreams[2].Value)
 }
+
+func TestPipeline_GetAllConnectionNamesForAsset_ConnectionlessIngestr(t *testing.T) {
+	t.Parallel()
+
+	p := &pipeline.Pipeline{}
+
+	// source_connection naming a public source: only the destination is returned.
+	chess := &pipeline.Asset{
+		Type:       pipeline.AssetTypeIngestr,
+		Connection: "duck",
+		Parameters: pipeline.ParameterMap{
+			"source_connection": "chess.com",
+			"source_table":      "profiles:magnuscarlsen",
+			"destination":       "duckdb",
+		},
+	}
+	names, err := p.GetAllConnectionNamesForAsset(chess)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"duck"}, names)
+
+	// A missing source_connection still errors.
+	other := &pipeline.Asset{
+		Type:       pipeline.AssetTypeIngestr,
+		Connection: "duck",
+		Parameters: pipeline.ParameterMap{
+			"source_table": "table1",
+			"destination":  "duckdb",
+		},
+	}
+	_, err = p.GetAllConnectionNamesForAsset(other)
+	require.Error(t, err)
+
+	// With a source connection, both connections are returned (unchanged).
+	withConn := &pipeline.Asset{
+		Type:       pipeline.AssetTypeIngestr,
+		Connection: "duck",
+		Parameters: pipeline.ParameterMap{
+			"source_connection": "my-sf",
+			"source_table":      "table1",
+			"destination":       "duckdb",
+		},
+	}
+	names, err = p.GetAllConnectionNamesForAsset(withConn)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"duck", "my-sf"}, names)
+}


### PR DESCRIPTION
## What

A `source_connection` can name a public, credential-less source directly — `chess.com` or `frankfurter.dev` — with no connection defined. The base URI is synthesized and all source parameters come from the table name.

**Chess:**
```yaml
type: ingestr
connection: duckdb-default   # destination
parameters:
  source_connection: chess.com
  source_table: 'profiles:MagnusCarlsen,Hikaru'
  destination: duckdb
```

**Frankfurter:**
```yaml
type: ingestr
connection: duckdb-default   # destination
parameters:
  source_connection: frankfurter.dev
  source_table: 'latest:USD'
  destination: duckdb
```

## Behavior

- Only the canonical domain names (`chess.com`, `frankfurter.dev`) trigger this. Other names still require a defined connection.
- A defined connection with that name always wins, so existing pipelines are unaffected.
- A public-source name is not treated as a real connection dependency (nothing with credentials to resolve).