### PR TITLE
Validate pipeline variables against JSON Schema

### DIFF
--- a/cmd/const_test.go
+++ b/cmd/const_test.go
@@ -215,3 +215,24 @@ func TestVariableOverridesMutator_VariantWinsOnOverlap(t *testing.T) {
 		assert.ErrorContains(t, err, `no such variable "nope"`)
 	})
 }
+
+func TestVariableOverridesMutator_RejectsValuesFailingTheSchema(t *testing.T) {
+	t.Parallel()
+
+	p := &pipeline.Pipeline{
+		Variables: pipeline.Variables{
+			"seat_denominator": {
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "reachable",
+			},
+		},
+	}
+
+	mutator := variableOverridesMutator([]string{`seat_denominator="Contracted"`})
+	_, err := mutator(t.Context(), p)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid variable overrides")
+	require.ErrorContains(t, err, "seat_denominator")
+	assert.Equal(t, "reachable", p.Variables["seat_denominator"]["default"])
+}

--- a/docs/pipelines/variants.md
+++ b/docs/pipelines/variants.md
@@ -63,7 +63,7 @@ Rules:
 - **Variant name** must match `[a-zA-Z0-9_-]+`.
 - **Variable names** under each variant must reference variables already declared in the pipeline's `variables:` block. Unknown names fail validation with `references unknown variable "X"`.
 - A variant can override **any subset** of variables; unmentioned variables keep their `default` value.
-- Variant overrides must match the type of the underlying variable (e.g., a variable typed as `integer` cannot be overridden with a string).
+- Variant overrides must satisfy the underlying variable's JSON Schema, including its type and constraints such as `enum`, `minimum`, and `maximum`.
 
 ## Running a Variant
 

--- a/docs/variables/custom.md
+++ b/docs/variables/custom.md
@@ -29,7 +29,7 @@ variables:
 
 ## Supported JSON Schema Keywords
 
-Bruin accepts [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html) keywords in variable definitions. At parse time, it currently enforces that each variable has a `default` value; full schema validation is not yet enforced.
+Bruin accepts [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html) keywords in variable definitions. Each variable's `default` value is validated against its schema, and runtime or variant overrides must satisfy the same schema before replacing the default.
 
 | `type` value | Description | Example default |
 |--------------|-------------|-----------------|
@@ -39,9 +39,13 @@ Bruin accepts [JSON Schema draft-07](https://json-schema.org/draft-07/json-schem
 | `boolean`    | `true` / `false` flags | `false` |
 | `object`     | Maps with nested schemas | `{ "region": "us-east-1" }` |
 | `array`      | Lists of values | `["alice", "bob"]` |
-| `null`       | Explicitly nullable values | `null` |
+| `"null"`     | Explicitly nullable values | `null` |
 
-Additional keywords: `enum`, `const`, `minimum`, `maximum`, `pattern`, `items`, `properties`, `required`.
+Quote `"null"` when using it as a `type`: YAML reads an unquoted `null` as an empty value rather than the string, and the variable then fails validation.
+
+Additional keywords: `enum`, `const`, `minimum`, `maximum`, `pattern`, `format`, `items`, `properties`, `required`.
+
+`pattern` is compiled with Go's RE2 engine, which has no lookahead or backreferences. `format` is enforced rather than advisory, so a `default` of `"team"` under `format: email` is rejected.
 
 ## Complex Variable Examples
 

--- a/pkg/pipeline/variables.go
+++ b/pkg/pipeline/variables.go
@@ -2,13 +2,20 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
 )
 
-func varSchemaLoader() *gojsonschema.SchemaLoader { //nolint:unused
+func varSchemaLoader() *gojsonschema.SchemaLoader {
 	loader := gojsonschema.NewSchemaLoader()
+	// gojsonschema bundles the Draft 7 meta-schema under its canonical HTTP URL.
+	// Disabling auto-detection makes the loader use that bundled schema instead of
+	// trying to fetch the HTTPS URL returned by Variables.Schema.
+	loader.AutoDetect = false
 	loader.Draft = gojsonschema.Draft7
 	loader.Validate = true
 	return loader
@@ -17,22 +24,22 @@ func varSchemaLoader() *gojsonschema.SchemaLoader { //nolint:unused
 type Variables map[string]map[string]any
 
 func (v *Variables) Validate() error {
-	// TODO(turtledev):
-	// - validate the defaults actually satisfy the schema
-	// - make "properties" a required field for object types
-	//
-	// BUG: Schema compiler fetches the schema from the spec URL, which may break
-	// in environments where internet access is restricted.
-
-	// TODO: Use a local copy of the schema.
-	// _, err := varSchemaLoader().Compile(gojsonschema.NewGoLoader(v.Schema()))
-	// if err != nil {
-	// 	return fmt.Errorf("invalid variables schema: %w", err)
-	// }
-	for key, value := range *v {
+	// The missing-default check runs first because its message is far more
+	// actionable than the meta-schema complaint an empty variable body produces.
+	for _, key := range sortedVariableKeys(*v) {
+		value := (*v)[key]
 		if _, ok := value["default"]; !ok {
 			return fmt.Errorf("invalid variable %q: must have a default value", key)
 		}
+	}
+
+	schema, err := v.compiledSchema()
+	if err != nil {
+		return err
+	}
+
+	if err := validateVariableValues(schema, v.Value()); err != nil {
+		return fmt.Errorf("invalid variable defaults: %w", err)
 	}
 	return nil
 }
@@ -61,22 +68,101 @@ func (v *Variables) SchemaMap() map[string]any {
 	return schema
 }
 
+// Schema returns the JSON Schema describing the pipeline's variables. It is built
+// from SchemaMap so that the declared defaults stay out of the document: a default
+// is data, and embedding it here makes an unmarshallable value (a YAML map with
+// non-string keys, say) surface as a bogus "invalid variables schema" error.
 func (v *Variables) Schema() any {
 	return map[string]any{
 		"$schema":    "https://json-schema.org/draft-07/schema",
 		"type":       "object",
-		"properties": *v,
+		"properties": v.SchemaMap(),
 	}
 }
 
 func (v *Variables) Merge(other map[string]any) error {
-	for key, value := range other {
+	if len(other) == 0 {
+		return nil
+	}
+
+	for _, key := range sortedVariableKeys(other) {
 		if _, ok := (*v)[key]; !ok {
 			return fmt.Errorf("no such variable %q", key)
+		}
+	}
+
+	schema, err := v.compiledSchema()
+	if err != nil {
+		return err
+	}
+	// Callers already describe the context (a --var override, a variant), so the
+	// validation error is returned as-is to avoid stuttering messages.
+	if err := validateVariableValues(schema, other); err != nil {
+		return err
+	}
+
+	for key, value := range other {
+		// A variable declared with an empty body decodes to a nil map, which cannot
+		// be assigned to.
+		if (*v)[key] == nil {
+			(*v)[key] = make(map[string]any, 1)
 		}
 		(*v)[key]["default"] = value
 	}
 	return nil
+}
+
+func (v *Variables) compiledSchema() (*gojsonschema.Schema, error) {
+	schema, err := varSchemaLoader().Compile(gojsonschema.NewGoLoader(v.Schema()))
+	if err != nil {
+		return nil, fmt.Errorf("invalid variables schema: %s", flattenMessages(strings.Split(err.Error(), "\n")))
+	}
+	return schema, nil
+}
+
+func validateVariableValues(schema *gojsonschema.Schema, values map[string]any) error {
+	result, err := schema.Validate(gojsonschema.NewGoLoader(values))
+	if err != nil {
+		// YAML mappings with non-string keys decode to map[any]any, which has no JSON
+		// representation. Say so, because the raw error names only the Go type.
+		var unsupported *json.UnsupportedTypeError
+		if errors.As(err, &unsupported) {
+			return fmt.Errorf("value is not JSON-encodable (%s): object keys must be strings, so quote them", unsupported.Type)
+		}
+		return fmt.Errorf("failed to validate values: %w", err)
+	}
+	if result.Valid() {
+		return nil
+	}
+
+	messages := make([]string, 0, len(result.Errors()))
+	for _, validationErr := range result.Errors() {
+		messages = append(messages, validationErr.String())
+	}
+	return fmt.Errorf("schema validation failed: %s", flattenMessages(messages))
+}
+
+// flattenMessages turns a set of validation messages into a single sorted line.
+// gojsonschema reports meta-schema failures as a newline-joined string with a
+// trailing newline, which renders badly once the error becomes a lint issue.
+func flattenMessages(messages []string) string {
+	cleaned := make([]string, 0, len(messages))
+	for _, message := range messages {
+		if message = strings.TrimSpace(message); message != "" {
+			cleaned = append(cleaned, message)
+		}
+	}
+	sort.Strings(cleaned)
+	return strings.Join(cleaned, "; ")
+}
+
+func sortedVariableKeys[V any](variables map[string]V) []string {
+	keys := make([]string, 0, len(variables))
+	for key := range variables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // This ensures that when an empty object {} is provided, it clears the variables.

--- a/pkg/pipeline/variables_test.go
+++ b/pkg/pipeline/variables_test.go
@@ -12,18 +12,19 @@ import (
 func TestVariables(t *testing.T) {
 	t.Parallel()
 
-	// TODO: restore this test when meta-schema validation is implemented
-	// t.Run("Should return an error if the variables are not valid JSONSchema object", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	vars := pipeline.Variables{
-	// 		"user": {
-	// 			"type": "complex",
-	// 		},
-	// 	}
-	// 	err := vars.Validate()
-	// 	require.Error(t, err)
-	// 	assert.Contains(t, err.Error(), "invalid variables schema")
-	// })
+	t.Run("Should return an error if the variables are not valid JSONSchema object", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"user": {
+				"type":    "complex",
+				"default": "alice",
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid variables schema")
+		assert.NotContains(t, err.Error(), "\n", "schema errors must stay on a single line to render as one lint issue")
+	})
 	t.Run("Should return an error if the default is not set", func(t *testing.T) {
 		t.Parallel()
 		vars := pipeline.Variables{
@@ -31,6 +32,16 @@ func TestVariables(t *testing.T) {
 				"type": "string",
 			},
 		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must have a default value")
+	})
+	t.Run("Should report the missing default for an empty variable body", func(t *testing.T) {
+		t.Parallel()
+		// A bare `foo:` in pipeline.yml decodes to a nil body. The missing-default
+		// check has to run before schema compilation, otherwise this surfaces as an
+		// opaque meta-schema type error instead.
+		vars := pipeline.Variables{"user": nil}
 		err := vars.Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must have a default value")
@@ -45,6 +56,72 @@ func TestVariables(t *testing.T) {
 		}
 		err := vars.Validate()
 		require.NoError(t, err)
+	})
+	t.Run("Should blame the default, not the schema, when a default is not JSON-encodable", func(t *testing.T) {
+		t.Parallel()
+		// YAML decodes non-string mapping keys into map[any]any, which json.Marshal
+		// rejects. Defaults stay out of the compiled schema document so this reads as
+		// a problem with the default rather than with the variable's schema.
+		vars := pipeline.Variables{
+			"budgets": {
+				"type":    "object",
+				"default": map[any]any{2024: 100},
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid variable defaults")
+		assert.Contains(t, err.Error(), "object keys must be strings")
+		assert.NotContains(t, err.Error(), "invalid variables schema")
+	})
+	t.Run("Should return an error if a default does not satisfy its enum", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"seat_denominator": {
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "Contracted",
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid variable defaults")
+		assert.Contains(t, err.Error(), "seat_denominator")
+	})
+	t.Run("Should return an error if a default is outside numeric bounds", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"forecast_horizon_days": {
+				"type":    "integer",
+				"minimum": 7,
+				"maximum": 90,
+				"default": 0,
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid variable defaults")
+		assert.Contains(t, err.Error(), "forecast_horizon_days")
+	})
+	t.Run("Should validate nested defaults", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"users": {
+				"type": "array",
+				"items": map[string]any{
+					"type":     "object",
+					"required": []any{"name"},
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+				},
+				"default": []any{map[string]any{"age": 42}},
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "users.0")
+		assert.Contains(t, err.Error(), "name")
 	})
 	t.Run("Should use default values to construct the variables", func(t *testing.T) {
 		t.Parallel()
@@ -299,5 +376,79 @@ func TestVariables_Merge(t *testing.T) {
 
 		assert.Equal(t, "string", vars["foo"]["type"])
 		assert.Equal(t, "new", vars["foo"]["default"])
+	})
+
+	t.Run("rejects an override that does not satisfy its enum", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"seat_denominator": {
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "reachable",
+			},
+		}
+
+		err := vars.Merge(map[string]any{"seat_denominator": "Contracted"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schema validation failed")
+		assert.Contains(t, err.Error(), "seat_denominator")
+		assert.Equal(t, "reachable", vars["seat_denominator"]["default"])
+	})
+
+	t.Run("rejects overrides outside numeric bounds", func(t *testing.T) {
+		t.Parallel()
+
+		for _, value := range []int{0, 9999} {
+			vars := pipeline.Variables{
+				"forecast_horizon_days": {
+					"type":    "integer",
+					"minimum": 7,
+					"maximum": 90,
+					"default": 30,
+				},
+			}
+
+			err := vars.Merge(map[string]any{"forecast_horizon_days": value})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "forecast_horizon_days")
+			assert.Equal(t, 30, vars["forecast_horizon_days"]["default"])
+		}
+	})
+
+	t.Run("overriding a variable declared with an empty body does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		// A bare `foo:` in pipeline.yml decodes to a nil map, which cannot be
+		// assigned to.
+		vars := pipeline.Variables{"foo": nil}
+
+		err := vars.Merge(map[string]any{"foo": 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, vars["foo"]["default"])
+	})
+
+	t.Run("does not apply any overrides when one is invalid", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"environment": {
+				"type":    "string",
+				"default": "dev",
+			},
+			"forecast_horizon_days": {
+				"type":    "integer",
+				"minimum": 7,
+				"default": 30,
+			},
+		}
+
+		err := vars.Merge(map[string]any{
+			"environment":           "prod",
+			"forecast_horizon_days": 0,
+		})
+		require.Error(t, err)
+		assert.Equal(t, "dev", vars["environment"]["default"])
+		assert.Equal(t, 30, vars["forecast_horizon_days"]["default"])
 	})
 }

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -33,11 +33,13 @@ func (vs VariantSet) Names() []string {
 
 // Validate ensures the variant set is well-formed against the given Variables block.
 func (vs VariantSet) Validate(vars Variables) error {
-	for name, values := range vs {
+	for _, name := range vs.Names() {
+		values := vs[name]
 		if !variantNameRegex.MatchString(name) {
 			return fmt.Errorf("invalid variant name %q: must match [a-zA-Z0-9_-]+", name)
 		}
-		for key, value := range values {
+		for _, key := range sortedVariableKeys(values) {
+			value := values[key]
 			schema, ok := vars[key]
 			if !ok {
 				return fmt.Errorf("variant %q references unknown variable %q", name, key)
@@ -45,6 +47,24 @@ func (vs VariantSet) Validate(vars Variables) error {
 			if err := validateOverrideType(value, schema); err != nil {
 				return fmt.Errorf("variant %q variable %q: %w", name, key, err)
 			}
+		}
+	}
+
+	if len(vs) == 0 {
+		return nil
+	}
+
+	schema, err := vars.compiledSchema()
+	if err != nil {
+		return err
+	}
+	for _, name := range vs.Names() {
+		values := vs[name]
+		if values == nil {
+			values = map[string]any{}
+		}
+		if err := validateVariableValues(schema, values); err != nil {
+			return fmt.Errorf("variant %q: %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -70,6 +70,33 @@ func TestVariantSet_Validate(t *testing.T) {
 		vs := pipeline.VariantSet{"v1": {"client": "a"}, "v2": {"client": "b"}}
 		require.NoError(t, vs.Validate(vars))
 	})
+
+	t.Run("accepts a nil variant body as an empty override set", func(t *testing.T) {
+		t.Parallel()
+		vs := pipeline.VariantSet{"noop": nil}
+		require.NoError(t, vs.Validate(vars))
+	})
+
+	t.Run("rejects every variant that violates a variable constraint", func(t *testing.T) {
+		t.Parallel()
+		constrainedVars := pipeline.Variables{
+			"client": map[string]any{
+				"type":    "string",
+				"enum":    []any{"a", "b"},
+				"default": "a",
+			},
+		}
+		vs := pipeline.VariantSet{
+			"active":   {"client": "a"},
+			"inactive": {"client": "c"},
+		}
+
+		err := vs.Validate(constrainedVars)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `variant "inactive"`)
+		assert.Contains(t, err.Error(), "client")
+		assert.Contains(t, err.Error(), "one of")
+	})
 }
 
 func TestVariantSet_Validate_TypeChecking(t *testing.T) {


### PR DESCRIPTION
## What
Validate pipeline variable defaults and overrides against their JSON Schema constraints.

## Changes
- Enforce Draft 7 schemas for defaults, runtime overrides, and every variant without network access.
- Keep override application atomic and improve deterministic validation errors.
- Add regression tests and update variable and variant documentation.

## How to test
1. Run `make format`.
2. Run `make test`.
3. Run `make build-no-duckdb`.

## Risk & rollback
- **Risk:** Low; previously accepted invalid variable values will now fail validation.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
