### PR TITLE
fix(connections): initialize MongoDB Atlas clients lazily

### DIFF
--- a/pkg/mongo_atlas/db.go
+++ b/pkg/mongo_atlas/db.go
@@ -26,28 +26,18 @@ func NewDB(c *Config) (*DB, error) {
 	return &DB{config: c, Name: c.Database}, nil
 }
 
-func NewClient(ctx context.Context, c *Config) (*DB, error) {
-	clientOptions := options.Client().ApplyURI(c.GetIngestrURI())
-
-	client, err := mongo.Connect(ctx, clientOptions)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create MongoDB client")
-	}
-
-	return &DB{
-		client: client,
-		config: c,
-		Name:   c.Database,
-	}, nil
+// NewClient returns a DB without opening a connection. The underlying MongoDB
+// client is created lazily by ensureClient on first actual use, so merely
+// registering the connection never starts driver monitoring or DNS discovery.
+func NewClient(_ context.Context, c *Config) (*DB, error) {
+	return &DB{config: c, Name: c.Database}, nil
 }
 
 func (db *DB) GetIngestrURI() (string, error) {
 	return db.config.GetIngestrURI(), nil
 }
 
-// ensureClient lazily establishes a connection. The connection manager builds
-// Atlas connections via NewClient (eager), but instances created through NewDB
-// connect on first use instead.
+// ensureClient lazily establishes the underlying MongoDB client on first use.
 func (db *DB) ensureClient(ctx context.Context) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()


### PR DESCRIPTION
## Summary
- `mongoatlas.NewClient` no longer calls `mongo.Connect`; it just builds the `DB` struct and the client is created lazily by `ensureClient` on first actual use (ping, query, diff).

## Context
The connection manager (`AddMongoAtlasConnectionFromConfig`) eagerly connected to every configured MongoDB Atlas connection when a task pod started — even for BigQuery-only tasks. That call starts MongoDB driver monitoring and DNS discovery goroutines which were never disconnected, producing:

- unnecessary DNS queries to Atlas SRV hosts from every pod,
- ICMP `Destination Unreachable / Port Unreachable` replies to kube-dns after the short-lived task's UDP resolver socket closed, which Cilium drops and Hubble reports as `POLICY_DENIED`.

With hundreds of short-lived pods, this generated constant noise. With lazy init, connections that never use Mongo never touch it at all.

## Test plan
- `go build / go vet` on `pkg/mongo`, `pkg/mongo_atlas`, `pkg/connection`
- `go test ./pkg/mongo/... ./pkg/mongo_atlas/... ./pkg/connection/...`
- `make format` (no diffs) and `make test`