### PR TITLE
feat: support full refresh in asset parameters

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -237,7 +237,8 @@ func Render() *cli.Command {
 				}
 			}
 
-			runCtx := context.WithValue(ctx, pipeline.RunConfigFullRefresh, c.Bool("full-refresh"))
+			fullRefresh = asset.FullRefreshEnabled(fullRefresh)
+			runCtx := context.WithValue(ctx, pipeline.RunConfigFullRefresh, fullRefresh)
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigRunID, "your-run-id")
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigStartDate, startDate)
 			runCtx = context.WithValue(runCtx, pipeline.RunConfigEndDate, endDate)

--- a/docs/assets/definition-schema.md
+++ b/docs/assets/definition-schema.md
@@ -191,6 +191,21 @@ connection: bigquery-default
 
 - **Type:** `String`
 
+## `parameters`
+
+Asset-type-specific configuration. The supported keys depend on the asset type; for example, an ingestr asset uses parameters to select its source table and destination.
+
+`full_refresh` is available to every asset type. Set it to `true` to always run that asset in full-refresh mode, even when the pipeline run does not use `--full-refresh`:
+
+```yaml
+parameters:
+  full_refresh: true
+```
+
+This affects materialization, sets the built-in `full_refresh` Jinja variable, and exposes `BRUIN_FULL_REFRESH=1` to Python and R assets. The run-level `--full-refresh` flag remains a global override, so `parameters.full_refresh: false` does not opt an asset out of a full-refresh run. Use `full_refresh_restricted: true` for that protection; the restriction takes precedence over both forms.
+
+- **Type:** `Object`
+
 ## `owner`
 
 The owner of the asset, has no functional implications on Bruin CLI as of today, allows documenting the ownership information. On [Bruin Cloud](https://getbruin.com), it is used to analyze ownership information, used in governance reports and ownership lineage.

--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -74,6 +74,7 @@ parameters:
   sql_limit: integer
   sql_exclude_columns: string
   no_inference: true|false
+  full_refresh: true|false
   mask: string
   trim_whitespace: true|false
   pipelines_dir: string
@@ -134,6 +135,7 @@ parameters:
 | `sql_limit` | No | `--sql-limit` | Applies a `LIMIT` clause when extracting from the source. |
 | `sql_exclude_columns` | No | `--sql-exclude-columns` | List of columns to skip during extraction. |
 | `no_inference` | No | `--no-inference` | Uses `columns` as the source schema for schema-less sources instead of inferring types. |
+| `full_refresh` | No | `--full-refresh` | Runs this asset in full-refresh mode on every run. The run-level `--full-refresh` flag still applies to all assets. |
 | `mask` | No | `--mask` | Adds a column masking rule such as `email:hash`. |
 | `pipelines_dir` | No | `--pipelines-dir` | Directory where Ingestr stores pipeline metadata. |
 | `staging_bucket` | No | `--staging-bucket` | Overrides the staging bucket that Ingestr uses for intermediate files. |
@@ -255,7 +257,7 @@ The incremental key must be returned by the query. For incremental runs, include
 Pipeline run options propagate to ingestr automatically:
 
 * When a run defines an interval start or end date, Bruin appends `--interval-start` and `--interval-end` with the resolved timestamps (including interval modifiers, when enabled).
-* Running with `--full-refresh` adds the `--full-refresh` flag to Ingestr.
+* Running with `--full-refresh`, or setting `parameters.full_refresh: true` on the asset, adds the `--full-refresh` flag to Ingestr.
 * For a streaming asset (`stream: true`), Bruin omits `--interval-end` so the live tail is not truncated, and does not pass `--full-refresh`.
 
 ## Streaming assets

--- a/docs/assets/materialization.md
+++ b/docs/assets/materialization.md
@@ -196,7 +196,7 @@ The result will be a table `dashboard.hello_bq` with the result of the query.
 
 ## Full Refresh and `full_refresh_restricted`
 
-When running assets with the `--full-refresh` flag, Bruin will drop and recreate tables to ensure a clean state. However, there are cases where you may want to protect certain tables from being dropped during a full refresh, such as:
+When running assets with the `--full-refresh` flag, Bruin will drop and recreate tables to ensure a clean state. You can also opt a single asset into this behavior on every run with `parameters.full_refresh: true`. However, there are cases where you may want to protect certain tables from being dropped during a full refresh, such as:
 
 - Tables with external dependencies
 - Tables that take a long time to rebuild

--- a/docs/assets/python-sdk.md
+++ b/docs/assets/python-sdk.md
@@ -182,7 +182,7 @@ from bruin import context, query
 
 
 def materialize():
-    # context.is_full_refresh is True when the run was invoked with --full-refresh.
+    # context.is_full_refresh is True when the run or asset enables full refresh.
     # Use it to branch between a full reload and an incremental slice.
     if context.is_full_refresh:
         sql = """
@@ -693,7 +693,7 @@ from bruin import context
 | `context.pipeline` | `str \| None` | `BRUIN_PIPELINE` | Pipeline name |
 | `context.asset_name` | `str \| None` | `BRUIN_ASSET` | Current asset name |
 | `context.connection` | `str \| None` | `BRUIN_CONNECTION` | Asset's default connection |
-| `context.is_full_refresh` | `bool` | `BRUIN_FULL_REFRESH` | `True` when `--full-refresh` flag is set |
+| `context.is_full_refresh` | `bool` | `BRUIN_FULL_REFRESH` | `True` when `--full-refresh` is set or the asset uses `parameters.full_refresh: true` |
 | `context.commit_hash` | `str \| None` | `BRUIN_COMMIT_HASH` | Git commit hash of the pipeline's repository |
 | `context.vars` | `dict` | `BRUIN_VARS` | Pipeline variables (types preserved from JSON Schema) |
 

--- a/docs/assets/python.md
+++ b/docs/assets/python.md
@@ -226,7 +226,7 @@ The following environment variables are available in every Python asset executio
 | `BRUIN_EXECUTION_TIMESTAMP` | The execution timestamp of the pipeline run in RFC3339 format with timezone (e.g. `2024-01-15T13:45:30.000000Z07:00`) |
 | `BRUIN_RUN_ID`          | The unique identifier for the pipeline run                                                                        |
 | `BRUIN_PIPELINE`        | The name of the pipeline being executed                                                                           |
-| `BRUIN_FULL_REFRESH`    | Set to `1` when the pipeline is running with the `--full-refresh` flag, empty string otherwise                   |
+| `BRUIN_FULL_REFRESH`    | Set to `1` when the run uses `--full-refresh` or the asset sets `parameters.full_refresh: true`, empty otherwise |
 | `BRUIN_COMMIT_HASH`    | The current git commit hash (`git rev-parse HEAD`) of the repository containing the pipeline                     |
 | `BRUIN_ASSET`            | The name of the current Python asset (alias for `BRUIN_THIS`)                                                      |
 | `BRUIN_THIS`             | The name of the current Python asset                                                                              |

--- a/docs/assets/r.md
+++ b/docs/assets/r.md
@@ -167,7 +167,7 @@ The following environment variables are available in every R asset execution:
 | `BRUIN_EXECUTION_TIMESTAMP` | The execution timestamp of the pipeline run in RFC3339 format with timezone (e.g. `2024-01-15T13:45:30.000000Z07:00`) |
 | `BRUIN_RUN_ID`          | The unique identifier for the pipeline run                                                                        |
 | `BRUIN_PIPELINE`        | The name of the pipeline being executed                                                                           |
-| `BRUIN_FULL_REFRESH`    | Set to `1` when the pipeline is running with the `--full-refresh` flag, empty otherwise                           |
+| `BRUIN_FULL_REFRESH`    | Set to `1` when the run uses `--full-refresh` or the asset sets `parameters.full_refresh: true`, empty otherwise   |
 | `BRUIN_THIS`            | The name of the R asset                                                                                           |
 | `BRUIN_ASSET`           | The name of the R asset (same as BRUIN_THIS)                                                                      |
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -41,7 +41,7 @@ table td:first-child {
 | `--force` | bool | `false` | Do not ask for confirmation in a production environment. |
 | `--no-log-file` | bool | `false` | Do not create a log file for this run. |
 | `--sensor-mode` | str | `'once'` | Set sensor mode: `skip`, `once`, or `wait`. |
-| `--full-refresh` | bool | `false` | Truncate the table before running. Also sets the `full_refresh` jinja variable to `True` and `BRUIN_FULL_REFRESH` environment variable to `1`. |
+| `--full-refresh` | bool | `false` | Truncate tables before running. Also sets the `full_refresh` Jinja variable to `True` and `BRUIN_FULL_REFRESH` to `1`. A single asset can opt in on every run with `parameters.full_refresh: true`. |
 | `--apply-interval-modifiers` | bool | `false` | Apply [interval modifiers](/assets/interval-modifiers). Off by default on the CLI because you pass the dates yourself; Bruin Cloud applies them automatically. Ignored together with `--full-refresh`. |
 | `--continue` | bool | `false` | Continue from the last failed asset. |
 | `--selector` | str | - | Select assets with dbt-style syntax. Supports `tag:`, `path:`, `file:`, `fqn:`, `+`, `n+`, `@`, space unions, and comma intersections. |

--- a/pkg/athena/materialization_test.go
+++ b/pkg/athena/materialization_test.go
@@ -139,6 +139,23 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 		},
 		{
+			name: "materialize to a table, full refresh parameter defaults to create+replace",
+			task: &pipeline.Asset{
+				Name:       "my.asset",
+				Parameters: pipeline.ParameterMap{"full_refresh": true},
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+			},
+			query: "SELECT 1",
+			want: []string{
+				"CREATE TABLE __bruin_tmp_abcefghi WITH (table_type='ICEBERG', is_external=false, location='s3://bucket/__bruin_tmp_abcefghi') AS SELECT 1",
+				"DROP TABLE IF EXISTS my.asset",
+				"ALTER TABLE __bruin_tmp_abcefghi RENAME TO my.asset",
+			},
+		},
+		{
 			name: "materialize to a table with append",
 			task: &pipeline.Asset{
 				Name: "my.asset",

--- a/pkg/athena/materializer.go
+++ b/pkg/athena/materializer.go
@@ -26,7 +26,7 @@ func (m *Materializer) Render(asset *pipeline.Asset, query, location string) ([]
 	}
 
 	strategy := mat.Strategy
-	if m.fullRefresh && mat.Type == pipeline.MaterializationTypeTable {
+	if asset.FullRefreshEnabled(m.fullRefresh) && mat.Type == pipeline.MaterializationTypeTable {
 		if mat.Strategy != pipeline.MaterializationStrategyDDL {
 			strategy = pipeline.MaterializationStrategyCreateReplace
 		}
@@ -71,7 +71,7 @@ func (r *Renderer) Render(asset *pipeline.Asset, query string) (string, error) {
 }
 
 func (m *Materializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
-	if !m.fullRefresh {
+	if !asset.FullRefreshEnabled(m.fullRefresh) {
 		return nil
 	}
 

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -142,7 +142,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	if o.materializer.IsFullRefresh() && t.Materialization.Strategy != pipeline.MaterializationStrategyDDL {
+	if t.FullRefreshEnabled(o.materializer.IsFullRefresh()) && t.Materialization.Strategy != pipeline.MaterializationStrategyDDL {
 		err = conn.DropTableOnMismatch(ctx, t.Name, t)
 		if err != nil {
 			return errors.Wrapf(err, "failed to check for mismatches for table '%s'", t.Name)

--- a/pkg/clickhouse/materialization_test.go
+++ b/pkg/clickhouse/materialization_test.go
@@ -76,6 +76,27 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 		},
 		{
+			name: "materialize to a table, full refresh parameter defaults to create+replace",
+			task: &pipeline.Asset{
+				Name:       "my.asset",
+				Parameters: pipeline.ParameterMap{"full_refresh": true},
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+				Columns: []pipeline.Column{
+					{
+						Name:       "id",
+						PrimaryKey: true,
+					},
+				},
+			},
+			query: "SELECT 1",
+			want: []string{
+				"CREATE OR REPLACE TABLE my.asset PRIMARY KEY (id) AS SELECT 1",
+			},
+		},
+		{
 			name: "materialize to a table, full refresh with composite primary key falls back to create+replace",
 			task: &pipeline.Asset{
 				Name: "my.asset",

--- a/pkg/clickhouse/materializer.go
+++ b/pkg/clickhouse/materializer.go
@@ -26,7 +26,7 @@ func (m *Materializer) Render(asset *pipeline.Asset, query string) ([]string, er
 	}
 
 	strategy := mat.Strategy
-	if m.fullRefresh && mat.Type == pipeline.MaterializationTypeTable {
+	if asset.FullRefreshEnabled(m.fullRefresh) && mat.Type == pipeline.MaterializationTypeTable {
 		if mat.Strategy != pipeline.MaterializationStrategyDDL {
 			strategy = pipeline.MaterializationStrategyCreateReplace
 		}
@@ -50,7 +50,7 @@ func (m *Materializer) RenderWithCleanup(asset *pipeline.Asset, query string) ([
 	}
 
 	strategy := asset.Materialization.Strategy
-	if m.fullRefresh && asset.Materialization.Type == pipeline.MaterializationTypeTable && strategy != pipeline.MaterializationStrategyDDL {
+	if asset.FullRefreshEnabled(m.fullRefresh) && asset.Materialization.Type == pipeline.MaterializationTypeTable && strategy != pipeline.MaterializationStrategyDDL {
 		strategy = pipeline.MaterializationStrategyCreateReplace
 	}
 
@@ -94,7 +94,7 @@ func (r *Renderer) Render(asset *pipeline.Asset, query string) (string, error) {
 }
 
 func (m *Materializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
-	if !m.fullRefresh {
+	if !asset.FullRefreshEnabled(m.fullRefresh) {
 		return nil
 	}
 

--- a/pkg/clickhouse/materializer_test.go
+++ b/pkg/clickhouse/materializer_test.go
@@ -110,3 +110,22 @@ func TestMaterializer_RenderWithCleanupFullRefreshDoesNotReturnMergeCleanup(t *t
 	require.Len(t, queries, 1)
 	require.Empty(t, cleanup)
 }
+
+func TestMaterializer_RenderWithCleanupFullRefreshParameterDoesNotReturnMergeCleanup(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		Name:       "my.asset",
+		Parameters: pipeline.ParameterMap{"full_refresh": true},
+		Materialization: pipeline.Materialization{
+			Type:     pipeline.MaterializationTypeTable,
+			Strategy: pipeline.MaterializationStrategyMerge,
+		},
+		Columns: []pipeline.Column{{Name: "id", PrimaryKey: true}},
+	}
+
+	queries, cleanup, err := NewMaterializer(false).RenderWithCleanup(asset, "SELECT 1 AS id")
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Empty(t, cleanup)
+}

--- a/pkg/databricks/materialization_test.go
+++ b/pkg/databricks/materialization_test.go
@@ -68,6 +68,23 @@ func TestMaterializer_Render(t *testing.T) {
 			},
 		},
 		{
+			name: "materialize to a table, full refresh parameter defaults to create+replace",
+			task: &pipeline.Asset{
+				Name:       "my.asset",
+				Parameters: pipeline.ParameterMap{"full_refresh": true},
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyMerge,
+				},
+			},
+			query: "SELECT 1",
+			want: []string{
+				"CREATE TABLE my\\.__bruin_tmp_.+ AS SELECT 1;",
+				"DROP TABLE IF EXISTS my\\.asset;",
+				"ALTER TABLE my\\.__bruin_tmp_.+ RENAME TO my\\.asset;",
+			},
+		},
+		{
 			name: "materialize to a table with cluster, single field to cluster",
 			task: &pipeline.Asset{
 				Name: "my.asset",

--- a/pkg/databricks/materializer.go
+++ b/pkg/databricks/materializer.go
@@ -24,7 +24,7 @@ func (m *Materializer) Render(asset *pipeline.Asset, query string) ([]string, er
 	}
 
 	strategy := mat.Strategy
-	if m.fullRefresh && mat.Type == pipeline.MaterializationTypeTable {
+	if asset.FullRefreshEnabled(m.fullRefresh) && mat.Type == pipeline.MaterializationTypeTable {
 		if mat.Strategy != pipeline.MaterializationStrategyDDL {
 			strategy = pipeline.MaterializationStrategyCreateReplace
 		}
@@ -66,7 +66,7 @@ func (r *Renderer) Render(asset *pipeline.Asset, query string) (string, error) {
 }
 
 func (m *Materializer) LogIfFullRefreshAndDDL(writer interface{}, asset *pipeline.Asset) error {
-	if !m.fullRefresh {
+	if !asset.FullRefreshEnabled(m.fullRefresh) {
 		return nil
 	}
 

--- a/pkg/env/variables.go
+++ b/pkg/env/variables.go
@@ -19,6 +19,12 @@ func SetupVariables(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Asset
 	if err != nil {
 		return nil, err
 	}
+	if runFullRefresh, ok := ctx.Value(pipeline.RunConfigFullRefresh).(bool); ok {
+		env["BRUIN_FULL_REFRESH"] = ""
+		if t.FullRefreshEnabled(runFullRefresh) {
+			env["BRUIN_FULL_REFRESH"] = "1"
+		}
+	}
 
 	if selectedEnv, ok := ctx.Value(config.EnvironmentContextKey).(*config.Environment); ok && selectedEnv != nil {
 		env["BRUIN_SCHEMA_PREFIX"] = selectedEnv.SchemaPrefix
@@ -56,10 +62,11 @@ func envMutateIntervals(ctx context.Context, p *pipeline.Pipeline, t *pipeline.A
 	if !ok {
 		return nil, errors.New("run ID not found - please check if the run exists")
 	}
-	fullRefresh, ok := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	runFullRefresh, ok := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
 	if !ok {
 		return nil, errors.New("invalid or missing full refresh setting - must be true or false")
 	}
+	fullRefresh := t.FullRefreshEnabled(runFullRefresh)
 
 	modifiedStartDate := pipeline.ModifyDate(startDate, t.IntervalModifiers.Start)
 	modifiedEndDate := pipeline.ModifyDate(endDate, t.IntervalModifiers.End)

--- a/pkg/env/variables_test.go
+++ b/pkg/env/variables_test.go
@@ -326,4 +326,21 @@ func TestSetupVariables(t *testing.T) {
 
 		assert.Equal(t, "dev_", result["BRUIN_SCHEMA_PREFIX"])
 	})
+
+	t.Run("BRUIN_FULL_REFRESH is set from asset parameters", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		ctx = context.WithValue(ctx, pipeline.RunConfigStartDate, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+		ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))
+		ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+		ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run")
+		ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, false)
+
+		asset := &pipeline.Asset{Parameters: pipeline.ParameterMap{"full_refresh": true}}
+		result, err := env.SetupVariables(ctx, &pipeline.Pipeline{Name: "test-pipeline"}, asset, map[string]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, "1", result["BRUIN_FULL_REFRESH"])
+	})
 }

--- a/pkg/executor/sequential.go
+++ b/pkg/executor/sequential.go
@@ -39,9 +39,11 @@ func (e *AssetTimeoutError) Unwrap() error {
 
 func (s Sequential) RunSingleTask(ctx context.Context, instance scheduler.TaskInstance) error {
 	task := instance.GetAsset()
-	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
-	if fullRefresh && task.RefreshRestricted != nil && *task.RefreshRestricted {
-		ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, false)
+	runFullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	fullRefreshRequested := task.FullRefreshRequested(runFullRefresh)
+	fullRefresh := task.FullRefreshEnabled(runFullRefresh)
+	ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, fullRefresh)
+	if fullRefreshRequested && !fullRefresh {
 		if instance.GetType() == scheduler.TaskInstanceTypeMain {
 			if printer, ok := ctx.Value(KeyPrinter).(io.Writer); ok {
 				_, _ = fmt.Fprintf(printer, "Warning: full refresh is restricted for asset %q; running incrementally.\n", task.Name)

--- a/pkg/executor/sequential_test.go
+++ b/pkg/executor/sequential_test.go
@@ -93,6 +93,34 @@ func TestLocal_RunSingleTask(t *testing.T) {
 		mockOperator.AssertExpectations(t)
 	})
 
+	t.Run("full refresh asset parameter is applied before dispatch", func(t *testing.T) {
+		t.Parallel()
+
+		parameterAsset := &pipeline.Asset{
+			Name:       "parameter-task",
+			Type:       "test",
+			Parameters: pipeline.ParameterMap{"full_refresh": true},
+		}
+		parameterInstance := &scheduler.AssetInstance{Asset: parameterAsset}
+		mockOperator := new(mockOperator)
+		mockOperator.On("Run", mock.MatchedBy(func(ctx context.Context) bool {
+			fullRefresh, ok := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+			return ok && fullRefresh
+		}), parameterInstance).Return(nil)
+		l := Sequential{
+			TaskTypeMap: map[pipeline.AssetType]Config{
+				"test": {
+					scheduler.TaskInstanceTypeMain: mockOperator,
+				},
+			},
+		}
+
+		err := l.RunSingleTask(t.Context(), parameterInstance)
+
+		require.NoError(t, err)
+		mockOperator.AssertExpectations(t)
+	})
+
 	t.Run("missing instance is rejected", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -640,6 +640,41 @@ func TestBasicOperator_ConvertTaskInstanceToIngestrCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "full refresh parameter - incremental strategy, incremental key updated_at, multiple pk",
+			asset: &pipeline.Asset{
+				Name:       "asset-name",
+				Connection: "bq",
+				Columns: []pipeline.Column{
+					{Name: "id", PrimaryKey: true},
+					{Name: "date", PrimaryKey: true},
+					{Name: "name"},
+					{Name: "updated_at"},
+				},
+				Parameters: pipeline.ParameterMap{
+					"source_connection":    "sf",
+					"source_table":         "source-table",
+					"destination":          "bigquery",
+					"incremental_strategy": "merge",
+					"incremental_key":      "updated_at",
+					"full_refresh":         true,
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "snowflake://uri-here",
+				"--source-table", "source-table",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "asset-name",
+				"--yes",
+				"--progress", "log",
+				"--incremental-key", "updated_at",
+				"--incremental-strategy", "merge",
+				"--primary-key", "id",
+				"--primary-key", "date",
+				"--full-refresh",
+			},
+		},
+		{
 			name: "public chess source via domain name (no connection defined)",
 			asset: &pipeline.Asset{
 				Name:       "asset-name",

--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -260,7 +260,8 @@ func (r *Renderer) CloneForAsset(ctx context.Context, pipe *pipeline.Pipeline, a
 		return r, nil
 	}
 
-	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	runFullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	fullRefresh := asset.FullRefreshEnabled(runFullRefresh)
 
 	applyModifiers, ok := ctx.Value(pipeline.RunConfigApplyIntervalModifiers).(bool)
 	if ok && applyModifiers {

--- a/pkg/jinja/jinja_test.go
+++ b/pkg/jinja/jinja_test.go
@@ -1260,23 +1260,29 @@ func TestRenderer_IsFullRefresh(t *testing.T) {
 		},
 	}
 
-	asset := &pipeline.Asset{
-		Name: "test-asset",
-	}
-
 	tests := []struct {
 		name                 string
-		fullRefresh          bool
+		runFullRefresh       bool
+		parameters           pipeline.ParameterMap
+		expectedFullRefresh  bool
 		expectedRenderedText string
 	}{
 		{
 			name:                 "full_refresh is false when full refresh is disabled",
-			fullRefresh:          false,
+			runFullRefresh:       false,
+			expectedFullRefresh:  false,
 			expectedRenderedText: "False",
 		},
 		{
 			name:                 "full_refresh is true when full refresh is enabled",
-			fullRefresh:          true,
+			runFullRefresh:       true,
+			expectedFullRefresh:  true,
+			expectedRenderedText: "True",
+		},
+		{
+			name:                 "full_refresh is true when enabled in asset parameters",
+			parameters:           pipeline.ParameterMap{"full_refresh": true},
+			expectedFullRefresh:  true,
 			expectedRenderedText: "True",
 		},
 	}
@@ -1290,7 +1296,11 @@ func TestRenderer_IsFullRefresh(t *testing.T) {
 			ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
 			ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, executionDate)
 			ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
-			ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, tt.fullRefresh)
+			ctx = context.WithValue(ctx, pipeline.RunConfigFullRefresh, tt.runFullRefresh)
+			asset := &pipeline.Asset{
+				Name:       "test-asset",
+				Parameters: tt.parameters,
+			}
 
 			baseRenderer := NewRendererWithStartEndDates(&startDate, &endDate, &executionDate, basePipeline.Name, "test-run-id", basePipeline.Variables.Value())
 			clonedRenderer, err := baseRenderer.CloneForAsset(ctx, basePipeline, asset)
@@ -1306,7 +1316,7 @@ func TestRenderer_IsFullRefresh(t *testing.T) {
 			conditionalQuery := `{% if full_refresh %}full{% else %}incremental{% endif %}`
 			conditionalResult, err := clonedRenderer.Render(conditionalQuery)
 			require.NoError(t, err)
-			if tt.fullRefresh {
+			if tt.expectedFullRefresh {
 				require.Equal(t, "full", conditionalResult)
 			} else {
 				require.Equal(t, "incremental", conditionalResult)

--- a/pkg/mysql/operator.go
+++ b/pkg/mysql/operator.go
@@ -124,7 +124,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, asset 
 		}
 	}
 
-	if asset.Materialization.IsSCD2() && !o.materializer.IsFullRefresh() {
+	if asset.Materialization.IsSCD2() && !asset.FullRefreshEnabled(o.materializer.IsFullRefresh()) {
 		if err := scd2migration.MySQL(ctx, conn, asset.Name); err != nil {
 			return err
 		}

--- a/pkg/oracle/operator.go
+++ b/pkg/oracle/operator.go
@@ -99,7 +99,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, asset 
 	// On the incremental SCD2 path the target table already exists and keeps its
 	// original column types. Migrate legacy naive bruin_valid_from/bruin_valid_until
 	// columns to timezone-aware types before writing tz-aware values into them.
-	if asset.Materialization.IsSCD2() && !o.materializer.IsFullRefresh() {
+	if asset.Materialization.IsSCD2() && !asset.FullRefreshEnabled(o.materializer.IsFullRefresh()) {
 		if err := scd2migration.Oracle(ctx, conn, asset.Name); err != nil {
 			return err
 		}

--- a/pkg/pipeline/materializer.go
+++ b/pkg/pipeline/materializer.go
@@ -27,11 +27,10 @@ func (m *Materializer) Render(asset *Asset, query string) (string, error) {
 	}
 
 	strategy := mat.Strategy
-	if m.FullRefresh && mat.Type == MaterializationTypeTable {
+	if asset.FullRefreshEnabled(m.FullRefresh) && mat.Type == MaterializationTypeTable {
 		// Only override to CreateReplace if strategy is not explicitly set to DDL
 		// This strategy should never be overridden, even with full refresh
-		// Also respect full refresh restriction - if true, don't drop/recreate the table
-		if mat.Strategy != MaterializationStrategyDDL && (asset.RefreshRestricted == nil || !*asset.RefreshRestricted) {
+		if mat.Strategy != MaterializationStrategyDDL {
 			// Data Vault strategies are only overridden on platforms that implement them, since
 			// those route CreateReplace back into their own builders. Overriding it elsewhere would
 			// silently produce a plain table dump with none of the Data Vault loading rules applied.
@@ -63,7 +62,7 @@ func (m *Materializer) IsFullRefresh() bool {
 }
 
 func (m *Materializer) LogIfFullRefreshAndDDL(writer interface{}, asset *Asset) error {
-	if !m.FullRefresh {
+	if !asset.FullRefreshEnabled(m.FullRefresh) {
 		return nil
 	}
 

--- a/pkg/pipeline/materializer_test.go
+++ b/pkg/pipeline/materializer_test.go
@@ -18,6 +18,7 @@ func TestMaterializer_Render(t *testing.T) {
 		name              string
 		matMap            AssetMaterializationMap
 		fullRefresh       bool
+		parameters        ParameterMap
 		refreshRestricted *bool
 		query             string
 		expected          string
@@ -47,6 +48,19 @@ func TestMaterializer_Render(t *testing.T) {
 			fullRefresh: true,
 			query:       "SELECT * FROM table",
 			expected:    "SELECT 1;SELECT * FROM table",
+		},
+		{
+			name: "full refresh from asset parameters",
+			matMap: AssetMaterializationMap{
+				MaterializationTypeTable: {
+					MaterializationStrategyCreateReplace: func(task *Asset, query string) (string, error) {
+						return "SELECT 1;" + query, nil
+					},
+				},
+			},
+			parameters: ParameterMap{"full_refresh": true},
+			query:      "SELECT * FROM table",
+			expected:   "SELECT 1;SELECT * FROM table",
 		},
 		{
 			name: "full refresh respects refresh restricted",
@@ -81,6 +95,7 @@ func TestMaterializer_Render(t *testing.T) {
 					Type:     MaterializationTypeTable,
 					Strategy: MaterializationStrategyMerge,
 				},
+				Parameters:        tt.parameters,
 				RefreshRestricted: tt.refreshRestricted,
 			}
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1360,6 +1360,36 @@ func (a *Asset) IsEnabled() bool {
 	return enabled
 }
 
+// FullRefreshRequested reports whether either the run-level flag or the asset's
+// parameters.full_refresh value requests a full refresh. The run-level flag is
+// a global override, so parameters.full_refresh=false cannot disable it.
+func (a *Asset) FullRefreshRequested(runFullRefresh bool) bool {
+	if runFullRefresh {
+		return true
+	}
+	if a == nil {
+		return false
+	}
+
+	value, ok := a.Parameters.GetString("full_refresh")
+	if !ok {
+		return false
+	}
+
+	requested, err := strconv.ParseBool(strings.TrimSpace(value))
+	return err == nil && requested
+}
+
+// FullRefreshEnabled applies the asset-level full-refresh restriction to the
+// effective request from FullRefreshRequested.
+func (a *Asset) FullRefreshEnabled(runFullRefresh bool) bool {
+	if !a.FullRefreshRequested(runFullRefresh) {
+		return false
+	}
+
+	return a == nil || a.RefreshRestricted == nil || !*a.RefreshRestricted
+}
+
 func (a *Asset) EnabledValue() (bool, error) {
 	if a == nil || a.Enabled == nil {
 		return true, nil

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -151,6 +151,77 @@ func TestParameterMapGetString(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestAssetFullRefresh(t *testing.T) {
+	t.Parallel()
+
+	trueValue := true
+	tests := []struct {
+		name                string
+		asset               *pipeline.Asset
+		runFullRefresh      bool
+		expectedRequested   bool
+		expectedFullRefresh bool
+	}{
+		{
+			name:                "disabled by default",
+			asset:               &pipeline.Asset{},
+			expectedRequested:   false,
+			expectedFullRefresh: false,
+		},
+		{
+			name: "enabled by a boolean asset parameter",
+			asset: &pipeline.Asset{Parameters: pipeline.ParameterMap{
+				"full_refresh": true,
+			}},
+			expectedRequested:   true,
+			expectedFullRefresh: true,
+		},
+		{
+			name: "enabled by a string asset parameter",
+			asset: &pipeline.Asset{Parameters: pipeline.ParameterMap{
+				"full_refresh": "true",
+			}},
+			expectedRequested:   true,
+			expectedFullRefresh: true,
+		},
+		{
+			name: "false asset parameter does not disable the run flag",
+			asset: &pipeline.Asset{Parameters: pipeline.ParameterMap{
+				"full_refresh": false,
+			}},
+			runFullRefresh:      true,
+			expectedRequested:   true,
+			expectedFullRefresh: true,
+		},
+		{
+			name: "invalid asset parameter is ignored",
+			asset: &pipeline.Asset{Parameters: pipeline.ParameterMap{
+				"full_refresh": "sometimes",
+			}},
+			expectedRequested:   false,
+			expectedFullRefresh: false,
+		},
+		{
+			name: "restriction wins over an asset parameter",
+			asset: &pipeline.Asset{
+				Parameters:        pipeline.ParameterMap{"full_refresh": true},
+				RefreshRestricted: &trueValue,
+			},
+			expectedRequested:   true,
+			expectedFullRefresh: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expectedRequested, tt.asset.FullRefreshRequested(tt.runFullRefresh))
+			assert.Equal(t, tt.expectedFullRefresh, tt.asset.FullRefreshEnabled(tt.runFullRefresh))
+		})
+	}
+}
+
 func TestAssetParametersYAMLSupportStructuredValues(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/postgres/operator.go
+++ b/pkg/postgres/operator.go
@@ -126,7 +126,7 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	if t.Materialization.IsSCD2() && !o.materializer.IsFullRefresh() {
+	if t.Materialization.IsSCD2() && !t.FullRefreshEnabled(o.materializer.IsFullRefresh()) {
 		if err = scd2migration.Postgres(ctx, conn, t.Name); err != nil {
 			return err
 		}

--- a/pkg/python/helper.go
+++ b/pkg/python/helper.go
@@ -55,7 +55,8 @@ func isStreamingParams(params pipeline.ParameterMap) bool {
 }
 
 func ConsolidatedParameters(ctx context.Context, asset *pipeline.Asset, cmdArgs []string, columnOpts *ColumnHintOptions) ([]string, error) {
-	fullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	runFullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
+	fullRefresh := asset.FullRefreshEnabled(runFullRefresh)
 	cmdArgs = appendIngestrParameterFlags(asset.Parameters, cmdArgs)
 	cmdArgs = appendIngestrMaskFlags(asset.Parameters, asset.Columns, cmdArgs, columnOpts != nil && columnOpts.NormalizeColumnNames)
 

--- a/pkg/python/helper_test.go
+++ b/pkg/python/helper_test.go
@@ -181,6 +181,33 @@ func TestConsolidatedParameters_StreamGating(t *testing.T) {
 	})
 }
 
+func TestConsolidatedParameters_FullRefreshParameter(t *testing.T) {
+	t.Parallel()
+
+	asset := &pipeline.Asset{
+		StartDate: "2020-01-01",
+		Parameters: pipeline.ParameterMap{
+			"full_refresh": true,
+		},
+		IntervalModifiers: pipeline.IntervalModifiers{
+			Start: pipeline.TimeModifier{Days: 1},
+			End:   pipeline.TimeModifier{Days: 1},
+		},
+	}
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+	ctx = context.WithValue(ctx, pipeline.RunConfigApplyIntervalModifiers, true)
+
+	result, err := ConsolidatedParameters(ctx, asset, []string{"--existing"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"--existing",
+		"--interval-start", "2020-01-02T00:00:00Z",
+		"--interval-end", "2025-01-03T00:00:00Z",
+		"--full-refresh",
+	}, result)
+}
+
 func TestConsolidatedParameters_TrimWhitespace(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/snowflake/operator.go
+++ b/pkg/snowflake/operator.go
@@ -138,14 +138,15 @@ func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pip
 		}
 	}
 
-	if o.materializer.IsFullRefresh() {
+	fullRefresh := t.FullRefreshEnabled(o.materializer.IsFullRefresh())
+	if fullRefresh {
 		err = conn.RecreateTableOnMaterializationTypeMismatch(ctx, t)
 		if err != nil {
 			return err
 		}
 	}
 
-	if t.Materialization.IsSCD2() && !o.materializer.IsFullRefresh() {
+	if t.Materialization.IsSCD2() && !fullRefresh {
 		if err = scd2migration.Snowflake(ctx, conn, t.Name); err != nil {
 			return err
 		}

--- a/pkg/synapse/materialization_test.go
+++ b/pkg/synapse/materialization_test.go
@@ -83,6 +83,22 @@ func TestMaterializer_Render(t *testing.T) {
 				"DROP TABLE #bruin_tmp_.+;$"},
 		},
 		{
+			name: "materialize to a table with append and full refresh parameter results in create_replace",
+			task: &pipeline.Asset{
+				Name:       "my.asset",
+				Parameters: pipeline.ParameterMap{"full_refresh": true},
+				Materialization: pipeline.Materialization{
+					Type:     pipeline.MaterializationTypeTable,
+					Strategy: pipeline.MaterializationStrategyAppend,
+				},
+			},
+			query: "SELECT 1",
+			want: []string{"^SELECT tmp\\.\\* INTO #bruin_tmp_.+ FROM \\(SELECT 1\\) AS tmp;\n" +
+				"IF OBJECT_ID\\('my\\.asset', 'U'\\) IS NOT NULL DROP TABLE my\\.asset;\n" +
+				"SELECT \\* INTO my\\.asset FROM #bruin_tmp_.+;\n" +
+				"DROP TABLE #bruin_tmp_.+;$"},
+		},
+		{
 			name: "incremental strategies require the incremental_key to be set",
 			task: &pipeline.Asset{
 				Name: "my.asset",

--- a/pkg/synapse/materializer.go
+++ b/pkg/synapse/materializer.go
@@ -22,7 +22,7 @@ func (m *Materializer) Render(asset *pipeline.Asset, query string) ([]string, er
 	}
 
 	strategy := mat.Strategy
-	if m.fullRefresh && mat.Type == pipeline.MaterializationTypeTable {
+	if asset.FullRefreshEnabled(m.fullRefresh) && mat.Type == pipeline.MaterializationTypeTable {
 		if mat.Strategy != pipeline.MaterializationStrategyDDL {
 			strategy = pipeline.MaterializationStrategyCreateReplace
 		}


### PR DESCRIPTION
## What
Allow assets to opt into full-refresh behavior with `parameters.full_refresh: true`.

## Changes
- Propagate asset-level full refresh through execution, SQL materializers, ingestr, Jinja, and Python/R environments.
- Preserve the global run flag and `full_refresh_restricted` precedence, with tests and documentation.

## How to test
1. Run `make format`.
2. Run `make build-no-duckdb`.
3. Run `make test`.
4. Run `make integration-test-light`.

## Risk & rollback
- **Risk:** Low; behavior is opt-in and existing precedence is preserved.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test-light`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.