### PR TITLE
fix(templates): correct broken doc links in posthog-bigquery README

### DIFF
--- a/docs/getting-started/templates-docs/posthog-bigquery-README.md
+++ b/docs/getting-started/templates-docs/posthog-bigquery-README.md
@@ -97,7 +97,7 @@ shared `posthog-default` connection with BigQuery as the destination:
 The PostHog source handles incrementality itself, so the assets do not declare
 a `materialization` block. Each table uses the primary key, incremental key,
 and strategy that the source defines — see
-[Available Source Tables](https://getbruin.com/docs/ingestion/posthog.html#available-source-tables)
+[Available Source Tables](https://getbruin.com/docs/bruin/ingestion/posthog.html#available-source-tables)
 for the full list, including `cohorts`, `annotations`, `event_definitions`, and
 the `property_definitions:*` tables you can add the same way.
 
@@ -253,7 +253,7 @@ carried onto historical months.
 
 ### Dashboard
 
-`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dashboards)
+`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dac/)
 dashboard over the reports layer: headline account KPIs, engagement trend by plan,
 a PQL leaderboard with conditional formatting, an expansion/churn-risk table,
 feature adoption, and retention.
@@ -475,6 +475,6 @@ bruin run --exclude-tag posthog_raw my-posthog-pipeline
 
 ## Documentation
 
-- [PostHog ingestion](https://getbruin.com/docs/ingestion/posthog.html)
-- [Ingestr assets](https://getbruin.com/docs/assets/ingestr.html)
-- [BigQuery platform](https://getbruin.com/docs/platforms/bigquery.html)
+- [PostHog ingestion](https://getbruin.com/docs/bruin/ingestion/posthog.html)
+- [Ingestr assets](https://getbruin.com/docs/bruin/assets/ingestr.html)
+- [BigQuery platform](https://getbruin.com/docs/bruin/platforms/bigquery.html)

--- a/templates/posthog-bigquery/README.md
+++ b/templates/posthog-bigquery/README.md
@@ -96,7 +96,7 @@ shared `posthog-default` connection with BigQuery as the destination:
 The PostHog source handles incrementality itself, so the assets do not declare
 a `materialization` block. Each table uses the primary key, incremental key,
 and strategy that the source defines — see
-[Available Source Tables](https://getbruin.com/docs/ingestion/posthog.html#available-source-tables)
+[Available Source Tables](https://getbruin.com/docs/bruin/ingestion/posthog.html#available-source-tables)
 for the full list, including `cohorts`, `annotations`, `event_definitions`, and
 the `property_definitions:*` tables you can add the same way.
 
@@ -252,7 +252,7 @@ carried onto historical months.
 
 ### Dashboard
 
-`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dashboards)
+`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dac/)
 dashboard over the reports layer: headline account KPIs, engagement trend by plan,
 a PQL leaderboard with conditional formatting, an expansion/churn-risk table,
 feature adoption, and retention.
@@ -474,6 +474,6 @@ bruin run --exclude-tag posthog_raw my-posthog-pipeline
 
 ## Documentation
 
-- [PostHog ingestion](https://getbruin.com/docs/ingestion/posthog.html)
-- [Ingestr assets](https://getbruin.com/docs/assets/ingestr.html)
-- [BigQuery platform](https://getbruin.com/docs/platforms/bigquery.html)
+- [PostHog ingestion](https://getbruin.com/docs/bruin/ingestion/posthog.html)
+- [Ingestr assets](https://getbruin.com/docs/bruin/assets/ingestr.html)
+- [BigQuery platform](https://getbruin.com/docs/bruin/platforms/bigquery.html)


### PR DESCRIPTION
## What

Fixes broken documentation links in `templates/posthog-bigquery/README.md`. Every link in the file was tested; five were broken.

The Bruin CLI docs are served under `getbruin.com/docs/bruin/`, but several README links omitted the `/bruin/` path segment and returned 404. The bare `/docs/dashboards` link was also a 404.

## Fixes

| Before (404) | After (200) |
| --- | --- |
| `.../docs/ingestion/posthog.html#available-source-tables` | `.../docs/bruin/ingestion/posthog.html#available-source-tables` |
| `.../docs/ingestion/posthog.html` | `.../docs/bruin/ingestion/posthog.html` |
| `.../docs/assets/ingestr.html` | `.../docs/bruin/assets/ingestr.html` |
| `.../docs/platforms/bigquery.html` | `.../docs/bruin/platforms/bigquery.html` |
| `.../docs/dashboards` | `.../docs/dac/` (DAC overview) |

Verified already-correct and left unchanged: the DAC installation link, `posthog.com/docs/api#authentication`, GitHub issue #2588, and all in-page anchor links.

## Notes

`posthog-bigquery` is in the `SYNCED` list in `scripts/sync_template_docs.py`, so the generated docs page `docs/getting-started/templates-docs/posthog-bigquery-README.md` was regenerated with `make sync-template-docs` and is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)