### PR TITLE
feat(templates): show company name and Stripe link in stripe-bigquery dashboard

### DIFF
--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -226,7 +226,7 @@ Use the stage models as a stable interface for your own reports. Review the sele
 
 ## View the billing dashboard
 
-The included DAC dashboard visualizes native-currency MRR, ARR, customer count, retention, movement components, invoice billings, and the latest customer MRR distribution. It deliberately filters to one currency at a time because no FX rates are applied. The reporting tables retain money in native minor units; the dashboard queries divide by the selected currency's exponent so the widgets read in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
+The included DAC dashboard visualizes native-currency MRR, ARR, customer count, retention, movement components, invoice billings, and the latest customer MRR distribution. The customer breakdown labels each account by company name (falling back to CRM account or Stripe customer id) and lists a deep link to open the customer in the Stripe Dashboard. It deliberately filters to one currency at a time because no FX rates are applied. The reporting tables retain money in native minor units; the dashboard queries divide by the selected currency's exponent so the widgets read in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
 
 After configuring `gcp-default`, install a verified DAC release by following the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html). Then install its dashboard-authoring skill from the project root:
 

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -226,7 +226,7 @@ Use the stage models as a stable interface for your own reports. Review the sele
 
 ## View the billing dashboard
 
-The included DAC dashboard visualizes native-currency MRR, ARR, customer count, retention, movement components, invoice billings, and the latest customer MRR distribution. It deliberately filters to one currency at a time because no FX rates are applied. The reporting tables retain money in native minor units; the dashboard queries divide by the selected currency's exponent so the widgets read in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
+The included DAC dashboard visualizes native-currency MRR, ARR, customer count, retention, movement components, invoice billings, and the latest customer MRR distribution. The customer breakdown labels each account by company name (falling back to CRM account or Stripe customer id) and lists a deep link to open the customer in the Stripe Dashboard. It deliberately filters to one currency at a time because no FX rates are applied. The reporting tables retain money in native minor units; the dashboard queries divide by the selected currency's exponent so the widgets read in major units, using a divisor of 1 for Stripe's zero-decimal currencies.
 
 After configuring `gcp-default`, install a verified DAC release by following the [DAC installation guide](https://getbruin.com/docs/dac/getting-started/installation.html). Then install its dashboard-authoring skill from the project root:
 

--- a/templates/stripe-bigquery/assets/stripe_reports/monthly_mrr_by_customer.sql
+++ b/templates/stripe-bigquery/assets/stripe_reports/monthly_mrr_by_customer.sql
@@ -53,6 +53,9 @@ columns:
     primary_key: true
     checks:
       - name: not_null
+  - name: customer_name
+    type: STRING
+    description: Customer's full or business name carried from the customer record.
   - name: crm_account_id
     type: STRING
     description: CRM account identifier carried from the customer metadata.
@@ -112,6 +115,7 @@ SELECT
     ) = 1 AS has_contiguous_global_prior_snapshot,
   snapshot.stripe_customer_id,
   snapshot.currency,
+  customer.customer_name,
   customer.crm_account_id,
   customer.customer_segment,
   customer.customer_region,

--- a/templates/stripe-bigquery/dashboards/stripe-billing-analytics.yml
+++ b/templates/stripe-bigquery/dashboards/stripe-billing-analytics.yml
@@ -150,9 +150,15 @@ queries:
         SELECT
           metric_month,
           stripe_customer_id,
+          customer_name,
           crm_account_id,
-          COALESCE(NULLIF(crm_account_id, ''), stripe_customer_id)
-            AS customer_label,
+          COALESCE(
+            NULLIF(customer_name, ''),
+            NULLIF(crm_account_id, ''),
+            stripe_customer_id
+          ) AS customer_label,
+          CONCAT('https://dashboard.stripe.com/customers/', stripe_customer_id)
+            AS stripe_customer_url,
           customer_segment,
           customer_region,
           sales_owner,
@@ -272,6 +278,10 @@ rows:
         query: latest_customer_mrr
         col: 12
         columns:
+          - name: customer_name
+            label: Company
+          - name: stripe_customer_url
+            label: Stripe link
           - name: stripe_customer_id
             label: Stripe customer
           - name: crm_account_id

--- a/templates/stripe-bigquery/dashboards/stripe-billing-analytics.yml
+++ b/templates/stripe-bigquery/dashboards/stripe-billing-analytics.yml
@@ -153,8 +153,8 @@ queries:
           customer_name,
           crm_account_id,
           COALESCE(
-            NULLIF(customer_name, ''),
-            NULLIF(crm_account_id, ''),
+            NULLIF(TRIM(customer_name), ''),
+            NULLIF(TRIM(crm_account_id), ''),
             stripe_customer_id
           ) AS customer_label,
           CONCAT('https://dashboard.stripe.com/customers/', stripe_customer_id)


### PR DESCRIPTION
## What

Surfaces each customer's **company name** and a **deep link to the customer in the Stripe Dashboard** on the Stripe Billing Analytics DAC dashboard in the `stripe-bigquery` template.

## Changes

- **Report layer** (`stripe_reports.monthly_mrr_by_customer`): carry `customer_name` from `stripe_stage.customers` (the report already joins customers for the other account attributes).
- **Dashboard** (`stripe-billing-analytics.yml`) `latest_customer_mrr` query:
  - select `customer_name`
  - prefer company name in `customer_label` — `COALESCE(customer_name, crm_account_id, stripe_customer_id)`
  - build `stripe_customer_url` = `https://dashboard.stripe.com/customers/<id>`
- **Customer detail table**: adds a **Company** column and a **Stripe link** column.
- **Customer MRR chart**: bars are now labelled by company name.
- Updated the template README and its docs copy.

## Verification

- `dac validate` passes on the template dashboard.
- Built a synthetic DuckDB replica of the report table and ran `dac check` (both queries pass) + a headless browser render: the Company column, Stripe-link column, and company-name chart labels all appear; the label falls back to CRM account / customer id when the name is blank.
- `bruin internal parse-pipeline` confirms `customer_name` now flows through the report columns.
- `go test ./cmd` stripe-template tests pass.

## Note

DAC standalone renders the `Stripe link` cell as the deep-link URL text (table cells are not auto-linkified; only `text`-widget markdown links are clickable). The value is the correct per-customer Stripe Dashboard URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)