### PR TITLE
feat(docs): add collapse/expand-all button to sidebar

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,10 +1,55 @@
 <script setup>
 import DefaultTheme from 'vitepress/theme'
 import CopyPageButton from './CopyPageButton.vue'
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
+import { nextTick, ref, watch } from 'vue'
 
 const { Layout } = DefaultTheme
 const { frontmatter } = useData()
+const route = useRoute()
+
+// Tracks whether the next click should expand or collapse every section.
+const allExpanded = ref(true)
+
+function collapsibleItems() {
+  return Array.from(
+    document.querySelectorAll('.VPSidebar .VPSidebarItem.collapsible')
+  )
+}
+
+// Wait for Vue to flush the re-render so the collapsed class reflects reality
+// before the next pass reads it (otherwise a pass toggles items back).
+function afterRender() {
+  return nextTick().then(
+    () => new Promise((resolve) => requestAnimationFrame(resolve))
+  )
+}
+
+async function setAll(expand) {
+  // Loop until stable: expanding a parent can reveal nested collapsible items,
+  // and each pass must wait for the DOM to update before re-reading state.
+  for (let pass = 0; pass < 20; pass++) {
+    const targets = collapsibleItems().filter(
+      (item) => item.classList.contains('collapsed') === expand
+    )
+    if (targets.length === 0) break
+    for (const item of targets) {
+      item.querySelector(':scope > .item > .caret')?.click()
+    }
+    await afterRender()
+  }
+}
+
+async function toggleAll() {
+  const expand = !allExpanded.value
+  await setAll(expand)
+  allExpanded.value = expand
+}
+
+// Reset the label when navigating to a new page (sidebar re-renders).
+watch(() => route.path, () => {
+  allExpanded.value = true
+})
 </script>
 
 <template>
@@ -13,6 +58,16 @@ const { frontmatter } = useData()
       <div class="copy-page-wrapper" v-if="frontmatter.layout !== 'home'">
         <CopyPageButton />
       </div>
+    </template>
+    <template #sidebar-nav-before>
+      <button
+        type="button"
+        class="collapse-all-button"
+        @click="toggleAll"
+      >
+        <span class="vpi-chevron-right collapse-all-icon" :class="{ expanded: allExpanded }" />
+        {{ allExpanded ? 'Collapse all' : 'Expand all' }}
+      </button>
     </template>
   </Layout>
 </template>
@@ -23,5 +78,32 @@ const { frontmatter } = useData()
   margin-top: 4px;
   position: relative;
   z-index: 10;
+}
+
+.collapse-all-button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 4px 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  transition: color 0.25s;
+}
+
+.collapse-all-button:hover {
+  color: var(--vp-c-text-1);
+}
+
+.collapse-all-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.25s;
+}
+
+.collapse-all-icon.expanded {
+  transform: rotate(90deg);
 }
 </style>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -11,6 +11,11 @@ const route = useRoute()
 // Tracks whether the next click should expand or collapse every section.
 const allExpanded = ref(true)
 
+// Identifies the current toggle run. A new click or page navigation bumps this,
+// so any earlier run that is still awaiting a render bails out instead of
+// clobbering the newer state or the label.
+let runId = 0
+
 function collapsibleItems() {
   return Array.from(
     document.querySelectorAll('.VPSidebar .VPSidebarItem.collapsible')
@@ -25,7 +30,7 @@ function afterRender() {
   )
 }
 
-async function setAll(expand) {
+async function setAll(expand, myRun) {
   // Loop until stable: expanding a parent can reveal nested collapsible items,
   // and each pass must wait for the DOM to update before re-reading state.
   for (let pass = 0; pass < 20; pass++) {
@@ -37,17 +42,25 @@ async function setAll(expand) {
       item.querySelector(':scope > .item > .caret')?.click()
     }
     await afterRender()
+    // A newer toggle or a navigation happened while we waited — stop and let it win.
+    if (myRun !== runId) return false
   }
+  return true
 }
 
 async function toggleAll() {
   const expand = !allExpanded.value
-  await setAll(expand)
-  allExpanded.value = expand
+  const myRun = ++runId
+  const completed = await setAll(expand, myRun)
+  if (completed && myRun === runId) {
+    allExpanded.value = expand
+  }
 }
 
-// Reset the label when navigating to a new page (sidebar re-renders).
+// Cancel any in-flight run and reset the label when navigating to a new page
+// (the sidebar re-renders on navigation).
 watch(() => route.path, () => {
+  runId++
   allExpanded.value = true
 })
 </script>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -8,12 +8,14 @@ const { Layout } = DefaultTheme
 const { frontmatter } = useData()
 const route = useRoute()
 
-// Tracks whether the next click should expand or collapse every section.
+// The desired state for every section, and the source of truth for the label.
+// It is flipped synchronously on each click so a rapid second click reverses an
+// in-flight operation instead of repeating its direction.
 const allExpanded = ref(true)
 
 // Identifies the current toggle run. A new click or page navigation bumps this,
 // so any earlier run that is still awaiting a render bails out instead of
-// clobbering the newer state or the label.
+// fighting the newer run.
 let runId = 0
 
 function collapsibleItems() {
@@ -49,12 +51,12 @@ async function setAll(expand, myRun) {
 }
 
 async function toggleAll() {
+  // Flip the desired state (and the label) immediately so a click that lands
+  // mid-render reverses the direction rather than reusing the stale one.
   const expand = !allExpanded.value
+  allExpanded.value = expand
   const myRun = ++runId
-  const completed = await setAll(expand, myRun)
-  if (completed && myRun === runId) {
-    allExpanded.value = expand
-  }
+  await setAll(expand, myRun)
 }
 
 // Cancel any in-flight run and reset the label when navigating to a new page


### PR DESCRIPTION
## What

Adds a **Collapse all / Expand all** toggle at the top of the docs sidebar (left nav), letting readers open or close every section at once.

## How

- Injects a button via the default theme's `#sidebar-nav-before` slot in `docs/.vitepress/theme/Layout.vue`.
- Clicking iterates every `.VPSidebarItem.collapsible` and toggles the ones not already in the target state.
- Each pass awaits a render tick (`nextTick` + `requestAnimationFrame`) before reading state again, so nested sections revealed on expand are handled and items aren't toggled back. The chevron rotates to reflect state; the label resets on page navigation.

## Testing

Verified in a headless browser against the running dev server:
- Collapse all: 6 → 32/33 sections collapsed
- Expand all: 32 → 0/33 collapsed
- No console errors

(The single unaffected item is a headerless top-level group that has no toggle control.)

Docs-only change (VitePress theme component), so Go format/test suites were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)