### PR TITLE
docs: preload and accelerate local search

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -19,6 +19,43 @@ const bruinPythonGrammar = JSON.parse(
     fs.readFileSync(path.resolve(__dirname, "theme/bruinpython.json"), "utf8")
 );
 
+// VitePress intentionally lazy-loads local search and waits 200 ms after each
+// keystroke. That is a good default for small sites, but our large local index
+// made opening and using search feel sluggish. Keep the search code and index
+// warm, and use a short debounce so interaction stays below a frame or two.
+const fastLocalSearch = {
+    name: "bruin-fast-local-search",
+    enforce: "pre",
+    transform(code, id) {
+        if (id.endsWith("/theme-default/components/VPNavBarSearch.vue")) {
+            const searchState = "const showSearch = ref(false)";
+            if (!code.includes(searchState)) {
+                throw new Error("Unable to preload the VitePress local search component");
+            }
+
+            return code.replace(
+                searchState,
+                `${searchState}\n\n// Warm the search chunk without delaying the initial page render.\nonMounted(() => {\n  const runWhenIdle = window.requestIdleCallback || ((callback) => setTimeout(callback, 1))\n  runWhenIdle(() => import('./VPLocalSearchBox.vue'))\n})`,
+            );
+        }
+
+        if (id.endsWith("/theme-default/components/VPLocalSearchBox.vue")) {
+            const searchIndexDeclaration = "const searchIndexData = shallowRef(localSearchIndex)";
+            const debounce = "{ debounce: 200, immediate: true }";
+            if (!code.includes(searchIndexDeclaration) || !code.includes(debounce)) {
+                throw new Error("Unable to tune the VitePress local search implementation");
+            }
+
+            return code
+                .replace(
+                    searchIndexDeclaration,
+                    `${searchIndexDeclaration}\n\n// Download the index while the reader is browsing instead of after search opens.\nObject.values(localSearchIndex).forEach((load) => load())`,
+                )
+                .replace(debounce, "{ debounce: 25, immediate: true }");
+        }
+    },
+};
+
 // https://vitepress.dev/reference/site-config
 export default withMermaid({
     title: "Bruin CLI",
@@ -609,6 +646,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         class: "mermaid my-class", // set additional css classes for parent container
     },
     vite: {
+        plugins: [fastLocalSearch],
         optimizeDeps: {
             esbuildOptions: {
                 target: "esnext",


### PR DESCRIPTION
### Motivation

- The docs site uses VitePress local search which lazily loads the search component and index and uses a 200ms debounce, causing noticeable delay for our large local index when opening the search popup and when typing queries.

### Description

- Add a Vite transform plugin `fastLocalSearch` in `docs/.vitepress/config.mjs` that injects an idle-time `import('./VPLocalSearchBox.vue')` to warm the local-search chunk so search UI opens without lazy-load delay. 
- Preload the local search index by invoking all `localSearchIndex` loaders while the reader is browsing so the ~2MB index is available before the user opens search. 
- Reduce the search debounce from `{ debounce: 200, immediate: true }` to `{ debounce: 25, immediate: true }` to tighten query-response latency. 
- Add defensive checks that throw clear build-time errors if upstream VitePress internal strings change, preventing silent regressions. 

### Testing

- Ran `npm run docs:build` to validate the site build and asset generation, and it completed successfully. 
- Ran `git diff --check` and `git status --short` to validate the working tree and produced no actionable issues. 
- Attempted an automated search-performance measurement with Playwright (`node .search-perf.cjs`), but the headless Chromium/Playwright launch was blocked by the environment (snap/chromium and network-proxy download issues), so end-to-end timing could not be collected here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80ea4f92608320a9208a808ee49d14)