### PR TITLE
fix(jinja): load pipeline macros during validation

### DIFF
--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -67,6 +67,20 @@ func LoadMacros(fs afero.Fs, macrosPath string) (string, error) {
 	return macroContent.String(), nil
 }
 
+func pipelineMacroContent(pipe *pipeline.Pipeline) string {
+	if pipe == nil || len(pipe.Macros) == 0 {
+		return ""
+	}
+
+	var macroContent strings.Builder
+	for _, macro := range pipe.Macros {
+		macroContent.WriteString(string(macro))
+		macroContent.WriteString("\n")
+	}
+
+	return macroContent.String()
+}
+
 func NewRenderer(context Context) *Renderer {
 	addBuiltinFunctions(context)
 	return &Renderer{
@@ -262,6 +276,10 @@ func (r *Renderer) CloneForAsset(ctx context.Context, pipe *pipeline.Pipeline, a
 
 	runFullRefresh, _ := ctx.Value(pipeline.RunConfigFullRefresh).(bool)
 	fullRefresh := asset.FullRefreshEnabled(runFullRefresh)
+	macroContent := r.macroContent
+	if macroContent == "" {
+		macroContent = pipelineMacroContent(pipe)
+	}
 
 	applyModifiers, ok := ctx.Value(pipeline.RunConfigApplyIntervalModifiers).(bool)
 	if ok && applyModifiers {
@@ -271,6 +289,7 @@ func (r *Renderer) CloneForAsset(ctx context.Context, pipe *pipeline.Pipeline, a
 		tempRenderer := &Renderer{
 			context:         exec.NewContext(tempContext),
 			queryRenderLock: &sync.Mutex{},
+			macroContent:    macroContent,
 		}
 		// Use non-mutating template resolution to avoid modifying the original asset
 		resolvedStartModifier, err := asset.IntervalModifiers.Start.ResolveTemplateToNew(tempRenderer)
@@ -300,7 +319,7 @@ func (r *Renderer) CloneForAsset(ctx context.Context, pipe *pipeline.Pipeline, a
 	return &Renderer{
 		context:         exec.NewContext(jinjaContext),
 		queryRenderLock: &sync.Mutex{},
-		macroContent:    r.macroContent, // Preserve macro content when cloning
+		macroContent:    macroContent,
 	}, nil
 }
 

--- a/pkg/jinja/macros_test.go
+++ b/pkg/jinja/macros_test.go
@@ -1,8 +1,12 @@
 package jinja
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -196,17 +200,57 @@ SELECT * FROM {{ table_name }}
 	}
 }
 
-func TestRendererClonePreservesMacros(t *testing.T) {
+func TestRendererCloneLoadsPipelineMacros(t *testing.T) {
 	t.Parallel()
+
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	executionDate := endDate
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, executionDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
+
+	pipe := &pipeline.Pipeline{
+		Name: "test-pipeline",
+		Macros: []pipeline.Macro{
+			`{% macro test_macro(value) %}SELECT {{ value }}{% endmacro %}`,
+		},
+	}
+	asset := &pipeline.Asset{Name: "test.asset"}
+	renderer := NewRendererWithYesterday("test-pipeline", "test-run-id")
+
+	clonedRenderer, err := renderer.CloneForAsset(ctx, pipe, asset)
+	require.NoError(t, err)
+
+	result, err := clonedRenderer.Render("{{ test_macro(1) }}")
+	require.NoError(t, err)
+	require.Equal(t, "SELECT 1", strings.TrimSpace(result))
+}
+
+func TestRendererClonePreservesExplicitMacros(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	executionDate := endDate
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, executionDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
 
 	macroContent := `{% macro test_macro() %}SELECT 1{% endmacro %}`
 	renderer := NewRendererWithMacros(Context{}, macroContent)
+	pipe := &pipeline.Pipeline{
+		Name:   "test-pipeline",
+		Macros: []pipeline.Macro{`{% macro test_macro() %}SELECT 2{% endmacro %}`},
+	}
+	asset := &pipeline.Asset{Name: "test.asset"}
 
-	// Render using the original renderer
-	result1, err := renderer.Render("{{ test_macro() }}")
+	clonedRenderer, err := renderer.CloneForAsset(ctx, pipe, asset)
 	require.NoError(t, err)
-	require.Equal(t, "\nSELECT 1", result1)
 
-	// The macro should work in the original renderer
-	require.Equal(t, macroContent, renderer.macroContent)
+	result, err := clonedRenderer.Render("{{ test_macro() }}")
+	require.NoError(t, err)
+	require.Equal(t, "\nSELECT 1", result)
 }

--- a/pkg/lint/query_test.go
+++ b/pkg/lint/query_test.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -132,6 +133,58 @@ func TestQueryValidatorRule_ValidateAssetWithHookScope(t *testing.T) {
 	validator.AssertExpectations(t)
 	extractor.AssertExpectations(t)
 	materializer.AssertExpectations(t)
+	connections.AssertExpectations(t)
+}
+
+func TestQueryValidatorRule_ValidateAssetWithPipelineMacro(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
+
+	asset := &pipeline.Asset{
+		Name: "dataset.table",
+		Type: pipeline.AssetTypeBigqueryQuery,
+		ExecutableFile: pipeline.ExecutableFile{
+			Content: "{{ test_macro(1) }}",
+		},
+	}
+	p := &pipeline.Pipeline{
+		Name:   "test-pipeline",
+		Assets: []*pipeline.Asset{asset},
+		Macros: []pipeline.Macro{
+			`{% macro test_macro(value) %}SELECT {{ value }}{% endmacro %}`,
+		},
+		DefaultConnections: map[string]string{
+			"google_cloud_platform": "gcp-conn",
+		},
+	}
+
+	validator := new(mockValidator)
+	validator.On("IsValid", mock.Anything, mock.MatchedBy(func(q *query.Query) bool {
+		return strings.TrimSpace(q.Query) == "SELECT 1"
+	})).Return(true, nil)
+
+	connections := new(mockConnectionManager)
+	connections.On("GetConnection", "gcp-conn").Return(validator)
+
+	rule := &QueryValidatorRule{
+		TaskType:    pipeline.AssetTypeBigqueryQuery,
+		Connections: connections,
+		Extractor: &query.WholeFileExtractor{
+			Renderer: jinja.NewRendererWithYesterday("test-pipeline", "test-run-id"),
+		},
+		Logger: zap.NewNop().Sugar(),
+	}
+
+	issues, err := rule.ValidateAsset(ctx, p, asset)
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+	validator.AssertExpectations(t)
 	connections.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## What
Fix `bruin validate` failing when assets call pipeline macros.

## Changes
- Load parsed pipeline macros when cloning a renderer without explicit macro content.
- Add renderer and query-validator regression coverage.

## How to test
1. Run `make format`, `make test`, and `make build-no-duckdb`.

## Risk & rollback
- **Risk:** Low; explicitly configured renderer macros still take precedence.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`) — not affected
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #2588
