### PR TITLE
feat(clickhouse): add Bruin client identification

### DIFF
--- a/pkg/clickhouse/config.go
+++ b/pkg/clickhouse/config.go
@@ -7,7 +7,10 @@ import (
 	"strconv"
 
 	click_house "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/bruin-data/bruin/pkg/version"
 )
+
+const clientName = "bruin"
 
 type Config struct {
 	Username string
@@ -35,6 +38,14 @@ func (c *Config) ToClickHouseOptions() *click_house.Options {
 			Database: c.Database,
 			Username: c.Username,
 			Password: c.Password,
+		},
+		ClientInfo: click_house.ClientInfo{
+			Products: []struct {
+				Name    string
+				Version string
+			}{
+				{Name: clientName, Version: version.Version},
+			},
 		},
 	}
 	return &opt

--- a/pkg/clickhouse/config_test.go
+++ b/pkg/clickhouse/config_test.go
@@ -1,6 +1,11 @@
 package clickhouse
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/version"
+)
 
 func TestConfig_ToClickHouseOptions(t *testing.T) {
 	t.Parallel()
@@ -24,5 +29,8 @@ func TestConfig_ToClickHouseOptions(t *testing.T) {
 	}
 	if options.Auth.Password != "password" {
 		t.Errorf("expected password, got %s", options.Auth.Password)
+	}
+	if userAgent := options.ClientInfo.String(); !strings.HasPrefix(userAgent, "bruin/"+version.Version+" clickhouse-go/") {
+		t.Errorf("expected ClickHouse user agent to identify Bruin, got %s", userAgent)
 	}
 }


### PR DESCRIPTION
## What
Identify Bruin and its version in ClickHouse client metadata.

## Changes
- Add `bruin/<version>` to clickhouse-go `ClientInfo`.
- Test the generated user-agent prefix.

## How to test
1. Run `make format`.
2. Run `make test`.

## Risk & rollback
- **Risk:** Low; only client-identification metadata changes.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (not affected)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
N/A