### PR TITLE
feat(import): add Fabric as an ingestr destination

### DIFF
--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1048,6 +1048,11 @@ func TestValidateIngestrImportFlags(t *testing.T) {
 			ingestrImport: true,
 			destination:   "duckdb",
 		},
+		{
+			name:          "ingestr accepts fabric destination",
+			ingestrImport: true,
+			destination:   "fabric",
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -173,7 +173,7 @@ Bruin resolves the destination connection in this order:
 2. `parameters.destination_connection`, when set.
 3. The pipeline default connection for `parameters.destination`.
 
-When Bruin infers a destination connection from `parameters.destination`, the built-in destination values are `athena`, `bigquery`, `clickhouse`, `databricks`, `doris`, `duckdb`, `dynamodb`, `elasticsearch`, `gsheets`, `motherduck`, `mssql`, `oracle`, `postgres`, `redshift`, `snowflake`, `starrocks`, `synapse`, and `vertica`. Other ingestr destinations can still be used when you set `connection` or `destination_connection` to a compatible Bruin connection.
+When Bruin infers a destination connection from `parameters.destination`, the built-in destination values are `athena`, `bigquery`, `clickhouse`, `databricks`, `doris`, `duckdb`, `dynamodb`, `elasticsearch`, `fabric`, `gsheets`, `iceberg`, `motherduck`, `mssql`, `oracle`, `postgres`, `redshift`, `snowflake`, `starrocks`, `synapse`, and `vertica`. Other ingestr destinations can still be used when you set `connection` or `destination_connection` to a compatible Bruin connection.
 
 Bruin forwards these write strategies to ingestr:
 
@@ -203,9 +203,9 @@ Destination support depends on ingestr's destination implementation:
 | DuckDB, MotherDuck / `duckdb`, `motherduck`, `md` | Yes for `duckdb` and `motherduck` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
 | DynamoDB / `dynamodb` | Yes | `replace`, `append`, `merge` |
 | Elasticsearch / `elasticsearch` | Yes | `replace`, `append` |
-| Fabric / `fabric` | No, set `connection` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Fabric / `fabric` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
 | Google Sheets / `gsheets` | Yes | `replace`, `append` |
-| Iceberg / `iceberg`, `iceberg+rest`, etc. | No, set `connection` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
+| Iceberg / `iceberg`, `iceberg+rest`, etc. | Yes for `iceberg` | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |
 | MaxCompute / `maxcompute`, `odps` | No, set `connection` | `replace`, `append`, `truncate+insert` without primary keys |
 | MongoDB / `mongodb`, `mongodb+srv` | No, set `connection` | `replace`, `append`, `merge` |
 | MS SQL Server / `mssql` | Yes | `replace`, `append`, `merge`, `delete+insert`, `truncate+insert` |

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1051,6 +1051,7 @@ var IngestrTypeConnectionMapping = map[string]AssetType{
 	"mssql":         AssetTypeMsSQLQuery,
 	"databricks":    AssetTypeDatabricksQuery,
 	"synapse":       AssetTypeSynapseQuery,
+	"fabric":        AssetTypeFabricQuery,
 	"duckdb":        AssetTypeDuckDBQuery,
 	"clickhouse":    AssetTypeClickHouse,
 	"doris":         AssetTypeDorisQuery,


### PR DESCRIPTION
## What

Adds Microsoft Fabric as a selectable destination for the database importer and for ingestr connection inference.

`bruin import database --ingestr --destination fabric ...` now works directly:

```bash
bruin import database --connection edwh --schema dv --ingestr --destination fabric --environment production postgres_dv_to_fabric
```

## Why

Fabric already works as an ingestr destination at runtime (the `fabric://` scheme, gated by `ensureFabricEngineSupport`), but it was missing from `pipeline.IngestrTypeConnectionMapping`.
