### PR TITLE
Remove catchup param from stripe-bigquery template

### DIFF
--- a/templates/stripe-bigquery/pipeline.yml
+++ b/templates/stripe-bigquery/pipeline.yml
@@ -1,7 +1,6 @@
 name: stripe-bigquery
 schedule: daily
 start_date: "2023-01-01"
-catchup: false
 
 metadata_push:
   bigquery: true


### PR DESCRIPTION
## What

Removes the redundant `catchup: false` line from the `stripe-bigquery` starter template's `pipeline.yml`.

## Why

`catchup` already defaults to `false` when omitted (see `docs/pipelines/definition.md` — "`false` (or omitted): no catchup"). Setting it explicitly in the starter template adds no behavior and just adds noise to the minimal template config.

## Notes

- No README/docs changes required: neither the template `README.md` nor its docs mirror (`docs/getting-started/templates-docs/stripe-bigquery-README.md`) reference `catchup`, and neither embeds the full `pipeline.yml`. The general `catchup` documentation in `docs/pipelines/definition.md` documents the parameter itself and is unrelated to this template.
- `cmd/init_template_test.go` template tests pass (they assert on `name`/`source_connection`/`destination`, not `catchup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)