### PR TITLE
Fix Fabric unit-test CTE column aliases

### DIFF
--- a/pkg/sqlparser/parser_test.go
+++ b/pkg/sqlparser/parser_test.go
@@ -1293,6 +1293,19 @@ func TestSqlParser_ExtractSelect(t *testing.T) { //nolint
 		require.Contains(t, strings.ToUpper(got), "WITH")
 	})
 
+	t.Run("Fabric preserves the case of unaliased CTE column outputs", func(t *testing.T) {
+		queries := []string{
+			"WITH a AS (SELECT AccountDimId FROM dbo.DimAccount) SELECT AccountDimId FROM a",
+			"WITH a AS (SELECT d.AccountDimId FROM dbo.DimAccount AS d) SELECT a.AccountDimId FROM a",
+		}
+		for _, query := range queries {
+			got, err := parser.ExtractSelect(query, "fabric")
+			require.NoError(t, err)
+			require.Contains(t, got, "AS AccountDimId")
+			require.NotContains(t, got, "AS accountdimid")
+		}
+	})
+
 	t.Run("DDL with no inner SELECT is an error", func(t *testing.T) {
 		_, err := parser.ExtractSelect("CREATE TABLE analytics.t (id BIGINT, name VARCHAR)", "duckdb")
 		require.Error(t, err)

--- a/pkg/unittest/warehouse_duckdb_test.go
+++ b/pkg/unittest/warehouse_duckdb_test.go
@@ -59,6 +59,27 @@ func TestBuildWarehouseQuery_RunsOnDuckDB(t *testing.T) {
 		require.EqualValues(t, 100, res.Rows[0][0])
 	})
 
+	t.Run("Fabric fixture injection preserves unaliased CTE column casing", func(t *testing.T) {
+		t.Parallel()
+		input := pipeline.UnitTestInput{
+			Asset: "dbo.DimAccount",
+			Rows:  []map[string]interface{}{{"AccountDimId": 1, "RevenueType": "Management Fees"}},
+		}
+		queries := []string{
+			"WITH a AS (SELECT AccountDimId FROM dbo.DimAccount) SELECT AccountDimId FROM a",
+			"WITH a AS (SELECT d.AccountDimId FROM dbo.DimAccount AS d) SELECT a.AccountDimId FROM a",
+		}
+
+		for _, assetSQL := range queries {
+			sql, err := unittest.BuildWarehouseQuery(parser, "fabric", assetSQL,
+				pipeline.UnitTest{Inputs: []pipeline.UnitTestInput{input}}, nil)
+			require.NoError(t, err)
+			require.Contains(t, sql, "AS AccountDimId")
+			require.NotContains(t, sql, "AS accountdimid")
+			require.NotContains(t, sql, "dbo.DimAccount")
+		}
+	})
+
 	t.Run("unmocked upstream is an empty typed CTE so a LEFT JOIN yields only mocked rows", func(t *testing.T) {
 		t.Parallel()
 		schemas := map[string][]pipeline.Column{

--- a/pythonsrc/parser/main.py
+++ b/pythonsrc/parser/main.py
@@ -601,6 +601,33 @@ def is_single_select_query(query: str, dialect: str = None) -> dict:
 _WRITE_NODES = (exp.Insert, exp.Update, exp.Delete, exp.Merge)
 
 
+def _preserve_fabric_derived_column_case(expression: exp.Expr) -> None:
+    """Keep unaliased Fabric CTE/subquery output names case-sensitive.
+
+    SQLGlot's T-SQL generator adds aliases to bare column projections in derived
+    tables, but normalizes those generated aliases to lowercase. Fabric can use
+    a case-sensitive collation, so an outer ``AccountDimId`` reference then no
+    longer binds to the generated ``accountdimid`` output. Adding the implicit
+    alias ourselves preserves the identifier's original spelling. Explicit
+    aliases and derived tables with a declared output-column list already
+    control their output names and are left alone.
+    """
+    for derived in expression.find_all(exp.CTE, exp.Subquery):
+        alias = derived.args.get("alias")
+        if isinstance(alias, exp.TableAlias) and alias.columns:
+            continue
+
+        for projection in derived.this.selects:
+            if isinstance(projection, exp.Column) and not projection.alias:
+                projection.replace(
+                    exp.alias_(
+                        projection.copy(),
+                        projection.name,
+                        quoted=projection.this.quoted,
+                    )
+                )
+
+
 def extract_select(query: str, dialect: str = None) -> dict:
     """Reduce an asset statement to the read-only SELECT that produces its rows.
 
@@ -654,6 +681,9 @@ def extract_select(query: str, dialect: str = None) -> dict:
         return {
             "error": "asset contains a write statement and cannot be unit tested read-only"
         }
+
+    if dialect == "fabric":
+        _preserve_fabric_derived_column_case(inner)
 
     return {"query": inner.sql(dialect=dialect or None)}
 

--- a/pythonsrc/parser/main.py
+++ b/pythonsrc/parser/main.py
@@ -602,16 +602,7 @@ _WRITE_NODES = (exp.Insert, exp.Update, exp.Delete, exp.Merge)
 
 
 def _preserve_fabric_derived_column_case(expression: exp.Expr) -> None:
-    """Keep unaliased Fabric CTE/subquery output names case-sensitive.
-
-    SQLGlot's T-SQL generator adds aliases to bare column projections in derived
-    tables, but normalizes those generated aliases to lowercase. Fabric can use
-    a case-sensitive collation, so an outer ``AccountDimId`` reference then no
-    longer binds to the generated ``accountdimid`` output. Adding the implicit
-    alias ourselves preserves the identifier's original spelling. Explicit
-    aliases and derived tables with a declared output-column list already
-    control their output names and are left alone.
-    """
+    """Preserve source casing for unaliased Fabric derived-table columns."""
     for derived in expression.find_all(exp.CTE, exp.Subquery):
         alias = derived.args.get("alias")
         if isinstance(alias, exp.TableAlias) and alias.columns:


### PR DESCRIPTION
## What

Fix Fabric unit tests that failed to resolve mixed-case columns after mock CTE inlining.

## Changes

- Preserve source casing when SQLGlot adds aliases to Fabric CTE and subquery projections.
- Add parser and fixture-injection regressions for qualified and unqualified columns.

## How to test

1. Run `make format`.
2. Run `make test`.
3. Run `make build-no-duckdb`.

## Risk & rollback

- **Risk:** Low; the rewrite is scoped to Fabric derived-table projections.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues

None.