### PR TITLE
fix(templates): accumulate stripe-bigquery daily snapshots

### DIFF
--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -87,12 +87,22 @@ subscription, subscription-item, invoice, and invoice-line-item models. It also
 builds daily snapshots of subscription items and customer MRR by native
 currency, stamped with the pipeline end date.
 
-Every stage and report asset is materialized as a `CREATE OR REPLACE TABLE`, so
-each run rebuilds its table from the current raw data. That keeps the
-pipeline idempotent and easy to reason about, and it also means the snapshot
-tables hold only the most recent run's observation rather than an accumulated
-history. To retain a snapshot history, switch the two snapshot assets to an
-incremental strategy such as `merge` on their existing primary keys.
+Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`,
+so each run rebuilds its table from the current raw data. That keeps the
+pipeline idempotent and easy to reason about.
+
+The two daily snapshot assets are the exception. They use
+`delete+insert` on `snapshot_date`, so each run replaces only the day it
+observes and leaves earlier days in place. That accumulates the daily
+observation history the reports layer needs for month-over-month movement and
+retention, while keeping a re-run of any single date idempotent. Because
+`delete+insert` writes into an existing table, the first load has to create
+these two tables with `--full-refresh`; see
+[Run the pipeline](#run-the-pipeline).
+
+The snapshots record the Stripe state visible when the pipeline runs, so
+history builds up from the first run forward and cannot be backfilled from
+current Stripe records.
 
 ### Billing reports
 
@@ -102,6 +112,39 @@ The `stripe_reports` dataset provides four ready-to-query tables:
 - `monthly_mrr_movements` — customer-level new, reactivation, expansion, contraction, and churn movements.
 - `monthly_subscription_kpis` — recurring-revenue, retention, and customer-count metrics by currency.
 - `monthly_invoice_billings` — non-draft, non-void invoice billings by finalization month, with a labeled creation-date fallback.
+
+### Asset summary
+
+All 19 assets materialize as tables. `create+replace` is the default when no
+incremental strategy is listed, so those assets are rebuilt from their upstreams
+on every run.
+
+| Schema | Asset | Materialization | Incremental strategy | Partition | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `stripe_raw` | `customer` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe customers into BigQuery |
+| `stripe_raw` | `product` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe product catalog into BigQuery |
+| `stripe_raw` | `price` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe prices into BigQuery |
+| `stripe_raw` | `subscription` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe subscriptions into BigQuery |
+| `stripe_raw` | `subscription_item` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe subscription items into BigQuery |
+| `stripe_raw` | `invoice` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe invoices into BigQuery |
+| `stripe_stage` | `customers` | table | `create+replace` | — | Conform billing accounts and metadata keys |
+| `stripe_stage` | `products` | table | `create+replace` | — | Conform product catalog for packaging analysis |
+| `stripe_stage` | `prices` | table | `create+replace` | — | Conform prices with recurring-cadence attributes |
+| `stripe_stage` | `subscriptions` | table | `create+replace` | — | Conform current subscription, trial, and cancellation state |
+| `stripe_stage` | `subscription_items` | table | `create+replace` | — | Join items to prices and normalize gross MRR |
+| `stripe_stage` | `invoices` | table | `create+replace` | — | Conform invoice facts for billings and AR |
+| `stripe_stage` | `invoice_line_items` | table | `create+replace` | — | Flatten Stripe's embedded invoice-line payload |
+| `stripe_stage` | `subscription_item_daily_snapshot` | table | `delete+insert` on `snapshot_date` | `snapshot_date` | Accumulate daily subscription-item MRR observation history |
+| `stripe_stage` | `customer_currency_daily_mrr_snapshot` | table | `delete+insert` on `snapshot_date` | `snapshot_date` | Accumulate daily customer-currency MRR observation history |
+| `stripe_reports` | `monthly_mrr_by_customer` | table | `create+replace` | — | Month-end MRR and run-rate ARR per customer |
+| `stripe_reports` | `monthly_mrr_movements` | table | `create+replace` | — | Classify new, expansion, contraction, and churn movements |
+| `stripe_reports` | `monthly_subscription_kpis` | table | `create+replace` | — | Recurring-revenue, retention, and customer-count scorecard |
+| `stripe_reports` | `monthly_invoice_billings` | table | `create+replace` | — | Invoice billings by finalization month and currency |
+
+The two snapshot assets are partitioned on `snapshot_date` because they
+accumulate indefinitely: their per-run `DELETE` prunes to the single day being
+replaced instead of scanning the whole history. The other assets are rebuilt in
+full each run, so partitioning would not save any scan.
 
 ### Column-level documentation
 
@@ -115,8 +158,9 @@ generates a browsable documentation site from the same schemas.
 ## Example report rows
 
 The following illustrative rows use minor currency units: `9900` USD means
-$99.00. They show the shape of each table across several months, which assumes
-retained snapshot history; see [Conformed billing models](#conformed-billing-models).
+$99.00. They show the shape of each table across several months, which fills in
+once the snapshots have accumulated that many months of history; see
+[Conformed billing models](#conformed-billing-models).
 Query the four tables in `stripe_reports` directly, then adapt the columns to
 the definitions used by your finance and revenue teams.
 
@@ -154,8 +198,10 @@ the definitions used by your finance and revenue teams.
 
 ## Metric policy
 
-All monetary values remain in each currency's minor units. Do not add amounts
-across currencies without an FX source and explicit conversion policy.
+All monetary values in the `stripe_stage` and `stripe_reports` tables remain in
+each currency's minor units; only the dashboard converts to major units for
+display. Do not add amounts across currencies without an FX source and explicit
+conversion policy.
 
 MRR is a gross list-price run rate from active and past-due subscriptions with
 licensed recurring monthly or annual prices. Free, one-time, metered, and
@@ -163,10 +209,10 @@ discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither
 measure is recognized revenue, bookings, cash, or a financial statement.
 
 The daily snapshots capture the Stripe state visible when the pipeline runs.
-They do not reconstruct prior daily MRR history from current Stripe records,
-and because every asset is rebuilt with create+replace, each run keeps only the
-latest observation. Month-over-month movement and retention metrics therefore
-need snapshot history retained first.
+They do not reconstruct prior daily MRR history from current Stripe records, so
+the accumulated history starts at the first run. Month-over-month movement and
+retention metrics need two contiguous monthly observations, so they stay empty
+until the snapshots span a second month.
 
 ## Configure connections
 
@@ -242,17 +288,29 @@ bruin validate --fast my-stripe-pipeline
 
 On a new BigQuery destination, load every table before running query validation.
 The raw assets load only their run window, so pass an explicit range to pull
-your Stripe history in the first load:
+your Stripe history in the first load. Use `--full-refresh` on this first run:
+the two daily snapshot assets use `delete+insert`, which writes into an existing
+table, so their tables have to be created before a normal run can add days to
+them.
 
 ```bash
-bruin run --start-date 2023-01-01 --end-date $(date -u +%F) \
+bruin run --full-refresh --start-date 2023-01-01 --end-date $(date -u +%F) \
   --no-validation my-stripe-pipeline
 ```
 
 After the initial load, run `bruin validate my-stripe-pipeline` and schedule the
-pipeline daily. The stage and report assets are rebuilt with create+replace, so
-any run is safe to repeat; the raw assets upsert on `id`, so re-running a window
-does not duplicate rows.
+pipeline daily without `--full-refresh`:
+
+```bash
+bruin run --start-date $(date -u +%F) --end-date $(date -u +%F) my-stripe-pipeline
+```
+
+Any run is safe to repeat. The raw assets upsert on `id`, the other stage and
+report assets are rebuilt with create+replace, and the two snapshot assets
+replace only the `snapshot_date` they observe, so re-running a date does not
+duplicate rows or drop the days around it. Avoid `--full-refresh` after the
+initial load: it rebuilds the snapshot tables from scratch and discards the
+accumulated history.
 
 ## Customize it
 
@@ -265,8 +323,10 @@ definitions, identity mapping, and FX policy where required.
 
 The included DAC dashboard visualizes native-currency MRR, ARR, customer count,
 retention, movement components, invoice billings, and the latest customer MRR
-distribution. It deliberately filters to one currency at a time because the
-reporting tables retain money in native minor units and do not apply FX rates.
+distribution. It deliberately filters to one currency at a time because no FX
+rates are applied. The reporting tables retain money in native minor units; the
+dashboard queries divide by the selected currency's exponent so the widgets read
+in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
 
 After configuring `gcp-default`, install a verified DAC release by following
 the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html).
@@ -294,5 +354,4 @@ This screenshot uses synthetic data solely to demonstrate the dashboard's
 layout and charts.
 
 MRR movement and retention metrics need two contiguous monthly snapshots, so
-they stay empty while the snapshot tables are rebuilt with create+replace on
-every run.
+they stay empty until the accumulated snapshot history spans a second month.

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -87,12 +87,22 @@ subscription, subscription-item, invoice, and invoice-line-item models. It also
 builds daily snapshots of subscription items and customer MRR by native
 currency, stamped with the pipeline end date.
 
-Every stage and report asset is materialized as a `CREATE OR REPLACE TABLE`, so
-each run rebuilds its table from the current raw data. That keeps the
-pipeline idempotent and easy to reason about, and it also means the snapshot
-tables hold only the most recent run's observation rather than an accumulated
-history. To retain a snapshot history, switch the two snapshot assets to an
-incremental strategy such as `merge` on their existing primary keys.
+Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`,
+so each run rebuilds its table from the current raw data. That keeps the
+pipeline idempotent and easy to reason about.
+
+The two daily snapshot assets are the exception. They use
+`delete+insert` on `snapshot_date`, so each run replaces only the day it
+observes and leaves earlier days in place. That accumulates the daily
+observation history the reports layer needs for month-over-month movement and
+retention, while keeping a re-run of any single date idempotent. Because
+`delete+insert` writes into an existing table, the first load has to create
+these two tables with `--full-refresh`; see
+[Run the pipeline](#run-the-pipeline).
+
+The snapshots record the Stripe state visible when the pipeline runs, so
+history builds up from the first run forward and cannot be backfilled from
+current Stripe records.
 
 ### Billing reports
 
@@ -102,6 +112,39 @@ The `stripe_reports` dataset provides four ready-to-query tables:
 - `monthly_mrr_movements` — customer-level new, reactivation, expansion, contraction, and churn movements.
 - `monthly_subscription_kpis` — recurring-revenue, retention, and customer-count metrics by currency.
 - `monthly_invoice_billings` — non-draft, non-void invoice billings by finalization month, with a labeled creation-date fallback.
+
+### Asset summary
+
+All 19 assets materialize as tables. `create+replace` is the default when no
+incremental strategy is listed, so those assets are rebuilt from their upstreams
+on every run.
+
+| Schema | Asset | Materialization | Incremental strategy | Partition | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `stripe_raw` | `customer` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe customers into BigQuery |
+| `stripe_raw` | `product` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe product catalog into BigQuery |
+| `stripe_raw` | `price` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe prices into BigQuery |
+| `stripe_raw` | `subscription` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe subscriptions into BigQuery |
+| `stripe_raw` | `subscription_item` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe subscription items into BigQuery |
+| `stripe_raw` | `invoice` | table | `merge` (upsert on `id`, cursor `created`) | — | Load Stripe invoices into BigQuery |
+| `stripe_stage` | `customers` | table | `create+replace` | — | Conform billing accounts and metadata keys |
+| `stripe_stage` | `products` | table | `create+replace` | — | Conform product catalog for packaging analysis |
+| `stripe_stage` | `prices` | table | `create+replace` | — | Conform prices with recurring-cadence attributes |
+| `stripe_stage` | `subscriptions` | table | `create+replace` | — | Conform current subscription, trial, and cancellation state |
+| `stripe_stage` | `subscription_items` | table | `create+replace` | — | Join items to prices and normalize gross MRR |
+| `stripe_stage` | `invoices` | table | `create+replace` | — | Conform invoice facts for billings and AR |
+| `stripe_stage` | `invoice_line_items` | table | `create+replace` | — | Flatten Stripe's embedded invoice-line payload |
+| `stripe_stage` | `subscription_item_daily_snapshot` | table | `delete+insert` on `snapshot_date` | `snapshot_date` | Accumulate daily subscription-item MRR observation history |
+| `stripe_stage` | `customer_currency_daily_mrr_snapshot` | table | `delete+insert` on `snapshot_date` | `snapshot_date` | Accumulate daily customer-currency MRR observation history |
+| `stripe_reports` | `monthly_mrr_by_customer` | table | `create+replace` | — | Month-end MRR and run-rate ARR per customer |
+| `stripe_reports` | `monthly_mrr_movements` | table | `create+replace` | — | Classify new, expansion, contraction, and churn movements |
+| `stripe_reports` | `monthly_subscription_kpis` | table | `create+replace` | — | Recurring-revenue, retention, and customer-count scorecard |
+| `stripe_reports` | `monthly_invoice_billings` | table | `create+replace` | — | Invoice billings by finalization month and currency |
+
+The two snapshot assets are partitioned on `snapshot_date` because they
+accumulate indefinitely: their per-run `DELETE` prunes to the single day being
+replaced instead of scanning the whole history. The other assets are rebuilt in
+full each run, so partitioning would not save any scan.
 
 ### Column-level documentation
 
@@ -115,8 +158,9 @@ generates a browsable documentation site from the same schemas.
 ## Example report rows
 
 The following illustrative rows use minor currency units: `9900` USD means
-$99.00. They show the shape of each table across several months, which assumes
-retained snapshot history; see [Conformed billing models](#conformed-billing-models).
+$99.00. They show the shape of each table across several months, which fills in
+once the snapshots have accumulated that many months of history; see
+[Conformed billing models](#conformed-billing-models).
 Query the four tables in `stripe_reports` directly, then adapt the columns to
 the definitions used by your finance and revenue teams.
 
@@ -154,8 +198,10 @@ the definitions used by your finance and revenue teams.
 
 ## Metric policy
 
-All monetary values remain in each currency's minor units. Do not add amounts
-across currencies without an FX source and explicit conversion policy.
+All monetary values in the `stripe_stage` and `stripe_reports` tables remain in
+each currency's minor units; only the dashboard converts to major units for
+display. Do not add amounts across currencies without an FX source and explicit
+conversion policy.
 
 MRR is a gross list-price run rate from active and past-due subscriptions with
 licensed recurring monthly or annual prices. Free, one-time, metered, and
@@ -163,10 +209,10 @@ discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither
 measure is recognized revenue, bookings, cash, or a financial statement.
 
 The daily snapshots capture the Stripe state visible when the pipeline runs.
-They do not reconstruct prior daily MRR history from current Stripe records,
-and because every asset is rebuilt with create+replace, each run keeps only the
-latest observation. Month-over-month movement and retention metrics therefore
-need snapshot history retained first.
+They do not reconstruct prior daily MRR history from current Stripe records, so
+the accumulated history starts at the first run. Month-over-month movement and
+retention metrics need two contiguous monthly observations, so they stay empty
+until the snapshots span a second month.
 
 ## Configure connections
 
@@ -242,17 +288,29 @@ bruin validate --fast my-stripe-pipeline
 
 On a new BigQuery destination, load every table before running query validation.
 The raw assets load only their run window, so pass an explicit range to pull
-your Stripe history in the first load:
+your Stripe history in the first load. Use `--full-refresh` on this first run:
+the two daily snapshot assets use `delete+insert`, which writes into an existing
+table, so their tables have to be created before a normal run can add days to
+them.
 
 ```bash
-bruin run --start-date 2023-01-01 --end-date $(date -u +%F) \
+bruin run --full-refresh --start-date 2023-01-01 --end-date $(date -u +%F) \
   --no-validation my-stripe-pipeline
 ```
 
 After the initial load, run `bruin validate my-stripe-pipeline` and schedule the
-pipeline daily. The stage and report assets are rebuilt with create+replace, so
-any run is safe to repeat; the raw assets upsert on `id`, so re-running a window
-does not duplicate rows.
+pipeline daily without `--full-refresh`:
+
+```bash
+bruin run --start-date $(date -u +%F) --end-date $(date -u +%F) my-stripe-pipeline
+```
+
+Any run is safe to repeat. The raw assets upsert on `id`, the other stage and
+report assets are rebuilt with create+replace, and the two snapshot assets
+replace only the `snapshot_date` they observe, so re-running a date does not
+duplicate rows or drop the days around it. Avoid `--full-refresh` after the
+initial load: it rebuilds the snapshot tables from scratch and discards the
+accumulated history.
 
 ## Customize it
 
@@ -265,8 +323,10 @@ definitions, identity mapping, and FX policy where required.
 
 The included DAC dashboard visualizes native-currency MRR, ARR, customer count,
 retention, movement components, invoice billings, and the latest customer MRR
-distribution. It deliberately filters to one currency at a time because the
-reporting tables retain money in native minor units and do not apply FX rates.
+distribution. It deliberately filters to one currency at a time because no FX
+rates are applied. The reporting tables retain money in native minor units; the
+dashboard queries divide by the selected currency's exponent so the widgets read
+in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
 
 After configuring `gcp-default`, install a verified DAC release by following
 the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html).
@@ -294,5 +354,4 @@ This screenshot uses synthetic data solely to demonstrate the dashboard's
 layout and charts.
 
 MRR movement and retention metrics need two contiguous monthly snapshots, so
-they stay empty while the snapshot tables are rebuilt with create+replace on
-every run.
+they stay empty until the accumulated snapshot history spans a second month.

--- a/templates/stripe-bigquery/assets/stripe_stage/customer_currency_daily_mrr_snapshot.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/customer_currency_daily_mrr_snapshot.sql
@@ -2,13 +2,25 @@
 name: stripe_stage.customer_currency_daily_mrr_snapshot
 type: bq.sql
 description: >
-  Daily MRR snapshot at Stripe customer and native-currency grain, rebuilt on
-  every run for the pipeline end date. It starts from subscriptions and left
-  joins subscription items, retaining a zero-MRR row when a cancelled or
-  itemless subscription has no MRR-eligible items.
+  Daily MRR observation history at Stripe customer and native-currency grain,
+  and the snapshot every monthly report reads. Stripe subscription records are
+  mutable and overwrite their own past, so a repriced or cancelled subscription
+  reports only its current state and prior daily MRR cannot be recovered from
+  Stripe; this asset records that state while it is still current. Each run
+  observes the pipeline end date and adds that day, replacing only the rows for
+  the date being run, so re-running a date is idempotent. History accrues from
+  the first run onward and cannot be backfilled, and the movement and retention
+  reports need two contiguous monthly observations before they return anything.
+  It starts from subscriptions and left joins subscription items, retaining a
+  zero-MRR row when a cancelled or itemless subscription has no MRR-eligible
+  items, so a churned customer stays visible at zero instead of disappearing
+  from the snapshot and becoming indistinguishable from missing data.
 
 materialization:
   type: table
+  strategy: delete+insert
+  incremental_key: snapshot_date
+  partition_by: snapshot_date
 
 depends:
   - stripe_stage.subscriptions
@@ -62,7 +74,10 @@ custom_checks:
 columns:
   - name: snapshot_date
     type: DATE
-    description: UTC date represented by the snapshot.
+    description: >
+      UTC date this row observed. It is the incremental key and the partition
+      key, so a re-run replaces only its own day and leaves the rest of the
+      history in place.
     primary_key: true
     checks:
       - name: not_null

--- a/templates/stripe-bigquery/assets/stripe_stage/customers.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/customers.sql
@@ -70,9 +70,9 @@ SELECT
   email AS customer_email,
   livemode AS is_live_mode,
   metadata AS customer_metadata,
-  JSON_VALUE(metadata, '$.crm_account_id') AS crm_account_id,
-  JSON_VALUE(metadata, '$.segment') AS customer_segment,
-  JSON_VALUE(metadata, '$.region') AS customer_region,
-  JSON_VALUE(metadata, '$.sales_owner') AS sales_owner,
-  JSON_VALUE(metadata, '$.acquisition_channel') AS acquisition_channel
+  LAX_STRING(metadata.crm_account_id) AS crm_account_id,
+  LAX_STRING(metadata.segment) AS customer_segment,
+  LAX_STRING(metadata.region) AS customer_region,
+  LAX_STRING(metadata.sales_owner) AS sales_owner,
+  LAX_STRING(metadata.acquisition_channel) AS acquisition_channel
 FROM stripe_raw.customer;

--- a/templates/stripe-bigquery/assets/stripe_stage/invoices.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/invoices.sql
@@ -110,9 +110,9 @@ SELECT
   customer AS stripe_customer_id,
   TIMESTAMP_SECONDS(SAFE_CAST(created AS INT64)) AS invoice_created_at,
   TIMESTAMP_SECONDS(SAFE_CAST(due_date AS INT64)) AS invoice_due_at,
-  TIMESTAMP_SECONDS(SAFE_CAST(
-    JSON_VALUE(status_transitions, '$.finalized_at') AS INT64
-  )) AS invoice_finalized_at,
+  TIMESTAMP_SECONDS(
+    LAX_INT64(status_transitions.finalized_at)
+  ) AS invoice_finalized_at,
   status AS invoice_status,
   billing_reason,
   collection_method,
@@ -131,6 +131,6 @@ SELECT
     'subscription_update',
     'subscription_threshold'
   ) AS is_subscription_invoice,
-  SAFE_CAST(JSON_VALUE(lines, '$.has_more') AS BOOL) AS invoice_lines_has_more,
+  LAX_BOOL(lines.has_more) AS invoice_lines_has_more,
   lines AS invoice_lines
 FROM stripe_raw.invoice;

--- a/templates/stripe-bigquery/assets/stripe_stage/prices.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/prices.sql
@@ -94,13 +94,13 @@ SELECT
   p.billing_scheme,
   p.recurring AS recurring_config,
   p.type = 'recurring' AS is_recurring,
-  JSON_VALUE(p.recurring, '$.interval') AS recurring_interval,
+  LAX_STRING(p.recurring.interval) AS recurring_interval,
   COALESCE(
-    SAFE_CAST(JSON_VALUE(p.recurring, '$.interval_count') AS INT64),
+    LAX_INT64(p.recurring.interval_count),
     1
   ) AS recurring_interval_count,
   COALESCE(
-    JSON_VALUE(p.recurring, '$.usage_type'),
+    LAX_STRING(p.recurring.usage_type),
     'licensed'
   ) AS recurring_usage_type,
   p.metadata AS price_metadata

--- a/templates/stripe-bigquery/assets/stripe_stage/subscription_item_daily_snapshot.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/subscription_item_daily_snapshot.sql
@@ -2,12 +2,20 @@
 name: stripe_stage.subscription_item_daily_snapshot
 type: bq.sql
 description: >
-  Daily snapshot of current subscription-item MRR state, rebuilt on every run
-  for the pipeline end date. It cannot reconstruct historic state from mutable
-  Stripe subscription records.
+  Daily observation history of subscription-item MRR state at item grain, kept
+  so a customer's MRR change can be traced to the price, plan, and quantity
+  behind it. Stripe subscription records are mutable and overwrite their own
+  past, so historic item state cannot be reconstructed from Stripe; this asset
+  records that state while it is still current. Each run observes the pipeline
+  end date and adds that day, replacing only the rows for the date being run, so
+  re-running a date is idempotent. History accrues from the first run onward and
+  cannot be backfilled.
 
 materialization:
   type: table
+  strategy: delete+insert
+  incremental_key: snapshot_date
+  partition_by: snapshot_date
 
 depends:
   - stripe_stage.subscription_items
@@ -52,7 +60,10 @@ custom_checks:
 columns:
   - name: snapshot_date
     type: DATE
-    description: UTC date represented by the snapshot.
+    description: >
+      UTC date this row observed. It is the incremental key and the partition
+      key, so a re-run replaces only its own day and leaves the rest of the
+      history in place.
     primary_key: true
     checks:
       - name: not_null

--- a/templates/stripe-bigquery/assets/stripe_stage/subscription_items.sql
+++ b/templates/stripe-bigquery/assets/stripe_stage/subscription_items.sql
@@ -6,7 +6,9 @@ description: >
   is normalized from active or past-due monthly and annual licensed recurring
   prices only. price_based_recurring_mrr_minor normalizes the same price shape
   regardless of subscription status for operational risk and trial-conversion
-  reporting, with each currency reported independently.
+  reporting, with each currency reported independently. This model holds current
+  state only, because Stripe overwrites its own history; use the daily
+  subscription-item snapshot for as-of reporting over time.
 
 materialization:
   type: table

--- a/templates/stripe-bigquery/dashboards/stripe-billing-analytics.yml
+++ b/templates/stripe-bigquery/dashboards/stripe-billing-analytics.yml
@@ -13,11 +13,19 @@ filters:
 queries:
   latest_subscription_kpis:
     sql: |
+      WITH currency_units AS (
+        SELECT IF(UPPER('{{ filters.currency }}') IN (
+          'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+          'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
+        ), 1, 100) AS minor_unit_divisor
+      )
       SELECT
         metric_month,
         currency,
-        ending_mrr_minor,
-        ending_run_rate_arr_minor,
+        ending_mrr_minor
+          / (SELECT minor_unit_divisor FROM currency_units) AS ending_mrr,
+        ending_run_rate_arr_minor
+          / (SELECT minor_unit_divisor FROM currency_units) AS ending_run_rate_arr,
         ending_active_customer_count
       FROM `stripe_reports.monthly_subscription_kpis`
       WHERE metric_month >= CAST('{{ filters.date_range.start }}' AS DATE)
@@ -27,14 +35,22 @@ queries:
 
   latest_invoice_billings:
     sql: |
+      WITH currency_units AS (
+        SELECT IF(UPPER('{{ filters.currency }}') IN (
+          'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+          'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
+        ), 1, 100) AS minor_unit_divisor
+      )
       SELECT
         invoice_billing_month,
         currency,
         SUM(issued_invoice_count) AS issued_invoice_count,
         SUM(subscription_invoice_count) AS subscription_invoice_count,
-        SUM(invoiced_billings_minor) AS invoiced_billings_minor,
+        SUM(invoiced_billings_minor)
+          / (SELECT minor_unit_divisor FROM currency_units) AS invoiced_billings,
         SUM(invoiced_subscription_billings_minor)
-          AS invoiced_subscription_billings_minor
+          / (SELECT minor_unit_divisor FROM currency_units)
+          AS invoiced_subscription_billings
       FROM `stripe_reports.monthly_invoice_billings`
       WHERE invoice_billing_month >= CAST('{{ filters.date_range.start }}' AS DATE)
         AND invoice_billing_month <= CAST('{{ filters.date_range.end }}' AS DATE)
@@ -44,9 +60,16 @@ queries:
 
   monthly_mrr:
     sql: |
+      WITH currency_units AS (
+        SELECT IF(UPPER('{{ filters.currency }}') IN (
+          'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+          'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
+        ), 1, 100) AS minor_unit_divisor
+      )
       SELECT
         metric_month,
-        SUM(ending_mrr_minor) AS ending_mrr_minor
+        SUM(ending_mrr_minor)
+          / (SELECT minor_unit_divisor FROM currency_units) AS ending_mrr
       FROM `stripe_reports.monthly_mrr_by_customer`
       WHERE metric_month >= CAST('{{ filters.date_range.start }}' AS DATE)
         AND metric_month <= CAST('{{ filters.date_range.end }}' AS DATE)
@@ -56,14 +79,25 @@ queries:
 
   monthly_mrr_movements:
     sql: |
-      WITH monthly_movements AS (
+      WITH currency_units AS (
+        SELECT IF(UPPER('{{ filters.currency }}') IN (
+          'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+          'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
+        ), 1, 100) AS minor_unit_divisor
+      ),
+      monthly_movements AS (
         SELECT
           metric_month,
-          SUM(new_mrr_minor) AS new_mrr_minor,
-          SUM(reactivation_mrr_minor) AS reactivation_mrr_minor,
-          SUM(expansion_mrr_minor) AS expansion_mrr_minor,
-          -SUM(contraction_mrr_minor) AS contraction_mrr_loss_minor,
-          -SUM(churned_mrr_minor) AS churned_mrr_loss_minor
+          SUM(new_mrr_minor)
+            / (SELECT minor_unit_divisor FROM currency_units) AS new_mrr,
+          SUM(reactivation_mrr_minor)
+            / (SELECT minor_unit_divisor FROM currency_units) AS reactivation_mrr,
+          SUM(expansion_mrr_minor)
+            / (SELECT minor_unit_divisor FROM currency_units) AS expansion_mrr,
+          -SUM(contraction_mrr_minor)
+            / (SELECT minor_unit_divisor FROM currency_units) AS contraction_mrr_loss,
+          -SUM(churned_mrr_minor)
+            / (SELECT minor_unit_divisor FROM currency_units) AS churned_mrr_loss
         FROM `stripe_reports.monthly_mrr_movements`
         WHERE metric_month >= CAST('{{ filters.date_range.start }}' AS DATE)
           AND metric_month <= CAST('{{ filters.date_range.end }}' AS DATE)
@@ -73,23 +107,30 @@ queries:
       SELECT
         metric_month,
         movement_category,
-        movement_mrr_minor
+        movement_mrr
       FROM monthly_movements,
       UNNEST([
-        STRUCT('New' AS movement_category, new_mrr_minor AS movement_mrr_minor),
-        STRUCT('Reactivation', reactivation_mrr_minor),
-        STRUCT('Expansion', expansion_mrr_minor),
-        STRUCT('Contraction', contraction_mrr_loss_minor),
-        STRUCT('Churn', churned_mrr_loss_minor)
+        STRUCT('New' AS movement_category, new_mrr AS movement_mrr),
+        STRUCT('Reactivation', reactivation_mrr),
+        STRUCT('Expansion', expansion_mrr),
+        STRUCT('Contraction', contraction_mrr_loss),
+        STRUCT('Churn', churned_mrr_loss)
       ])
       ORDER BY metric_month, movement_category
 
   monthly_invoice_billings:
     sql: |
+      WITH currency_units AS (
+        SELECT IF(UPPER('{{ filters.currency }}') IN (
+          'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+          'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
+        ), 1, 100) AS minor_unit_divisor
+      )
       SELECT
         invoice_billing_month,
         invoice_billing_date_basis,
-        SUM(invoiced_billings_minor) AS invoiced_billings_minor
+        SUM(invoiced_billings_minor)
+          / (SELECT minor_unit_divisor FROM currency_units) AS invoiced_billings
       FROM `stripe_reports.monthly_invoice_billings`
       WHERE invoice_billing_month >= CAST('{{ filters.date_range.start }}' AS DATE)
         AND invoice_billing_month <= CAST('{{ filters.date_range.end }}' AS DATE)
@@ -99,7 +140,13 @@ queries:
 
   latest_customer_mrr:
     sql: |
-      WITH filtered_customer_mrr AS (
+      WITH currency_units AS (
+        SELECT IF(UPPER('{{ filters.currency }}') IN (
+          'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA',
+          'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
+        ), 1, 100) AS minor_unit_divisor
+      ),
+      filtered_customer_mrr AS (
         SELECT
           metric_month,
           stripe_customer_id,
@@ -110,8 +157,10 @@ queries:
           customer_region,
           sales_owner,
           active_subscription_count,
-          ending_mrr_minor,
+          ending_mrr_minor
+            / (SELECT minor_unit_divisor FROM currency_units) AS ending_mrr,
           run_rate_arr_minor
+            / (SELECT minor_unit_divisor FROM currency_units) AS run_rate_arr
         FROM `stripe_reports.monthly_mrr_by_customer`
         WHERE metric_month >= CAST('{{ filters.date_range.start }}' AS DATE)
           AND metric_month <= CAST('{{ filters.date_range.end }}' AS DATE)
@@ -120,7 +169,7 @@ queries:
       SELECT *
       FROM filtered_customer_mrr
       QUALIFY metric_month = MAX(metric_month) OVER ()
-      ORDER BY ending_mrr_minor DESC, stripe_customer_id
+      ORDER BY ending_mrr DESC, stripe_customer_id
       LIMIT 20
 
 rows:
@@ -132,26 +181,26 @@ rows:
 
           Recurring revenue and billings are shown for one native currency at a time. Enter the three-letter Stripe currency code to avoid aggregating monetary amounts across currencies.
 
-          **Metric policy:** MRR is gross list-price run rate from eligible active and past-due subscriptions. It is not recognized revenue, bookings, cash, or a financial statement. Monetary amounts remain in native minor units.
+          **Metric policy:** MRR is gross list-price run rate from eligible active and past-due subscriptions. It is not recognized revenue, bookings, cash, or a financial statement. The `stripe_reports` tables store money in native minor units; these widgets divide by the currency's exponent to display major units, and apply no FX conversion.
         col: 12
 
   - widgets:
-      - name: Latest Ending MRR (minor units)
+      - name: Latest Ending MRR
         type: metric
         query: latest_subscription_kpis
         value:
-          field: ending_mrr_minor
+          field: ending_mrr
           type: number
-          format: ",.0f"
+          format: ",.2f"
         col: 3
 
-      - name: Latest Run-Rate ARR (minor units)
+      - name: Latest Run-Rate ARR
         type: metric
         query: latest_subscription_kpis
         value:
-          field: ending_run_rate_arr_minor
+          field: ending_run_rate_arr
           type: number
-          format: ",.0f"
+          format: ",.2f"
         col: 3
 
       - name: Active Customers
@@ -163,13 +212,13 @@ rows:
           format: ",.0f"
         col: 3
 
-      - name: Latest Invoice Billings (minor units)
+      - name: Latest Invoice Billings
         type: metric
         query: latest_invoice_billings
         value:
-          field: invoiced_billings_minor
+          field: invoiced_billings
           type: number
-          format: ",.0f"
+          format: ",.2f"
         col: 3
 
   - widgets:
@@ -180,41 +229,41 @@ rows:
         col: 12
 
   - widgets:
-      - name: Monthly Ending MRR (minor units)
+      - name: Monthly Ending MRR
         type: chart
         chart: line
         query: monthly_mrr
         x: { field: metric_month }
-        y: { field: [ending_mrr_minor] }
+        y: { field: [ending_mrr], type: number, format: ",.2f" }
         col: 6
 
-      - name: Monthly MRR Movement Components (minor units; requires prior snapshot)
+      - name: Monthly MRR Movement Components (requires prior snapshot)
         type: chart
         chart: bar
         query: monthly_mrr_movements
         x: { field: metric_month }
-        y: { field: [movement_mrr_minor] }
+        y: { field: [movement_mrr], type: number, format: ",.2f" }
         color: { field: movement_category }
         stacked: true
         col: 6
 
   - widgets:
-      - name: Monthly Invoice Billings by Date Basis (minor units)
+      - name: Monthly Invoice Billings by Date Basis
         type: chart
         chart: bar
         query: monthly_invoice_billings
         x: { field: invoice_billing_month }
-        y: { field: [invoiced_billings_minor] }
+        y: { field: [invoiced_billings], type: number, format: ",.2f" }
         color: { field: invoice_billing_date_basis }
         stacked: true
         col: 6
 
-      - name: Latest Customer MRR (minor units)
+      - name: Latest Customer MRR
         type: chart
         chart: bar
         query: latest_customer_mrr
         x: { field: customer_label }
-        y: { field: [ending_mrr_minor] }
+        y: { field: [ending_mrr], type: number, format: ",.2f" }
         col: 6
 
   - widgets:
@@ -235,10 +284,12 @@ rows:
             label: Sales owner
           - name: active_subscription_count
             label: Active subscriptions
-          - name: ending_mrr_minor
-            label: Ending MRR (minor units)
-          - name: run_rate_arr_minor
-            label: Run-rate ARR (minor units)
+          - name: ending_mrr
+            label: Ending MRR
+            number: ",.2f"
+          - name: run_rate_arr
+            label: Run-rate ARR
+            number: ",.2f"
 
   - widgets:
       - name: Sources and limitations
@@ -248,5 +299,5 @@ rows:
 
           **Method:** The MRR movement chart treats contraction and churn as negative values; its components reconcile to ending MRR only for contiguous monthly snapshots. Invoice billings use finalization date when available and flag creation-date fallback separately.
 
-          **Limitations:** The first snapshot month is a baseline, so retention and movement metrics may be unavailable until the next contiguous monthly observation. No FX conversion is applied.
+          **Limitations:** The first snapshot month is a baseline, so retention and movement metrics may be unavailable until the next contiguous monthly observation. Amounts are shown in the selected currency's major units; no FX conversion is applied.
         col: 12


### PR DESCRIPTION
## The bug

The two daily snapshot assets in `stripe-bigquery` declared:

```yaml
materialization:
  type: table
```

`type: table` with no strategy is create+replace, so each run rebuilt the table from scratch. Each asset emits exactly one `DATE('{{ end_date }}')` row, so the tables only ever held the most recent run's day — every prior day was destroyed.

That breaks the entire reports layer:

- `monthly_mrr_by_customer` groups by `DATE_TRUNC(snapshot_date, MONTH)`, so it could only ever produce one month
- `monthly_mrr_movements` had no prior month to compare against, so every row classified as `new`
- `net_revenue_retention_rate_excluding_reactivation` was always null

The 59 quality checks did not catch it: with a single month, beginning MRR is 0 and `mrr_movements_roll_forward_to_ending_mrr` reconciles trivially.

## The fix

Both snapshots now use `delete+insert` on `snapshot_date`, so a run replaces only the day it observes and leaves earlier days in place. `append` was not an option — re-running a date would duplicate rows and fail the existing `snapshot_keys_are_unique` check.

They are also partitioned on `snapshot_date`. These tables now grow indefinitely by design, so without partitioning each run's `DELETE` would scan the whole accumulated history to remove one day.

**One caveat worth reviewing carefully.** Incremental strategies in bruin write into an existing table — `delete+insert` emits `DELETE FROM <target>` with no create-if-missing, and the operator only creates the *dataset*. So the first run against a fresh destination fails:

```
Catalog Error: Table with name ... does not exist!
```

I verified this holds for `append` and `truncate+insert` too, and every platform's builder has the same shape. It's a deliberate, uniform contract, documented only in `docs/platforms/clickhouse.md`. The README run instructions now use `--full-refresh` for the first load, matching the convention in `templates/shopify-clickhouse` and `templates/clickhouse`.

## Also included

**`LAX_*` instead of `JSON_VALUE`** at the 10 call sites over BigQuery JSON columns, which drops the `SAFE_CAST` wrappers. The precondition holds: the raw assets declare these `type: json`, `pkg/python/columns.go` maps that to the ingestr `json` hint, and dlt maps `"json": "JSON"` for BigQuery. Column lineage re-resolves every converted column to the right source. The deep-path calls in `invoice_line_items.sql` and `subscription_items.sql` are left alone.

**Dashboard in major units.** A customer paying \$99/month rendered as `9900`. The reports layer deliberately stays in minor units; only the dashboard queries convert, dividing by the currency's exponent with a divisor of 1 for Stripe's zero-decimal currencies. Keyed off the `currency` filter rather than the column, because four of the six queries filter on `currency` without selecting it.

**Documentation.** The snapshots' purpose is now in their descriptions — Stripe overwrites its own history, so these are the pipeline's only source of as-of state and cannot be backfilled. Added an asset summary table (schema, materialization, strategy, partition, purpose) for all 19 assets, generated from `parse-pipeline` output rather than transcribed. Synced the docs mirror.

## Verification

- `make format` clean, `make test` exit 0
- `bruin init` → `validate --fast`: 19 assets, no issues
- `dac validate`: dashboard OK
- Rendered SQL confirms `PARTITION BY snapshot_date` on create and a pruned `DELETE` on normal runs
- Accumulation tested on a scratch DuckDB pipeline: three dates run, then one re-run, left three distinct dates with one row each
- Docs page renders and lints clean

`make integration-test-light` has two failures, `query-semantic-cli-flags` and `query-semantic-window-metric`. Both are pre-existing — they fail identically on a clean tree with these changes stashed.

## Not done

- The dashboard preview screenshot still shows minor units and needs re-capturing. It was taken from a modified local variant with synthetic data that isn't in the repo.
- No end-to-end run against real BigQuery — no credentials available here.
- The Academy course at getbruin.com/learn/stripe-bigquery describes the old create+replace behavior. Asset and column names are unchanged, so nothing there breaks, but the narrative is now stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)