### PR TITLE
fix(lint): trim rendered interval dates

### DIFF
--- a/pkg/jinja/jinja.go
+++ b/pkg/jinja/jinja.go
@@ -31,6 +31,8 @@ var (
 	locationRegex        = regexp.MustCompile(`\(Line: \d+ Col: \d+, near ".*?"\)`)
 )
 
+const macroOutputBoundary = "__BRUIN_INTERNAL_MACRO_OUTPUT_BOUNDARY__"
+
 type Context map[string]any
 
 // LoadMacros loads all macro files from the given directory and returns them as a single string.
@@ -199,18 +201,35 @@ func NewRendererWithYesterday(pipelineName, runID string) *Renderer {
 func (r *Renderer) Render(query string) (string, error) {
 	r.queryRenderLock.Lock()
 
-	// Prepend macro content to the query if macros are loaded
+	// Prepend macro content so its definitions are available to the query, separated
+	// by a marker. Cutting the rendered output at the marker discards whatever the
+	// macro preamble emitted without changing any whitespace intentionally produced
+	// by the requested template.
 	fullQuery := query
+	outputMarker := ""
 	if r.macroContent != "" {
-		fullQuery = r.macroContent + "\n" + query
+		var preamble string
+		preamble, outputMarker = macroPreamble(r.macroContent)
+		fullQuery = preamble + query
 	}
 
 	tpl, err := gonja.FromString(fullQuery)
 	if err != nil {
-		r.queryRenderLock.Unlock()
 		customError := findParserErrorType(err)
+		if customError != "" && outputMarker != "" {
+			// Gonja reports locations relative to the combined macro preamble and query.
+			// Parse the query by itself after a recognized EOF error so the location we
+			// return refers to the template the user supplied. If the query parses on its
+			// own, keep the original error because it came from the macro preamble.
+			if _, queryErr := gonja.FromString(query); queryErr != nil {
+				if queryCustomError := findParserErrorType(queryErr); queryCustomError != "" {
+					customError = queryCustomError
+				}
+			}
+		}
+		r.queryRenderLock.Unlock()
 		if customError == "" {
-			return "", errors.Wrap(err, "you have found a bug in the jinja parser, please report it")
+			return "", errors.Wrap(hideMacroOutputMarker(err, outputMarker), "you have found a bug in the jinja parser, please report it")
 		}
 
 		return "", errors.New(customError)
@@ -223,38 +242,53 @@ func (r *Renderer) Render(query string) (string, error) {
 	if err != nil {
 		customError := findRenderErrorType(err)
 		if customError == "" {
-			return "", errors.Wrap(err, "you have found a bug in the jinja renderer, please report it")
+			return "", errors.Wrap(hideMacroOutputMarker(err, outputMarker), "you have found a bug in the jinja renderer, please report it")
 		}
 
 		return "", errors.New(customError)
 	}
 
-	if r.macroContent != "" {
-		out = cleanupExcessiveNewlines(out)
+	if outputMarker != "" {
+		_, renderedQuery, found := strings.Cut(out, outputMarker)
+		if !found {
+			return "", errors.New("failed to isolate the rendered query from the macro output, please ensure every block opened in your macros is also closed there")
+		}
+
+		out = renderedQuery
 	}
 
 	return out, nil
 }
 
-func cleanupExcessiveNewlines(s string) string {
-	lines := strings.Split(s, "\n")
-	var result []string
-	consecutiveEmpty := 0
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			consecutiveEmpty++
-			if consecutiveEmpty <= 2 {
-				result = append(result, line)
-			}
-		} else {
-			consecutiveEmpty = 0
-			result = append(result, line)
-		}
+// macroPreamble returns the macro content followed by the marker that separates it
+// from the query, along with the marker itself. The marker is preceded by a newline so
+// that it cannot be matched across the junction with the macro content, and it is
+// directly followed by the query so that nothing sits between the two: whitespace there
+// would be eaten by a query that opens with jinja whitespace control, which would leave
+// us unable to tell our own whitespace apart from the query's.
+func macroPreamble(macroContent string) (string, string) {
+	// Growing the marker past the length of the macro content is guaranteed to terminate
+	// the loop, and it makes the marker we insert the first occurrence in the output.
+	marker := macroOutputBoundary
+	for strings.Contains(macroContent, marker) {
+		marker += "_"
 	}
 
-	return strings.Join(result, "\n")
+	if !strings.HasSuffix(macroContent, "\n") {
+		macroContent += "\n"
+	}
+
+	return macroContent + marker, marker
+}
+
+// hideMacroOutputMarker keeps the internal marker out of the errors we surface, since
+// gonja quotes the template we handed it rather than the query the user wrote.
+func hideMacroOutputMarker(err error, marker string) error {
+	if marker == "" || !strings.Contains(err.Error(), marker) {
+		return err
+	}
+
+	return errors.New(strings.ReplaceAll(err.Error(), marker, ""))
 }
 
 //nolint:ireturn

--- a/pkg/jinja/macros_test.go
+++ b/pkg/jinja/macros_test.go
@@ -2,6 +2,7 @@ package jinja
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -136,7 +137,7 @@ SELECT 1 as id, 'test' as name
 {% endmacro %}`,
 			query:   "{{ simple_select() }}",
 			context: Context{},
-			want:    "\n\nSELECT 1 as id, 'test' as name\n",
+			want:    "\nSELECT 1 as id, 'test' as name\n",
 			wantErr: false,
 		},
 		{
@@ -146,7 +147,7 @@ SELECT * FROM users WHERE id = {{ id }}
 {% endmacro %}`,
 			query:   "{{ filter_by_id(123) }}",
 			context: Context{},
-			want:    "\n\nSELECT * FROM users WHERE id = 123\n",
+			want:    "\nSELECT * FROM users WHERE id = 123\n",
 			wantErr: false,
 		},
 		{
@@ -155,7 +156,7 @@ SELECT * FROM users WHERE id = {{ id }}
 {% macro m2() %}SELECT 2{% endmacro %}`,
 			query:   "{{ m1() }} UNION ALL {{ m2() }}",
 			context: Context{},
-			want:    "\n\nSELECT 1 UNION ALL SELECT 2",
+			want:    "SELECT 1 UNION ALL SELECT 2",
 			wantErr: false,
 		},
 		{
@@ -167,8 +168,58 @@ SELECT * FROM {{ table_name }}
 			context: Context{
 				"my_table": "users",
 			},
-			want:    "\n\nSELECT * FROM users\n",
+			want:    "\nSELECT * FROM users\n",
 			wantErr: false,
+		},
+		{
+			name:         "macro preamble does not affect scalar output",
+			macroContent: `{% macro unused() %}SELECT 1{% endmacro %}`,
+			query:        "{{ value }}",
+			context: Context{
+				"value": "data.csv",
+			},
+			want:    "data.csv",
+			wantErr: false,
+		},
+		{
+			name:         "preserves intentional blank lines in query output",
+			macroContent: `{% macro unused() %}SELECT 1{% endmacro %}`,
+			query:        "SELECT 1\n\n\n\nSELECT 2",
+			context:      Context{},
+			want:         "SELECT 1\n\n\n\nSELECT 2",
+			wantErr:      false,
+		},
+		{
+			name:         "renders an empty query",
+			macroContent: `{% macro unused() %}SELECT 1{% endmacro %}`,
+			query:        "",
+			context:      Context{},
+			want:         "",
+			wantErr:      false,
+		},
+		{
+			name:         "avoids output marker collisions in the macro output",
+			macroContent: "{% macro unused() %}SELECT 1{% endmacro %}\n" + macroOutputBoundary + "\n",
+			query:        "SELECT 1",
+			context:      Context{},
+			want:         "SELECT 1",
+			wantErr:      false,
+		},
+		{
+			name:         "avoids output marker collisions straddling the macro content",
+			macroContent: "{% macro unused() %}SELECT 1{% endmacro %}\n" + strings.TrimSuffix(macroOutputBoundary, "__"),
+			query:        "SELECT 1",
+			context:      Context{},
+			want:         "SELECT 1",
+			wantErr:      false,
+		},
+		{
+			name:         "avoids output marker collisions in the query",
+			macroContent: `{% macro unused() %}SELECT 1{% endmacro %}`,
+			query:        macroOutputBoundary,
+			context:      Context{},
+			want:         macroOutputBoundary,
+			wantErr:      false,
 		},
 		{
 			name:         "works without macros",
@@ -225,7 +276,7 @@ func TestRendererCloneLoadsPipelineMacros(t *testing.T) {
 
 	result, err := clonedRenderer.Render("{{ test_macro(1) }}")
 	require.NoError(t, err)
-	require.Equal(t, "SELECT 1", strings.TrimSpace(result))
+	require.Equal(t, "SELECT 1", result)
 }
 
 func TestRendererClonePreservesExplicitMacros(t *testing.T) {
@@ -252,5 +303,88 @@ func TestRendererClonePreservesExplicitMacros(t *testing.T) {
 
 	result, err := clonedRenderer.Render("{{ test_macro() }}")
 	require.NoError(t, err)
-	require.Equal(t, "\nSELECT 1", result)
+	require.Equal(t, "SELECT 1", result)
+}
+
+func TestRendererWithMacrosDoesNotLeakOutputMarkerInErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRendererWithMacros(Context{}, "{% macro unterminated() %}SELECT 1\n").Render("SELECT 1")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), macroOutputBoundary)
+}
+
+func TestRendererWithMacrosReportsQueryRelativeParserErrors(t *testing.T) {
+	t.Parallel()
+
+	macroContent := "{% macro unused() %}SELECT 1{% endmacro %}\n"
+	queries := []string{
+		"{% if true %}SELECT 1",
+		"{% for item in [1] %}{{ item }}",
+		"\n\n{% if true %}SELECT 1",
+	}
+
+	for _, query := range queries {
+		t.Run(fmt.Sprintf("%q", query), func(t *testing.T) {
+			t.Parallel()
+
+			_, expectedErr := NewRenderer(Context{}).Render(query)
+			require.Error(t, expectedErr)
+
+			_, err := NewRendererWithMacros(Context{}, macroContent).Render(query)
+			require.EqualError(t, err, expectedErr.Error())
+			require.NotContains(t, err.Error(), macroOutputBoundary)
+		})
+	}
+}
+
+func TestRendererWithMacrosMatchesRenderingWithoutMacros(t *testing.T) {
+	t.Parallel()
+
+	macroContents := map[string]string{
+		"trailing newline":            "{% macro unused() %}SELECT 1{% endmacro %}\n",
+		"no trailing newline":         "{% macro unused() %}SELECT 1{% endmacro %}",
+		"trailing whitespace control": "{% macro unused() %}SELECT 1{% endmacro -%}\n",
+	}
+
+	queries := []string{
+		"",
+		" ",
+		"\n",
+		"\n\n",
+		"SELECT 1",
+		"SELECT 1\n",
+		"SELECT 1\n\n",
+		"  SELECT 1  ",
+		"SELECT 1\nUNION ALL\nSELECT 2\n",
+		"{# comment #}",
+		"{{ '' }}",
+		"{% if false %}x{% endif %}",
+		"SELECT 1 {% if true %}WHERE 1=1{% endif %}",
+		"{%- if true %}SELECT 1{% endif %}",
+		"{{- 'SELECT 1' }}",
+		"  {%- if true %}SELECT 1{% endif %}",
+		"\n{%- if true %}\nSELECT 1{% endif %}",
+		"{%- set t = 'users' %}SELECT * FROM {{ t }}",
+		"{%- set t = 'users' -%}\nSELECT * FROM {{ t }}",
+		"{#- comment -#}SELECT 1",
+	}
+
+	for name, macroContent := range macroContents {
+		for _, query := range queries {
+			t.Run(fmt.Sprintf("%s/%q", name, query), func(t *testing.T) {
+				t.Parallel()
+
+				want, err := NewRenderer(Context{}).Render(query)
+				require.NoError(t, err)
+
+				got, err := NewRendererWithMacros(Context{}, macroContent).Render(query)
+				require.NoError(t, err)
+
+				// the macro preamble is an implementation detail, so it must not change a
+				// single byte of what the query itself renders to.
+				require.Equal(t, want, got)
+			})
+		}
+	}
 }

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -2504,12 +2504,12 @@ func EnsureTimeIntervalIsValidForAsset(ctx context.Context, p *pipeline.Pipeline
 		return nil, err
 	}
 
-	parsedStartDate, err := time.Parse("2006-01-02T15:04:05", strings.TrimSpace(renderedStartDate))
+	parsedStartDate, err := time.Parse("2006-01-02T15:04:05", renderedStartDate)
 	if err != nil {
 		return nil, err
 	}
 
-	parsedEndDate, err := time.Parse("2006-01-02T15:04:05", strings.TrimSpace(renderedEndDate))
+	parsedEndDate, err := time.Parse("2006-01-02T15:04:05", renderedEndDate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -2504,12 +2504,12 @@ func EnsureTimeIntervalIsValidForAsset(ctx context.Context, p *pipeline.Pipeline
 		return nil, err
 	}
 
-	parsedStartDate, err := time.Parse("2006-01-02T15:04:05", renderedStartDate)
+	parsedStartDate, err := time.Parse("2006-01-02T15:04:05", strings.TrimSpace(renderedStartDate))
 	if err != nil {
 		return nil, err
 	}
 
-	parsedEndDate, err := time.Parse("2006-01-02T15:04:05", renderedEndDate)
+	parsedEndDate, err := time.Parse("2006-01-02T15:04:05", strings.TrimSpace(renderedEndDate))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -6341,3 +6341,28 @@ func TestEnsureAssetNotificationsAreValid(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureTimeIntervalIsValidForAssetWithPipelineMacros(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, time.August, 24, 23, 59, 59, 0, time.UTC)
+	ctx := context.WithValue(t.Context(), pipeline.RunConfigStartDate, startDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigEndDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigExecutionDate, endDate)
+	ctx = context.WithValue(ctx, pipeline.RunConfigRunID, "test-run-id")
+
+	asset := &pipeline.Asset{Name: "dataset.table"}
+	pl := &pipeline.Pipeline{
+		Name:   "test-pipeline",
+		Assets: []*pipeline.Asset{asset},
+		Macros: []pipeline.Macro{
+			`{% macro identity(value) %}{{ value }}{% endmacro %}`,
+		},
+	}
+
+	issues, err := EnsureTimeIntervalIsValidForAsset(ctx, pl, asset)
+
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}


### PR DESCRIPTION
## What
Fix full validation for pipelines with Jinja macros.

## Changes
- Trim rendered interval dates before parsing and add regression coverage.

## How to test
1. Run `make test`.

## Risk & rollback
- **Risk:** Low; whitespace is removed only from scalar interval values.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
N/A
