### PR TITLE
fix: match exact pipeline definition filenames

### DIFF
--- a/pkg/path/walk.go
+++ b/pkg/path/walk.go
@@ -86,7 +86,7 @@ func GetPipelinePathsWithExclusions(root string, pipelineDefinitionFile []string
 
 		// Check if the file matches any of the pipeline definition file names
 		for _, pipelineDefinition := range pipelineDefinitionFile {
-			if strings.HasSuffix(path, pipelineDefinition) {
+			if d.Name() == pipelineDefinition {
 				abs, err := filepath.Abs(path)
 				if err != nil {
 					return errors.Wrapf(err, "failed to get absolute path for %s", path)

--- a/pkg/path/walk_test.go
+++ b/pkg/path/walk_test.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,6 +53,22 @@ func TestGetPipelinePaths(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGetPipelinePathsMatchesExactBasenames(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pipelineDir := filepath.Join(root, "pipeline")
+	nonPipelineDir := filepath.Join(root, "non-pipeline")
+	require.NoError(t, os.MkdirAll(pipelineDir, 0o755))
+	require.NoError(t, os.MkdirAll(nonPipelineDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pipelineDir, "pipeline.yml"), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(nonPipelineDir, "simple-pipeline.yml"), nil, 0o644))
+
+	got, err := GetPipelinePaths(root, []string{"pipeline.yml"})
+	require.NoError(t, err)
+	require.Equal(t, []string{pipelineDir}, got)
 }
 
 func TestGetAllPossibleAssetPaths(t *testing.T) {


### PR DESCRIPTION
## Summary
- match pipeline definition files by exact basename during recursive discovery
- ignore suffix matches such as `simple-pipeline.yml` when looking for `pipeline.yml`
- add regression coverage for exact basename matching

## Testing
- `go test -tags="no_duckdb_arrow" ./pkg/path -run "TestGetPipelinePaths" -count=1`
- `make format`
- `make test`