### PR TITLE
docs: clarify .bruin.yml lives at the project root, not the pipeline folder

### DIFF
--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -37,20 +37,25 @@ When you run `bruin init`, it:
 3. Merges any template-level `.bruin.yml` configuration into your existing (or newly created) root `.bruin.yml`.
 4. Optionally initializes a **Git repository** if none exists.
 5. Outputs next steps, such as validating or running your new pipeline.
+
 ## Folder Structure
 
-Every initialized pipeline follows this convention:
+`bruin init` keeps your connection config (`.bruin.yml`) at the **project root** and places pipeline files in a named pipeline folder. `.bruin.yml` is **never** written inside the pipeline folder.
+
+For a brand-new project (no existing Git repo), Bruin creates a `bruin/` root:
 
 ```text
-my-pipeline/
-├─ pipeline.yml        # Defines the pipeline metadata
-└─ assets/             # Contains all assets for this pipeline
-   ├─ raw.orders.asset.yml
-   ├─ stg.orders.sql
-   └─ mart.sales_daily.sql
+bruin/                 # project root, created by bruin init
+├─ .bruin.yml          # environments & connections
+└─ my-pipeline/        # your pipeline
+   ├─ pipeline.yml     # defines the pipeline metadata
+   └─ assets/          # contains all assets for this pipeline
+      ├─ raw.orders.asset.yml
+      ├─ stg.orders.sql
+      └─ mart.sales_daily.sql
 ```
 
-If `--in-place` is used, the structure is created inside your current directory instead of nesting under `bruin/`.
+When you run `bruin init` **inside an existing Git repository**, no `bruin/` wrapper is created: the pipeline folder is created in your current directory, and `.bruin.yml` is placed at the **repository root** — which may be several levels above the pipeline folder. Use `--in-place` in a fresh project to skip the `bruin/` wrapper and use the current directory instead.
 
 ## Behavior Details
 
@@ -142,5 +147,5 @@ The `shopify-clickhouse` template creates raw Shopify ingestion assets, conforme
 ## Notes
 
 * Traversing up/down the filesystem (e.g., `../pipeline`) is not allowed for safety.
-* `.bruin.yml` is automatically created or updated during initialization.
+* `.bruin.yml` is automatically created or updated at your **project root** during initialization — the Git repository root when you are inside an existing repo, or a new `bruin/` folder for a fresh project.
 * The command is safe to run multiple times — Bruin intelligently merges existing configuration.

--- a/docs/getting-started/introduction/quickstart.md
+++ b/docs/getting-started/introduction/quickstart.md
@@ -20,11 +20,14 @@ cd bruin/my-pipeline
 
 This command will:
 
-- Create a project named `my-pipeline`.
-- Generate a folder called `my-pipeline` containing the following:
+- Create a new Bruin project under a `bruin/` folder (your **project root**).
+- Place `.bruin.yml` at the project root (`bruin/.bruin.yml`) with sample duckdb connections used in this guide (you can edit it or use a secrets manager, see [Secrets](../../secrets/overview.md)).
+- Generate a pipeline folder `bruin/my-pipeline/` containing:
   - `assets/` with three sample assets: ingestr, Python, and SQL (we will walk through them below)
-  - `.bruin.yml` with sample duckdb connections used in this guide (you can edit it or use a secrets manager, see [Secrets](../../secrets/overview.md))
   - `pipeline.yml` file to manage your pipeline.
+
+> [!INFO]
+> `.bruin.yml` always lives at your project root, never inside the pipeline folder. If you run `bruin init` inside an existing Git repository, it is placed at the repo root instead of a new `bruin/` folder. See [Project configuration](../../core-concepts/project.md).
 
 Once you have the project structure, you can run the whole pipeline:
 

--- a/docs/getting-started/introduction/quickstart.md
+++ b/docs/getting-started/introduction/quickstart.md
@@ -20,14 +20,14 @@ cd bruin/my-pipeline
 
 This command will:
 
-- Create a new Bruin project under a `bruin/` folder (your **project root**).
-- Place `.bruin.yml` at the project root (`bruin/.bruin.yml`) with sample duckdb connections used in this guide (you can edit it or use a secrets manager, see [Secrets](../../secrets/overview.md)).
-- Generate a pipeline folder `bruin/my-pipeline/` containing:
+- Set up a **project root**. Because this example runs in an empty directory, Bruin creates a wrapper folder for you named `bruin/` (a fixed default name — you don't choose it) and uses it as the project root. If you instead run `bruin init` inside an existing Git repository, that repo's root is used as the project root and no `bruin/` folder is created.
+- Place `.bruin.yml` at the project root (`bruin/.bruin.yml` here) with sample duckdb connections used in this guide (you can edit it or use a secrets manager, see [Secrets](../../secrets/overview.md)).
+- Generate a pipeline folder named after the second argument — `my-pipeline/` in this example — inside the project root (`bruin/my-pipeline/`), containing:
   - `assets/` with three sample assets: ingestr, Python, and SQL (we will walk through them below)
   - `pipeline.yml` file to manage your pipeline.
 
 > [!INFO]
-> `.bruin.yml` always lives at your project root, never inside the pipeline folder. If you run `bruin init` inside an existing Git repository, it is placed at the repo root instead of a new `bruin/` folder. See [Project configuration](../../core-concepts/project.md).
+> `.bruin.yml` always lives at the project root, never inside the pipeline folder. See [Project configuration](../../core-concepts/project.md).
 
 Once you have the project structure, you can run the whole pipeline:
 

--- a/docs/getting-started/templates-docs/bronze-silver-postgres-README.md
+++ b/docs/getting-started/templates-docs/bronze-silver-postgres-README.md
@@ -24,6 +24,8 @@ bronze-silver-postgres/
     └── silver_aggregated.sql
 ```
 
+> The tree above shows the template's own files. After `bruin init`, the `.bruin.yml` is merged into the `.bruin.yml` at your **project root** (never inside the pipeline folder). See [Project configuration](../../core-concepts/project.md).
+
 - **Bronze Layer (`bronze_raw_data.asset.yml`)**
   - Uses `ingestr` to pull daily FX rates from the Frankfurter API into PostgreSQL.
   - Adds column integrity checks, deduplication verification, and freshness monitoring.

--- a/docs/getting-started/templates-docs/clickhouse-README.md
+++ b/docs/getting-started/templates-docs/clickhouse-README.md
@@ -34,6 +34,8 @@ clickhouse/
         └── customer_regions.py
 ~~~
 
+> The tree above shows the template's own files. After `bruin init`, the `.bruin.yml` is merged into the `.bruin.yml` at your **project root** (never inside the pipeline folder). See [Project configuration](../../core-concepts/project.md).
+
 ## Pipeline at a glance
 
 ~~~text

--- a/docs/getting-started/tutorials/first-tutorial.md
+++ b/docs/getting-started/tutorials/first-tutorial.md
@@ -22,24 +22,32 @@ Run the `bruin init chess` command to set up your Bruin project using the `chess
 bruin init chess
 ```
 
-After running the command you will see the following folder appear on your project :
+After running the command you will see the following structure appear on your project :
 
 ```plaintext
-chess/
-├─ assets/
-│  ├─ chess_games.asset.yml
-│  ├─ chess_profiles.asset.yml
-│  ├─ player_summary.sql
-│
-├─ .bruin.yml
-├─ pipeline.yml  
-├─ .gitignore
-└─ README.md
+your-project/          # project root — this is where .bruin.yml lives
+├─ .bruin.yml          # environments & connections
+└─ chess/              # your new pipeline
+   ├─ assets/
+   │  ├─ chess_games.asset.yml
+   │  ├─ chess_profiles.asset.yml
+   │  └─ player_summary.sql
+   ├─ pipeline.yml
+   └─ README.md
 ```
+
+> [!INFO]
+> **Where does `.bruin.yml` live?**
+> `.bruin.yml` is always created at your **project root**, never inside the pipeline folder (`chess/`).
+>
+> - If you run `bruin init` **inside an existing Git repository**, `.bruin.yml` is placed at the repository root — which may be **several levels above** your pipeline folder.
+> - If you run it in an **empty folder**, Bruin creates a new `bruin/` project root and puts `.bruin.yml` there (pass `--in-place` to use the current folder instead).
+>
+> See [Project configuration](../../core-concepts/project.md) for the full details.
 
 ## Step 2: Edit Your `.bruin.yml` file
 
-After initializing your project with `bruin init`, edit the `.bruin.yml` file to configure your environments and connections. This file specifies the default environment settings and connections your pipeline will use.
+After initializing your project with `bruin init`, edit the `.bruin.yml` file at your **project root** (see the note above about where it lives) to configure your environments and connections. This file specifies the default environment settings and connections your pipeline will use.
 
 Add or modify the `.bruin.yml` file as follows:
 


### PR DESCRIPTION
## What & why

The tutorial and quickstart folder trees showed `.bruin.yml` **inside** the pipeline folder, which contradicts how `bruin init` actually works. In reality `.bruin.yml` is written to the **project root**:

- **inside an existing Git repo** → the repo root (which can be several levels above the pipeline folder)
- **in a fresh folder** → a new `bruin/` project root (or the current dir with `--in-place`)

This regularly confuses first-time users. A user ran `bruin init` inside an existing repo, saw `pipeline.yml` appear but no `.bruin.yml` beside it, and assumed init was broken — the file was at the repo root the whole time.

## Changes

- **`first-tutorial.md`** — corrected the folder tree (`.bruin.yml` now at the project root above `chess/`; dropped the non-existent `.gitignore` the chess template doesn't ship), added an INFO callout explaining the two placement scenarios, and pointed Step 2 at the project root.
- **`quickstart.md`** — moved `.bruin.yml` out of the `my-pipeline/` listing to the project root (`bruin/.bruin.yml`), plus a short note about the existing-repo case.
- **`commands/init.md`** — the Folder Structure section now shows `.bruin.yml` at the root and explains repo-root vs `bruin/` placement; Notes updated to match.
- **`clickhouse` / `bronze-silver-postgres` template READMEs** — note that the template's `.bruin.yml` is merged into the project-root config after init, not left inside the pipeline folder.

All changed pages verified rendering locally in VitePress (200) and pass markdownlint.

## Follow-up

CLI-side improvement tracked separately in bruin-data/bruin#2575: have `bruin init` print the resolved `.bruin.yml` path (and whether it was created or reused) plus first-run next steps, which removes the root cause of the confusion.
