### PR TITLE
docs: reflow hard-wrapped Markdown to soft wrap

### DIFF
--- a/docs/assets/columns.md
+++ b/docs/assets/columns.md
@@ -8,8 +8,7 @@ Bruin supports column definitions inside assets to make them a part of your data
 
 ## Definition Schema
 
-The top level `columns` key is where you can define your columns. This is a list that contains all the columns defined
-with the asset, along with their quality checks and other metadata.
+The top level `columns` key is where you can define your columns. This is a list that contains all the columns defined with the asset, along with their quality checks and other metadata.
 
 Here's an example column definition:
 
@@ -61,9 +60,7 @@ Each column will have the following keys:
 
 ### Foreign keys
 
-`foreign_key` documents that a column references a column in another asset. It captures
-the relationship for documentation and lineage purposes; whether it is enforced depends on
-the target platform (most warehouses store it as metadata only).
+`foreign_key` documents that a column references a column in another asset. It captures the relationship for documentation and lineage purposes; whether it is enforced depends on the target platform (most warehouses store it as metadata only).
 
 ```yaml
 columns:
@@ -79,17 +76,11 @@ columns:
 | `table`  | String | yes  | The name of the referenced asset             |
 | `column` | String | yes  | The referenced column within that asset      |
 
-These fields are optional, but when set, `bruin validate` checks that they are well-formed:
-a foreign key must name both a `table` and a `column`, the referenced asset must exist in
-the pipeline, and the referenced column must exist on it. Numeric type detail is also
-checked — `precision`/`length` must be positive, `scale` must not be negative, and `scale`
-must not exceed `precision`.
+These fields are optional, but when set, `bruin validate` checks that they are well-formed: a foreign key must name both a `table` and a `column`, the referenced asset must exist in the pipeline, and the referenced column must exist on it. Numeric type detail is also checked — `precision`/`length` must be positive, `scale` must not be negative, and `scale` must not exceed `precision`.
 
 ### Type detail
 
-`precision`, `scale`, `length`, and `collation` complement `type` with the structured
-detail that databases keep at the column level. They do not replace `type`; you can set
-`type: decimal` and add `precision`/`scale` instead of encoding it as `decimal(10,2)`.
+`precision`, `scale`, `length`, and `collation` complement `type` with the structured detail that databases keep at the column level. They do not replace `type`; you can set `type: decimal` and add `precision`/`scale` instead of encoding it as `decimal(10,2)`.
 
 ```yaml
 columns:
@@ -106,12 +97,7 @@ columns:
 
 ### DDL generation
 
-When an asset uses the `ddl` [materialization](./materialization.md) strategy, these fields
-are emitted into the generated `CREATE TABLE` statement: `precision`/`scale`/`length` become
-type modifiers (e.g. `decimal(10, 2)`, `varchar(255)`), and `collation`, `default`, and
-`foreign_key` become column/table clauses. Foreign keys are emitted as `NOT ENFORCED` on
-platforms that only store them as metadata (e.g. BigQuery). Support is currently available
-for PostgreSQL, BigQuery, and Snowflake, and is being extended to the other platforms.
+When an asset uses the `ddl` [materialization](./materialization.md) strategy, these fields are emitted into the generated `CREATE TABLE` statement: `precision`/`scale`/`length` become type modifiers (e.g. `decimal(10, 2)`, `varchar(255)`), and `collation`, `default`, and `foreign_key` become column/table clauses. Foreign keys are emitted as `NOT ENFORCED` on platforms that only store them as metadata (e.g. BigQuery). Support is currently available for PostgreSQL, BigQuery, and Snowflake, and is being extended to the other platforms.
 
 ### Quality Checks
 
@@ -127,9 +113,7 @@ For more details on the quality checks, please refer to the  [Quality](../qualit
 
 ### Column name mapping (ingestr assets)
 
-For ingestr assets, you can rename a column on its way from the source to the destination
-by setting `source_column` on the column entry. The `name` field stays the destination
-column name; `source_column` is the column that exists on the source.
+For ingestr assets, you can rename a column on its way from the source to the destination by setting `source_column` on the column entry. The `name` field stays the destination column name; `source_column` is the column that exists on the source.
 
 ```yaml
 columns:
@@ -145,12 +129,9 @@ columns:
     type: timestamp
 ```
 
-With the mapping above, the source table's `fname`, `eml`, and `crtd_ts` columns land in
-the destination as `first_name`, `email`, and `created_at`. Columns without
-`source_column` keep their original source names.
+With the mapping above, the source table's `fname`, `eml`, and `crtd_ts` columns land in the destination as `first_name`, `email`, and `created_at`. Columns without `source_column` keep their original source names.
 
-For the mapping to take effect, `enforce_schema: "true"` must be set under the asset's
-`parameters` block. 
+For the mapping to take effect, `enforce_schema: "true"` must be set under the asset's `parameters` block.
 
 ```yaml
 parameters:
@@ -166,9 +147,7 @@ columns:
 
 ### Column masking (ingestr assets)
 
-For ingestr assets, you can define a column mask next to the column metadata. If `mask`
-contains only the masking method, Bruin qualifies it with the column name before passing
-it to ingestr:
+For ingestr assets, you can define a column mask next to the column metadata. If `mask` contains only the masking method, Bruin qualifies it with the column name before passing it to ingestr:
 
 ```yaml
 columns:
@@ -177,8 +156,7 @@ columns:
     mask: hash
 ```
 
-The example above is passed to ingestr as `--mask email:hash`. You can also provide the
-full ingestr mask rule directly:
+The example above is passed to ingestr as `--mask email:hash`. You can also provide the full ingestr mask rule directly:
 
 ```yaml
 columns:

--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -75,8 +75,7 @@ Standalone YAML assets must use the file name suffix `<name>.asset.yml` or `<nam
 
 ## `name`
 
-The name of the asset, used for many things including dependencies, materialization and more. Corresponds to the `schema.table` convention.
-Must consist of letters and dot `.` character.
+The name of the asset, used for many things including dependencies, materialization and more. Corresponds to the `schema.table` convention. Must consist of letters and dot `.` character.
 
 - **Type:** `String`
 
@@ -184,8 +183,7 @@ enabled: "{{ var.asset_enabled }}"
 
 ## `connection`
 
-The connection name used to run this asset. If omitted, Bruin uses the pipeline-level `default_connections` value for the asset platform in most cases.
-For Python assets with `materialization.type: table`, `connection` must be set explicitly on the asset.
+The connection name used to run this asset. If omitted, Bruin uses the pipeline-level `default_connections` value for the asset platform in most cases. For Python assets with `materialization.type: table`, `connection` must be set explicitly on the asset.
 
 ```yaml
 connection: bigquery-default
@@ -223,9 +221,7 @@ Additional metadata for the asset stored as key-value pairs. This can be used to
 
 ## `depends`
 
-The list of assets this asset depends on. This list determines the execution order.
-In other words, the asset will be executed only when all of the assets in the `depends` list have succeeded.
-The items of this list can be just a `String` with the name of the asset in the same pipeline or an `Object` which can contain the following attributes
+The list of assets this asset depends on. This list determines the execution order. In other words, the asset will be executed only when all of the assets in the `depends` list have succeeded. The items of this list can be just a `String` with the name of the asset in the same pipeline or an `Object` which can contain the following attributes
 
 - `asset` : The name of the asset. Must be on the same pipeline
 - `uri` : The URI of the upstream asset. This is used in [cloud](../cloud/overview.md) when you want to have an upstream on a different pipeline. See [uri](#uri) above
@@ -259,8 +255,7 @@ interval_modifiers:
   start: '{% if start_timestamp|date_format("%H") == "00" %}-20d{% else %}0{% endif %}'
 ```
 
-Supported time units: `ns` (nanoseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `M` (months).
-See [interval modifiers](./interval-modifiers) for more details.
+Supported time units: `ns` (nanoseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `M` (months). See [interval modifiers](./interval-modifiers) for more details.
 
 - **Type:** `Object`
 
@@ -290,8 +285,7 @@ Sets the timeout for an asset. During `bruin run`, an execution step that exceed
 timeout: 1h30m
 ```
 
-If omitted, the asset inherits `default.timeout` from `pipeline.yml` when one is configured.
-The timeout must be at least one second. It is separate from the run-wide [`bruin run --timeout`](/commands/run) setting; whichever deadline is reached first cancels the execution.
+If omitted, the asset inherits `default.timeout` from `pipeline.yml` when one is configured. The timeout must be at least one second. It is separate from the run-wide [`bruin run --timeout`](/commands/run) setting; whichever deadline is reached first cancels the execution.
 
 - **Type:** `String` (Go duration)
 

--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -346,8 +346,7 @@ Supported platforms for `merge_sql`:
 - Athena (Iceberg tables): supported
 - Databricks, ClickHouse, Trino, DuckDB, Dremio, Sail: not supported
 
-Spark `merge` requires a catalog and table format that implement row-level
-`MERGE INTO`, such as Iceberg with the Spark SQL extensions enabled.
+Spark `merge` requires a catalog and table format that implement row-level `MERGE INTO`, such as Iceberg with the Spark SQL extensions enabled.
 
 > [!INFO]
 > An important difference between `merge` and `delete+insert` is that `merge` will update the existing rows, while `delete+insert` will delete the existing rows and insert the new rows. This means if your source has deleted rows, `merge` will not delete them from the destination, whereas `delete+insert` will if their `incremental_key` matches.
@@ -463,12 +462,9 @@ The strategy will:
 
 ### `DDL`
 
-The `DDL` (Data Definition Language) strategy is used to create a new table using the information provided in the
-embedded YAML section of the asset. This is useful when you want to create a new table with a specific schema and structure
-and ensure that this table is only created once.
+The `DDL` (Data Definition Language) strategy is used to create a new table using the information provided in the embedded YAML section of the asset. This is useful when you want to create a new table with a specific schema and structure and ensure that this table is only created once.
 
-The `DDL` strategy defines the table structure via column definitions in the columns field of the asset.
-For this reason, you should not include any query after the embedded YAML section.
+The `DDL` strategy defines the table structure via column definitions in the columns field of the asset. For this reason, you should not include any query after the embedded YAML section.
 
 Here's an example of an asset with `DDL` materialization:
 
@@ -508,8 +504,7 @@ This strategy will:
 - Create a new empty table with the name `dashboard.products`
 - Use the provided schema to define the column names, column types as well as optional primary key constraints and descriptions.
 
-The strategy also supports partitioning and clustering for data warehouses that support these features. You can specify
-in the materialization definition with the following keys:
+The strategy also supports partitioning and clustering for data warehouses that support these features. You can specify in the materialization definition with the following keys:
 
 - `partition_by`
 - `cluster_by`
@@ -705,8 +700,7 @@ This strategy automatically detects changes in non-primary key columns and creat
 - At least one column must be marked as `primary_key: true`
 - The column names `_valid_from`, `_valid_until`, and `_is_current` are reserved and cannot be used in your column definitions
 
-**How it works:**
-When changes are detected in non-primary key columns:
+**How it works:** When changes are detected in non-primary key columns:
 
 1. The existing record is marked as historical (`_is_current: false`) and gets an end timestamp in `_valid_until`
 2. A new record is inserted with the updated values (`_is_current: true`) and `_valid_until` set to '9999-12-31'
@@ -869,8 +863,7 @@ The `scd2_by_time` strategy implements [Slowly Changing Dimension Type 2](https:
 - An `incremental_key` must be specified that references a column of type `TIMESTAMP` or `DATE`
 - The column names `_valid_from`, `_valid_until`, and `_is_current` are reserved and cannot be used in your column definitions
 
-**How it works:**
-The strategy tracks changes based on the time values in the `incremental_key` column:
+**How it works:** The strategy tracks changes based on the time values in the `incremental_key` column:
 
 1. When a record has a newer timestamp than existing records, it creates a new version
 2. Previous versions are marked as historical (`_is_current: false`) with their `_valid_until` updated

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -193,9 +193,7 @@ bruin cloud runs trigger \
   --end-date 2024-01-31
 ```
 
-On success, the command prints the created run ID so you can match the invocation
-to its logs and status. With `--output json`, the response includes the ID in
-`run_id`.
+On success, the command prints the created run ID so you can match the invocation to its logs and status. With `--output json`, the response includes the ID in `run_id`.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
@@ -210,9 +208,7 @@ to its logs and status. With `--output json`, the response includes the ID in
 | `--split` | str | - | Trigger a backfill, splitting the date range into one run per interval by unit: `minute`, `hour`, `day`, `week`, `month`, `year`. |
 | `--chunk-size` | int | `1` | Number of split units per batch (used with `--split`). |
 
-**Run only selected assets.** Select assets with `--asset` using their **full name**
-(`schema.table`, repeatable or comma-separated). Without a selection, the whole pipeline
-runs.
+**Run only selected assets.** Select assets with `--asset` using their **full name** (`schema.table`, repeatable or comma-separated). Without a selection, the whole pipeline runs.
 
 ```bash
 # Run a single asset (full schema.table name)
@@ -228,9 +224,7 @@ bruin cloud runs trigger \
   --asset analytics.raw_events,analytics.daily_summary
 ```
 
-**Include downstream assets.** Add `--downstream` to also run everything that depends on
-the selected `--asset`(s), following the pipeline's dependency graph. It requires
-`--asset`.
+**Include downstream assets.** Add `--downstream` to also run everything that depends on the selected `--asset`(s), following the pipeline's dependency graph. It requires `--asset`.
 
 ```bash
 # Run raw_events and everything downstream of it
@@ -240,9 +234,7 @@ bruin cloud runs trigger \
   --asset analytics.raw_events --downstream
 ```
 
-**Full refresh.** Pass `--full-refresh` (bare, no value) to truncate assets before
-running. It covers the `--asset` selection when you give one, otherwise every asset in
-the pipeline.
+**Full refresh.** Pass `--full-refresh` (bare, no value) to truncate assets before running. It covers the `--asset` selection when you give one, otherwise every asset in the pipeline.
 
 ```bash
 # Full-refresh the whole pipeline (every asset)
@@ -268,9 +260,7 @@ bruin cloud runs trigger \
 > `--full-refresh` truncates whatever the run covers: with `--asset` it refreshes only
 > the selected assets, without it the whole pipeline.
 
-**Override pipeline variables.** Each `--var` is `key=value`, where the **value is parsed
-as JSON**. So a string must be quoted (`"prod"`), while numbers and booleans are written
-bare. Repeat `--var` for multiple keys, or pass a whole JSON object at once.
+**Override pipeline variables.** Each `--var` is `key=value`, where the **value is parsed as JSON**. So a string must be quoted (`"prod"`), while numbers and booleans are written bare. Repeat `--var` for multiple keys, or pass a whole JSON object at once.
 
 ```bash
 # String value — note the JSON quotes (wrapped in single quotes for the shell)
@@ -292,10 +282,7 @@ bruin cloud runs trigger \
   --var '{"env":"prod","retries":3}'
 ```
 
-**Split a range into batches (monthly, weekly, …).** With `--split`, the trigger
-becomes a **backfill**: the date range is split into one run per interval
-(by unit and chunk size) as a single backfill. This is
-how you backfill selected assets with monthly batches:
+**Split a range into batches (monthly, weekly, …).** With `--split`, the trigger becomes a **backfill**: the date range is split into one run per interval (by unit and chunk size) as a single backfill. This is how you backfill selected assets with monthly batches:
 
 ```bash
 # One run per month across the quarter, for a single asset
@@ -306,8 +293,7 @@ bruin cloud runs trigger \
   --asset my_asset
 ```
 
-Use `--chunk-size` to group several split units into each batch. For example weekly
-batches via 7-day chunks, or two-month batches:
+Use `--chunk-size` to group several split units into each batch. For example weekly batches via 7-day chunks, or two-month batches:
 
 ```bash
 # One run per week (7-day chunks)
@@ -335,8 +321,7 @@ bruin cloud runs trigger \
 > include a final period, pass the date one period past it — e.g. `--end-date 2024-01-04`
 > to cover `2024-01-03` with `--split day`.
 
-When a `--split` trigger succeeds, the command prints a link to track the backfill
-in the dashboard:
+When a `--split` trigger succeeds, the command prints a link to track the backfill in the dashboard:
 
 ```text
 Successfully triggered backfill (split by day, chunk size 1) for pipeline 'my-pipeline' in project 'my-project'
@@ -426,14 +411,11 @@ List recent backfills, optionally filtered by project and pipeline:
 bruin cloud backfills list --project-id <project-id> --pipeline <pipeline-name>
 ```
 
-Each row shows the backfill ID (the `multiple_action_id`), its overall interval,
-and how many runs it fanned out into. Use `--limit` to control how many backfills
-are returned (default 20).
+Each row shows the backfill ID (the `multiple_action_id`), its overall interval, and how many runs it fanned out into. Use `--limit` to control how many backfills are returned (default 20).
 
 #### `runs`
 
-List the individual runs that make up a single backfill, using the backfill ID
-from `backfills list`:
+List the individual runs that make up a single backfill, using the backfill ID from `backfills list`:
 
 ```bash
 bruin cloud backfills runs --id <backfill-id>
@@ -545,9 +527,7 @@ bruin cloud glossary get --project-id <project-id> --entity <entity-name>
 
 ### `agents`
 
-Interact with Bruin Cloud AI agents from the terminal. Agents are scoped to your
-account (team) via the API key, not to a specific project, so these commands do
-not take a `--project-id`.
+Interact with Bruin Cloud AI agents from the terminal. Agents are scoped to your account (team) via the API key, not to a specific project, so these commands do not take a `--project-id`.
 
 #### `list`
 
@@ -559,10 +539,7 @@ bruin cloud agents list
 
 #### `usage-stats`
 
-Show AI usage across the agents you can see — total messages/threads, the
-current month's counters, and a per-agent breakdown. Defaults to the last 30
-days; pass `--days`, or an explicit `--start-date`/`--end-date` window. Use
-`--output json` for the full payload (per-day/per-month/per-user series).
+Show AI usage across the agents you can see — total messages/threads, the current month's counters, and a per-agent breakdown. Defaults to the last 30 days; pass `--days`, or an explicit `--start-date`/`--end-date` window. Use `--output json` for the full payload (per-day/per-month/per-user series).
 
 ```bash
 bruin cloud agents usage-stats
@@ -573,8 +550,7 @@ bruin cloud agents usage-stats --output json
 
 #### `delete`
 
-Delete an agent. Cascades to its scheduled agents, dashboards and chat threads,
-and revokes its Cloud-CLI token. Requires an owner or team admin.
+Delete an agent. Cascades to its scheduled agents, dashboards and chat threads, and revokes its Cloud-CLI token. Requires an owner or team admin.
 
 ```bash
 bruin cloud agents delete --agent-id <agent-id>
@@ -582,9 +558,7 @@ bruin cloud agents delete --agent-id <agent-id>
 
 #### `connections`
 
-List the connections available to an agent — names and types only (never
-credential values). Use it to pick a connection the agent can actually query,
-e.g. for a dashboard's `connection`:
+List the connections available to an agent — names and types only (never credential values). Use it to pick a connection the agent can actually query, e.g. for a dashboard's `connection`:
 
 ```bash
 bruin cloud agents connections --agent-id 7
@@ -593,10 +567,7 @@ bruin cloud agents connections --agent-id 7 --output json
 
 ##### `connections add`
 
-Add a connection to an agent's connection set so it can query it. By default the
-connection is read from your local `.bruin.yml` by name; alternatively pass the
-credentials inline with `--credentials` (JSON) and `--type`. Credential values
-are sent to Bruin Cloud but never printed.
+Add a connection to an agent's connection set so it can query it. By default the connection is read from your local `.bruin.yml` by name; alternatively pass the credentials inline with `--credentials` (JSON) and `--type`. Credential values are sent to Bruin Cloud but never printed.
 
 ```bash
 # From local .bruin.yml (reads type + credentials for the named connection)
@@ -612,8 +583,7 @@ bruin cloud agents connections add \
 
 #### `mcp`
 
-Manage an agent's external MCP servers (Linear, GitHub, Notion, …). Each MCP kind
-is backed by a `bruin.yml` connection from the agent's dev-env set.
+Manage an agent's external MCP servers (Linear, GitHub, Notion, …). Each MCP kind is backed by a `bruin.yml` connection from the agent's dev-env set.
 
 `list` shows the agent's current picks plus the connections eligible for each kind:
 
@@ -699,9 +669,7 @@ bruin cloud agents messages \
 
 #### `export-thread`
 
-Export a whole thread as JSON (thread, agent, and every message pair with
-input/output, agent logs, and query logs). Prints to stdout, or writes to a file
-with `--file`:
+Export a whole thread as JSON (thread, agent, and every message pair with input/output, agent logs, and query logs). Prints to stdout, or writes to a file with `--file`:
 
 ```bash
 bruin cloud agents export-thread \
@@ -716,13 +684,11 @@ bruin cloud agents export-thread \
 
 ### `connections`
 
-Manage the connections stored in Bruin Cloud. Connections live in your team's
-vault and are shared by your cloud pipelines.
+Manage the connections stored in Bruin Cloud. Connections live in your team's vault and are shared by your cloud pipelines.
 
 #### `add`
 
-Push a connection to Bruin Cloud. By default it reads the connection straight
-from your local `.bruin.yml`, so you don't have to retype credentials:
+Push a connection to Bruin Cloud. By default it reads the connection straight from your local `.bruin.yml`, so you don't have to retype credentials:
 
 ```bash
 # Reads the "my_pg" connection from the selected environment in .bruin.yml
@@ -735,16 +701,11 @@ bruin cloud connections add --name my_pg --environment prod
 bruin cloud connections add --name my_pg --config-file ./path/to/.bruin.yml
 ```
 
-When `--environment` is omitted, the `default_environment` from `.bruin.yml` is
-used (falling back to `default`).
+When `--environment` is omitted, the `default_environment` from `.bruin.yml` is used (falling back to `default`).
 
-For service-account based connections (BigQuery, GCS, Spanner, …) the CLI reads
-the local `service_account_file` and uploads its contents, since the cloud
-runner can't reach your local disk. A relative `service_account_file` is
-resolved against the `.bruin.yml` directory.
+For service-account based connections (BigQuery, GCS, Spanner, …) the CLI reads the local `service_account_file` and uploads its contents, since the cloud runner can't reach your local disk. A relative `service_account_file` is resolved against the `.bruin.yml` directory.
 
-To add a connection without a local `.bruin.yml` (e.g. in CI), pass the
-credentials inline. `--type` is required in this mode:
+To add a connection without a local `.bruin.yml` (e.g. in CI), pass the credentials inline. `--type` is required in this mode:
 
 ```bash
 bruin cloud connections add \
@@ -774,11 +735,7 @@ bruin cloud connections delete --name my_pg
 
 ### `connection-sets`
 
-Manage connection **sets** — named bundles of connections an agent runs against
-(assigned to an agent via its connection set). Distinct from individual
-connections. Credentials are write-only: reads never return config values, and
-create/update always send a full config per connection (read from the local
-`.bruin.yml`).
+Manage connection **sets** — named bundles of connections an agent runs against (assigned to an agent via its connection set). Distinct from individual connections. Credentials are write-only: reads never return config values, and create/update always send a full config per connection (read from the local `.bruin.yml`).
 
 #### `list`
 
@@ -805,8 +762,7 @@ bruin cloud connection-sets create --name prod \
   --connection my_pg --connection my_bq
 ```
 
-Use `--skip-validation` to skip the live connection test, and `--environment` /
-`--config-file` to pick a specific `.bruin.yml` / environment.
+Use `--skip-validation` to skip the live connection test, and `--environment` / `--config-file` to pick a specific `.bruin.yml` / environment.
 
 #### `update`
 
@@ -828,8 +784,7 @@ To assign a set to an agent, use `bruin cloud agents update --agent-id <id> --co
 
 ### `dashboards`
 
-Read the dashboards in your Bruin Cloud team — useful for inspecting or
-version-controlling a dashboard's definition.
+Read the dashboards in your Bruin Cloud team — useful for inspecting or version-controlling a dashboard's definition.
 
 #### `list`
 
@@ -853,12 +808,9 @@ bruin cloud dashboards get --dashboard-id 42 --output json
 
 #### `create`
 
-Create a dashboard from a definition. The definition is written to the dashboard's
-**draft** — it is never published automatically; publish it from the Bruin Cloud UI.
+Create a dashboard from a definition. The definition is written to the dashboard's **draft** — it is never published automatically; publish it from the Bruin Cloud UI.
 
-Pass `--agent-id` to bind the dashboard to an agent so its canvas chat and refresh
-work. If omitted, the server falls back to the agent encoded in a Cloud-CLI token;
-a generic team token has none, so the dashboard opens without a chat panel.
+Pass `--agent-id` to bind the dashboard to an agent so its canvas chat and refresh work. If omitted, the server falls back to the agent encoded in a Cloud-CLI token; a generic team token has none, so the dashboard opens without a chat panel.
 
 ```bash
 # Title only (empty draft)
@@ -948,10 +900,7 @@ filters:
     options: { query: "SELECT DISTINCT region FROM orders ORDER BY 1" }
 ```
 
-A widget's SQL references a filter with a double-brace placeholder named after the
-filter. Single-value filters (`date`, `text`, `number`, `select`) resolve to one
-value; a `date-range` filter resolves to a `.start` / `.end` pair; a multi-select
-(`select` with `multiple: true`) resolves to a list, so guard it and expand it:
+A widget's SQL references a filter with a double-brace placeholder named after the filter. Single-value filters (`date`, `text`, `number`, `select`) resolve to one value; a `date-range` filter resolves to a `.start` / `.end` pair; a multi-select (`select` with `multiple: true`) resolves to a list, so guard it and expand it:
 
 ```sql
 SELECT * FROM orders
@@ -967,11 +916,7 @@ Filters only act on `sql` widgets, so a dashboard built purely from inline data 
 
 #### `update`
 
-Update an existing dashboard's title, visibility, or definition. Only the flags
-you pass are changed. Like `create`, a new definition is written to the
-dashboard's **draft** — never published automatically; publish it from the Bruin
-Cloud UI. Changing visibility requires manage-access (the dashboard creator or a
-team admin).
+Update an existing dashboard's title, visibility, or definition. Only the flags you pass are changed. Like `create`, a new definition is written to the dashboard's **draft** — never published automatically; publish it from the Bruin Cloud UI. Changing visibility requires manage-access (the dashboard creator or a team admin).
 
 ```bash
 # Rename
@@ -987,9 +932,7 @@ bruin cloud dashboards update --dashboard-id 42 --visibility team
 
 #### `delete`
 
-Delete a dashboard so it stops appearing. Requires manage-access (the dashboard
-creator or a team admin); repo (DAC) dashboards are managed in the repo and can't
-be deleted here.
+Delete a dashboard so it stops appearing. Requires manage-access (the dashboard creator or a team admin); repo (DAC) dashboards are managed in the repo and can't be deleted here.
 
 ```bash
 bruin cloud dashboards delete --dashboard-id 42
@@ -1011,10 +954,7 @@ bruin cloud scheduled-agents get --scheduled-agent-id 42 --output json
 
 #### `create`
 
-Create a scheduled agent from a plan. It is stored as an inactive **draft** — a
-human reviews and activates it from the Bruin Cloud UI; the CLI never activates a
-run. Pass the plan with convenience flags, or the full plan via `--state-file`
-(JSON or YAML with `schedule`, `instructions`, `verified_sqls`, `memory`, ...).
+Create a scheduled agent from a plan. It is stored as an inactive **draft** — a human reviews and activates it from the Bruin Cloud UI; the CLI never activates a run. Pass the plan with convenience flags, or the full plan via `--state-file` (JSON or YAML with `schedule`, `instructions`, `verified_sqls`, `memory`, ...).
 
 ```bash
 bruin cloud scheduled-agents create --agent-id 7 --title "Daily revenue" \
@@ -1025,8 +965,7 @@ bruin cloud scheduled-agents create --agent-id 7 --state-file ./plan.yaml
 
 #### `update`
 
-Update a run's title or plan. Only the flags you pass change. Activation stays in
-the UI.
+Update a run's title or plan. Only the flags you pass change. Activation stays in the UI.
 
 ```bash
 bruin cloud scheduled-agents update --scheduled-agent-id 42 --cron "0 8 * * 1"
@@ -1035,9 +974,7 @@ bruin cloud scheduled-agents update --scheduled-agent-id 42 --state-file ./plan.
 
 #### `trigger`
 
-Run a scheduled agent now, off its schedule — the "Run now" action. The schedule
-is untouched (the next scheduled run still fires as planned). Refused while a run
-is already in progress. Prints the execution and thread ids.
+Run a scheduled agent now, off its schedule — the "Run now" action. The schedule is untouched (the next scheduled run still fires as planned). Refused while a run is already in progress. Prints the execution and thread ids.
 
 ```bash
 bruin cloud scheduled-agents trigger --scheduled-agent-id 42
@@ -1053,10 +990,7 @@ bruin cloud scheduled-agents delete --scheduled-agent-id 42
 
 #### `run-states`
 
-Manage a scheduled agent's **run-state** files — the markdown "memory" the agent
-persists across runs (keyed by name, upserted on write). Reads and writes both
-require only the `scheduled-agent:list` ability, so any Cloud-CLI-enabled agent
-can manage its own run state.
+Manage a scheduled agent's **run-state** files — the markdown "memory" the agent persists across runs (keyed by name, upserted on write). Reads and writes both require only the `scheduled-agent:list` ability, so any Cloud-CLI-enabled agent can manage its own run state.
 
 ```bash
 # List the files on a scheduled agent
@@ -1077,8 +1011,7 @@ bruin cloud scheduled-agents run-states delete --scheduled-agent-id 42 --name me
 
 ### `skills`
 
-Manage the team **skill library** — named instruction snippets you attach to
-agents. Team-scoped (you only see your own team's skills).
+Manage the team **skill library** — named instruction snippets you attach to agents. Team-scoped (you only see your own team's skills).
 
 ```bash
 # List
@@ -1171,9 +1104,7 @@ bruin cloud runs trigger \
   --end-date 2024-01-31
 ```
 
-To reprocess in batches — one run per month, week, or day — add `--split` (and
-optionally `--chunk-size`). Combine it with an `--asset` selection to backfill just
-part of the pipeline:
+To reprocess in batches — one run per month, week, or day — add `--split` (and optionally `--chunk-size`). Combine it with an `--asset` selection to backfill just part of the pipeline:
 
 ```bash
 # One run per month across the year, for a single asset

--- a/docs/commands/connections.md
+++ b/docs/commands/connections.md
@@ -132,8 +132,7 @@ bruin connections delete -e staging -n test-connection -o json
 
 ## Test Connection
 
-To test if a connection is valid, you can use the test command.
-This command runs a simple validation check for the connection.
+To test if a connection is valid, you can use the test command. This command runs a simple validation check for the connection.
 
 ```bash
 bruin connections test --name <connection-name> [--env <environment>]

--- a/docs/commands/curl.md
+++ b/docs/commands/curl.md
@@ -1,8 +1,6 @@
 # Curl Command
 
-The `curl` command runs the installed `curl` executable with arguments rendered from Bruin
-connections. It is a pass-through wrapper, so it supports the complete option and variable
-surface of the installed curl version without Bruin needing to duplicate curl's flags.
+The `curl` command runs the installed `curl` executable with arguments rendered from Bruin connections. It is a pass-through wrapper, so it supports the complete option and variable surface of the installed curl version without Bruin needing to duplicate curl's flags.
 
 Put Bruin's flags before `--` and all curl flags, values, and URLs after it:
 
@@ -13,17 +11,11 @@ bruin curl -- \
   "https://api.example.com/v1/items"
 ```
 
-Bruin renders each argument and passes the resulting argument list directly to the installed curl
-executable in the same order. It does not inspect, validate, or maintain a list of curl options, so
-options supported by the installed curl version work without a corresponding Bruin release. Curl
-alone interprets the rendered arguments and determines whether they are valid. Bruin connects
-curl's stdin, stdout, and stderr directly to the caller.
+Bruin renders each argument and passes the resulting argument list directly to the installed curl executable in the same order. It does not inspect, validate, or maintain a list of curl options, so options supported by the installed curl version work without a corresponding Bruin release. Curl alone interprets the rendered arguments and determines whether they are valid. Bruin connects curl's stdin, stdout, and stderr directly to the caller.
 
 ## Referencing connections
 
-Build the URL, headers, and body from the connection — do not hardcode hosts, project
-ids, or tokens. Call `bruin.connection("<name>")` from Jinja to retrieve a connection
-by its existing Bruin name. Its fields use the same snake_case names as `.bruin.yml`:
+Build the URL, headers, and body from the connection — do not hardcode hosts, project ids, or tokens. Call `bruin.connection("<name>")` from Jinja to retrieve a connection by its existing Bruin name. Its fields use the same snake_case names as `.bruin.yml`:
 
 ```yaml
 environments:
@@ -43,24 +35,19 @@ bruin curl -- \
   'https://api.example.com/accounts/{{ bruin.connection("my-api").name }}'
 ```
 
-One command may reference any number of connections, and repeated references to the same connection
-are resolved only once. Fields nested inside a connection can be traversed with additional dots:
+One command may reference any number of connections, and repeated references to the same connection are resolved only once. Fields nested inside a connection can be traversed with additional dots:
 
 ```jinja
 {{ bruin.connection("service-api").credentials.client_id }}
 ```
 
-If you do not know which field a connection exposes — `api_key` or `api_token`, for instance — run
-`bruin connections list`. The `FILLED FIELDS` column lists the field names that are set on each
-connection, without printing their values.
+If you do not know which field a connection exposes — `api_key` or `api_token`, for instance — run `bruin connections list`. The `FILLED FIELDS` column lists the field names that are set on each connection, without printing their values.
 
 The usual Bruin Jinja helpers remain available in the same namespace. For example,
 <code v-pre>{{ bruin.slugify("Account Name") }}</code> renders as `account_name`. Most other helpers
-generate SQL expressions and are primarily useful in asset templates; see [Jinja templating and
-built-in functions](/assets/templating/macros).
+generate SQL expressions and are primarily useful in asset templates; see [Jinja templating and built-in functions](/assets/templating/macros).
 
-Use `--environment` (or `--env`) to select a non-default environment and `--config-file` to use a
-specific `.bruin.yml` file. Bruin's global `--secrets-backend` flag is also supported:
+Use `--environment` (or `--env`) to select a non-default environment and `--config-file` to use a specific `.bruin.yml` file. Bruin's global `--secrets-backend` flag is also supported:
 
 ```bash
 bruin --secrets-backend vault curl -- \
@@ -68,14 +55,11 @@ bruin --secrets-backend vault curl -- \
   https://api.example.com
 ```
 
-Connections from a secrets backend are fetched by the names used in the Jinja expressions; Bruin
-does not need to enumerate every secret in the backend.
+Connections from a secrets backend are fetched by the names used in the Jinja expressions; Bruin does not need to enumerate every secret in the backend.
 
 ## Curl variables
 
-Curl uses <code v-pre>{{name}}</code>-style expressions for values supplied with `--variable`, which
-overlaps with Jinja syntax. Bruin recognizes curl's variable syntax and leaves those expressions for
-curl while still rendering connection references in the same argument:
+Curl uses <code v-pre>{{name}}</code>-style expressions for values supplied with `--variable`, which overlaps with Jinja syntax. Bruin recognizes curl's variable syntax and leaves those expressions for curl while still rendering connection references in the same argument:
 
 ```bash
 bruin curl -- \
@@ -83,13 +67,9 @@ bruin curl -- \
   --expand-url 'https://{{ bruin.connection("my-api").host }}/v1/{{path:url}}'
 ```
 
-Curl variable names are alphanumeric with underscores and do not contain dots, optionally followed
-by colon-separated functions such as <code v-pre>{{path:trim:url}}</code>. Bruin connection expressions are
-namespaced under `bruin.connection(...)`, which makes the two forms unambiguous.
+Curl variable names are alphanumeric with underscores and do not contain dots, optionally followed by colon-separated functions such as <code v-pre>{{path:trim:url}}</code>. Bruin connection expressions are namespaced under `bruin.connection(...)`, which makes the two forms unambiguous.
 
-All curl arguments, including option names, option values, URLs, and curl variable declarations,
-are rendered independently. Use `bruin curl -- --help all` to view every option supported by the
-installed curl executable.
+All curl arguments, including option names, option values, URLs, and curl variable declarations, are rendered independently. Use `bruin curl -- --help all` to view every option supported by the installed curl executable.
 
 > Rendered values are passed as curl process arguments and may be visible to local process-inspection
 > tools. Curl can also reveal credentials through `--verbose`, `--trace`, `--trace-ascii`, `--libcurl`,

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -2,8 +2,7 @@
 
 ## Overview
 
-The `bruin init` command bootstraps a new **Bruin pipeline** from a predefined template.
-It automatically sets up the folder structure, initializes configuration files, and optionally creates a new Git repository.
+The `bruin init` command bootstraps a new **Bruin pipeline** from a predefined template. It automatically sets up the folder structure, initializes configuration files, and optionally creates a new Git repository.
 
 You can use it to start a new data pipeline project quickly, or to add a new pipeline inside an existing repository.
 
@@ -33,8 +32,7 @@ bruin init self-heal-demo
 
 When you run `bruin init`, it:
 
-1. Lists available templates from Bruin’s internal template registry.
-   You can interactively select one via a terminal UI.
+1. Lists available templates from Bruin’s internal template registry. You can interactively select one via a terminal UI.
 2. Copies all template files (e.g. `.asset.yml`, `.sql`, `.py`) into the target folder.
 3. Merges any template-level `.bruin.yml` configuration into your existing (or newly created) root `.bruin.yml`.
 4. Optionally initializes a **Git repository** if none exists.
@@ -76,8 +74,7 @@ If the selected template contains its own `.bruin.yml`, Bruin merges:
 * **Secrets**
 * **Default settings**
 
-into the existing `.bruin.yml` at your project root.
-This ensures shared environments (like `dev`, `prod`, etc.) stay consistent across pipelines.
+into the existing `.bruin.yml` at your project root. This ensures shared environments (like `dev`, `prod`, etc.) stay consistent across pipelines.
 
 ## Arguments
 

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -1,7 +1,6 @@
 # Query Command
 
-The `query` command executes and retrieves the results of a query on a specified connection and
-returns the results in table format, JSON, or CSV.
+The `query` command executes and retrieves the results of a query on a specified connection and returns the results in table format, JSON, or CSV.
 
 You can run it in three modes:
 
@@ -79,9 +78,7 @@ Each file includes the header row with column names.
 
 ## Template variables
 
-You can inject Jinja template variables into a query with `--var`. The flag can be passed
-multiple times and supports flat, nested, and JSON values, so you can test dashboard-style
-SQL — including nested `filters.*` variables — directly from the CLI.
+You can inject Jinja template variables into a query with `--var`. The flag can be passed multiple times and supports flat, nested, and JSON values, so you can test dashboard-style SQL — including nested `filters.*` variables — directly from the CLI.
 
 **Flat variables:**
 
@@ -93,8 +90,7 @@ bruin query --connection my_connection \
 
 **Nested variables (dot-notation):**
 
-Use a dotted key to build a nested object. This matches the nested `filters` object the
-dashboard runtime injects, so <span v-pre>`{{ filters.start_date }}`</span> resolves as expected:
+Use a dotted key to build a nested object. This matches the nested `filters` object the dashboard runtime injects, so <span v-pre>`{{ filters.start_date }}`</span> resolves as expected:
 
 ```bash
 bruin query --connection my_connection \
@@ -113,15 +109,11 @@ bruin query --connection my_connection \
   --var filters='{"start_date":"2026-05-20","end_date":"2026-05-27"}'
 ```
 
-Scalar values are kept as literal strings (matching how pipeline variables work in YAML);
-only values that look like a JSON object or array are parsed as JSON.
+Scalar values are kept as literal strings (matching how pipeline variables work in YAML); only values that look like a JSON object or array are parsed as JSON.
 
 ## Querying MongoDB
 
-MongoDB connections (`mongo` and `mongo_atlas`) are not SQL, so the `--query` value is a JSON
-object describing a single **find** or **aggregation** against one collection instead of a SQL
-statement. The returned documents are flattened into a table: columns are the union of the
-top-level fields (in first-seen order), and nested documents and arrays are shown as JSON.
+MongoDB connections (`mongo` and `mongo_atlas`) are not SQL, so the `--query` value is a JSON object describing a single **find** or **aggregation** against one collection instead of a SQL statement. The returned documents are flattened into a table: columns are the union of the top-level fields (in first-seen order), and nested documents and arrays are shown as JSON.
 
 The envelope fields are:
 
@@ -136,9 +128,7 @@ The envelope fields are:
 | `aggregate`  | Aggregation pipeline (an array of stages). Mutually exclusive with `filter`/`projection`/`sort`. |
 | `database`   | Override the connection's configured database for this query.               |
 
-Values are parsed as [MongoDB Extended JSON](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/),
-so query operators such as `$gt`, `$and`, and `$match` pass through unchanged while type wrappers
-such as `{"$oid":"..."}` and `{"$date":"..."}` are interpreted as the corresponding BSON types.
+Values are parsed as [MongoDB Extended JSON](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/), so query operators such as `$gt`, `$and`, and `$match` pass through unchanged while type wrappers such as `{"$oid":"..."}` and `{"$date":"..."}` are interpreted as the corresponding BSON types.
 
 > [!NOTE]
 > The SQL-oriented `--limit` flag does not apply to MongoDB queries. Set `"limit"` inside the

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -16,8 +16,7 @@ In more concrete terms, an asset can be:
 - a machine learning model
 - an MS Excel/Google Sheets/Airbyte/Notion document
 
-This abstraction enables building multi-language data pipelines that are agnostic of a database/destinations.
-You will primarily be interacting with assets when using Bruin.
+This abstraction enables building multi-language data pipelines that are agnostic of a database/destinations. You will primarily be interacting with assets when using Bruin.
 
 Here's an example SQL asset:
 
@@ -62,9 +61,7 @@ The details on the asset definition can be seen [here](/assets/definition-schema
 
 ## Pipeline
 
-A pipeline is a group of assets that are executed together in the right order.
-For instance, if you have an asset that ingests data from an API, and another one that creates another table from the ingested data, you have a pipeline.
-Asset executions occur on a pipeline level.
+A pipeline is a group of assets that are executed together in the right order. For instance, if you have an asset that ingests data from an API, and another one that creates another table from the ingested data, you have a pipeline. Asset executions occur on a pipeline level.
 
 For complete pipeline documentation, see [Pipeline Definition](/pipelines/definition).
 
@@ -101,8 +98,7 @@ bruin run my-pipeline
 
 ## Asset Instance
 
-An asset instance is a single execution of an asset at a given time.
-For instance, if you have a Python asset and you run it, Bruin creates an asset instance that executes your code.
+An asset instance is a single execution of an asset at a given time. For instance, if you have a Python asset and you run it, Bruin creates an asset instance that executes your code.
 
 Asset instance is an internal concept, although it is relevant to understand since actual executions are based on asset instances.
 
@@ -129,8 +125,7 @@ When you run a pipeline, Bruin will find this file in the repo root, parse the c
 
 ## Default Connections
 
-Default connections are top-level defaults that reduces repetition by stating what connections to use on types of assets.
-For instance, a pipeline might have SQL queries that run on Google BigQuery or Snowflake, and based on the type of an asset Bruin picks the appropriate connection.
+Default connections are top-level defaults that reduces repetition by stating what connections to use on types of assets. For instance, a pipeline might have SQL queries that run on Google BigQuery or Snowflake, and based on the type of an asset Bruin picks the appropriate connection.
 
 ## Defaults
 

--- a/docs/getting-started/introduction/quickstart.md
+++ b/docs/getting-started/introduction/quickstart.md
@@ -69,8 +69,7 @@ That's it, this asset will load data from the `chess` source and load it into yo
 
 ### Setting up your `.bruin.yml` file
 
-This file specifies environments and the connections your pipeline will use. To ensure assets you add work correctly, configure your environments and connections by editing your `.bruin.yml` file.
-If you used `bruin init default`, this is already included. Otherwise, add the following:
+This file specifies environments and the connections your pipeline will use. To ensure assets you add work correctly, configure your environments and connections by editing your `.bruin.yml` file. If you used `bruin init default`, this is already included. Otherwise, add the following:
 
 ```yaml
 default_environment: default
@@ -106,8 +105,7 @@ bruin run assets/players.asset.yml
 
 ### Creating a SQL asset
 
-The template includes a SQL asset in `assets/player_stats.sql`:
-The file in your directory might include extra sections such as `columns`, `checks`, or `custom_checks`. Later in this guide, we will cover adding quality checks.
+The template includes a SQL asset in `assets/player_stats.sql`: The file in your directory might include extra sections such as `columns`, `checks`, or `custom_checks`. Later in this guide, we will cover adding quality checks.
 
 ```bruin-sql
 /* @bruin
@@ -133,8 +131,7 @@ This asset has a few lines of configuration at the top:
 - `type`: `duckdb.sql` means DuckDB SQL, Bruin supports many other types of assets.
 - `materialization`: take the query result and materialize it as a table
 
-Bruin will take the result of the given query, and will create a `dataset.player_stats` table on DuckDB with it. You can also use `view`
-materialization type instead of `table` to create a view instead.
+Bruin will take the result of the given query, and will create a `dataset.player_stats` table on DuckDB with it. You can also use `view` materialization type instead of `table` to create a view instead.
 
 > [!INFO]
 > Bruin supports many [asset](/assets/definition-schema.html) types, including BigQuery, Snowflake, Python, R, Redshift, Databricks, and more.

--- a/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
+++ b/docs/getting-started/templates-docs/iceberg-glue-s3-README.md
@@ -1,9 +1,6 @@
 # Bruin — Iceberg with AWS Glue and S3
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** tables catalogued in AWS Glue with the
-data in S3. This is the shape most AWS deployments use: a managed catalog, so
-there is no metastore to run.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables catalogued in AWS Glue with the data in S3. This is the shape most AWS deployments use: a managed catalog, so there is no metastore to run.
 
 ## Setup
 
@@ -12,8 +9,7 @@ An IAM user or role that can reach both halves:
 - **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
 - **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
-Then fill in the blanks in `.bruin.yml` — the connection is already there, only
-the marked values are missing:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only the marked values are missing:
 
 ```yaml
       iceberg:
@@ -33,8 +29,7 @@ the marked values are missing:
               secret_key: "${AWS_SECRET_ACCESS_KEY}"
 ```
 
-Replace each `${...}` with the value, or export them as environment variables
-and leave the file alone — Bruin expands both:
+Replace each `${...}` with the value, or export them as environment variables and leave the file alone — Bruin expands both:
 
 ```bash
 export AWS_REGION=eu-north-1
@@ -43,9 +38,7 @@ export AWS_SECRET_ACCESS_KEY=…
 export S3_BUCKET=my-company-lake
 ```
 
-Use a long-lived access key, not SSO or STS credentials — those expire within
-hours and a scheduled pipeline would start failing overnight. If you must use
-them, add `session_token` to both `auth` blocks.
+Use a long-lived access key, not SSO or STS credentials — those expire within hours and a scheduled pipeline would start failing overnight. If you must use them, add `session_token` to both `auth` blocks.
 
 ## Run it
 
@@ -53,15 +46,10 @@ them, add `session_token` to both `auth` blocks.
 bruin run iceberg-glue-s3
 ```
 
-The tables appear in Glue under the `raw` database, with data at
-`s3://$S3_BUCKET/warehouse/raw.db/`.
+The tables appear in Glue under the `raw` database, with data at `s3://$S3_BUCKET/warehouse/raw.db/`.
 
 ## Notes
 
-The catalog and the storage have **separate** `auth` blocks. They are the same
-credentials here, but they do not have to be — Glue is an AWS API and the bucket
-is storage, and Bruin sends each set to the right place.
+The catalog and the storage have **separate** `auth` blocks. They are the same credentials here, but they do not have to be — Glue is an AWS API and the bucket is storage, and Bruin sends each set to the right place.
 
-`region` is required for both: Glue needs to know which regional endpoint to
-call, and S3 uses it to route the request. A wrong one gives you
-`PermanentRedirect`; an empty one gives you `Invalid region`.
+`region` is required for both: Glue needs to know which regional endpoint to call, and S3 uses it to route the request. A wrong one gives you `PermanentRedirect`; an empty one gives you `Invalid region`.

--- a/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
+++ b/docs/getting-started/templates-docs/iceberg-hadoop-gcsinterop-README.md
@@ -1,20 +1,14 @@
 # Bruin — Iceberg with no catalog service, on GCS
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** tables that need no catalog service at
-all. The `hadoop` catalog keeps its metadata in the warehouse itself, so the
-bucket is the only thing to provision.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables that need no catalog service at all. The `hadoop` catalog keeps its metadata in the warehouse itself, so the bucket is the only thing to provision.
 
-Storage is Google Cloud Storage reached through its **S3 interoperability API**,
-the alternative to a service-account key.
+Storage is Google Cloud Storage reached through its **S3 interoperability API**, the alternative to a service-account key.
 
 ## Setup
 
-An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
-*Create a key*. It looks like an AWS key pair and is used as one.
+An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability → *Create a key*. It looks like an AWS key pair and is used as one.
 
-Then fill in the blanks in `.bruin.yml` — the connection is already there, only
-the marked values are missing:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only the marked values are missing:
 
 ```yaml
       iceberg:
@@ -32,8 +26,7 @@ the marked values are missing:
             allow-unsafe-commits: "true"
 ```
 
-Replace each `${...}` with the value, or export them as environment variables
-and leave the file alone — Bruin expands both:
+Replace each `${...}` with the value, or export them as environment variables and leave the file alone — Bruin expands both:
 
 ```bash
 export GCS_BUCKET=my-company-lake
@@ -55,10 +48,6 @@ bruin run iceberg-hadoop-gcsinterop
 > not for concurrent production writes. Move to Glue, REST or Postgres when that
 > matters.
 
-The storage block says `type: s3` with an `s3://` warehouse even though the
-bucket is Google's, because the S3 interop endpoint really is an S3 API — only
-`endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://`
-warehouse and a service-account key, as in `iceberg-postgres-gcs`.
+The storage block says `type: s3` with an `s3://` warehouse even though the bucket is Google's, because the S3 interop endpoint really is an S3 API — only `endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://` warehouse and a service-account key, as in `iceberg-postgres-gcs`.
 
-No `region` here: Google ignores it, and ingestr supplies the placeholder the
-AWS SDK insists on. AWS S3 still needs a real one.
+No `region` here: Google ignores it, and ingestr supplies the placeholder the AWS SDK insists on. AWS S3 still needs a real one.

--- a/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
+++ b/docs/getting-started/templates-docs/iceberg-postgres-gcs-README.md
@@ -1,20 +1,13 @@
 # Bruin — Iceberg with a Postgres catalog and Google Cloud Storage
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** tables catalogued in Postgres with the
-data in Google Cloud Storage. Useful on GCP, or anywhere you would rather own the
-catalog than depend on a cloud service: any Postgres will do — Cloud SQL, Neon,
-RDS, or one you run.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables catalogued in Postgres with the data in Google Cloud Storage. Useful on GCP, or anywhere you would rather own the catalog than depend on a cloud service: any Postgres will do — Cloud SQL, Neon, RDS, or one you run.
 
 ## Setup
 
-1. **A Postgres database** for the catalog. It needs no schema; Iceberg creates
-   its own tables on first run.
-2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
-   Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
+1. **A Postgres database** for the catalog. It needs no schema; Iceberg creates its own tables on first run.
+2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket. Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
 
-Then fill in the blanks in `.bruin.yml` — the connection is already there, only
-the marked values are missing:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only the marked values are missing:
 
 ```yaml
       iceberg:
@@ -35,8 +28,7 @@ the marked values are missing:
             sslmode: "require"
 ```
 
-Replace each `${...}` with the value, or export them as environment variables
-and leave the file alone — Bruin expands both.
+Replace each `${...}` with the value, or export them as environment variables and leave the file alone — Bruin expands both.
 
 ## Run it
 
@@ -48,12 +40,6 @@ Data lands at `gs://$GCS_BUCKET/warehouse/raw.db/`.
 
 ## Notes
 
-`sslmode: require` is in `properties` because managed Postgres — Neon, RDS,
-Cloud SQL — refuses plaintext connections. Drop it for a local database that
-does not speak TLS.
+`sslmode: require` is in `properties` because managed Postgres — Neon, RDS, Cloud SQL — refuses plaintext connections. Drop it for a local database that does not speak TLS.
 
-Storage authenticates with a service-account key, given as `key_file` (a path)
-or `key_json` (the key inline). A path is fine here, where the pipeline runs on
-your machine; use `key_json` anywhere the run happens elsewhere, such as Bruin
-Cloud, since the file will not be on that machine. Leave both out to use
-Application Default Credentials.
+Storage authenticates with a service-account key, given as `key_file` (a path) or `key_json` (the key inline). A path is fine here, where the pipeline runs on your machine; use `key_json` anywhere the run happens elsewhere, such as Bruin Cloud, since the file will not be on that machine. Leave both out to use Application Default Credentials.

--- a/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
+++ b/docs/getting-started/templates-docs/iceberg-rest-minio-README.md
@@ -1,8 +1,6 @@
 # Bruin — Iceberg with a REST catalog and MinIO
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** — with a real catalog server in front
-of real object storage, both running locally in Docker. Still no cloud account.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** — with a real catalog server in front of real object storage, both running locally in Docker. Still no cloud account.
 
 - `raw/currencies.asset.yml` — the list of currency codes and names.
 - `raw/exchange_rates.asset.yml` — the latest rates.
@@ -14,8 +12,7 @@ docker compose up -d          # MinIO + the bucket + the REST catalog
 bruin run iceberg-rest-minio
 ```
 
-Browse what landed in the MinIO console at `localhost:9001` (`minioadmin` /
-`minioadmin`), under `warehouse/raw/`:
+Browse what landed in the MinIO console at `localhost:9001` (`minioadmin` / `minioadmin`), under `warehouse/raw/`:
 
 ```
 raw/currencies/data/00000-0-….parquet
@@ -26,11 +23,7 @@ Tear it down with `docker compose down -v`.
 
 ## Notes
 
-An Iceberg connection is a **catalog** (where table metadata lives) and
-**storage** (where the data files go). Here the catalog is a server you talk to
-over HTTP and storage is S3-compatible, which is the shape most production
-setups have — swap in Glue or Postgres and a real S3 bucket and nothing about
-the assets changes.
+An Iceberg connection is a **catalog** (where table metadata lives) and **storage** (where the data files go). Here the catalog is a server you talk to over HTTP and storage is S3-compatible, which is the shape most production setups have — swap in Glue or Postgres and a real S3 bucket and nothing about the assets changes.
 
 ```yaml
       iceberg:
@@ -50,9 +43,5 @@ the assets changes.
               secret_key: "minioadmin"
 ```
 
-Two things about that `endpoint`. It marks the store as S3-*compatible* rather
-than S3, which ingestr turns into `s3.compat-mode` — MinIO does not need it, but
-GCS over its S3 endpoint does. And the REST catalog reaches storage **itself** to
-write metadata, which is why the same MinIO credentials appear in
-`docker-compose.yml`; the ones above configure only Bruin.
+Two things about that `endpoint`. It marks the store as S3-*compatible* rather than S3, which ingestr turns into `s3.compat-mode` — MinIO does not need it, but GCS over its S3 endpoint does. And the REST catalog reaches storage **itself** to write metadata, which is why the same MinIO credentials appear in `docker-compose.yml`; the ones above configure only Bruin.
 

--- a/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
+++ b/docs/getting-started/templates-docs/iceberg-sqlite-local-README.md
@@ -1,8 +1,6 @@
 # Bruin — Iceberg on your laptop
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate
-API, into **Apache Iceberg** tables on your own disk. No cloud account, no
-credentials, no services to start.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables on your own disk. No cloud account, no credentials, no services to start.
 
 - `raw/currencies.asset.yml` — the list of currency codes and names.
 - `raw/exchange_rates.asset.yml` — the latest rates.
@@ -42,12 +40,6 @@ SELECT * FROM iceberg_scan('warehouse/raw.db/currencies');
 
 ## Notes
 
-An Iceberg connection is a **catalog** (where table metadata lives) and
-**storage** (where the data files go). This template picks the simplest of each:
-a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
-Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
-assets never change.
+An Iceberg connection is a **catalog** (where table metadata lives) and **storage** (where the data files go). This template picks the simplest of each: a SQLite file and a local directory. Everything else — Glue, REST, Postgres, Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The assets never change.
 
-Not for production — the point is to see Iceberg work before committing to
-infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)
-for the real backends.
+Not for production — the point is to see Iceberg work before committing to infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html) for the real backends.

--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -1,14 +1,8 @@
 # Stripe Billing Analytics to BigQuery
 
-`stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery.
-It loads the customer, product, price, subscription, subscription-item, and
-invoice resources into `stripe_raw`; builds reusable billing models in
-`stripe_stage`; and publishes recurring-revenue and invoice-billing reports in
-`stripe_reports`.
+`stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery. It loads the customer, product, price, subscription, subscription-item, and invoice resources into `stripe_raw`; builds reusable billing models in `stripe_stage`; and publishes recurring-revenue and invoice-billing reports in `stripe_reports`.
 
-The template contains 19 assets across three layers. It is a practical starting
-point for analyzing Stripe subscription billing while keeping the data model
-small enough to adapt to your own reporting needs.
+The template contains 19 assets across three layers. It is a practical starting point for analyzing Stripe subscription billing while keeping the data model small enough to adapt to your own reporting needs.
 
 ## Project structure
 
@@ -47,62 +41,29 @@ stripe-bigquery/
 
 ### Raw Stripe data
 
-The `stripe_raw` dataset contains the six Stripe resources that underpin the
-billing models. Ingestr loads them with the shared `stripe-default` connection,
-and BigQuery is the destination.
+The `stripe_raw` dataset contains the six Stripe resources that underpin the billing models. Ingestr loads them with the shared `stripe-default` connection, and BigQuery is the destination.
 
-Each source asset uses ingestr's
-[incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading)
-(`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the
-Stripe object `id`, so a run only fetches the records created inside its own
-time window and upserts them.
+Each source asset uses ingestr's [incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading) (`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the Stripe object `id`, so a run only fetches the records created inside its own time window and upserts them.
 
-Incremental mode filters on Stripe's `created` timestamp and does not revisit
-records created in earlier windows. That matters for the mutable resources — a
-subscription cancelled or upgraded months after it was created, an invoice
-finalized, paid, or voided after its creation date. To pick those edits up,
-periodically re-run over a wider window:
+Incremental mode filters on Stripe's `created` timestamp and does not revisit records created in earlier windows. That matters for the mutable resources — a subscription cancelled or upgraded months after it was created, an invoice finalized, paid, or voided after its creation date. To pick those edits up, periodically re-run over a wider window:
 
 ```bash
 bruin run --start-date 2023-01-01 --end-date $(date -u +%F) my-stripe-pipeline
 ```
 
-Choose that cadence to match how current your reporting needs to be, or switch
-the mutable assets to `source_table: subscription` for
-[standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default),
-which reloads full history on every run. See
-[loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs)
-for the comparison.
+Choose that cadence to match how current your reporting needs to be, or switch the mutable assets to `source_table: subscription` for [standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default), which reloads full history on every run. See [loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs) for the comparison.
 
-Each raw asset also declares its full column schema, which pins those columns
-into the destination table. That matters for fields Stripe leaves null on some
-accounts: `invoice.due_date` is only set for invoices collected with
-`send_invoice`, and a schema inferred purely from the data would drop the column
-and break the stage model.
+Each raw asset also declares its full column schema, which pins those columns into the destination table. That matters for fields Stripe leaves null on some accounts: `invoice.due_date` is only set for invoices collected with `send_invoice`, and a schema inferred purely from the data would drop the column and break the stage model.
 
 ### Conformed billing models
 
-The `stripe_stage` dataset exposes typed customer, product, price,
-subscription, subscription-item, invoice, and invoice-line-item models. It also
-builds daily snapshots of subscription items and customer MRR by native
-currency, stamped with the pipeline end date.
+The `stripe_stage` dataset exposes typed customer, product, price, subscription, subscription-item, invoice, and invoice-line-item models. It also builds daily snapshots of subscription items and customer MRR by native currency, stamped with the pipeline end date.
 
-Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`,
-so each run rebuilds its table from the current raw data. That keeps the
-pipeline idempotent and easy to reason about.
+Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`, so each run rebuilds its table from the current raw data. That keeps the pipeline idempotent and easy to reason about.
 
-The two daily snapshot assets are the exception. They use
-`delete+insert` on `snapshot_date`, so each run replaces only the day it
-observes and leaves earlier days in place. That accumulates the daily
-observation history the reports layer needs for month-over-month movement and
-retention, while keeping a re-run of any single date idempotent. Because
-`delete+insert` writes into an existing table, the first load has to create
-these two tables with `--full-refresh`; see
-[Run the pipeline](#run-the-pipeline).
+The two daily snapshot assets are the exception. They use `delete+insert` on `snapshot_date`, so each run replaces only the day it observes and leaves earlier days in place. That accumulates the daily observation history the reports layer needs for month-over-month movement and retention, while keeping a re-run of any single date idempotent. Because `delete+insert` writes into an existing table, the first load has to create these two tables with `--full-refresh`; see [Run the pipeline](#run-the-pipeline).
 
-The snapshots record the Stripe state visible when the pipeline runs, so
-history builds up from the first run forward and cannot be backfilled from
-current Stripe records.
+The snapshots record the Stripe state visible when the pipeline runs, so history builds up from the first run forward and cannot be backfilled from current Stripe records.
 
 ### Billing reports
 
@@ -115,9 +76,7 @@ The `stripe_reports` dataset provides four ready-to-query tables:
 
 ### Asset summary
 
-All 19 assets materialize as tables. `create+replace` is the default when no
-incremental strategy is listed, so those assets are rebuilt from their upstreams
-on every run.
+All 19 assets materialize as tables. `create+replace` is the default when no incremental strategy is listed, so those assets are rebuilt from their upstreams on every run.
 
 | Schema | Asset | Materialization | Incremental strategy | Partition | Purpose |
 | --- | --- | --- | --- | --- | --- |
@@ -141,28 +100,15 @@ on every run.
 | `stripe_reports` | `monthly_subscription_kpis` | table | `create+replace` | — | Recurring-revenue, retention, and customer-count scorecard |
 | `stripe_reports` | `monthly_invoice_billings` | table | `create+replace` | — | Invoice billings by finalization month and currency |
 
-The two snapshot assets are partitioned on `snapshot_date` because they
-accumulate indefinitely: their per-run `DELETE` prunes to the single day being
-replaced instead of scanning the whole history. The other assets are rebuilt in
-full each run, so partitioning would not save any scan.
+The two snapshot assets are partitioned on `snapshot_date` because they accumulate indefinitely: their per-run `DELETE` prunes to the single day being replaced instead of scanning the whole history. The other assets are rebuilt in full each run, so partitioning would not save any scan.
 
 ### Column-level documentation
 
-Every asset in all three layers declares its full column schema: each column
-carries a type, a description, and primary-key marks on the grain, so the
-reporting grain and the metric definitions are readable from the asset files
-themselves. `metadata_push` in `pipeline.yml` publishes those descriptions to
-the BigQuery table and column metadata, and `bruin docs my-stripe-pipeline`
-generates a browsable documentation site from the same schemas.
+Every asset in all three layers declares its full column schema: each column carries a type, a description, and primary-key marks on the grain, so the reporting grain and the metric definitions are readable from the asset files themselves. `metadata_push` in `pipeline.yml` publishes those descriptions to the BigQuery table and column metadata, and `bruin docs my-stripe-pipeline` generates a browsable documentation site from the same schemas.
 
 ## Example report rows
 
-The following illustrative rows use minor currency units: `9900` USD means
-$99.00. They show the shape of each table across several months, which fills in
-once the snapshots have accumulated that many months of history; see
-[Conformed billing models](#conformed-billing-models).
-Query the four tables in `stripe_reports` directly, then adapt the columns to
-the definitions used by your finance and revenue teams.
+The following illustrative rows use minor currency units: `9900` USD means $99.00. They show the shape of each table across several months, which fills in once the snapshots have accumulated that many months of history; see [Conformed billing models](#conformed-billing-models). Query the four tables in `stripe_reports` directly, then adapt the columns to the definitions used by your finance and revenue teams.
 
 ### `monthly_mrr_by_customer`
 
@@ -198,27 +144,15 @@ the definitions used by your finance and revenue teams.
 
 ## Metric policy
 
-All monetary values in the `stripe_stage` and `stripe_reports` tables remain in
-each currency's minor units; only the dashboard converts to major units for
-display. Do not add amounts across currencies without an FX source and explicit
-conversion policy.
+All monetary values in the `stripe_stage` and `stripe_reports` tables remain in each currency's minor units; only the dashboard converts to major units for display. Do not add amounts across currencies without an FX source and explicit conversion policy.
 
-MRR is a gross list-price run rate from active and past-due subscriptions with
-licensed recurring monthly or annual prices. Free, one-time, metered, and
-discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither
-measure is recognized revenue, bookings, cash, or a financial statement.
+MRR is a gross list-price run rate from active and past-due subscriptions with licensed recurring monthly or annual prices. Free, one-time, metered, and discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither measure is recognized revenue, bookings, cash, or a financial statement.
 
-The daily snapshots capture the Stripe state visible when the pipeline runs.
-They do not reconstruct prior daily MRR history from current Stripe records, so
-the accumulated history starts at the first run. Month-over-month movement and
-retention metrics need two contiguous monthly observations, so they stay empty
-until the snapshots span a second month.
+The daily snapshots capture the Stripe state visible when the pipeline runs. They do not reconstruct prior daily MRR history from current Stripe records, so the accumulated history starts at the first run. Month-over-month movement and retention metrics need two contiguous monthly observations, so they stay empty until the snapshots span a second month.
 
 ## Configure connections
 
-Initializing the template adds placeholder connections to the repository-level
-`.bruin.yml`. Keep the connection names `gcp-default` and `stripe-default`, or
-rename them consistently in both `.bruin.yml` and `pipeline.yml`.
+Initializing the template adds placeholder connections to the repository-level `.bruin.yml`. Keep the connection names `gcp-default` and `stripe-default`, or rename them consistently in both `.bruin.yml` and `pipeline.yml`.
 
 ```yaml
 default_environment: default
@@ -238,25 +172,16 @@ environments:
 
 Replace both BigQuery placeholders before running the pipeline:
 
-- `project_id` — the Google Cloud project that owns the BigQuery datasets this
-  pipeline writes to, for example `my-company-analytics`.
-- `location` — the region or multi-region of those datasets, for example `US`,
-  `EU`, or `europe-west3`. It must match the location of the existing datasets;
-  BigQuery cannot query a dataset from a different location. See
-  [BigQuery locations](https://cloud.google.com/bigquery/docs/locations).
+- `project_id` — the Google Cloud project that owns the BigQuery datasets this pipeline writes to, for example `my-company-analytics`.
+- `location` — the region or multi-region of those datasets, for example `US`, `EU`, or `europe-west3`. It must match the location of the existing datasets; BigQuery cannot query a dataset from a different location. See [BigQuery locations](https://cloud.google.com/bigquery/docs/locations).
 
-The connection uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials),
-so authenticate with `gcloud` once:
+The connection uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials), so authenticate with `gcloud` once:
 
 ```bash
 gcloud auth application-default login
 ```
 
-To use a service account instead, replace
-`use_application_default_credentials: true` with
-`service_account_file: /path/to/service-account.json`. Either way, the
-credentials need permission to create datasets and tables and to run queries in
-the project.
+To use a service account instead, replace `use_application_default_credentials: true` with `service_account_file: /path/to/service-account.json`. Either way, the credentials need permission to create datasets and tables and to run queries in the project.
 
 Set the Stripe secret key in your shell before running the pipeline:
 
@@ -264,12 +189,7 @@ Set the Stripe secret key in your shell before running the pipeline:
 export STRIPE_API_KEY='sk_test_your_secret_key'
 ```
 
-Use either an `sk_test_...` or `sk_live_...` secret key. A publishable
-`pk_...` key cannot read Stripe data. Keep test and live data in separate
-BigQuery projects or datasets and do not commit credentials. The ingestr docs
-cover where to find the key and how to
-[create a restricted key](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#setting-up-a-stripe-integration)
-with read-only access to the resources this pipeline loads.
+Use either an `sk_test_...` or `sk_live_...` secret key. A publishable `pk_...` key cannot read Stripe data. Keep test and live data in separate BigQuery projects or datasets and do not commit credentials. The ingestr docs cover where to find the key and how to [create a restricted key](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#setting-up-a-stripe-integration) with read-only access to the resources this pipeline loads.
 
 ## Run the pipeline
 
@@ -279,66 +199,42 @@ Initialize a project from the template:
 bruin init stripe-bigquery my-stripe-pipeline
 ```
 
-Set `start_date` in `pipeline.yml` to the earliest Stripe history you need,
-then run the fast validation checks:
+Set `start_date` in `pipeline.yml` to the earliest Stripe history you need, then run the fast validation checks:
 
 ```bash
 bruin validate --fast my-stripe-pipeline
 ```
 
-On a new BigQuery destination, load every table before running query validation.
-The raw assets load only their run window, so pass an explicit range to pull
-your Stripe history in the first load. Use `--full-refresh` on this first run:
-the two daily snapshot assets use `delete+insert`, which writes into an existing
-table, so their tables have to be created before a normal run can add days to
-them.
+On a new BigQuery destination, load every table before running query validation. The raw assets load only their run window, so pass an explicit range to pull your Stripe history in the first load. Use `--full-refresh` on this first run: the two daily snapshot assets use `delete+insert`, which writes into an existing table, so their tables have to be created before a normal run can add days to them.
 
 ```bash
 bruin run --full-refresh --start-date 2023-01-01 --end-date $(date -u +%F) \
   --no-validation my-stripe-pipeline
 ```
 
-After the initial load, run `bruin validate my-stripe-pipeline` and schedule the
-pipeline daily without `--full-refresh`:
+After the initial load, run `bruin validate my-stripe-pipeline` and schedule the pipeline daily without `--full-refresh`:
 
 ```bash
 bruin run --start-date $(date -u +%F) --end-date $(date -u +%F) my-stripe-pipeline
 ```
 
-Any run is safe to repeat. The raw assets upsert on `id`, the other stage and
-report assets are rebuilt with create+replace, and the two snapshot assets
-replace only the `snapshot_date` they observe, so re-running a date does not
-duplicate rows or drop the days around it. Avoid `--full-refresh` after the
-initial load: it rebuilds the snapshot tables from scratch and discards the
-accumulated history.
+Any run is safe to repeat. The raw assets upsert on `id`, the other stage and report assets are rebuilt with create+replace, and the two snapshot assets replace only the `snapshot_date` they observe, so re-running a date does not duplicate rows or drop the days around it. Avoid `--full-refresh` after the initial load: it rebuilds the snapshot tables from scratch and discards the accumulated history.
 
 ## Customize it
 
-Use the stage models as a stable interface for your own reports. Review the
-selected assets, source fields, quality checks, and metric policy before using
-the results for financial reporting. Extend the pipeline with your business
-definitions, identity mapping, and FX policy where required.
+Use the stage models as a stable interface for your own reports. Review the selected assets, source fields, quality checks, and metric policy before using the results for financial reporting. Extend the pipeline with your business definitions, identity mapping, and FX policy where required.
 
 ## View the billing dashboard
 
-The included DAC dashboard visualizes native-currency MRR, ARR, customer count,
-retention, movement components, invoice billings, and the latest customer MRR
-distribution. It deliberately filters to one currency at a time because no FX
-rates are applied. The reporting tables retain money in native minor units; the
-dashboard queries divide by the selected currency's exponent so the widgets read
-in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
+The included DAC dashboard visualizes native-currency MRR, ARR, customer count, retention, movement components, invoice billings, and the latest customer MRR distribution. It deliberately filters to one currency at a time because no FX rates are applied. The reporting tables retain money in native minor units; the dashboard queries divide by the selected currency's exponent so the widgets read in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
 
-After configuring `gcp-default`, install a verified DAC release by following
-the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html).
-Then install its dashboard-authoring skill from the project root:
+After configuring `gcp-default`, install a verified DAC release by following the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html). Then install its dashboard-authoring skill from the project root:
 
 ```bash
 dac skills install --dir . create-dashboard
 ```
 
-Restart your coding agent after installing the skill so it can use the local
-`create-dashboard` instructions. Then validate the dashboard, execute its
-queries, and serve the DAC app:
+Restart your coding agent after installing the skill so it can use the local `create-dashboard` instructions. Then validate the dashboard, execute its queries, and serve the DAC app:
 
 ```bash
 dac --config .bruin.yml validate --dir dashboards
@@ -350,8 +246,6 @@ dac --config .bruin.yml serve --dir dashboards --port 8321
 
 ![Stripe billing analytics dashboard preview](/stripe-billing-analytics-demo.png)
 
-This screenshot uses synthetic data solely to demonstrate the dashboard's
-layout and charts.
+This screenshot uses synthetic data solely to demonstrate the dashboard's layout and charts.
 
-MRR movement and retention metrics need two contiguous monthly snapshots, so
-they stay empty until the accumulated snapshot history spans a second month.
+MRR movement and retention metrics need two contiguous monthly snapshots, so they stay empty until the accumulated snapshot history spans a second month.

--- a/docs/ingestion/mongo.md
+++ b/docs/ingestion/mongo.md
@@ -37,8 +37,7 @@ Bruin turns this configuration into a MongoDB URI in the following form:
 mongodb://testUser:testPass123@localhost:27017
 ```
 
-If `username` is empty, Bruin omits the username and password from the URI.
-If your username or password contains special characters, Bruin URL-encodes them when it builds the URI.
+If `username` is empty, Bruin omits the username and password from the URI. If your username or password contains special characters, Bruin URL-encodes them when it builds the URI.
 
 > [!CAUTION]
 > Always set `port` for `mongo` connections. The current configuration loader does not apply the schema default when reading `.bruin.yml`, so omitting `port` will build a URI with port `0`.

--- a/docs/ingestion/phantombuster.md
+++ b/docs/ingestion/phantombuster.md
@@ -50,8 +50,7 @@ parameters:
 |-------|----|---------|--------------| ------- |
 | `completed_phantoms:<agent_id>` | container_id | ended_at | merge | Gets all containers associated to a specified agent. Where agent id is a unique identifier for a specific Phantom which can be found in URI of a specific phantom. |
 
-For now, we only support `completed_phantoms` tables followed by an agent ID. For example:
-`completed_phantoms:<agentid>`. An Agent ID is a unique identifier for a specific Phantom.
+For now, we only support `completed_phantoms` tables followed by an agent ID. For example: `completed_phantoms:<agentid>`. An Agent ID is a unique identifier for a specific Phantom.
 
 ### Step 3: [Run](/commands/run) asset to ingest data
 

--- a/docs/ingestion/tiktokads.md
+++ b/docs/ingestion/tiktokads.md
@@ -48,16 +48,9 @@ parameters:
 - `type`: Specifies the type of the asset. Set this to ingestr to use the ingestr data pipeline.
 - `connection`: This is the destination connection, which defines where the data should be stored. For example: `postgres` indicates that the ingested data will be stored in a Postgres database.
 - `source_connection`: The name of the  TikTok Ads connection defined in .bruin.yml.
-- `source_table`: The custom report in TikTok Ads you want to ingest based on the dimension and metrics.
-Custom Table Format:
+- `source_table`: The custom report in TikTok Ads you want to ingest based on the dimension and metrics. Custom Table Format:
 
-`custom:<dimensions>:<metrics>[:<filter_name,filter_values>]`
-Parameters:
-`dimensions`(required): A comma-separated list of dimensions to retrieve.
-`metrics` (required): A comma-separated list of metrics to retrieve.
-`filters (optional): Filters are specified in the format <filter_name=filter_values>.
-`filter_name`: The name of the filter (e.g. campaign_ids).
-`filter_values`: A comma-separated list of one or more values associated with the filter name (e.g., camp_id123,camp_id456). Only the IN filter type is supported. Learn more about filters [here](https://business-api.tiktok.com/portal/docs?id=1751443975608321).
+`custom:<dimensions>:<metrics>[:<filter_name,filter_values>]` Parameters: `dimensions`(required): A comma-separated list of dimensions to retrieve. `metrics` (required): A comma-separated list of metrics to retrieve. `filters (optional): Filters are specified in the format <filter_name=filter_values>. `filter_name`: The name of the filter (e.g. campaign_ids). `filter_values`: A comma-separated list of one or more values associated with the filter name (e.g., camp_id123,camp_id456). Only the IN filter type is supported. Learn more about filters [here](https://business-api.tiktok.com/portal/docs?id=1751443975608321).
 
 ## Available Source Tables
 

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -2,12 +2,9 @@
 
 ## Overview
 
-A pipeline is a group of assets that are executed together in the right order.
-For instance, if you have an asset that ingests data from an API, and another one that creates another table from the
-ingested data, you have a pipeline.
+A pipeline is a group of assets that are executed together in the right order. For instance, if you have an asset that ingests data from an API, and another one that creates another table from the ingested data, you have a pipeline.
 
-A pipeline is defined with a `pipeline.yml` file, and all the assets need to be under a folder called `assets` next to
-this file:
+A pipeline is defined with a `pipeline.yml` file, and all the assets need to be under a folder called `assets` next to this file:
 
 ```diff
 my-pipeline/
@@ -143,9 +140,7 @@ name: analytics-daily
 
 ### Schedule
 
-Defines **how often** your pipeline should execute.
-This setting is used by your orchestrator (for example, Bruin Cloud or an external scheduler) to automatically trigger
-the pipeline at regular intervals.
+Defines **how often** your pipeline should execute. This setting is used by your orchestrator (for example, Bruin Cloud or an external scheduler) to automatically trigger the pipeline at regular intervals.
 
 You can use simple presets like `@daily` or `@hourly`, or define a custom **cron expression** for more granular control.
 
@@ -185,8 +180,7 @@ start_date: "2024-01-01"
 
 ### Default connections
 
-Define per‑platform default connection names that assets inherit automatically. Use this to avoid repeating connection
-settings; override at the asset level when an asset needs a different connection.
+Define per‑platform default connection names that assets inherit automatically. Use this to avoid repeating connection settings; override at the asset level when an asset needs a different connection.
 
 Example:
 
@@ -203,8 +197,7 @@ default_connections:
 
 ### Tags
 
-Attach labels to organize your pipeline and to target subsets of work. Useful for filtering in UIs/CLI (e.g., selecting
-by tag) and for reporting.
+Attach labels to organize your pipeline and to target subsets of work. Useful for filtering in UIs/CLI (e.g., selecting by tag) and for reporting.
 
 Example:
 
@@ -217,8 +210,7 @@ tags: [ "daily", "analytics" ]
 
 ### Domains
 
-Group your pipeline by business domain (e.g., marketing, finance) to improve discoverability and governance. Helps
-organize views and ownership in larger repos.
+Group your pipeline by business domain (e.g., marketing, finance) to improve discoverability and governance. Helps organize views and ownership in larger repos.
 
 Example:
 
@@ -231,8 +223,7 @@ domains: [ "marketing" ]
 
 ### Meta
 
-Add custom key/value annotations for cost attribution, or anything your team tracks. Great for search,
-dashboards, and lightweight governance.
+Add custom key/value annotations for cost attribution, or anything your team tracks. Great for search, dashboards, and lightweight governance.
 
 Example:
 
@@ -259,8 +250,7 @@ owner: data-platform
 
 ### Notifications
 
-Send alerts when runs succeed or fail so your team stays informed. Choose one or more channels and specify where to
-deliver the message (e.g., Slack channel or a webhook connection).
+Send alerts when runs succeed or fail so your team stays informed. Choose one or more channels and specify where to deliver the message (e.g., Slack channel or a webhook connection).
 
 Example:
 
@@ -293,8 +283,7 @@ notifications:
 
 ### Catchup
 
-Backfill any missed intervals between start_date and now. Turn this on when you need to automatically recover historical
-runs after downtime or late onboarding.
+Backfill any missed intervals between start_date and now. Turn this on when you need to automatically recover historical runs after downtime or late onboarding.
 
 `catchup` accepts either a boolean or a string mode:
 
@@ -315,8 +304,7 @@ catchup: active
 
 ### Metadata push
 
-Export pipeline and asset metadata to external systems (e.g., a data catalog). Enable when you want lineage, discovery,
-or governance powered by your warehouse or catalog tooling.
+Export pipeline and asset metadata to external systems (e.g., a data catalog). Enable when you want lineage, discovery, or governance powered by your warehouse or catalog tooling.
 
 Example:
 
@@ -335,8 +323,7 @@ Fields:
 
 ### Retries
 
-Control resilience to transient failures by retrying assets/runs a limited number of times. Increase for flaky
-networks/services; keep low to surface real issues.
+Control resilience to transient failures by retrying assets/runs a limited number of times. Increase for flaky networks/services; keep low to surface real issues.
 
 Example:
 
@@ -373,8 +360,7 @@ default:
 
 ### Concurrency
 
-Limit how many runs you can take at the same time for this pipeline in Bruin Cloud.
-Defaults to 1 for safety.
+Limit how many runs you can take at the same time for this pipeline in Bruin Cloud. Defaults to 1 for safety.
 
 Example:
 
@@ -411,13 +397,9 @@ max_active_steps: 8
 
 ### Default (pipeline-level defaults)
 
-Set sensible defaults for all assets in the pipeline so you don't repeat yourself. Override at the asset level only when
-a task needs something different. The `default` block accepts asset definition fields except file-derived/runtime-only
-fields such as `id`, `run`/executable file details, definition file details, and derived `retries_delay`.
+Set sensible defaults for all assets in the pipeline so you don't repeat yourself. Override at the asset level only when a task needs something different. The `default` block accepts asset definition fields except file-derived/runtime-only fields such as `id`, `run`/executable file details, definition file details, and derived `retries_delay`.
 
-Scalar defaults fill only empty asset fields. Maps such as `parameters`, `meta`, and `metadata` are merged without
-overwriting asset keys. Repeated fields such as `tags`, `domains`, `depends`, `extends`, `columns`, `custom_checks`,
-and `notifications` are added when they are not already present.
+Scalar defaults fill only empty asset fields. Maps such as `parameters`, `meta`, and `metadata` are merged without overwriting asset keys. Repeated fields such as `tags`, `domains`, `depends`, `extends`, `columns`, `custom_checks`, and `notifications` are added when they are not already present.
 
 Example:
 
@@ -472,8 +454,7 @@ Fields:
 | refresh_restricted | Boolean                    | —       | Default full-refresh restriction |
 | notifications      | Object                     | —       | Default asset notifications      |
 
-Asset identity/runtime fields such as `name`, `uri`, executable file metadata, definition file metadata, and `retries_delay`
-are not supported in pipeline defaults.
+Asset identity/runtime fields such as `name`, `uri`, executable file metadata, definition file metadata, and `retries_delay` are not supported in pipeline defaults.
 
 Secrets item:
 

--- a/docs/platforms/duckdb.md
+++ b/docs/platforms/duckdb.md
@@ -43,8 +43,7 @@ This is useful when you only need to read from a shared DuckDB database and want
 
 ## Assets
 
-DuckDB assets should use the type `duckdb.sql` and if you specify a connection it must be of the `duckdb` type.
-For detailed parameters, you can check [Definition Schema](../assets/definition-schema.md) page.
+DuckDB assets should use the type `duckdb.sql` and if you specify a connection it must be of the `duckdb` type. For detailed parameters, you can check [Definition Schema](../assets/definition-schema.md) page.
 
 Asset names may be `table`, `schema.table`, or `catalog.schema.table`. A three-part name targets an attached database (catalog); Bruin creates the schema in that catalog automatically, but the catalog must already be attached.
 
@@ -278,8 +277,7 @@ catalog:
 
 #### S3
 
-Bruin currently only supports explicit AWS credentials in the `auth` block.
-Session tokens are supported for temporary credentials (AWS STS).
+Bruin currently only supports explicit AWS credentials in the `auth` block. Session tokens are supported for temporary credentials (AWS STS).
 
 ```yaml
 storage:
@@ -330,9 +328,7 @@ storage:
 
 #### GCS
 
-Bruin currently supports explicit GCS HMAC credentials in the `auth` block (`access_key` and `secret_key`).
-You need to create GCS HMAC keys first and declare them here.
-Quick link (GCP Console): [Interoperability settings](https://console.cloud.google.com/storage/settings;tab=interoperability)
+Bruin currently supports explicit GCS HMAC credentials in the `auth` block (`access_key` and `secret_key`). You need to create GCS HMAC keys first and declare them here. Quick link (GCP Console): [Interoperability settings](https://console.cloud.google.com/storage/settings;tab=interoperability)
 ```yaml
 storage:
   type: gcs
@@ -344,9 +340,7 @@ storage:
 
 #### Azure
 
-Bruin supports Azure Blob Storage for DuckLake. Authenticate either with an account-key
-`connection_string`, or with `account_name` alone to use DuckDB's credential chain
-(managed identity, `az login`, or environment credentials).
+Bruin supports Azure Blob Storage for DuckLake. Authenticate either with an account-key `connection_string`, or with `account_name` alone to use DuckDB's credential chain (managed identity, `az login`, or environment credentials).
 
 ```yaml
 storage:
@@ -365,9 +359,7 @@ storage:
     account_name: "${AZURE_STORAGE_ACCOUNT}"
 ```
 
-Bruin loads the `azure` extension and sets `azure_transport_option_type = 'curl'`
-(globally) so TLS to `*.blob.core.windows.net` uses the system CA bundle — required on
-Linux/containers, which must have `ca-certificates` installed.
+Bruin loads the `azure` extension and sets `azure_transport_option_type = 'curl'` (globally) so TLS to `*.blob.core.windows.net` uses the system CA bundle — required on Linux/containers, which must have `ca-certificates` installed.
 
 > [!NOTE]
 > DuckLake maintenance calls that delete/scan blobs (e.g.

--- a/docs/platforms/starrocks.md
+++ b/docs/platforms/starrocks.md
@@ -55,8 +55,7 @@ View materialization is also supported. For local and single-node StarRocks clus
 
 #### Table layout
 
-Distribution and partitioning are taken from the standard materialization fields,
-so they work the same way as on the other platforms:
+Distribution and partitioning are taken from the standard materialization fields, so they work the same way as on the other platforms:
 
 - `materialization.cluster_by` → `DISTRIBUTED BY HASH(...)` (defaults to the key columns)
 - `materialization.partition_by` → `PARTITION BY (...)` (a column or expression such as `date_trunc('day', event_date)`)

--- a/docs/platforms/trino.md
+++ b/docs/platforms/trino.md
@@ -145,8 +145,7 @@ node.data-dir=/data/trino
 
 ### Guide: Iceberg + Glue + S3 {#guide-glue-s3}
 
-Use this when you want AWS Glue as the Iceberg catalog.
-The Docker setup below is an example for local testing purposes.
+Use this when you want AWS Glue as the Iceberg catalog. The Docker setup below is an example for local testing purposes.
 
 `docker-compose.yml`:
 
@@ -187,8 +186,7 @@ s3.region=us-east-1
 
 ### Guide: Iceberg + Nessie (In-Memory) + S3 {#guide-nessie-in-memory-s3}
 
-Use this for local testing with ephemeral Nessie metadata.
-The Docker setup below is an example for local testing and documentation purposes.
+Use this for local testing with ephemeral Nessie metadata. The Docker setup below is an example for local testing and documentation purposes.
 
 ```yaml
 services:
@@ -235,16 +233,15 @@ iceberg.nessie-catalog.default-warehouse-dir=s3://example-lakehouse/warehouse
 fs.native-s3.enabled=true
 s3.region=us-east-1
 ```
-- `iceberg.nessie-catalog.uri` points to the Nessie API, 
-- `iceberg.nessie-catalog.ref` selects the active branch/ref, and 
+- `iceberg.nessie-catalog.uri` points to the Nessie API,
+- `iceberg.nessie-catalog.ref` selects the active branch/ref, and
 - `iceberg.nessie-catalog.default-warehouse-dir` sets where Iceberg data files are written in S3.
 
 <br>
 
 ### Guide: Iceberg + Nessie (In-Memory) + GCS {#guide-nessie-in-memory-gcs}
 
-Use this for local testing with ephemeral Nessie metadata and GCS object storage.
-The Docker setup below is an example for local testing and documentation purposes.
+Use this for local testing with ephemeral Nessie metadata and GCS object storage. The Docker setup below is an example for local testing and documentation purposes.
 
 `docker-compose.yml`:
 

--- a/docs/quality/overview.md
+++ b/docs/quality/overview.md
@@ -2,10 +2,7 @@
 
 Quality checks are tests you can perform on your Bruin assets **after** they run to verify that the produced data satisfies your expectations. They are a great way to ensure your data is accurate, complete and consistent.
 
-Quality checks run after the asset has been executed. If a check fails and its
-`blocking` attribute is `true`, the asset is marked as failed and downstream
-assets are prevented from running. When `blocking` is `false`, the check failure
-is recorded but downstream assets are not blocked. `blocking` defaults to `true`.
+Quality checks run after the asset has been executed. If a check fails and its `blocking` attribute is `true`, the asset is marked as failed and downstream assets are prevented from running. When `blocking` is `false`, the check failure is recorded but downstream assets are not blocked. `blocking` defaults to `true`.
 
 Below is a short example of attaching checks to columns:
 

--- a/templates/iceberg-glue-s3/README.md
+++ b/templates/iceberg-glue-s3/README.md
@@ -1,9 +1,6 @@
 # Bruin — Iceberg with AWS Glue and S3
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** tables catalogued in AWS Glue with the
-data in S3. This is the shape most AWS deployments use: a managed catalog, so
-there is no metastore to run.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables catalogued in AWS Glue with the data in S3. This is the shape most AWS deployments use: a managed catalog, so there is no metastore to run.
 
 ## Setup
 
@@ -12,8 +9,7 @@ An IAM user or role that can reach both halves:
 - **Glue** — `glue:GetDatabase`, `glue:CreateDatabase`, `glue:GetTable`, `glue:CreateTable`, `glue:UpdateTable`
 - **The bucket** — `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
-Then fill in the blanks in `.bruin.yml` — the connection is already there, only
-the marked values are missing:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only the marked values are missing:
 
 ```yaml
       iceberg:
@@ -33,8 +29,7 @@ the marked values are missing:
               secret_key: "${AWS_SECRET_ACCESS_KEY}"
 ```
 
-Replace each `${...}` with the value, or export them as environment variables
-and leave the file alone — Bruin expands both:
+Replace each `${...}` with the value, or export them as environment variables and leave the file alone — Bruin expands both:
 
 ```bash
 export AWS_REGION=eu-north-1
@@ -43,9 +38,7 @@ export AWS_SECRET_ACCESS_KEY=…
 export S3_BUCKET=my-company-lake
 ```
 
-Use a long-lived access key, not SSO or STS credentials — those expire within
-hours and a scheduled pipeline would start failing overnight. If you must use
-them, add `session_token` to both `auth` blocks.
+Use a long-lived access key, not SSO or STS credentials — those expire within hours and a scheduled pipeline would start failing overnight. If you must use them, add `session_token` to both `auth` blocks.
 
 ## Run it
 
@@ -53,15 +46,10 @@ them, add `session_token` to both `auth` blocks.
 bruin run iceberg-glue-s3
 ```
 
-The tables appear in Glue under the `raw` database, with data at
-`s3://$S3_BUCKET/warehouse/raw.db/`.
+The tables appear in Glue under the `raw` database, with data at `s3://$S3_BUCKET/warehouse/raw.db/`.
 
 ## Notes
 
-The catalog and the storage have **separate** `auth` blocks. They are the same
-credentials here, but they do not have to be — Glue is an AWS API and the bucket
-is storage, and Bruin sends each set to the right place.
+The catalog and the storage have **separate** `auth` blocks. They are the same credentials here, but they do not have to be — Glue is an AWS API and the bucket is storage, and Bruin sends each set to the right place.
 
-`region` is required for both: Glue needs to know which regional endpoint to
-call, and S3 uses it to route the request. A wrong one gives you
-`PermanentRedirect`; an empty one gives you `Invalid region`.
+`region` is required for both: Glue needs to know which regional endpoint to call, and S3 uses it to route the request. A wrong one gives you `PermanentRedirect`; an empty one gives you `Invalid region`.

--- a/templates/iceberg-hadoop-gcsinterop/README.md
+++ b/templates/iceberg-hadoop-gcsinterop/README.md
@@ -1,20 +1,14 @@
 # Bruin — Iceberg with no catalog service, on GCS
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** tables that need no catalog service at
-all. The `hadoop` catalog keeps its metadata in the warehouse itself, so the
-bucket is the only thing to provision.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables that need no catalog service at all. The `hadoop` catalog keeps its metadata in the warehouse itself, so the bucket is the only thing to provision.
 
-Storage is Google Cloud Storage reached through its **S3 interoperability API**,
-the alternative to a service-account key.
+Storage is Google Cloud Storage reached through its **S3 interoperability API**, the alternative to a service-account key.
 
 ## Setup
 
-An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability →
-*Create a key*. It looks like an AWS key pair and is used as one.
+An **HMAC key** for the bucket: Cloud Storage → Settings → Interoperability → *Create a key*. It looks like an AWS key pair and is used as one.
 
-Then fill in the blanks in `.bruin.yml` — the connection is already there, only
-the marked values are missing:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only the marked values are missing:
 
 ```yaml
       iceberg:
@@ -32,8 +26,7 @@ the marked values are missing:
             allow-unsafe-commits: "true"
 ```
 
-Replace each `${...}` with the value, or export them as environment variables
-and leave the file alone — Bruin expands both:
+Replace each `${...}` with the value, or export them as environment variables and leave the file alone — Bruin expands both:
 
 ```bash
 export GCS_BUCKET=my-company-lake
@@ -55,10 +48,6 @@ bruin run iceberg-hadoop-gcsinterop
 > not for concurrent production writes. Move to Glue, REST or Postgres when that
 > matters.
 
-The storage block says `type: s3` with an `s3://` warehouse even though the
-bucket is Google's, because the S3 interop endpoint really is an S3 API — only
-`endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://`
-warehouse and a service-account key, as in `iceberg-postgres-gcs`.
+The storage block says `type: s3` with an `s3://` warehouse even though the bucket is Google's, because the S3 interop endpoint really is an S3 API — only `endpoint` points at Google. For native GCS instead, use `type: gcs`, a `gs://` warehouse and a service-account key, as in `iceberg-postgres-gcs`.
 
-No `region` here: Google ignores it, and ingestr supplies the placeholder the
-AWS SDK insists on. AWS S3 still needs a real one.
+No `region` here: Google ignores it, and ingestr supplies the placeholder the AWS SDK insists on. AWS S3 still needs a real one.

--- a/templates/iceberg-postgres-gcs/README.md
+++ b/templates/iceberg-postgres-gcs/README.md
@@ -1,20 +1,13 @@
 # Bruin — Iceberg with a Postgres catalog and Google Cloud Storage
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** tables catalogued in Postgres with the
-data in Google Cloud Storage. Useful on GCP, or anywhere you would rather own the
-catalog than depend on a cloud service: any Postgres will do — Cloud SQL, Neon,
-RDS, or one you run.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables catalogued in Postgres with the data in Google Cloud Storage. Useful on GCP, or anywhere you would rather own the catalog than depend on a cloud service: any Postgres will do — Cloud SQL, Neon, RDS, or one you run.
 
 ## Setup
 
-1. **A Postgres database** for the catalog. It needs no schema; Iceberg creates
-   its own tables on first run.
-2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket.
-   Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
+1. **A Postgres database** for the catalog. It needs no schema; Iceberg creates its own tables on first run.
+2. **A GCS service account** with `roles/storage.objectAdmin` on the bucket. Download its JSON key and save it next to `.bruin.yml` as `sa.json`.
 
-Then fill in the blanks in `.bruin.yml` — the connection is already there, only
-the marked values are missing:
+Then fill in the blanks in `.bruin.yml` — the connection is already there, only the marked values are missing:
 
 ```yaml
       iceberg:
@@ -35,8 +28,7 @@ the marked values are missing:
             sslmode: "require"
 ```
 
-Replace each `${...}` with the value, or export them as environment variables
-and leave the file alone — Bruin expands both.
+Replace each `${...}` with the value, or export them as environment variables and leave the file alone — Bruin expands both.
 
 ## Run it
 
@@ -48,12 +40,6 @@ Data lands at `gs://$GCS_BUCKET/warehouse/raw.db/`.
 
 ## Notes
 
-`sslmode: require` is in `properties` because managed Postgres — Neon, RDS,
-Cloud SQL — refuses plaintext connections. Drop it for a local database that
-does not speak TLS.
+`sslmode: require` is in `properties` because managed Postgres — Neon, RDS, Cloud SQL — refuses plaintext connections. Drop it for a local database that does not speak TLS.
 
-Storage authenticates with a service-account key, given as `key_file` (a path)
-or `key_json` (the key inline). A path is fine here, where the pipeline runs on
-your machine; use `key_json` anywhere the run happens elsewhere, such as Bruin
-Cloud, since the file will not be on that machine. Leave both out to use
-Application Default Credentials.
+Storage authenticates with a service-account key, given as `key_file` (a path) or `key_json` (the key inline). A path is fine here, where the pipeline runs on your machine; use `key_json` anywhere the run happens elsewhere, such as Bruin Cloud, since the file will not be on that machine. Leave both out to use Application Default Credentials.

--- a/templates/iceberg-rest-minio/README.md
+++ b/templates/iceberg-rest-minio/README.md
@@ -1,8 +1,6 @@
 # Bruin — Iceberg with a REST catalog and MinIO
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public
-exchange-rate API, into **Apache Iceberg** — with a real catalog server in front
-of real object storage, both running locally in Docker. Still no cloud account.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** — with a real catalog server in front of real object storage, both running locally in Docker. Still no cloud account.
 
 - `raw/currencies.asset.yml` — the list of currency codes and names.
 - `raw/exchange_rates.asset.yml` — the latest rates.
@@ -14,8 +12,7 @@ docker compose up -d          # MinIO + the bucket + the REST catalog
 bruin run iceberg-rest-minio
 ```
 
-Browse what landed in the MinIO console at `localhost:9001` (`minioadmin` /
-`minioadmin`), under `warehouse/raw/`:
+Browse what landed in the MinIO console at `localhost:9001` (`minioadmin` / `minioadmin`), under `warehouse/raw/`:
 
 ```
 raw/currencies/data/00000-0-….parquet
@@ -26,11 +23,7 @@ Tear it down with `docker compose down -v`.
 
 ## Notes
 
-An Iceberg connection is a **catalog** (where table metadata lives) and
-**storage** (where the data files go). Here the catalog is a server you talk to
-over HTTP and storage is S3-compatible, which is the shape most production
-setups have — swap in Glue or Postgres and a real S3 bucket and nothing about
-the assets changes.
+An Iceberg connection is a **catalog** (where table metadata lives) and **storage** (where the data files go). Here the catalog is a server you talk to over HTTP and storage is S3-compatible, which is the shape most production setups have — swap in Glue or Postgres and a real S3 bucket and nothing about the assets changes.
 
 ```yaml
       iceberg:
@@ -50,9 +43,5 @@ the assets changes.
               secret_key: "minioadmin"
 ```
 
-Two things about that `endpoint`. It marks the store as S3-*compatible* rather
-than S3, which ingestr turns into `s3.compat-mode` — MinIO does not need it, but
-GCS over its S3 endpoint does. And the REST catalog reaches storage **itself** to
-write metadata, which is why the same MinIO credentials appear in
-`docker-compose.yml`; the ones above configure only Bruin.
+Two things about that `endpoint`. It marks the store as S3-*compatible* rather than S3, which ingestr turns into `s3.compat-mode` — MinIO does not need it, but GCS over its S3 endpoint does. And the REST catalog reaches storage **itself** to write metadata, which is why the same MinIO credentials appear in `docker-compose.yml`; the ones above configure only Bruin.
 

--- a/templates/iceberg-sqlite-local/README.md
+++ b/templates/iceberg-sqlite-local/README.md
@@ -1,8 +1,6 @@
 # Bruin — Iceberg on your laptop
 
-Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate
-API, into **Apache Iceberg** tables on your own disk. No cloud account, no
-credentials, no services to start.
+Loads two tables from [Frankfurter](https://frankfurter.dev), a public exchange-rate API, into **Apache Iceberg** tables on your own disk. No cloud account, no credentials, no services to start.
 
 - `raw/currencies.asset.yml` — the list of currency codes and names.
 - `raw/exchange_rates.asset.yml` — the latest rates.
@@ -42,12 +40,6 @@ SELECT * FROM iceberg_scan('warehouse/raw.db/currencies');
 
 ## Notes
 
-An Iceberg connection is a **catalog** (where table metadata lives) and
-**storage** (where the data files go). This template picks the simplest of each:
-a SQLite file and a local directory. Everything else — Glue, REST, Postgres,
-Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The
-assets never change.
+An Iceberg connection is a **catalog** (where table metadata lives) and **storage** (where the data files go). This template picks the simplest of each: a SQLite file and a local directory. Everything else — Glue, REST, Postgres, Hive, and S3 or GCS storage — swaps in by changing those two blocks only. The assets never change.
 
-Not for production — the point is to see Iceberg work before committing to
-infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html)
-for the real backends.
+Not for production — the point is to see Iceberg work before committing to infrastructure. See the [Iceberg docs](https://getbruin.com/docs/bruin/ingestion/iceberg.html) for the real backends.

--- a/templates/migration-fivetran/.agents/skills/bruin-fivetran-migrator/SKILL.md
+++ b/templates/migration-fivetran/.agents/skills/bruin-fivetran-migrator/SKILL.md
@@ -5,35 +5,20 @@ description: Stage a review-gated migration from one Fivetran connection to a ne
 
 # Fivetran to Bruin migrator
 
-Use this skill when a user wants to migrate one Fivetran connection to Bruin.
-Read the repository-root `fivetran-bruin-prompt.md` and `plan.md` before
-acting. Follow the prompt's stages in order.
+Use this skill when a user wants to migrate one Fivetran connection to Bruin. Read the repository-root `fivetran-bruin-prompt.md` and `plan.md` before acting. Follow the prompt's stages in order.
 
-Use the sibling `import_fivetran.py` for Fivetran access. It makes GET requests
-only and writes redacted captures to `.artifacts/` at the repository root.
+Use the sibling `import_fivetran.py` for Fivetran access. It makes GET requests only and writes redacted captures to `.artifacts/` at the repository root.
 
 Rules:
 
 - Capture exactly one connection selected by the user.
-- Prefer an approved connector ID, which fetches that connection directly; a
-  connector name must match the Fivetran connection name exactly.
+- Prefer an approved connector ID, which fetches that connection directly; a connector name must match the Fivetran connection name exactly.
 - Never expose or store credentials, source data, endpoints, or Fivetran state.
-- Treat `.bruin.yml` and `.artifacts/` as sensitive even when they are
-  Git-ignored: do not print them, pass them to AI subprocesses, or copy them
-  into generated documentation.
+- Treat `.bruin.yml` and `.artifacts/` as sensitive even when they are Git-ignored: do not print them, pass them to AI subprocesses, or copy them into generated documentation.
 - Create the new `bruin/` project yourself; do not expect generated assets.
-- Pause after connection placeholders, before any destination write, and after
-  each approved v0 run.
-- Keep repository-root `plan.md` current with facts, decisions, TODOs, run
-  history, source-consistency boundaries, unsupported behavior, and cutover
-  work.
-- Before a historical ingestr run, obtain explicit start/end bounds and a
-  source-consistency boundary; `--full-refresh` does not by itself make the
-  ingestr source interval unbounded.
-- Run approved aggregate parity and quality checks after every v0 load. Use
-  cross-platform data diff as a pass/fail gate only when its representation is
-  explicitly reviewed as comparable.
-- Never use the importer `--replace` flag during a migration; preserve a new,
-  timestamped capture instead.
-- Do not enable schedules, run destructive refreshes, or disable Fivetran
-  without explicit user approval.
+- Pause after connection placeholders, before any destination write, and after each approved v0 run.
+- Keep repository-root `plan.md` current with facts, decisions, TODOs, run history, source-consistency boundaries, unsupported behavior, and cutover work.
+- Before a historical ingestr run, obtain explicit start/end bounds and a source-consistency boundary; `--full-refresh` does not by itself make the ingestr source interval unbounded.
+- Run approved aggregate parity and quality checks after every v0 load. Use cross-platform data diff as a pass/fail gate only when its representation is explicitly reviewed as comparable.
+- Never use the importer `--replace` flag during a migration; preserve a new, timestamped capture instead.
+- Do not enable schedules, run destructive refreshes, or disable Fivetran without explicit user approval.

--- a/templates/migration-fivetran/fivetran-bruin-prompt.md
+++ b/templates/migration-fivetran/fivetran-bruin-prompt.md
@@ -1,49 +1,24 @@
 # Fivetran to Bruin migration prompt
 
-Use this prompt from the repository root to migrate one Fivetran connection
-into a new Bruin ingestr project. This is a staged, review-gated workflow, not
-an automatic cutover. Keep customer captures and generated evidence under
-`.artifacts/`; never put credentials or source data in Git. The installed
-importer writes captures under the repository-root `.artifacts/` directory;
-do not pass a nested artifact directory unless the installed importer confirms
-that it supports one.
+Use this prompt from the repository root to migrate one Fivetran connection into a new Bruin ingestr project. This is a staged, review-gated workflow, not an automatic cutover. Keep customer captures and generated evidence under `.artifacts/`; never put credentials or source data in Git. The installed importer writes captures under the repository-root `.artifacts/` directory; do not pass a nested artifact directory unless the installed importer confirms that it supports one.
 
-You are a data-migration agent. Use the Bruin MCP and official Bruin
-documentation for all Bruin configuration and commands; do not guess syntax.
-Migrate exactly one Fivetran connection at a time. Ask the user whenever a
-connection, mapping, or migration decision is unclear.
+You are a data-migration agent. Use the Bruin MCP and official Bruin documentation for all Bruin configuration and commands; do not guess syntax. Migrate exactly one Fivetran connection at a time. Ask the user whenever a connection, mapping, or migration decision is unclear.
 
-Read the repository-root `plan.md` first and update it after every stage. Keep
-automated findings, human decisions, unsupported behavior, and open TODOs
-separate.
+Read the repository-root `plan.md` first and update it after every stage. Keep automated findings, human decisions, unsupported behavior, and open TODOs separate.
 
 ## Stage 0 — bootstrap the migration workspace
 
 Before importing anything:
 
-1. Verify that the Bruin CLI is installed and compatible. Do not update it
-   unless the user approves the update or a documented compatibility issue
-   requires it.
-2. Ask the user to confirm the Fivetran connection name or ID to migrate, the
-   source PostgreSQL connection name, the destination BigQuery connection name,
-   and the pipeline name if it should differ from `bruin`.
-3. Create or review the repository-root, Git-ignored `.bruin.yml`. It may
-   already contain user-supplied connection values or environment-variable
-   references. Confirm only its non-secret structure and the named source and
-   destination connections; never print, copy, commit, or modify credential
-   values. Keep generic Fivetran values named `fivetran_api_key` and
-   `fivetran_api_secret`.
-4. Create an empty Bruin pipeline in `bruin/`, including `pipeline.yml` and
-   `assets/`.
+1. Verify that the Bruin CLI is installed and compatible. Do not update it unless the user approves the update or a documented compatibility issue requires it.
+2. Ask the user to confirm the Fivetran connection name or ID to migrate, the source PostgreSQL connection name, the destination BigQuery connection name, and the pipeline name if it should differ from `bruin`.
+3. Create or review the repository-root, Git-ignored `.bruin.yml`. It may already contain user-supplied connection values or environment-variable references. Confirm only its non-secret structure and the named source and destination connections; never print, copy, commit, or modify credential values. Keep generic Fivetran values named `fivetran_api_key` and `fivetran_api_secret`.
+4. Create an empty Bruin pipeline in `bruin/`, including `pipeline.yml` and `assets/`.
 5. Verify `.bruin.yml` and `.artifacts/` are ignored by Git before any capture.
 
-When the destination is BigQuery, set the pipeline default under
-`default_connections.google_cloud_platform`; `default_connections.bigquery`
-does not resolve a BigQuery destination in the current Bruin CLI.
+When the destination is BigQuery, set the pipeline default under `default_connections.google_cloud_platform`; `default_connections.bigquery` does not resolve a BigQuery destination in the current Bruin CLI.
 
-Do not import Fivetran configuration until this setup is complete. Do not write
-destination data, enable schedules, disable Fivetran, or perform cutover work
-without the user's explicit approval.
+Do not import Fivetran configuration until this setup is complete. Do not write destination data, enable schedules, disable Fivetran, or perform cutover work without the user's explicit approval.
 
 Start with this implementation instruction:
 
@@ -69,8 +44,7 @@ Start with this implementation instruction:
 
 ## Stage 1 — import Fivetran configuration
 
-Ask the user to identify one connection by name or ID. Then capture exactly
-that connection using only GET requests:
+Ask the user to identify one connection by name or ID. Then capture exactly that connection using only GET requests:
 
 ```bash
 python3 .agents/skills/bruin-fivetran-migrator/import_fivetran.py \
@@ -79,75 +53,28 @@ python3 .agents/skills/bruin-fivetran-migrator/import_fivetran.py \
   --output-dir .artifacts/fivetran/<capture-id>
 ```
 
-Prefer `--connector-id` when it is available: the importer then fetches only
-that connection rather than listing connections to resolve a name. A name must
-be an exact connection-name match. Never use `--replace` during a migration;
-create a new, timestamped capture directory instead.
+Prefer `--connector-id` when it is available: the importer then fetches only that connection rather than listing connections to resolve a name. A name must be an exact connection-name match. Never use `--replace` during a migration; create a new, timestamped capture directory instead.
 
-Read the redacted `connection.json` and `schemas.json`. Update `plan.md` with the source/destination inventory, schedule/state,
-selected tables, missing metadata, compatibility gaps, and next user actions.
+Read the redacted `connection.json` and `schemas.json`. Update `plan.md` with the source/destination inventory, schedule/state, selected tables, missing metadata, compatibility gaps, and next user actions.
 
 ## Stage 2 — review Bruin connections, then pause
 
-Review the bootstrapped `.bruin.yml` and the empty `bruin/` project. Confirm
-the non-secret connection names and platform settings; do not add, print, or
-copy real connection values. Explain only the missing non-secret configuration,
-update the plan, and stop. Resume only when the user explicitly says the
-connections are ready; then test both named connections and record the result.
-After one failed connection test, perform at most one bounded, credential-free
-reachability diagnosis and pause for a user-directed configuration change. If
-PostgreSQL is reachable but rejects the connection through `pg_hba.conf`,
-correct an approved TLS mode to a valid Bruin value such as `require` (not
-`required`) and retest; never print connection values while diagnosing.
+Review the bootstrapped `.bruin.yml` and the empty `bruin/` project. Confirm the non-secret connection names and platform settings; do not add, print, or copy real connection values. Explain only the missing non-secret configuration, update the plan, and stop. Resume only when the user explicitly says the connections are ready; then test both named connections and record the result. After one failed connection test, perform at most one bounded, credential-free reachability diagnosis and pause for a user-directed configuration change. If PostgreSQL is reachable but rejects the connection through `pg_hba.conf`, correct an approved TLS mode to a valid Bruin value such as `require` (not `required`) and retest; never print connection values while diagnosing.
 
 ## Stage 3 — draft the MVP
 
-Read the imported capture, source definitions, Bruin documentation, and Bruin
-MCP. Build the Bruin ingestr pipeline and assets from scratch. For every table,
-record in `plan.md` the mapping, casts, renames, omissions, generated fields,
-materialization, keys, incremental strategy, schema ownership, schedule choice,
-and unsupported Fivetran behavior. Do not run ingestion yet.
+Read the imported capture, source definitions, Bruin documentation, and Bruin MCP. Build the Bruin ingestr pipeline and assets from scratch. For every table, record in `plan.md` the mapping, casts, renames, omissions, generated fields, materialization, keys, incremental strategy, schema ownership, schedule choice, and unsupported Fivetran behavior. Do not run ingestion yet.
 
 ## Stage 4 — resolve TODOs
 
-Walk through every open TODO with the user before any destination write. Obtain
-explicit answers for initial-run scope, isolated target names, date bounds,
-primary and incremental keys, materialization, delete/history behavior, schema
-handling, validation boundary, rollback, and operational ownership. Update the
-pipeline and plan after each answer. Stay paused if any required decision is
-missing.
+Walk through every open TODO with the user before any destination write. Obtain explicit answers for initial-run scope, isolated target names, date bounds, primary and incremental keys, materialization, delete/history behavior, schema handling, validation boundary, rollback, and operational ownership. Update the pipeline and plan after each answer. Stay paused if any required decision is missing.
 
-Also define a source-consistency boundary: record an approved source watermark
-or snapshot boundary before the run, apply it consistently to extraction and
-reconciliation, and state how concurrent source writes are handled.
+Also define a source-consistency boundary: record an approved source watermark or snapshot boundary before the run, apply it consistently to extraction and reconciliation, and state how concurrent source writes are handled.
 
 ## Stage 5 — approved v0 run
 
-After explicit approval, validate and run only the approved scope to isolated
-v0 tables. A `--full-refresh` still uses Bruin's run interval for ingestr
-filtering: profile the source `incremental_key` range first, then obtain
-explicit approval for inclusive/exclusive `--start-date` and `--end-date`
-bounds that cover the intended history. Use `bruin query` to compare source and
-target row counts, null and duplicate keys, and incremental ranges; normalize
-timestamps to the same timezone before comparing them. Run the reviewed
-quality checks after the load, not just `bruin validate`. Run `bruin data-diff
---full --tolerance 0 --fail-if-diff` when a reviewed common representation
-exists. Treat every mismatch as a failure, except documented, user-approved
-destination metadata or cross-platform type representation differences that
-make `data-diff` diagnostic-only; in that case the exact aggregate parity
-profile is the required pass/fail gate. Ingestr may add
-`_ingestr_loaded_at`; document and exclude that generated field from common
-column parity if approved. Preserve evidence in `.artifacts/`, update the
-plan's Run history, summarize the result, and pause.
+After explicit approval, validate and run only the approved scope to isolated v0 tables. A `--full-refresh` still uses Bruin's run interval for ingestr filtering: profile the source `incremental_key` range first, then obtain explicit approval for inclusive/exclusive `--start-date` and `--end-date` bounds that cover the intended history. Use `bruin query` to compare source and target row counts, null and duplicate keys, and incremental ranges; normalize timestamps to the same timezone before comparing them. Run the reviewed quality checks after the load, not just `bruin validate`. Run `bruin data-diff --full --tolerance 0 --fail-if-diff` when a reviewed common representation exists. Treat every mismatch as a failure, except documented, user-approved destination metadata or cross-platform type representation differences that make `data-diff` diagnostic-only; in that case the exact aggregate parity profile is the required pass/fail gate. Ingestr may add `_ingestr_loaded_at`; document and exclude that generated field from common column parity if approved. Preserve evidence in `.artifacts/`, update the plan's Run history, summarize the result, and pause.
 
 ## Stage 6 — final review only on request
 
-Ask whether the user wants a final review and metadata update. Only if they say
-yes, review the assets, manually add or review metadata, validate the result,
-create `bruin/README.md`, and complete the migration/cutover checklist in
-`plan.md`. Do not run `bruin ai enhance --codex` in the migration workspace:
-its subprocesses may inspect `.bruin.yml` or `.artifacts/`. If the user
-explicitly wants AI assistance, use an isolated temporary copy containing only
-sanitized asset definitions, then review its diff, validate the copied changes,
-and run the resulting quality checks. Do not disable Fivetran or enable a Bruin
-schedule without separate, explicit approval.
+Ask whether the user wants a final review and metadata update. Only if they say yes, review the assets, manually add or review metadata, validate the result, create `bruin/README.md`, and complete the migration/cutover checklist in `plan.md`. Do not run `bruin ai enhance --codex` in the migration workspace: its subprocesses may inspect `.bruin.yml` or `.artifacts/`. If the user explicitly wants AI assistance, use an isolated temporary copy containing only sanitized asset definitions, then review its diff, validate the copied changes, and run the resulting quality checks. Do not disable Fivetran or enable a Bruin schedule without separate, explicit approval.

--- a/templates/migration-fivetran/plan.md
+++ b/templates/migration-fivetran/plan.md
@@ -1,9 +1,6 @@
 # Fivetran to Bruin migration plan
 
-This is a reusable, reviewed plan template. During a runtime migration, replace
-only the placeholder values after reviewing the redacted files in
-`.artifacts/fivetran/<capture-id>/`. Do not put credentials, raw Fivetran
-exports, source data, or Fivetran cursor state in this file.
+This is a reusable, reviewed plan template. During a runtime migration, replace only the placeholder values after reviewing the redacted files in `.artifacts/fivetran/<capture-id>/`. Do not put credentials, raw Fivetran exports, source data, or Fivetran cursor state in this file.
 
 ## Status and provenance
 
@@ -22,18 +19,14 @@ exports, source data, or Fivetran cursor state in this file.
 
 ## Automated findings from import
 
-- `TODO`: record source service, selected objects, schedule/status, destination
-  renames, Fivetran schema policy, configured column overrides, and missing
-  metadata from the redacted `connection.json` and `schemas.json` capture.
-- `TODO`: list any source-to-Bruin compatibility mismatch. Mark it as automated
-  until a reviewer makes a decision.
+- `TODO`: record source service, selected objects, schedule/status, destination renames, Fivetran schema policy, configured column overrides, and missing metadata from the redacted `connection.json` and `schemas.json` capture.
+- `TODO`: list any source-to-Bruin compatibility mismatch. Mark it as automated until a reviewer makes a decision.
 
 ## Hand-authored decisions
 
 - Source and destination named Bruin connections: `TODO`.
 - Target isolation and naming: `TODO`.
-- Per-table strategy, primary key, incremental key, explicit bounds, and schema
-  contract: `TODO`.
+- Per-table strategy, primary key, incremental key, explicit bounds, and schema contract: `TODO`.
 - Delete/history/CDC/system-column behavior: `TODO`.
 - Scheduling, monitoring, alerting, ownership, and rollback: `TODO`.
 
@@ -45,42 +38,31 @@ exports, source data, or Fivetran cursor state in this file.
 
 ## Unsupported features and non-mappings
 
-- Fivetran credentials, networking, cursor/checkpoint state, alerts, retries,
-  and managed schedules are not imported.
-- `SOFT_DELETE`, `HISTORY`, Query-Based PostgreSQL, and Fivetran system columns
-  require a separate approved design. `TODO`: record the selected treatment.
-- `TODO`: list service-specific source features the generated ingestr asset
-  cannot express.
+- Fivetran credentials, networking, cursor/checkpoint state, alerts, retries, and managed schedules are not imported.
+- `SOFT_DELETE`, `HISTORY`, Query-Based PostgreSQL, and Fivetran system columns require a separate approved design. `TODO`: record the selected treatment.
+- `TODO`: list service-specific source features the generated ingestr asset cannot express.
 
 ## Open human-review items — must be empty before a write
 
-- [ ] Exact initial-run scope: full history, bounded history, one table, or
-  another scope; list tables and explicit start/end bounds.
-- [ ] Isolated destination target is confirmed; replace/truncate permission is
-  explicit when relevant.
+- [ ] Exact initial-run scope: full history, bounded history, one table, or another scope; list tables and explicit start/end bounds.
+- [ ] Isolated destination target is confirmed; replace/truncate permission is explicit when relevant.
 - [ ] Source/destination connection preflight passed.
-- [ ] Primary keys, incremental keys, materialization, delete handling, and
-  schema ownership are approved for each selected table.
-- [ ] Column mapping, quality checks, validation boundary, expected cost, and
-  rollback condition are approved.
-- [ ] Schedule/monitoring ownership is assigned; Fivetran remains active until
-  cutover criteria are met.
+- [ ] Primary keys, incremental keys, materialization, delete handling, and schema ownership are approved for each selected table.
+- [ ] Column mapping, quality checks, validation boundary, expected cost, and rollback condition are approved.
+- [ ] Schedule/monitoring ownership is assigned; Fivetran remains active until cutover criteria are met.
 
 ## v0 run and validation evidence
 
 - Requested scope and approval: `TODO`.
 - `bruin validate` result: `TODO`.
 - Run command, dates, and resulting target tables: `TODO`.
-- Source/destination profile: row count `TODO`, null keys `TODO`, duplicate
-  keys `TODO`.
+- Source/destination profile: row count `TODO`, null keys `TODO`, duplicate keys `TODO`.
 - `bruin data-diff --full --tolerance 0 --fail-if-diff` result: `TODO`.
 - Mismatches, accepted differences, and follow-up: `TODO`.
 
 ## Run history
 
-Add one dated entry for every connection preflight, validation attempt, and v0
-run. Keep detailed output only in `.artifacts/`; this plan records the
-reviewable summary and the next human decision.
+Add one dated entry for every connection preflight, validation attempt, and v0 run. Keep detailed output only in `.artifacts/`; this plan records the reviewable summary and the next human decision.
 
 ### `YYYY-MM-DDTHH:MM:SSZ` — `preflight | validation | v0_run`
 
@@ -92,16 +74,12 @@ reviewable summary and the next human decision.
 
 ## Completing the migration
 
-Complete this section only after the user requests final review and metadata
-updates.
+Complete this section only after the user requests final review and metadata updates.
 
 - [ ] Review pipeline/column metadata and `bruin ai enhance --codex` changes.
 - [ ] Publish a pipeline README and assign an operating owner.
 - [ ] Run final bounded reconciliation and document a rollback decision.
-- [ ] Refactor downstream assets/models/tables from Fivetran-specific names and
-  system-column assumptions.
+- [ ] Refactor downstream assets/models/tables from Fivetran-specific names and system-column assumptions.
 - [ ] Enable approved Bruin scheduling, monitoring, alerting, and runbook.
-- [ ] Pause/disable Fivetran only after the documented validation boundary and
-  rollback window are satisfied.
-- [ ] Retire Fivetran credentials, billing/configuration, and legacy artifacts
-  under the owner's change-control process.
+- [ ] Pause/disable Fivetran only after the documented validation boundary and rollback window are satisfied.
+- [ ] Retire Fivetran credentials, billing/configuration, and legacy artifacts under the owner's change-control process.

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -1,14 +1,8 @@
 # Stripe Billing Analytics to BigQuery
 
-`stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery.
-It loads the customer, product, price, subscription, subscription-item, and
-invoice resources into `stripe_raw`; builds reusable billing models in
-`stripe_stage`; and publishes recurring-revenue and invoice-billing reports in
-`stripe_reports`.
+`stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery. It loads the customer, product, price, subscription, subscription-item, and invoice resources into `stripe_raw`; builds reusable billing models in `stripe_stage`; and publishes recurring-revenue and invoice-billing reports in `stripe_reports`.
 
-The template contains 19 assets across three layers. It is a practical starting
-point for analyzing Stripe subscription billing while keeping the data model
-small enough to adapt to your own reporting needs.
+The template contains 19 assets across three layers. It is a practical starting point for analyzing Stripe subscription billing while keeping the data model small enough to adapt to your own reporting needs.
 
 ## Project structure
 
@@ -47,62 +41,29 @@ stripe-bigquery/
 
 ### Raw Stripe data
 
-The `stripe_raw` dataset contains the six Stripe resources that underpin the
-billing models. Ingestr loads them with the shared `stripe-default` connection,
-and BigQuery is the destination.
+The `stripe_raw` dataset contains the six Stripe resources that underpin the billing models. Ingestr loads them with the shared `stripe-default` connection, and BigQuery is the destination.
 
-Each source asset uses ingestr's
-[incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading)
-(`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the
-Stripe object `id`, so a run only fetches the records created inside its own
-time window and upserts them.
+Each source asset uses ingestr's [incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading) (`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the Stripe object `id`, so a run only fetches the records created inside its own time window and upserts them.
 
-Incremental mode filters on Stripe's `created` timestamp and does not revisit
-records created in earlier windows. That matters for the mutable resources — a
-subscription cancelled or upgraded months after it was created, an invoice
-finalized, paid, or voided after its creation date. To pick those edits up,
-periodically re-run over a wider window:
+Incremental mode filters on Stripe's `created` timestamp and does not revisit records created in earlier windows. That matters for the mutable resources — a subscription cancelled or upgraded months after it was created, an invoice finalized, paid, or voided after its creation date. To pick those edits up, periodically re-run over a wider window:
 
 ```bash
 bruin run --start-date 2023-01-01 --end-date $(date -u +%F) my-stripe-pipeline
 ```
 
-Choose that cadence to match how current your reporting needs to be, or switch
-the mutable assets to `source_table: subscription` for
-[standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default),
-which reloads full history on every run. See
-[loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs)
-for the comparison.
+Choose that cadence to match how current your reporting needs to be, or switch the mutable assets to `source_table: subscription` for [standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default), which reloads full history on every run. See [loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs) for the comparison.
 
-Each raw asset also declares its full column schema, which pins those columns
-into the destination table. That matters for fields Stripe leaves null on some
-accounts: `invoice.due_date` is only set for invoices collected with
-`send_invoice`, and a schema inferred purely from the data would drop the column
-and break the stage model.
+Each raw asset also declares its full column schema, which pins those columns into the destination table. That matters for fields Stripe leaves null on some accounts: `invoice.due_date` is only set for invoices collected with `send_invoice`, and a schema inferred purely from the data would drop the column and break the stage model.
 
 ### Conformed billing models
 
-The `stripe_stage` dataset exposes typed customer, product, price,
-subscription, subscription-item, invoice, and invoice-line-item models. It also
-builds daily snapshots of subscription items and customer MRR by native
-currency, stamped with the pipeline end date.
+The `stripe_stage` dataset exposes typed customer, product, price, subscription, subscription-item, invoice, and invoice-line-item models. It also builds daily snapshots of subscription items and customer MRR by native currency, stamped with the pipeline end date.
 
-Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`,
-so each run rebuilds its table from the current raw data. That keeps the
-pipeline idempotent and easy to reason about.
+Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`, so each run rebuilds its table from the current raw data. That keeps the pipeline idempotent and easy to reason about.
 
-The two daily snapshot assets are the exception. They use
-`delete+insert` on `snapshot_date`, so each run replaces only the day it
-observes and leaves earlier days in place. That accumulates the daily
-observation history the reports layer needs for month-over-month movement and
-retention, while keeping a re-run of any single date idempotent. Because
-`delete+insert` writes into an existing table, the first load has to create
-these two tables with `--full-refresh`; see
-[Run the pipeline](#run-the-pipeline).
+The two daily snapshot assets are the exception. They use `delete+insert` on `snapshot_date`, so each run replaces only the day it observes and leaves earlier days in place. That accumulates the daily observation history the reports layer needs for month-over-month movement and retention, while keeping a re-run of any single date idempotent. Because `delete+insert` writes into an existing table, the first load has to create these two tables with `--full-refresh`; see [Run the pipeline](#run-the-pipeline).
 
-The snapshots record the Stripe state visible when the pipeline runs, so
-history builds up from the first run forward and cannot be backfilled from
-current Stripe records.
+The snapshots record the Stripe state visible when the pipeline runs, so history builds up from the first run forward and cannot be backfilled from current Stripe records.
 
 ### Billing reports
 
@@ -115,9 +76,7 @@ The `stripe_reports` dataset provides four ready-to-query tables:
 
 ### Asset summary
 
-All 19 assets materialize as tables. `create+replace` is the default when no
-incremental strategy is listed, so those assets are rebuilt from their upstreams
-on every run.
+All 19 assets materialize as tables. `create+replace` is the default when no incremental strategy is listed, so those assets are rebuilt from their upstreams on every run.
 
 | Schema | Asset | Materialization | Incremental strategy | Partition | Purpose |
 | --- | --- | --- | --- | --- | --- |
@@ -141,28 +100,15 @@ on every run.
 | `stripe_reports` | `monthly_subscription_kpis` | table | `create+replace` | — | Recurring-revenue, retention, and customer-count scorecard |
 | `stripe_reports` | `monthly_invoice_billings` | table | `create+replace` | — | Invoice billings by finalization month and currency |
 
-The two snapshot assets are partitioned on `snapshot_date` because they
-accumulate indefinitely: their per-run `DELETE` prunes to the single day being
-replaced instead of scanning the whole history. The other assets are rebuilt in
-full each run, so partitioning would not save any scan.
+The two snapshot assets are partitioned on `snapshot_date` because they accumulate indefinitely: their per-run `DELETE` prunes to the single day being replaced instead of scanning the whole history. The other assets are rebuilt in full each run, so partitioning would not save any scan.
 
 ### Column-level documentation
 
-Every asset in all three layers declares its full column schema: each column
-carries a type, a description, and primary-key marks on the grain, so the
-reporting grain and the metric definitions are readable from the asset files
-themselves. `metadata_push` in `pipeline.yml` publishes those descriptions to
-the BigQuery table and column metadata, and `bruin docs my-stripe-pipeline`
-generates a browsable documentation site from the same schemas.
+Every asset in all three layers declares its full column schema: each column carries a type, a description, and primary-key marks on the grain, so the reporting grain and the metric definitions are readable from the asset files themselves. `metadata_push` in `pipeline.yml` publishes those descriptions to the BigQuery table and column metadata, and `bruin docs my-stripe-pipeline` generates a browsable documentation site from the same schemas.
 
 ## Example report rows
 
-The following illustrative rows use minor currency units: `9900` USD means
-$99.00. They show the shape of each table across several months, which fills in
-once the snapshots have accumulated that many months of history; see
-[Conformed billing models](#conformed-billing-models).
-Query the four tables in `stripe_reports` directly, then adapt the columns to
-the definitions used by your finance and revenue teams.
+The following illustrative rows use minor currency units: `9900` USD means $99.00. They show the shape of each table across several months, which fills in once the snapshots have accumulated that many months of history; see [Conformed billing models](#conformed-billing-models). Query the four tables in `stripe_reports` directly, then adapt the columns to the definitions used by your finance and revenue teams.
 
 ### `monthly_mrr_by_customer`
 
@@ -198,27 +144,15 @@ the definitions used by your finance and revenue teams.
 
 ## Metric policy
 
-All monetary values in the `stripe_stage` and `stripe_reports` tables remain in
-each currency's minor units; only the dashboard converts to major units for
-display. Do not add amounts across currencies without an FX source and explicit
-conversion policy.
+All monetary values in the `stripe_stage` and `stripe_reports` tables remain in each currency's minor units; only the dashboard converts to major units for display. Do not add amounts across currencies without an FX source and explicit conversion policy.
 
-MRR is a gross list-price run rate from active and past-due subscriptions with
-licensed recurring monthly or annual prices. Free, one-time, metered, and
-discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither
-measure is recognized revenue, bookings, cash, or a financial statement.
+MRR is a gross list-price run rate from active and past-due subscriptions with licensed recurring monthly or annual prices. Free, one-time, metered, and discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither measure is recognized revenue, bookings, cash, or a financial statement.
 
-The daily snapshots capture the Stripe state visible when the pipeline runs.
-They do not reconstruct prior daily MRR history from current Stripe records, so
-the accumulated history starts at the first run. Month-over-month movement and
-retention metrics need two contiguous monthly observations, so they stay empty
-until the snapshots span a second month.
+The daily snapshots capture the Stripe state visible when the pipeline runs. They do not reconstruct prior daily MRR history from current Stripe records, so the accumulated history starts at the first run. Month-over-month movement and retention metrics need two contiguous monthly observations, so they stay empty until the snapshots span a second month.
 
 ## Configure connections
 
-Initializing the template adds placeholder connections to the repository-level
-`.bruin.yml`. Keep the connection names `gcp-default` and `stripe-default`, or
-rename them consistently in both `.bruin.yml` and `pipeline.yml`.
+Initializing the template adds placeholder connections to the repository-level `.bruin.yml`. Keep the connection names `gcp-default` and `stripe-default`, or rename them consistently in both `.bruin.yml` and `pipeline.yml`.
 
 ```yaml
 default_environment: default
@@ -238,25 +172,16 @@ environments:
 
 Replace both BigQuery placeholders before running the pipeline:
 
-- `project_id` — the Google Cloud project that owns the BigQuery datasets this
-  pipeline writes to, for example `my-company-analytics`.
-- `location` — the region or multi-region of those datasets, for example `US`,
-  `EU`, or `europe-west3`. It must match the location of the existing datasets;
-  BigQuery cannot query a dataset from a different location. See
-  [BigQuery locations](https://cloud.google.com/bigquery/docs/locations).
+- `project_id` — the Google Cloud project that owns the BigQuery datasets this pipeline writes to, for example `my-company-analytics`.
+- `location` — the region or multi-region of those datasets, for example `US`, `EU`, or `europe-west3`. It must match the location of the existing datasets; BigQuery cannot query a dataset from a different location. See [BigQuery locations](https://cloud.google.com/bigquery/docs/locations).
 
-The connection uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials),
-so authenticate with `gcloud` once:
+The connection uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials), so authenticate with `gcloud` once:
 
 ```bash
 gcloud auth application-default login
 ```
 
-To use a service account instead, replace
-`use_application_default_credentials: true` with
-`service_account_file: /path/to/service-account.json`. Either way, the
-credentials need permission to create datasets and tables and to run queries in
-the project.
+To use a service account instead, replace `use_application_default_credentials: true` with `service_account_file: /path/to/service-account.json`. Either way, the credentials need permission to create datasets and tables and to run queries in the project.
 
 Set the Stripe secret key in your shell before running the pipeline:
 
@@ -264,12 +189,7 @@ Set the Stripe secret key in your shell before running the pipeline:
 export STRIPE_API_KEY='sk_test_your_secret_key'
 ```
 
-Use either an `sk_test_...` or `sk_live_...` secret key. A publishable
-`pk_...` key cannot read Stripe data. Keep test and live data in separate
-BigQuery projects or datasets and do not commit credentials. The ingestr docs
-cover where to find the key and how to
-[create a restricted key](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#setting-up-a-stripe-integration)
-with read-only access to the resources this pipeline loads.
+Use either an `sk_test_...` or `sk_live_...` secret key. A publishable `pk_...` key cannot read Stripe data. Keep test and live data in separate BigQuery projects or datasets and do not commit credentials. The ingestr docs cover where to find the key and how to [create a restricted key](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#setting-up-a-stripe-integration) with read-only access to the resources this pipeline loads.
 
 ## Run the pipeline
 
@@ -279,66 +199,42 @@ Initialize a project from the template:
 bruin init stripe-bigquery my-stripe-pipeline
 ```
 
-Set `start_date` in `pipeline.yml` to the earliest Stripe history you need,
-then run the fast validation checks:
+Set `start_date` in `pipeline.yml` to the earliest Stripe history you need, then run the fast validation checks:
 
 ```bash
 bruin validate --fast my-stripe-pipeline
 ```
 
-On a new BigQuery destination, load every table before running query validation.
-The raw assets load only their run window, so pass an explicit range to pull
-your Stripe history in the first load. Use `--full-refresh` on this first run:
-the two daily snapshot assets use `delete+insert`, which writes into an existing
-table, so their tables have to be created before a normal run can add days to
-them.
+On a new BigQuery destination, load every table before running query validation. The raw assets load only their run window, so pass an explicit range to pull your Stripe history in the first load. Use `--full-refresh` on this first run: the two daily snapshot assets use `delete+insert`, which writes into an existing table, so their tables have to be created before a normal run can add days to them.
 
 ```bash
 bruin run --full-refresh --start-date 2023-01-01 --end-date $(date -u +%F) \
   --no-validation my-stripe-pipeline
 ```
 
-After the initial load, run `bruin validate my-stripe-pipeline` and schedule the
-pipeline daily without `--full-refresh`:
+After the initial load, run `bruin validate my-stripe-pipeline` and schedule the pipeline daily without `--full-refresh`:
 
 ```bash
 bruin run --start-date $(date -u +%F) --end-date $(date -u +%F) my-stripe-pipeline
 ```
 
-Any run is safe to repeat. The raw assets upsert on `id`, the other stage and
-report assets are rebuilt with create+replace, and the two snapshot assets
-replace only the `snapshot_date` they observe, so re-running a date does not
-duplicate rows or drop the days around it. Avoid `--full-refresh` after the
-initial load: it rebuilds the snapshot tables from scratch and discards the
-accumulated history.
+Any run is safe to repeat. The raw assets upsert on `id`, the other stage and report assets are rebuilt with create+replace, and the two snapshot assets replace only the `snapshot_date` they observe, so re-running a date does not duplicate rows or drop the days around it. Avoid `--full-refresh` after the initial load: it rebuilds the snapshot tables from scratch and discards the accumulated history.
 
 ## Customize it
 
-Use the stage models as a stable interface for your own reports. Review the
-selected assets, source fields, quality checks, and metric policy before using
-the results for financial reporting. Extend the pipeline with your business
-definitions, identity mapping, and FX policy where required.
+Use the stage models as a stable interface for your own reports. Review the selected assets, source fields, quality checks, and metric policy before using the results for financial reporting. Extend the pipeline with your business definitions, identity mapping, and FX policy where required.
 
 ## View the billing dashboard
 
-The included DAC dashboard visualizes native-currency MRR, ARR, customer count,
-retention, movement components, invoice billings, and the latest customer MRR
-distribution. It deliberately filters to one currency at a time because no FX
-rates are applied. The reporting tables retain money in native minor units; the
-dashboard queries divide by the selected currency's exponent so the widgets read
-in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
+The included DAC dashboard visualizes native-currency MRR, ARR, customer count, retention, movement components, invoice billings, and the latest customer MRR distribution. It deliberately filters to one currency at a time because no FX rates are applied. The reporting tables retain money in native minor units; the dashboard queries divide by the selected currency's exponent so the widgets read in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
 
-After configuring `gcp-default`, install a verified DAC release by following
-the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html).
-Then install its dashboard-authoring skill from the project root:
+After configuring `gcp-default`, install a verified DAC release by following the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html). Then install its dashboard-authoring skill from the project root:
 
 ```bash
 dac skills install --dir . create-dashboard
 ```
 
-Restart your coding agent after installing the skill so it can use the local
-`create-dashboard` instructions. Then validate the dashboard, execute its
-queries, and serve the DAC app:
+Restart your coding agent after installing the skill so it can use the local `create-dashboard` instructions. Then validate the dashboard, execute its queries, and serve the DAC app:
 
 ```bash
 dac --config .bruin.yml validate --dir dashboards
@@ -350,8 +246,6 @@ dac --config .bruin.yml serve --dir dashboards --port 8321
 
 ![Stripe billing analytics dashboard preview](images/stripe-billing-analytics-demo.png)
 
-This screenshot uses synthetic data solely to demonstrate the dashboard's
-layout and charts.
+This screenshot uses synthetic data solely to demonstrate the dashboard's layout and charts.
 
-MRR movement and retention metrics need two contiguous monthly snapshots, so
-they stay empty until the accumulated snapshot history spans a second month.
+MRR movement and retention metrics need two contiguous monthly snapshots, so they stay empty until the accumulated snapshot history spans a second month.


### PR DESCRIPTION
Reflows hard-wrapped Markdown prose to soft wrap (one line per paragraph) across 33 docs pages and template READMEs. Source-only change — VitePress renders it identically, and code/YAML/tables/commands are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)