### PR TITLE
docs(templates): fix 404ing doc links in posthog-bigquery README

### DIFF
--- a/docs/getting-started/templates-docs/posthog-bigquery-README.md
+++ b/docs/getting-started/templates-docs/posthog-bigquery-README.md
@@ -97,7 +97,7 @@ shared `posthog-default` connection with BigQuery as the destination:
 The PostHog source handles incrementality itself, so the assets do not declare
 a `materialization` block. Each table uses the primary key, incremental key,
 and strategy that the source defines — see
-[Available Source Tables](https://getbruin.com/docs/ingestion/posthog.html#available-source-tables)
+[Available Source Tables](https://getbruin.com/docs/bruin/ingestion/posthog.html#available-source-tables)
 for the full list, including `cohorts`, `annotations`, `event_definitions`, and
 the `property_definitions:*` tables you can add the same way.
 
@@ -253,7 +253,7 @@ carried onto historical months.
 
 ### Dashboard
 
-`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dashboards)
+`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dac/)
 dashboard over the reports layer: headline account KPIs, engagement trend by plan,
 a PQL leaderboard with conditional formatting, an expansion/churn-risk table,
 feature adoption, and retention.
@@ -475,6 +475,6 @@ bruin run --exclude-tag posthog_raw my-posthog-pipeline
 
 ## Documentation
 
-- [PostHog ingestion](https://getbruin.com/docs/ingestion/posthog.html)
-- [Ingestr assets](https://getbruin.com/docs/assets/ingestr.html)
-- [BigQuery platform](https://getbruin.com/docs/platforms/bigquery.html)
+- [PostHog ingestion](https://getbruin.com/docs/bruin/ingestion/posthog.html)
+- [Ingestr assets](https://getbruin.com/docs/bruin/assets/ingestr.html)
+- [BigQuery platform](https://getbruin.com/docs/bruin/platforms/bigquery.html)

--- a/templates/posthog-bigquery/README.md
+++ b/templates/posthog-bigquery/README.md
@@ -96,7 +96,7 @@ shared `posthog-default` connection with BigQuery as the destination:
 The PostHog source handles incrementality itself, so the assets do not declare
 a `materialization` block. Each table uses the primary key, incremental key,
 and strategy that the source defines — see
-[Available Source Tables](https://getbruin.com/docs/ingestion/posthog.html#available-source-tables)
+[Available Source Tables](https://getbruin.com/docs/bruin/ingestion/posthog.html#available-source-tables)
 for the full list, including `cohorts`, `annotations`, `event_definitions`, and
 the `property_definitions:*` tables you can add the same way.
 
@@ -252,7 +252,7 @@ carried onto historical months.
 
 ### Dashboard
 
-`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dashboards)
+`dashboards/posthog-product-analytics.yml` is a [DAC](https://getbruin.com/docs/dac/)
 dashboard over the reports layer: headline account KPIs, engagement trend by plan,
 a PQL leaderboard with conditional formatting, an expansion/churn-risk table,
 feature adoption, and retention.
@@ -474,6 +474,6 @@ bruin run --exclude-tag posthog_raw my-posthog-pipeline
 
 ## Documentation
 
-- [PostHog ingestion](https://getbruin.com/docs/ingestion/posthog.html)
-- [Ingestr assets](https://getbruin.com/docs/assets/ingestr.html)
-- [BigQuery platform](https://getbruin.com/docs/platforms/bigquery.html)
+- [PostHog ingestion](https://getbruin.com/docs/bruin/ingestion/posthog.html)
+- [Ingestr assets](https://getbruin.com/docs/bruin/assets/ingestr.html)
+- [BigQuery platform](https://getbruin.com/docs/bruin/platforms/bigquery.html)


### PR DESCRIPTION
Five doc links in `templates/posthog-bigquery/README.md` returned 404.

| Line | Was | Now |
|---|---|---|
| 99 | `/docs/ingestion/posthog.html#available-source-tables` | `/docs/bruin/ingestion/posthog.html#available-source-tables` |
| 255 | `/docs/dashboards` | `/docs/dac/` |
| 477 | `/docs/ingestion/posthog.html` | `/docs/bruin/ingestion/posthog.html` |
| 478 | `/docs/assets/ingestr.html` | `/docs/bruin/assets/ingestr.html` |
| 479 | `/docs/platforms/bigquery.html` | `/docs/bruin/platforms/bigquery.html` |

Four were missing the `/bruin/` path segment; the DAC one pointed at the retired `/docs/dashboards` path.

Verified all six `getbruin.com` links in the README return 200, and the `#available-source-tables` anchor exists on the target page. No other template under `templates/` has the same pattern.

Line 261's `/docs/dac/getting-started/installation.html` was already correct and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)