### PR TITLE
fix(python): run assets by path when the path is not a valid module name

### DIFF
--- a/pkg/python/path.go
+++ b/pkg/python/path.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -41,6 +42,11 @@ type DependencyConfig struct {
 	ProjectRoot     string // Directory containing the dependency file
 	RequiresPython  string // The requires-python specifier from pyproject.toml (e.g., ">=3.13")
 }
+
+// pythonModulePath matches a dotted path whose every segment is a valid Python identifier.
+// Anything else — a leading dot (".claude/..."), a hyphen or a space in a segment — cannot be
+// imported, so such assets are executed by file path instead of with `--module`.
+var pythonModulePath = regexp.MustCompile(`^[A-Za-z_]\w*(\.[A-Za-z_]\w*)*$`)
 
 type ModulePathFinder struct {
 	PathSeparatorOverride int32

--- a/pkg/python/path_test.go
+++ b/pkg/python/path_test.go
@@ -386,3 +386,21 @@ func TestFindDependencyConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestPythonModulePath(t *testing.T) {
+	t.Parallel()
+
+	for module, want := range map[string]bool{
+		"assets.my_asset":           true,
+		"a1.b2c":                    true,
+		".claude.my-assets.push_ad": false,
+		"assets.my-asset":           false,
+		"assets..my_asset":          false,
+		"assets.1st":                false,
+		"":                          false,
+	} {
+		if got := pythonModulePath.MatchString(module); got != want {
+			t.Errorf("pythonModulePath.MatchString(%q) = %v, want %v", module, got, want)
+		}
+	}
+}

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -278,7 +278,11 @@ func (u *UvPythonRunner) runWithNoMaterialization(ctx context.Context, execCtx *
 		flags = append(flags, "--with-requirements", execCtx.requirementsTxt)
 	}
 
-	flags = append(flags, "--module", execCtx.module)
+	if pythonModulePath.MatchString(execCtx.module) {
+		flags = append(flags, "--module", execCtx.module)
+	} else {
+		flags = append(flags, execCtx.asset.ExecutableFile.Path)
+	}
 
 	noDependencyCommand := &CommandInstance{
 		Name:    u.binaryFullPath,
@@ -318,7 +322,12 @@ func (u *UvPythonRunner) runWithPyproject(ctx context.Context, execCtx *executio
 	modulePath := u.calculateModuleFromProjectRoot(execCtx, depConfig.ProjectRoot)
 
 	// Build command: uv run --python <version> --module <module>
-	flags := []string{"run", "--python", pythonVersion, "--module", modulePath}
+	flags := []string{"run", "--python", pythonVersion}
+	if pythonModulePath.MatchString(modulePath) {
+		flags = append(flags, "--module", modulePath)
+	} else {
+		flags = append(flags, execCtx.asset.ExecutableFile.Path)
+	}
 
 	command := &CommandInstance{
 		Name:    u.binaryFullPath,


### PR DESCRIPTION
Bruin turns an asset's file path into a dotted module name and runs it with `uv run --module`. When the path is not importable, the interpreter rejects it and the asset cannot run at all:

```
using module path: .claude.skills.my-assets.push_ad
>> python: Relative module names not supported
```

That covers any segment starting with a dot (`.claude/`, `.github/` — a leading dot means "relative import") and any segment that is not a valid Python identifier (`my-assets/`, `ad assets/`, `2024/`). The same file runs fine when executed by path; only the `-m` form is affected.

**Fix:** when the module name does not match `^[A-Za-z_]\w*(\.[A-Za-z_]\w*)*$`, pass the file path to `uv run` instead of `--module`. Valid module paths keep the existing behaviour.

Verified with a `@bruin`-headed asset under `.claude/…`: `Relative module names not supported` / FAIL before, runs / PASS after, with secrets still injected.

One caveat: an asset executed by path gets `sys.path[0]` set to its own directory instead of the repo root, so imports rooted at the repo will not resolve there. Those assets could not run at all before, so nothing regresses — happy to add the repo root to `PYTHONPATH` in that branch if you want the two forms fully equivalent.