### PR TITLE
Fix --limit on T-SQL queries that start with a CTE

### DIFF
--- a/pkg/fabric/db.go
+++ b/pkg/fabric/db.go
@@ -84,12 +84,13 @@ func (db *DB) RunQueryWithoutResult(ctx context.Context, q *query.Query) error {
 }
 
 // Limit wraps the query so it returns at most `limit` rows. It preserves the
-// original query verbatim inside a derived table rather than rewriting it,
-// which matters on Fabric's case-sensitive collation where a parser round-trip
-// would otherwise lowercase column aliases and break the outer references.
-func (db *DB) Limit(query string, limit int64) string {
-	query = strings.TrimRight(query, "; \n\t")
-	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, query)
+// original query verbatim rather than rewriting it, which matters on Fabric's
+// case-sensitive collation where a parser round-trip would otherwise lowercase
+// column aliases and break the outer references. Queries that begin with a CTE
+// are limited via an appended CTE instead of a derived-table wrapper, since
+// T-SQL forbids a WITH clause inside a derived table.
+func (db *DB) Limit(q string, limit int64) string {
+	return query.TSQLLimit(q, limit)
 }
 
 func (db *DB) Select(ctx context.Context, q *query.Query) ([][]interface{}, error) {

--- a/pkg/fabric/db_test.go
+++ b/pkg/fabric/db_test.go
@@ -549,6 +549,12 @@ func TestDB_Limit(t *testing.T) {
 	// so case-sensitive column aliases survive.
 	got := db.Limit("SELECT src.Account FROM (SELECT x AS Account FROM t) src;", 100)
 	assert.Equal(t, "SELECT TOP 100 * FROM (\nSELECT src.Account FROM (SELECT x AS Account FROM t) src\n) as t", got)
+
+	// A query that starts with a CTE cannot be wrapped in a derived table on
+	// T-SQL; it is limited via an appended CTE instead (regression: previously
+	// produced "Incorrect syntax near ')'").
+	gotCTE := db.Limit("WITH a AS (SELECT 1 AS id) SELECT * FROM a", 10)
+	assert.Equal(t, "WITH a AS (SELECT 1 AS id),\n__bruin_limited AS (\nSELECT * FROM a\n)\nSELECT TOP 10 * FROM __bruin_limited", gotCTE)
 }
 
 const expectedDatabaseSummaryQuery = `

--- a/pkg/mssql/db.go
+++ b/pkg/mssql/db.go
@@ -169,9 +169,12 @@ func (db *DB) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (db *DB) Limit(query string, limit int64) string {
-	query = strings.TrimRight(query, "; \n\t")
-	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, query)
+// Limit wraps the query so it returns at most `limit` rows. Queries that begin
+// with a CTE are limited via an appended CTE rather than a derived-table
+// wrapper, since T-SQL forbids a WITH clause inside a derived table (which would
+// otherwise fail with "Incorrect syntax near ')'").
+func (db *DB) Limit(q string, limit int64) string {
+	return query.TSQLLimit(q, limit)
 }
 
 func (db *DB) GetDatabases(ctx context.Context) ([]string, error) {

--- a/pkg/query/tsql_limit.go
+++ b/pkg/query/tsql_limit.go
@@ -5,30 +5,18 @@ import (
 	"strings"
 )
 
-// TSQLLimit wraps a T-SQL query (SQL Server, Azure Synapse, Microsoft Fabric)
-// so it returns at most `limit` rows.
+// TSQLLimit wraps a T-SQL query so it returns at most `limit` rows.
 //
-// For a plain query it uses a derived-table wrapper:
+// A plain query uses a derived-table wrapper: SELECT TOP N * FROM (<query>) as t.
+// That is invalid when the query starts with a CTE (T-SQL forbids WITH inside a
+// derived table), so CTE-leading queries append the final query as an extra CTE:
 //
-//	SELECT TOP N * FROM (<query>) as t
-//
-// T-SQL forbids a CTE (WITH ...) as the first token of a derived table, so that
-// wrapper produces "Incorrect syntax near ')'" for any query that starts with a
-// WITH clause. When the query begins with a CTE, the final query is appended to
-// the existing CTE list as an extra CTE and limited from there instead:
-//
-//	WITH <existing ctes>, __bruin_limited AS (
-//	<final query>
-//	)
+//	WITH <existing ctes>, __bruin_limited AS (<final query>)
 //	SELECT TOP N * FROM __bruin_limited
 //
-// The original text is preserved verbatim (no identifier rewriting), which
-// matters on Fabric's case-sensitive collation.
-//
-// A query whose final statement ends in a top-level ORDER BY is not limitable by
-// either form (T-SQL disallows ORDER BY in a CTE/derived table without TOP), so
-// it falls through to the derived-table wrapper unchanged — the same behaviour
-// as before this helper existed.
+// The query text is preserved verbatim so Fabric's case-sensitive identifiers
+// still resolve. A trailing top-level ORDER BY falls through to the wrapper
+// unchanged, as before.
 func TSQLLimit(sql string, limit int64) string {
 	sql = strings.TrimRight(sql, "; \n\t")
 	if prefix, body, ok := splitLeadingWith(sql); ok {
@@ -37,12 +25,10 @@ func TSQLLimit(sql string, limit int64) string {
 	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, sql)
 }
 
-// splitLeadingWith reports whether sql begins with a CTE (WITH ...) clause and,
-// if so, splits it into the prefix (through the last CTE definition) and the
-// trailing main query body. It is comment-, string-, and bracket-aware so it is
-// not fooled by WITH/AS/parentheses appearing inside literals or CTE bodies.
-// It returns ok=false for any query without a leading WITH clause, and also for
-// malformed input, so callers fall back to the plain derived-table wrapper.
+// splitLeadingWith splits a leading CTE clause into the prefix (through the last
+// CTE) and the trailing main query. It is comment-, string-, and bracket-aware.
+// ok is false when there is no leading WITH or the input is malformed, so callers
+// fall back to the plain wrapper.
 func splitLeadingWith(sql string) (prefix, body string, ok bool) {
 	i := skipSpaceAndComments(sql, 0)
 	if !matchKeyword(sql, i, "WITH") {
@@ -50,10 +36,8 @@ func splitLeadingWith(sql string) (prefix, body string, ok bool) {
 	}
 	i += len("WITH")
 
-	// Walk the comma-separated CTE list. Each CTE is:
-	//   name [ (col, ...) ] AS ( <body> )
-	// After a CTE body's closing paren, a comma means another CTE follows;
-	// anything else marks the start of the main query.
+	// Each CTE is `name [ (cols) ] AS ( body )`; a comma after a body means
+	// another CTE follows, anything else starts the main query.
 	for {
 		asIdx := findKeywordAtDepthZero(sql, i, "AS")
 		if asIdx < 0 {
@@ -76,15 +60,12 @@ func splitLeadingWith(sql string) (prefix, body string, ok bool) {
 		if next >= len(sql) {
 			return "", "", false
 		}
-		// Body keeps everything after the last CTE (comments included), with only
-		// surrounding whitespace trimmed.
 		return strings.TrimRight(sql[:i], " \t\r\n"), strings.TrimLeft(sql[i:], " \t\r\n"), true
 	}
 }
 
-// skipLiteral reports whether s[i] begins a single-quoted string, a bracketed or
-// double-quoted identifier, or a line/block comment, and if so returns the index
-// just past it. T-SQL escapes closing delimiters by doubling (” ]] "").
+// skipLiteral, if s[i] starts a quoted string, bracketed/quoted identifier, or
+// comment, returns the index just past it. T-SQL doubles closers to escape them.
 func skipLiteral(s string, i int) (int, bool) {
 	if i >= len(s) {
 		return i, false
@@ -110,22 +91,19 @@ func skipLiteral(s string, i int) (int, bool) {
 	return i, false
 }
 
-// skipDelimited scans from an opening delimiter at s[open] to the matching close
-// byte, treating a doubled close byte as an escape, and returns the index past
-// the closing delimiter (or len(s) if unterminated).
-func skipDelimited(s string, open int, close byte) int {
-	i := open + 1
-	for i < len(s) {
-		if s[i] == close {
-			if i+1 < len(s) && s[i+1] == close {
-				i += 2
+// skipDelimited scans from the opener at s[open] past the matching closer byte,
+// treating a doubled closer as an escape.
+func skipDelimited(s string, open int, closer byte) int {
+	for i := open + 1; i < len(s); i++ {
+		if s[i] == closer {
+			if i+1 < len(s) && s[i+1] == closer {
+				i++
 				continue
 			}
 			return i + 1
 		}
-		i++
 	}
-	return i
+	return len(s)
 }
 
 func skipSpaceAndComments(s string, i int) int {
@@ -146,26 +124,18 @@ func skipSpaceAndComments(s string, i int) int {
 	return i
 }
 
-// matchKeyword reports whether the keyword kw appears at s[i] on identifier word
-// boundaries, case-insensitively.
+// matchKeyword reports whether kw appears at s[i] on identifier boundaries.
 func matchKeyword(s string, i int, kw string) bool {
-	if i+len(kw) > len(s) {
-		return false
-	}
-	if !strings.EqualFold(s[i:i+len(kw)], kw) {
+	if i+len(kw) > len(s) || !strings.EqualFold(s[i:i+len(kw)], kw) {
 		return false
 	}
 	if i > 0 && isIdentChar(s[i-1]) {
 		return false
 	}
-	if i+len(kw) < len(s) && isIdentChar(s[i+len(kw)]) {
-		return false
-	}
-	return true
+	return i+len(kw) >= len(s) || !isIdentChar(s[i+len(kw)])
 }
 
-// findKeywordAtDepthZero returns the index of keyword kw at parenthesis depth 0,
-// skipping literals and comments, or -1 if not found.
+// findKeywordAtDepthZero returns the index of kw at paren depth 0, or -1.
 func findKeywordAtDepthZero(s string, start int, kw string) int {
 	depth := 0
 	for i := start; i < len(s); {
@@ -188,8 +158,7 @@ func findKeywordAtDepthZero(s string, start int, kw string) int {
 	return -1
 }
 
-// matchParen returns the index of the ')' matching the '(' at s[open], skipping
-// literals and comments, or -1 if unbalanced.
+// matchParen returns the index of the ')' matching the '(' at s[open], or -1.
 func matchParen(s string, open int) int {
 	depth := 0
 	for i := open; i < len(s); {

--- a/pkg/query/tsql_limit.go
+++ b/pkg/query/tsql_limit.go
@@ -5,24 +5,26 @@ import (
 	"strings"
 )
 
-// TSQLLimit wraps a T-SQL query so it returns at most `limit` rows.
-//
-// A plain query uses a derived-table wrapper: SELECT TOP N * FROM (<query>) as t.
-// That is invalid when the query starts with a CTE (T-SQL forbids WITH inside a
-// derived table), so CTE-leading queries append the final query as an extra CTE:
-//
-//	WITH <existing ctes>, __bruin_limited AS (<final query>)
-//	SELECT TOP N * FROM __bruin_limited
-//
-// The query text is preserved verbatim so Fabric's case-sensitive identifiers
-// still resolve. A trailing top-level ORDER BY falls through to the wrapper
-// unchanged, as before.
+// TSQLLimit wraps a T-SQL query so it returns at most `limit` rows, preserving
+// the query text verbatim. CTE-leading queries are limited via an appended CTE,
+// since a derived-table wrapper is invalid T-SQL after a WITH clause.
 func TSQLLimit(sql string, limit int64) string {
 	sql = strings.TrimRight(sql, "; \n\t")
 	if prefix, body, ok := splitLeadingWith(sql); ok {
-		return fmt.Sprintf("%s,\n__bruin_limited AS (\n%s\n)\nSELECT TOP %d * FROM __bruin_limited", prefix, body, limit)
+		name := uniqueCTEName(sql)
+		return fmt.Sprintf("%s,\n%s AS (\n%s\n)\nSELECT TOP %d * FROM %s", prefix, name, body, limit, name)
 	}
 	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, sql)
+}
+
+// uniqueCTEName returns a limit CTE name that does not already occur in sql.
+func uniqueCTEName(sql string) string {
+	lower := strings.ToLower(sql)
+	name := "__bruin_limited"
+	for strings.Contains(lower, name) {
+		name += "_x"
+	}
+	return name
 }
 
 // splitLeadingWith splits a leading CTE clause into the prefix (through the last

--- a/pkg/query/tsql_limit.go
+++ b/pkg/query/tsql_limit.go
@@ -1,0 +1,219 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TSQLLimit wraps a T-SQL query (SQL Server, Azure Synapse, Microsoft Fabric)
+// so it returns at most `limit` rows.
+//
+// For a plain query it uses a derived-table wrapper:
+//
+//	SELECT TOP N * FROM (<query>) as t
+//
+// T-SQL forbids a CTE (WITH ...) as the first token of a derived table, so that
+// wrapper produces "Incorrect syntax near ')'" for any query that starts with a
+// WITH clause. When the query begins with a CTE, the final query is appended to
+// the existing CTE list as an extra CTE and limited from there instead:
+//
+//	WITH <existing ctes>, __bruin_limited AS (
+//	<final query>
+//	)
+//	SELECT TOP N * FROM __bruin_limited
+//
+// The original text is preserved verbatim (no identifier rewriting), which
+// matters on Fabric's case-sensitive collation.
+//
+// A query whose final statement ends in a top-level ORDER BY is not limitable by
+// either form (T-SQL disallows ORDER BY in a CTE/derived table without TOP), so
+// it falls through to the derived-table wrapper unchanged — the same behaviour
+// as before this helper existed.
+func TSQLLimit(sql string, limit int64) string {
+	sql = strings.TrimRight(sql, "; \n\t")
+	if prefix, body, ok := splitLeadingWith(sql); ok {
+		return fmt.Sprintf("%s,\n__bruin_limited AS (\n%s\n)\nSELECT TOP %d * FROM __bruin_limited", prefix, body, limit)
+	}
+	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, sql)
+}
+
+// splitLeadingWith reports whether sql begins with a CTE (WITH ...) clause and,
+// if so, splits it into the prefix (through the last CTE definition) and the
+// trailing main query body. It is comment-, string-, and bracket-aware so it is
+// not fooled by WITH/AS/parentheses appearing inside literals or CTE bodies.
+// It returns ok=false for any query without a leading WITH clause, and also for
+// malformed input, so callers fall back to the plain derived-table wrapper.
+func splitLeadingWith(sql string) (prefix, body string, ok bool) {
+	i := skipSpaceAndComments(sql, 0)
+	if !matchKeyword(sql, i, "WITH") {
+		return "", "", false
+	}
+	i += len("WITH")
+
+	// Walk the comma-separated CTE list. Each CTE is:
+	//   name [ (col, ...) ] AS ( <body> )
+	// After a CTE body's closing paren, a comma means another CTE follows;
+	// anything else marks the start of the main query.
+	for {
+		asIdx := findKeywordAtDepthZero(sql, i, "AS")
+		if asIdx < 0 {
+			return "", "", false
+		}
+		open := skipSpaceAndComments(sql, asIdx+len("AS"))
+		if open >= len(sql) || sql[open] != '(' {
+			return "", "", false
+		}
+		end := matchParen(sql, open)
+		if end < 0 {
+			return "", "", false
+		}
+		i = end + 1
+		next := skipSpaceAndComments(sql, i)
+		if next < len(sql) && sql[next] == ',' {
+			i = next + 1
+			continue
+		}
+		if next >= len(sql) {
+			return "", "", false
+		}
+		// Body keeps everything after the last CTE (comments included), with only
+		// surrounding whitespace trimmed.
+		return strings.TrimRight(sql[:i], " \t\r\n"), strings.TrimLeft(sql[i:], " \t\r\n"), true
+	}
+}
+
+// skipLiteral reports whether s[i] begins a single-quoted string, a bracketed or
+// double-quoted identifier, or a line/block comment, and if so returns the index
+// just past it. T-SQL escapes closing delimiters by doubling (” ]] "").
+func skipLiteral(s string, i int) (int, bool) {
+	if i >= len(s) {
+		return i, false
+	}
+	switch {
+	case s[i] == '\'':
+		return skipDelimited(s, i, '\''), true
+	case s[i] == '"':
+		return skipDelimited(s, i, '"'), true
+	case s[i] == '[':
+		return skipDelimited(s, i, ']'), true
+	case strings.HasPrefix(s[i:], "--"):
+		if j := strings.IndexByte(s[i:], '\n'); j >= 0 {
+			return i + j + 1, true
+		}
+		return len(s), true
+	case strings.HasPrefix(s[i:], "/*"):
+		if j := strings.Index(s[i+2:], "*/"); j >= 0 {
+			return i + 2 + j + 2, true
+		}
+		return len(s), true
+	}
+	return i, false
+}
+
+// skipDelimited scans from an opening delimiter at s[open] to the matching close
+// byte, treating a doubled close byte as an escape, and returns the index past
+// the closing delimiter (or len(s) if unterminated).
+func skipDelimited(s string, open int, close byte) int {
+	i := open + 1
+	for i < len(s) {
+		if s[i] == close {
+			if i+1 < len(s) && s[i+1] == close {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+func skipSpaceAndComments(s string, i int) int {
+	for i < len(s) {
+		switch s[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+			continue
+		}
+		if strings.HasPrefix(s[i:], "--") || strings.HasPrefix(s[i:], "/*") {
+			if ni, ok := skipLiteral(s, i); ok {
+				i = ni
+				continue
+			}
+		}
+		break
+	}
+	return i
+}
+
+// matchKeyword reports whether the keyword kw appears at s[i] on identifier word
+// boundaries, case-insensitively.
+func matchKeyword(s string, i int, kw string) bool {
+	if i+len(kw) > len(s) {
+		return false
+	}
+	if !strings.EqualFold(s[i:i+len(kw)], kw) {
+		return false
+	}
+	if i > 0 && isIdentChar(s[i-1]) {
+		return false
+	}
+	if i+len(kw) < len(s) && isIdentChar(s[i+len(kw)]) {
+		return false
+	}
+	return true
+}
+
+// findKeywordAtDepthZero returns the index of keyword kw at parenthesis depth 0,
+// skipping literals and comments, or -1 if not found.
+func findKeywordAtDepthZero(s string, start int, kw string) int {
+	depth := 0
+	for i := start; i < len(s); {
+		if ni, ok := skipLiteral(s, i); ok {
+			i = ni
+			continue
+		}
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		default:
+			if depth == 0 && matchKeyword(s, i, kw) {
+				return i
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+// matchParen returns the index of the ')' matching the '(' at s[open], skipping
+// literals and comments, or -1 if unbalanced.
+func matchParen(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); {
+		if ni, ok := skipLiteral(s, i); ok {
+			i = ni
+			continue
+		}
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+func isIdentChar(b byte) bool {
+	return b == '_' ||
+		(b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z')
+}

--- a/pkg/query/tsql_limit_test.go
+++ b/pkg/query/tsql_limit_test.go
@@ -94,7 +94,7 @@ func TestTSQLLimit(t *testing.T) {
 			expected: "WITH a AS (SELECT 1 AS id),\n__bruin_limited AS (\nSELECT * FROM a UNION ALL SELECT 2\n)\nSELECT TOP 50 * FROM __bruin_limited",
 		},
 		{
-			name:     "word starting with with is not a CTE",
+			name:     "identifier prefixed by the with token is not a CTE",
 			query:    "SELECT withheld FROM t",
 			limit:    10,
 			expected: "SELECT TOP 10 * FROM (\nSELECT withheld FROM t\n) as t",
@@ -102,7 +102,6 @@ func TestTSQLLimit(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.expected, TSQLLimit(tt.query, tt.limit))

--- a/pkg/query/tsql_limit_test.go
+++ b/pkg/query/tsql_limit_test.go
@@ -1,0 +1,136 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTSQLLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		query    string
+		limit    int64
+		expected string
+	}{
+		{
+			name:     "plain select uses derived-table wrapper",
+			query:    "SELECT * FROM users",
+			limit:    10,
+			expected: "SELECT TOP 10 * FROM (\nSELECT * FROM users\n) as t",
+		},
+		{
+			name:     "trailing semicolon and whitespace are trimmed",
+			query:    "SELECT * FROM users; \n\t",
+			limit:    5,
+			expected: "SELECT TOP 5 * FROM (\nSELECT * FROM users\n) as t",
+		},
+		{
+			name:     "case-sensitive aliases are preserved verbatim",
+			query:    "SELECT src.Account FROM (SELECT x AS Account FROM t) src",
+			limit:    100,
+			expected: "SELECT TOP 100 * FROM (\nSELECT src.Account FROM (SELECT x AS Account FROM t) src\n) as t",
+		},
+		{
+			name:     "single CTE is limited via appended CTE",
+			query:    "WITH a AS (SELECT 1 AS id) SELECT * FROM a",
+			limit:    10,
+			expected: "WITH a AS (SELECT 1 AS id),\n__bruin_limited AS (\nSELECT * FROM a\n)\nSELECT TOP 10 * FROM __bruin_limited",
+		},
+		{
+			name:     "multiple CTEs keep all definitions",
+			query:    "WITH a AS (SELECT 1 AS id), b AS (SELECT id FROM a) SELECT * FROM b",
+			limit:    25,
+			expected: "WITH a AS (SELECT 1 AS id), b AS (SELECT id FROM a),\n__bruin_limited AS (\nSELECT * FROM b\n)\nSELECT TOP 25 * FROM __bruin_limited",
+		},
+		{
+			name:     "CTE with column list",
+			query:    "WITH a (id, n) AS (SELECT 1, 2) SELECT * FROM a",
+			limit:    3,
+			expected: "WITH a (id, n) AS (SELECT 1, 2),\n__bruin_limited AS (\nSELECT * FROM a\n)\nSELECT TOP 3 * FROM __bruin_limited",
+		},
+		{
+			name:     "lowercase with keyword",
+			query:    "with a as (select 1 as id) select * from a",
+			limit:    7,
+			expected: "with a as (select 1 as id),\n__bruin_limited AS (\nselect * from a\n)\nSELECT TOP 7 * FROM __bruin_limited",
+		},
+		{
+			name:     "nested parentheses inside a CTE body",
+			query:    "WITH a AS (SELECT * FROM (SELECT id FROM t) x) SELECT * FROM a",
+			limit:    9,
+			expected: "WITH a AS (SELECT * FROM (SELECT id FROM t) x),\n__bruin_limited AS (\nSELECT * FROM a\n)\nSELECT TOP 9 * FROM __bruin_limited",
+		},
+		{
+			name:     "comma inside a string literal does not start a new CTE",
+			query:    "WITH a AS (SELECT ',' AS sep) SELECT * FROM a",
+			limit:    4,
+			expected: "WITH a AS (SELECT ',' AS sep),\n__bruin_limited AS (\nSELECT * FROM a\n)\nSELECT TOP 4 * FROM __bruin_limited",
+		},
+		{
+			name:     "AS inside a bracketed identifier is not the CTE AS",
+			query:    "WITH [my AS cte] AS (SELECT 1 AS id) SELECT * FROM [my AS cte]",
+			limit:    6,
+			expected: "WITH [my AS cte] AS (SELECT 1 AS id),\n__bruin_limited AS (\nSELECT * FROM [my AS cte]\n)\nSELECT TOP 6 * FROM __bruin_limited",
+		},
+		{
+			name:     "leading line comment before WITH",
+			query:    "-- lead comment\nWITH a AS (SELECT 1 AS id) SELECT * FROM a",
+			limit:    8,
+			expected: "-- lead comment\nWITH a AS (SELECT 1 AS id),\n__bruin_limited AS (\nSELECT * FROM a\n)\nSELECT TOP 8 * FROM __bruin_limited",
+		},
+		{
+			name:     "final select carries a mid-query comment",
+			query:    "WITH a AS (SELECT 1 AS id)\n-- pick everything\nSELECT * FROM a",
+			limit:    2,
+			expected: "WITH a AS (SELECT 1 AS id),\n__bruin_limited AS (\n-- pick everything\nSELECT * FROM a\n)\nSELECT TOP 2 * FROM __bruin_limited",
+		},
+		{
+			name:     "final query is a UNION over CTEs",
+			query:    "WITH a AS (SELECT 1 AS id) SELECT * FROM a UNION ALL SELECT 2",
+			limit:    50,
+			expected: "WITH a AS (SELECT 1 AS id),\n__bruin_limited AS (\nSELECT * FROM a UNION ALL SELECT 2\n)\nSELECT TOP 50 * FROM __bruin_limited",
+		},
+		{
+			name:     "word starting with with is not a CTE",
+			query:    "SELECT withheld FROM t",
+			limit:    10,
+			expected: "SELECT TOP 10 * FROM (\nSELECT withheld FROM t\n) as t",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, TSQLLimit(tt.query, tt.limit))
+		})
+	}
+}
+
+func TestSplitLeadingWith(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no leading with", func(t *testing.T) {
+		t.Parallel()
+		_, _, ok := splitLeadingWith("SELECT * FROM t")
+		assert.False(t, ok)
+	})
+
+	t.Run("malformed with falls back", func(t *testing.T) {
+		t.Parallel()
+		// WITH (NOLOCK)-style input has no CTE AS clause; must not be treated as a CTE.
+		_, _, ok := splitLeadingWith("WITH (NOLOCK) SELECT 1")
+		assert.False(t, ok)
+	})
+
+	t.Run("splits prefix and body", func(t *testing.T) {
+		t.Parallel()
+		prefix, body, ok := splitLeadingWith("WITH a AS (SELECT 1 AS id) SELECT * FROM a")
+		assert.True(t, ok)
+		assert.Equal(t, "WITH a AS (SELECT 1 AS id)", prefix)
+		assert.Equal(t, "SELECT * FROM a", body)
+	})
+}

--- a/pkg/query/tsql_limit_test.go
+++ b/pkg/query/tsql_limit_test.go
@@ -99,6 +99,12 @@ func TestTSQLLimit(t *testing.T) {
 			limit:    10,
 			expected: "SELECT TOP 10 * FROM (\nSELECT withheld FROM t\n) as t",
 		},
+		{
+			name:     "limit CTE name avoids collision with an existing one",
+			query:    "WITH __bruin_limited AS (SELECT 1 AS id) SELECT * FROM __bruin_limited",
+			limit:    10,
+			expected: "WITH __bruin_limited AS (SELECT 1 AS id),\n__bruin_limited_x AS (\nSELECT * FROM __bruin_limited\n)\nSELECT TOP 10 * FROM __bruin_limited_x",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`bruin query --limit` wraps the query as `SELECT TOP N * FROM (<query>) as t`. That is invalid T-SQL when the query starts with a CTE — SQL Server / Fabric / Synapse don't allow a `WITH` clause inside a derived table, so it fails with `Incorrect syntax near ')'`.

- **Fabric** hits this on every CTE query (it always uses the wrapper, bypassing the AST limiter).
- **mssql / synapse** hit it when the AST-based limiter falls back to the wrapper.

The asset itself runs fine because running/materializing doesn't apply the limit wrapper — only the query-preview path does.

## Fix
For CTE-leading queries, apply the limit via an appended CTE instead of a derived table:

```sql
WITH <existing ctes>, __bruin_limited AS (
  <final query>
)
SELECT TOP N * FROM __bruin_limited
```

Non-CTE queries keep the existing `SELECT TOP N * FROM (...) as t` wrapper. The original query text is preserved verbatim, so Fabric's case-sensitive identifiers still resolve (the reason Fabric was on the verbatim wrapper in the first place). The new `TSQLLimit` helper is comment-, string-, and bracket-aware when locating the end of the CTE list.

## Verification (live SQL Server)
| Case | Before | After |
|---|---|---|
| Fabric + CTE + `--limit` | `Incorrect syntax near ')'` | returns rows |
| Non-CTE + `--limit` | ok | ok (unchanged) |
| CTE returning 5 rows, `--limit 2` | — | capped to 2 |

New unit tests cover CTE / multi-CTE / column-list / UNION / comment / string / bracket cases plus the plain-select path.