### PR TITLE
bruin cloud dashboards versions/version

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4591,6 +4591,8 @@ func CloudDashboards() *cli.Command {
 		Commands: []*cli.Command{
 			cloudDashboardsList(),
 			cloudDashboardsGet(),
+			cloudDashboardsVersions(),
+			cloudDashboardsVersion(),
 			cloudDashboardsCreate(),
 			cloudDashboardsUpdate(),
 			cloudDashboardsDelete(),
@@ -4771,6 +4773,113 @@ func yamlNodeToValue(n *yaml.Node) (any, error) {
 			return nil, err
 		}
 		return v, nil
+	}
+}
+
+func cloudDashboardsVersions() *cli.Command {
+	return &cli.Command{
+		Name:  "versions",
+		Usage: "List a dashboard's version history (who changed what, when)",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "dashboard-id",
+				Usage:    "dashboard ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			versions, err := client.ListDashboardVersions(ctx, c.Int("dashboard-id"))
+			if err != nil {
+				printError(err, output, "Failed to list dashboard versions")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(versions, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Kind", "Author", "Source", "Created At"})
+			for _, v := range versions {
+				source := "ui"
+				if v.ViaAPI {
+					source = "api"
+				}
+				t.AppendRow(table.Row{v.ID, v.Kind, v.Author, source, v.CreatedAt})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudDashboardsVersion() *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Get a single dashboard version including its full definition",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "dashboard-id",
+				Usage:    "dashboard ID",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:     "version-id",
+				Usage:    "version ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			version, err := client.GetDashboardVersion(ctx, c.Int("dashboard-id"), c.Int("version-id"))
+			if err != nil {
+				printError(err, output, "Failed to get dashboard version")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(version, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Version %d (%s) by %s at %s\n", version.ID, version.Kind, version.Author, version.CreatedAt)
+			// Print the definition (state) as pretty JSON so it can be inspected.
+			if len(version.State) > 0 {
+				var obj any
+				if err := json.Unmarshal(version.State, &obj); err == nil {
+					pretty, _ := json.MarshalIndent(obj, "", "  ")
+					fmt.Println(string(pretty))
+				} else {
+					fmt.Println(string(version.State))
+				}
+			}
+			return nil
+		},
 	}
 }
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -388,7 +388,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	cmd := CloudDashboards()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "dashboards", cmd.Name)
-	require.Len(t, cmd.Commands, 5)
+	require.Len(t, cmd.Commands, 7)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -396,6 +396,8 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	}
 	assert.Contains(t, subNames, "list")
 	assert.Contains(t, subNames, "get")
+	assert.Contains(t, subNames, "versions")
+	assert.Contains(t, subNames, "version")
 	assert.Contains(t, subNames, "create")
 	assert.Contains(t, subNames, "update")
 	assert.Contains(t, subNames, "delete")

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -851,6 +851,27 @@ bruin cloud dashboards get --dashboard-id 42
 bruin cloud dashboards get --dashboard-id 42 --output json
 ```
 
+#### `versions`
+
+List a dashboard's version history — each snapshot's id, kind (draft/published),
+author, source (ui/api), and time. Metadata only; use `version` to read a
+snapshot's definition.
+
+```bash
+bruin cloud dashboards versions --dashboard-id 42
+bruin cloud dashboards versions --dashboard-id 42 --output json
+```
+
+#### `version`
+
+Get a single version snapshot including its full definition (`state`) — e.g. to see
+what a past version contained or to reconstruct it.
+
+```bash
+bruin cloud dashboards version --dashboard-id 42 --version-id 108
+bruin cloud dashboards version --dashboard-id 42 --version-id 108 --output json
+```
+
 #### `create`
 
 Create a dashboard from a definition. The definition is written to the dashboard's

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -928,6 +928,27 @@ func (c *APIClient) DeleteDashboard(ctx context.Context, dashboardID int) error 
 	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/dashboards/%d", dashboardID), nil, nil)
 }
 
+// ListDashboardVersions returns a dashboard's version-history snapshots (newest
+// first), metadata only — no state. Read-only.
+func (c *APIClient) ListDashboardVersions(ctx context.Context, dashboardID int) ([]DashboardVersion, error) {
+	var resp struct {
+		Versions []DashboardVersion `json:"versions"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/dashboards/%d/versions", dashboardID), nil, &resp)
+	return resp.Versions, err
+}
+
+// GetDashboardVersion returns one snapshot including its full state, so the caller
+// can inspect exactly what that version contained.
+func (c *APIClient) GetDashboardVersion(ctx context.Context, dashboardID, versionID int) (*DashboardVersionDetail, error) {
+	var result DashboardVersionDetail
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/dashboards/%d/versions/%d", dashboardID, versionID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *APIClient) ListScheduledAgents(ctx context.Context) ([]ScheduledAgent, error) {
 	var resp struct {
 		ScheduledAgents []ScheduledAgent `json:"scheduled_agents"`

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -342,6 +342,22 @@ type Dashboard struct {
 	State      json.RawMessage `json:"state,omitempty"`
 }
 
+// DashboardVersion is one version-history snapshot's metadata (no state blob).
+type DashboardVersion struct {
+	ID         int    `json:"id"`
+	Kind       string `json:"kind"`        // "draft" | "published"
+	CreatedAt  string `json:"created_at"`  // ISO 8601; empty if unknown
+	Author     string `json:"author"`      // user / team / agent name; empty if unknown
+	AuthorKind string `json:"author_kind"` // "user" | "team" | "agent" | ""
+	ViaAPI     bool   `json:"via_api"`     // written through an API token (CLI) vs the UI
+}
+
+// DashboardVersionDetail is a snapshot including its full parsed state.
+type DashboardVersionDetail struct {
+	DashboardVersion
+	State json.RawMessage `json:"state"`
+}
+
 // ScheduledAgent represents a Bruin Cloud scheduled agent — a cron-based recurring
 // agent task. The nested plan fields (verified SQLs, memory, ...) are kept as raw
 // JSON so `--output json` round-trips the full server response faithfully.


### PR DESCRIPTION
Adds two commands to browse a dashboard's version history from the CLI:

- `bruin cloud dashboards versions --dashboard-id <id>` — list snapshots (kind, author, source, when)
- `bruin cloud dashboards version --dashboard-id <id> --version-id <vid>` — one snapshot with its full definition

Backed by the read-only cloud API. Lets the agent read history / reconstruct a prior version when asked.