### PR TITLE
feat(init): print the resolved .bruin.yml path and first-run next steps

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -334,8 +334,7 @@ func Init() *cli.Command {
 				configLocationNote = "This is your Git repo root, so it may sit several levels above the pipeline folder."
 			}
 
-			// Remember whether .bruin.yml was already there, so we can tell the user
-			// whether init created it or merged into an existing one.
+			// existed must be sampled before anything writes to bruinYmlPath.
 			configSummary := initConfigSummary{
 				path:         bruinYmlPath,
 				existed:      fileExists(bruinYmlPath),
@@ -516,17 +515,11 @@ func absOrSame(path string) string {
 	return abs
 }
 
-// initConfigSummary captures what happened to .bruin.yml during init, so the
-// command can report it accurately.
+// initConfigSummary captures what happened to .bruin.yml during init.
 type initConfigSummary struct {
-	// path is where .bruin.yml is expected, relative or absolute.
-	path string
-	// existed is true when a .bruin.yml was already there before init ran.
-	existed bool
-	// merged is true when init actually wrote template configuration into it.
-	// Templates that ship no .bruin.yml leave this false.
-	merged bool
-	// locationNote explains to the user why the config lives where it does.
+	path         string
+	existed      bool
+	merged       bool // false for templates that ship no .bruin.yml of their own
 	locationNote string
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -287,7 +287,7 @@ func Init() *cli.Command {
 			}
 
 			var bruinYmlPath string
-			configAtRepoRoot := false
+			var configLocationNote string
 			repoRoot, err := git.FindRepoFromPath(".")
 			//nolint:nestif
 			if err != nil {
@@ -322,19 +322,25 @@ func Init() *cli.Command {
 					// When using --in-place, use current directory for .bruin.yml and inputPath.
 					bruinYmlPath = filepath.Join(targetDir, ".bruin.yml")
 					inputPath = filepath.Join(targetDir, inputPath)
+					configLocationNote = "This is your Bruin project root."
 				} else {
 					// When not using --in-place, use bruin subdirectory.
 					bruinYmlPath = filepath.Join("bruin", ".bruin.yml")
 					inputPath = filepath.Join("bruin", inputPath)
+					configLocationNote = "This is the new Bruin project root created for you."
 				}
 			} else {
 				bruinYmlPath = filepath.Join(repoRoot.Path, ".bruin.yml")
-				configAtRepoRoot = true
+				configLocationNote = "This is your Git repo root, so it may sit several levels above the pipeline folder."
 			}
 
 			// Remember whether .bruin.yml was already there, so we can tell the user
 			// whether init created it or merged into an existing one.
-			bruinYmlExisted := fileExists(bruinYmlPath)
+			configSummary := initConfigSummary{
+				path:         bruinYmlPath,
+				existed:      fileExists(bruinYmlPath),
+				locationNote: configLocationNote,
+			}
 
 			// Handle ecommerce template with interactive stack picker
 			if templateName == "ecommerce" {
@@ -370,6 +376,7 @@ func Init() *cli.Command {
 					errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)
 					return cli.Exit("", 1)
 				}
+				configSummary.merged = true
 
 				// Generate all pipeline files
 				if err := generateEcommerceTemplate(inputPath, ecommerceChoices); err != nil {
@@ -390,7 +397,7 @@ func Init() *cli.Command {
 
 				successPrinter.Printf("\n\nEcommerce pipeline created successfully in folder '%s'.\n", inputPath)
 				printEcommerceSummary(ecommerceChoices)
-				printInitSummary(bruinYmlPath, inputPath, bruinYmlExisted, configAtRepoRoot)
+				printInitSummary(configSummary, inputPath)
 
 				return nil
 			}
@@ -421,6 +428,7 @@ func Init() *cli.Command {
 					errorPrinter.Printf("Could not write .bruin.yml file: %v\n", err)
 					return err
 				}
+				configSummary.merged = true
 			}
 
 			err = fs2.WalkDir(templates.Templates, templateName, func(path string, d fs2.DirEntry, err error) error {
@@ -482,7 +490,7 @@ func Init() *cli.Command {
 			})
 
 			successPrinter.Printf("\n\nA new '%s' pipeline created successfully in folder '%s'.\n", templateName, inputPath)
-			printInitSummary(bruinYmlPath, inputPath, bruinYmlExisted, configAtRepoRoot)
+			printInitSummary(configSummary, inputPath)
 
 			return nil
 		},
@@ -508,39 +516,60 @@ func absOrSame(path string) string {
 	return abs
 }
 
+// initConfigSummary captures what happened to .bruin.yml during init, so the
+// command can report it accurately.
+type initConfigSummary struct {
+	// path is where .bruin.yml is expected, relative or absolute.
+	path string
+	// existed is true when a .bruin.yml was already there before init ran.
+	existed bool
+	// merged is true when init actually wrote template configuration into it.
+	// Templates that ship no .bruin.yml leave this false.
+	merged bool
+	// locationNote explains to the user why the config lives where it does.
+	locationNote string
+}
+
 // printInitSummary tells the user where the pipeline and the .bruin.yml config
 // ended up, whether the config was created or reused, and what to do next.
 // The config location is not obvious: inside an existing Git repo it goes to the
 // repo root, which can be several levels above the pipeline folder.
-func printInitSummary(bruinYmlPath, pipelinePath string, configExisted, configAtRepoRoot bool) {
+func printInitSummary(cfg initConfigSummary, pipelinePath string) {
 	pipelineAbs := absOrSame(pipelinePath)
 
-	if fileExists(bruinYmlPath) {
-		configAbs := absOrSame(bruinYmlPath)
-
-		infoPrinter.Printf("\nConfig:   %s\n", configAbs)
-		infoPrinter.Printf("Pipeline: %s\n", pipelineAbs)
-
-		if configExisted {
-			infoPrinter.Printf("\nUsing existing .bruin.yml at %s (merged template config).\n", configAbs)
-		} else {
-			infoPrinter.Printf("\nCreated .bruin.yml at %s.\n", configAbs)
-		}
-
-		if configAtRepoRoot {
-			infoPrinter.Println("This is your Git repo root, so it may sit several levels above the pipeline folder.")
-		} else {
-			infoPrinter.Println("This is the new Bruin project root created for you.")
-		}
-
-		infoPrinter.Println("\nNext steps:")
-		infoPrinter.Printf("  1. Add your connection credentials to %s\n", configAbs)
-	} else {
+	if !fileExists(cfg.path) {
 		infoPrinter.Printf("\nPipeline: %s\n", pipelineAbs)
 		infoPrinter.Println("\nNext steps:")
 		infoPrinter.Println("  1. Create a .bruin.yml with your connection credentials")
+		printInitRunSteps(pipelinePath)
+
+		return
 	}
 
+	configAbs := absOrSame(cfg.path)
+
+	infoPrinter.Printf("\nConfig:   %s\n", configAbs)
+	infoPrinter.Printf("Pipeline: %s\n", pipelineAbs)
+
+	switch {
+	case cfg.existed && cfg.merged:
+		infoPrinter.Printf("\nUsing existing .bruin.yml at %s (merged template config).\n", configAbs)
+	case cfg.existed:
+		infoPrinter.Printf("\nUsing existing .bruin.yml at %s (left unchanged).\n", configAbs)
+	default:
+		infoPrinter.Printf("\nCreated .bruin.yml at %s.\n", configAbs)
+	}
+
+	if cfg.locationNote != "" {
+		infoPrinter.Println(cfg.locationNote)
+	}
+
+	infoPrinter.Println("\nNext steps:")
+	infoPrinter.Printf("  1. Add your connection credentials to %s\n", configAbs)
+	printInitRunSteps(pipelinePath)
+}
+
+func printInitRunSteps(pipelinePath string) {
 	infoPrinter.Printf("  2. Run: bruin validate %s\n", pipelinePath)
 	infoPrinter.Printf("  3. Run: bruin run %s\n\n", pipelinePath)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -287,6 +287,7 @@ func Init() *cli.Command {
 			}
 
 			var bruinYmlPath string
+			configAtRepoRoot := false
 			repoRoot, err := git.FindRepoFromPath(".")
 			//nolint:nestif
 			if err != nil {
@@ -328,7 +329,12 @@ func Init() *cli.Command {
 				}
 			} else {
 				bruinYmlPath = filepath.Join(repoRoot.Path, ".bruin.yml")
+				configAtRepoRoot = true
 			}
+
+			// Remember whether .bruin.yml was already there, so we can tell the user
+			// whether init created it or merged into an existing one.
+			bruinYmlExisted := fileExists(bruinYmlPath)
 
 			// Handle ecommerce template with interactive stack picker
 			if templateName == "ecommerce" {
@@ -384,10 +390,7 @@ func Init() *cli.Command {
 
 				successPrinter.Printf("\n\nEcommerce pipeline created successfully in folder '%s'.\n", inputPath)
 				printEcommerceSummary(ecommerceChoices)
-				infoPrinter.Println("\nNext steps:")
-				infoPrinter.Printf("  1. Edit .bruin.yml to add your real connection credentials\n")
-				infoPrinter.Printf("  2. Run: bruin validate %s\n", inputPath)
-				infoPrinter.Printf("  3. Run: bruin run %s\n\n", inputPath)
+				printInitSummary(bruinYmlPath, inputPath, bruinYmlExisted, configAtRepoRoot)
 
 				return nil
 			}
@@ -479,12 +482,65 @@ func Init() *cli.Command {
 			})
 
 			successPrinter.Printf("\n\nA new '%s' pipeline created successfully in folder '%s'.\n", templateName, inputPath)
-			infoPrinter.Println("\nYou can run the following commands to get started:")
-			infoPrinter.Printf("    bruin validate %s\n\n", inputPath)
+			printInitSummary(bruinYmlPath, inputPath, bruinYmlExisted, configAtRepoRoot)
 
 			return nil
 		},
 		Before: telemetry.BeforeCommand,
 		After:  telemetry.AfterCommand,
 	}
+}
+
+// fileExists reports whether the given path exists and is not a directory.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// absOrSame returns the absolute version of path, falling back to path itself
+// if it cannot be resolved.
+func absOrSame(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+
+	return abs
+}
+
+// printInitSummary tells the user where the pipeline and the .bruin.yml config
+// ended up, whether the config was created or reused, and what to do next.
+// The config location is not obvious: inside an existing Git repo it goes to the
+// repo root, which can be several levels above the pipeline folder.
+func printInitSummary(bruinYmlPath, pipelinePath string, configExisted, configAtRepoRoot bool) {
+	pipelineAbs := absOrSame(pipelinePath)
+
+	if fileExists(bruinYmlPath) {
+		configAbs := absOrSame(bruinYmlPath)
+
+		infoPrinter.Printf("\nConfig:   %s\n", configAbs)
+		infoPrinter.Printf("Pipeline: %s\n", pipelineAbs)
+
+		if configExisted {
+			infoPrinter.Printf("\nUsing existing .bruin.yml at %s (merged template config).\n", configAbs)
+		} else {
+			infoPrinter.Printf("\nCreated .bruin.yml at %s.\n", configAbs)
+		}
+
+		if configAtRepoRoot {
+			infoPrinter.Println("This is your Git repo root, so it may sit several levels above the pipeline folder.")
+		} else {
+			infoPrinter.Println("This is the new Bruin project root created for you.")
+		}
+
+		infoPrinter.Println("\nNext steps:")
+		infoPrinter.Printf("  1. Add your connection credentials to %s\n", configAbs)
+	} else {
+		infoPrinter.Printf("\nPipeline: %s\n", pipelineAbs)
+		infoPrinter.Println("\nNext steps:")
+		infoPrinter.Println("  1. Create a .bruin.yml with your connection credentials")
+	}
+
+	infoPrinter.Printf("  2. Run: bruin validate %s\n", pipelinePath)
+	infoPrinter.Printf("  3. Run: bruin run %s\n\n", pipelinePath)
 }

--- a/cmd/init_summary_test.go
+++ b/cmd/init_summary_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func captureInitSummary(t *testing.T, bruinYmlPath, pipelinePath string, configExisted, configAtRepoRoot bool) string {
+func captureInitSummary(t *testing.T, cfg initConfigSummary, pipelinePath string) string {
 	t.Helper()
 
 	buf := new(bytes.Buffer)
@@ -19,18 +19,30 @@ func captureInitSummary(t *testing.T, bruinYmlPath, pipelinePath string, configE
 	color.Output = buf
 	t.Cleanup(func() { color.Output = originalOutput })
 
-	printInitSummary(bruinYmlPath, pipelinePath, configExisted, configAtRepoRoot)
+	printInitSummary(cfg, pipelinePath)
 
 	return buf.String()
 }
 
+func writeBruinYml(t *testing.T, dir string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, ".bruin.yml")
+	require.NoError(t, os.WriteFile(path, []byte("environments: {}\n"), 0o600))
+
+	return path
+}
+
 func TestPrintInitSummaryReportsCreatedConfigAtRepoRoot(t *testing.T) {
 	repoRoot := t.TempDir()
-	bruinYmlPath := filepath.Join(repoRoot, ".bruin.yml")
-	require.NoError(t, os.WriteFile(bruinYmlPath, []byte("environments: {}\n"), 0o600))
-
+	bruinYmlPath := writeBruinYml(t, repoRoot)
 	pipelinePath := filepath.Join(repoRoot, "nested", "my-pipeline")
-	output := captureInitSummary(t, bruinYmlPath, pipelinePath, false, true)
+
+	output := captureInitSummary(t, initConfigSummary{
+		path:         bruinYmlPath,
+		merged:       true,
+		locationNote: "This is your Git repo root, so it may sit several levels above the pipeline folder.",
+	}, pipelinePath)
 
 	require.Contains(t, output, "Config:   "+bruinYmlPath)
 	require.Contains(t, output, "Pipeline: "+pipelinePath)
@@ -41,33 +53,55 @@ func TestPrintInitSummaryReportsCreatedConfigAtRepoRoot(t *testing.T) {
 	require.Contains(t, output, "bruin run "+pipelinePath)
 }
 
-func TestPrintInitSummaryReportsReusedConfig(t *testing.T) {
+func TestPrintInitSummaryReportsMergedIntoExistingConfig(t *testing.T) {
 	projectRoot := t.TempDir()
-	bruinYmlPath := filepath.Join(projectRoot, ".bruin.yml")
-	require.NoError(t, os.WriteFile(bruinYmlPath, []byte("environments: {}\n"), 0o600))
+	bruinYmlPath := writeBruinYml(t, projectRoot)
 
-	output := captureInitSummary(t, bruinYmlPath, filepath.Join(projectRoot, "my-pipeline"), true, false)
+	output := captureInitSummary(t, initConfigSummary{
+		path:         bruinYmlPath,
+		existed:      true,
+		merged:       true,
+		locationNote: "This is your Bruin project root.",
+	}, filepath.Join(projectRoot, "my-pipeline"))
 
-	require.Contains(t, output, "Using existing .bruin.yml at "+bruinYmlPath)
-	require.Contains(t, output, "merged template config")
+	require.Contains(t, output, "Using existing .bruin.yml at "+bruinYmlPath+" (merged template config).")
 	require.NotContains(t, output, "Created .bruin.yml")
-	require.Contains(t, output, "Bruin project root")
+	require.Contains(t, output, "This is your Bruin project root.")
+}
+
+// Templates such as migration-fivetran ship no .bruin.yml, so init must not claim
+// it merged anything into the config it found.
+func TestPrintInitSummaryReportsUnchangedExistingConfig(t *testing.T) {
+	projectRoot := t.TempDir()
+	bruinYmlPath := writeBruinYml(t, projectRoot)
+
+	output := captureInitSummary(t, initConfigSummary{
+		path:    bruinYmlPath,
+		existed: true,
+	}, filepath.Join(projectRoot, "my-pipeline"))
+
+	require.Contains(t, output, "Using existing .bruin.yml at "+bruinYmlPath+" (left unchanged).")
+	require.NotContains(t, output, "merged template config")
+	require.NotContains(t, output, "Created .bruin.yml")
 }
 
 func TestPrintInitSummaryWithoutConfigFile(t *testing.T) {
 	projectRoot := t.TempDir()
-	bruinYmlPath := filepath.Join(projectRoot, ".bruin.yml")
 
-	output := captureInitSummary(t, bruinYmlPath, filepath.Join(projectRoot, "my-pipeline"), false, true)
+	output := captureInitSummary(t, initConfigSummary{
+		path:         filepath.Join(projectRoot, ".bruin.yml"),
+		locationNote: "This is your Bruin project root.",
+	}, filepath.Join(projectRoot, "my-pipeline"))
 
 	require.NotContains(t, output, "Config:")
+	require.NotContains(t, output, "This is your Bruin project root.")
 	require.Contains(t, output, "Create a .bruin.yml with your connection credentials")
+	require.Contains(t, output, "bruin validate ")
 }
 
 func TestFileExists(t *testing.T) {
 	dir := t.TempDir()
-	filePath := filepath.Join(dir, "file.yml")
-	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+	filePath := writeBruinYml(t, dir)
 
 	require.True(t, fileExists(filePath))
 	require.False(t, fileExists(filepath.Join(dir, "missing.yml")))

--- a/cmd/init_summary_test.go
+++ b/cmd/init_summary_test.go
@@ -1,0 +1,75 @@
+//nolint:paralleltest
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/require"
+)
+
+func captureInitSummary(t *testing.T, bruinYmlPath, pipelinePath string, configExisted, configAtRepoRoot bool) string {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	originalOutput := color.Output
+	color.Output = buf
+	t.Cleanup(func() { color.Output = originalOutput })
+
+	printInitSummary(bruinYmlPath, pipelinePath, configExisted, configAtRepoRoot)
+
+	return buf.String()
+}
+
+func TestPrintInitSummaryReportsCreatedConfigAtRepoRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	bruinYmlPath := filepath.Join(repoRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(bruinYmlPath, []byte("environments: {}\n"), 0o600))
+
+	pipelinePath := filepath.Join(repoRoot, "nested", "my-pipeline")
+	output := captureInitSummary(t, bruinYmlPath, pipelinePath, false, true)
+
+	require.Contains(t, output, "Config:   "+bruinYmlPath)
+	require.Contains(t, output, "Pipeline: "+pipelinePath)
+	require.Contains(t, output, "Created .bruin.yml at "+bruinYmlPath)
+	require.Contains(t, output, "Git repo root")
+	require.Contains(t, output, "Add your connection credentials to "+bruinYmlPath)
+	require.Contains(t, output, "bruin validate "+pipelinePath)
+	require.Contains(t, output, "bruin run "+pipelinePath)
+}
+
+func TestPrintInitSummaryReportsReusedConfig(t *testing.T) {
+	projectRoot := t.TempDir()
+	bruinYmlPath := filepath.Join(projectRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(bruinYmlPath, []byte("environments: {}\n"), 0o600))
+
+	output := captureInitSummary(t, bruinYmlPath, filepath.Join(projectRoot, "my-pipeline"), true, false)
+
+	require.Contains(t, output, "Using existing .bruin.yml at "+bruinYmlPath)
+	require.Contains(t, output, "merged template config")
+	require.NotContains(t, output, "Created .bruin.yml")
+	require.Contains(t, output, "Bruin project root")
+}
+
+func TestPrintInitSummaryWithoutConfigFile(t *testing.T) {
+	projectRoot := t.TempDir()
+	bruinYmlPath := filepath.Join(projectRoot, ".bruin.yml")
+
+	output := captureInitSummary(t, bruinYmlPath, filepath.Join(projectRoot, "my-pipeline"), false, true)
+
+	require.NotContains(t, output, "Config:")
+	require.Contains(t, output, "Create a .bruin.yml with your connection credentials")
+}
+
+func TestFileExists(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.yml")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	require.True(t, fileExists(filePath))
+	require.False(t, fileExists(filepath.Join(dir, "missing.yml")))
+	require.False(t, fileExists(dir))
+}

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -71,15 +71,6 @@ If Bruin detects no existing `.git` repository:
 * A new Git repository is created (via `git init`).
 * The pipeline is placed under `bruin/` unless `--in-place` is used.
 
-### Where `.bruin.yml` Goes
-
-`.bruin.yml` does not live next to `pipeline.yml`. Its location depends on where you run `init`:
-
-* **Inside an existing Git repo** → the repo root, which can be several levels above the pipeline folder.
-* **In a folder that is not a Git repo** → the new `bruin/` project root, or the current folder with `--in-place`.
-
-`init` prints the resolved path when it finishes, so you never have to guess.
-
 ### Configuration Merge
 
 If the selected template contains its own `.bruin.yml`, Bruin merges:
@@ -149,9 +140,9 @@ Next steps:
   3. Run: bruin run bruin-pipeline
 ```
 
-The summary always prints the resolved `.bruin.yml` path, so you know where to add your
-credentials. If a `.bruin.yml` was already there, Bruin says whether it merged the
-template's configuration into it:
+The summary always prints the resolved `.bruin.yml` path, so you never have to guess where
+it landed (see [Folder Structure](#folder-structure)). If a `.bruin.yml` was already there,
+Bruin says whether it merged the template's configuration into it:
 
 ```bash
 Using existing .bruin.yml at /Users/me/my-repo/.bruin.yml (merged template config).

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -71,6 +71,15 @@ If Bruin detects no existing `.git` repository:
 * A new Git repository is created (via `git init`).
 * The pipeline is placed under `bruin/` unless `--in-place` is used.
 
+### Where `.bruin.yml` Goes
+
+`.bruin.yml` does not live next to `pipeline.yml`. Its location depends on where you run `init`:
+
+* **Inside an existing Git repo** → the repo root, which can be several levels above the pipeline folder.
+* **In a folder that is not a Git repo** → the new `bruin/` project root, or the current folder with `--in-place`.
+
+`init` prints the resolved path when it finishes, so you never have to guess.
+
 ### Configuration Merge
 
 If the selected template contains its own `.bruin.yml`, Bruin merges:
@@ -128,8 +137,24 @@ Please select a template below:
 
 A new 'default' pipeline created successfully in folder 'bruin-pipeline'.
 
-You can run the following commands to get started:
-    bruin validate bruin-pipeline
+Config:   /Users/me/my-repo/.bruin.yml
+Pipeline: /Users/me/my-repo/deep/nested/bruin-pipeline
+
+Created .bruin.yml at /Users/me/my-repo/.bruin.yml.
+This is your Git repo root, so it may sit several levels above the pipeline folder.
+
+Next steps:
+  1. Add your connection credentials to /Users/me/my-repo/.bruin.yml
+  2. Run: bruin validate bruin-pipeline
+  3. Run: bruin run bruin-pipeline
+```
+
+The summary always prints the resolved `.bruin.yml` path, so you know where to add your
+credentials. If a `.bruin.yml` was already there, Bruin merges the template config into it
+and says so instead:
+
+```bash
+Using existing .bruin.yml at /Users/me/my-repo/.bruin.yml (merged template config).
 ```
 
 ### Initializing a Shopify template

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -150,11 +150,17 @@ Next steps:
 ```
 
 The summary always prints the resolved `.bruin.yml` path, so you know where to add your
-credentials. If a `.bruin.yml` was already there, Bruin merges the template config into it
-and says so instead:
+credentials. If a `.bruin.yml` was already there, Bruin says whether it merged the
+template's configuration into it:
 
 ```bash
 Using existing .bruin.yml at /Users/me/my-repo/.bruin.yml (merged template config).
+```
+
+or left it as it was, which happens for templates that ship no `.bruin.yml`:
+
+```bash
+Using existing .bruin.yml at /Users/me/my-repo/.bruin.yml (left unchanged).
 ```
 
 ### Initializing a Shopify template


### PR DESCRIPTION
Closes #2575

## Problem

`bruin init` never printed where `.bruin.yml` ended up. The location isn't obvious:

- Inside an existing Git repo → repo root, which can be several levels above the pipeline folder.
- In a fresh folder → the new `bruin/` project root (or the current dir with `--in-place`).

Users running init deep inside an existing repo saw `pipeline.yml` appear with no `.bruin.yml` beside it and assumed init was broken. #2576 fixed the docs side of this; this PR fixes the command output.

## Change

`init` now prints a summary on completion for **all** templates, generalizing the previously ecommerce-only next-steps block:

- resolved `Config:` and `Pipeline:` absolute paths
- what happened to `.bruin.yml`: **created**, **merged into**, or **left unchanged**
- why it lives there: Git repo root / Bruin project root / newly created root
- next steps: add credentials → `bruin validate` → `bruin run`

If no `.bruin.yml` exists at all (template ships none, none at the root), the config lines are suppressed and step 1 tells the user to create one.

The config facts live in an `initConfigSummary` struct built where the placement decision is made, so the summary reports what actually happened rather than inferring it at print time. No change to file placement behavior.

## Verified output

Run against the built binary across 6 template/context combinations (paths shortened here):

| Context | Key line |
|---|---|
| `chess`, fresh non-git folder | `Created .bruin.yml at /tmp/a/bruin/.bruin.yml.` + `This is the new Bruin project root created for you.` |
| `duckdb`, 3 levels deep in existing repo | `Config: /tmp/myrepo/.bruin.yml` + `This is your Git repo root, so it may sit several levels above the pipeline folder.` |
| `frankfurter`, same repo, config exists | `Using existing .bruin.yml at /tmp/myrepo/.bruin.yml (merged template config).` |
| `migration-fivetran` (ships no `.bruin.yml`) | `Using existing .bruin.yml at /tmp/myrepo/.bruin.yml (left unchanged).` |
| `python --in-place` | `This is your Bruin project root.` |
| `empty`, no config anywhere | `1. Create a .bruin.yml with your connection credentials` |

Full sample, deep inside an existing repo:

```
A new 'duckdb' pipeline created successfully in folder 'duckdb'.

Config:   /tmp/myrepo/.bruin.yml
Pipeline: /tmp/myrepo/services/etl/deep/duckdb

Created .bruin.yml at /tmp/myrepo/.bruin.yml.
This is your Git repo root, so it may sit several levels above the pipeline folder.

Next steps:
  1. Add your connection credentials to /tmp/myrepo/.bruin.yml
  2. Run: bruin validate duckdb
  3. Run: bruin run duckdb
```

## Testing

- New unit tests in `cmd/init_summary_test.go` cover created-at-repo-root, merged-into-existing, existing-but-unchanged, missing-config, and the `fileExists` helper.
- Manually exercised the built binary in the 6 contexts above.
- `make format` (0 lint issues) and `make test` pass on the rebased tree.
- `docs/commands/init.md` updated with the new output. The placement explanation added by #2576 is left as the single source of truth and linked to, rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)