### PR TITLE
Add `bruin cloud dashboards publish`

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4771,6 +4771,7 @@ func CloudDashboards() *cli.Command {
 			cloudDashboardsVersion(),
 			cloudDashboardsCreate(),
 			cloudDashboardsUpdate(),
+			cloudDashboardsPublish(),
 			cloudDashboardsDelete(),
 		},
 	}
@@ -5337,6 +5338,60 @@ func cloudDashboardsDelete() *cli.Command {
 			}
 
 			successPrinter.Printf("Deleted dashboard %d.\n", c.Int("dashboard-id"))
+			return nil
+		},
+	}
+}
+
+func cloudDashboardsPublish() *cli.Command {
+	return &cli.Command{
+		Name:  "publish",
+		Usage: "Publish a dashboard's pending draft so it goes live",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "dashboard-id",
+				Usage:    "dashboard ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("dashboard-id") <= 0 {
+				printError(fmt.Errorf("--dashboard-id must be a positive integer, got %d", c.Int("dashboard-id")), output, "Invalid --dashboard-id")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			dashboard, err := client.PublishDashboard(ctx, c.Int("dashboard-id"))
+			if err != nil {
+				printError(err, output, "Failed to publish dashboard")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(dashboard, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			title := ""
+			if dashboard.Title != nil {
+				title = *dashboard.Title
+			}
+			if dashboard.URL != "" {
+				successPrinter.Printf("Published dashboard %d (%s): %s\n", dashboard.ID, title, dashboard.URL)
+			} else {
+				successPrinter.Printf("Published dashboard %d (%s).\n", dashboard.ID, title)
+			}
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -573,7 +573,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	cmd := CloudDashboards()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "dashboards", cmd.Name)
-	require.Len(t, cmd.Commands, 7)
+	require.Len(t, cmd.Commands, 8)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -585,6 +585,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "version")
 	assert.Contains(t, subNames, "create")
 	assert.Contains(t, subNames, "update")
+	assert.Contains(t, subNames, "publish")
 	assert.Contains(t, subNames, "delete")
 }
 
@@ -616,6 +617,24 @@ func TestCloudDashboardsCreate_RejectsNonPositiveAgentID(t *testing.T) {
 		}
 		_ = runCLI(t.Context(), cmd, []string{"create", "--title", "T", "--api-key", "k", "--agent-id", v})
 		assert.Equalf(t, 1, exitCode, "agent-id %q should be rejected", v)
+	}
+}
+
+func TestCloudDashboardsPublish_RejectsNonPositiveDashboardID(t *testing.T) {
+	t.Parallel()
+	// A non-positive --dashboard-id must fail locally rather than sending a bad
+	// request that resolves to a route mismatch.
+	for _, v := range []string{"0", "-3"} {
+		cmd := cloudDashboardsPublish()
+		exitCode := 0
+		cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, err error) {
+			var ec cli.ExitCoder
+			if errors.As(err, &ec) {
+				exitCode = ec.ExitCode()
+			}
+		}
+		_ = runCLI(t.Context(), cmd, []string{"publish", "--api-key", "k", "--dashboard-id", v})
+		assert.Equalf(t, 1, exitCode, "dashboard-id %q should be rejected", v)
 	}
 }
 

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -990,7 +990,7 @@ Filters only act on `sql` widgets, so a dashboard built purely from inline data 
 
 #### `update`
 
-Update an existing dashboard's title, visibility, or definition. Only the flags you pass are changed. Like `create`, a new definition is written to the dashboard's **draft** — never published automatically; publish it from the Bruin Cloud UI. Changing visibility requires manage-access (the dashboard creator or a team admin).
+Update an existing dashboard's title, visibility, or definition. Only the flags you pass are changed. Like `create`, a new definition is written to the dashboard's **draft** — never published automatically; publish it with `dashboards publish` or from the Bruin Cloud UI. Changing visibility requires manage-access (the dashboard creator or a team admin).
 
 ```bash
 # Rename
@@ -1002,6 +1002,14 @@ bruin cloud dashboards update --dashboard-id 42 --state-file ./dashboard.json
 
 # Change visibility
 bruin cloud dashboards update --dashboard-id 42 --visibility team
+```
+
+#### `publish`
+
+Publish a dashboard's pending draft so it goes live — the same as clicking Publish in the Bruin Cloud UI. `create` and `update` only ever write the draft, so this is how a dashboard built or edited from the CLI becomes visible to the team. Requires edit rights on the dashboard; errors if there is no draft to publish, and repo (DAC) dashboards are published from the repo.
+
+```bash
+bruin cloud dashboards publish --dashboard-id 42
 ```
 
 #### `delete`

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -928,6 +928,18 @@ func (c *APIClient) DeleteDashboard(ctx context.Context, dashboardID int) error 
 	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/dashboards/%d", dashboardID), nil, nil)
 }
 
+// PublishDashboard promotes a dashboard's pending draft to the live state,
+// mirroring the UI Publish button — create/update only ever write the draft.
+// Requires edit rights server-side; errors when there is no draft to publish.
+func (c *APIClient) PublishDashboard(ctx context.Context, dashboardID int) (*Dashboard, error) {
+	var result Dashboard
+	err := c.doRequest(ctx, http.MethodPost, fmt.Sprintf("/dashboards/%d/publish", dashboardID), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // ListDashboardVersions returns a dashboard's version-history snapshots (newest
 // first), metadata only — no state. Read-only.
 func (c *APIClient) ListDashboardVersions(ctx context.Context, dashboardID int) ([]DashboardVersion, error) {

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -928,9 +928,8 @@ func (c *APIClient) DeleteDashboard(ctx context.Context, dashboardID int) error 
 	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/dashboards/%d", dashboardID), nil, nil)
 }
 
-// PublishDashboard promotes a dashboard's pending draft to the live state,
-// mirroring the UI Publish button — create/update only ever write the draft.
-// Requires edit rights server-side; errors when there is no draft to publish.
+// PublishDashboard promotes a dashboard's pending draft to the live state (create/update
+// only ever write the draft). Requires edit rights; errors when there's no draft.
 func (c *APIClient) PublishDashboard(ctx context.Context, dashboardID int) (*Dashboard, error) {
 	var result Dashboard
 	err := c.doRequest(ctx, http.MethodPost, fmt.Sprintf("/dashboards/%d/publish", dashboardID), nil, &result)

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1405,6 +1405,23 @@ func TestDeleteDashboard(t *testing.T) {
 	require.NoError(t, client.DeleteDashboard(t.Context(), 9))
 }
 
+func TestPublishDashboard(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/dashboards/9/publish", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		title := "Q1 Revenue"
+		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "team", URL: "https://cloud.getbruin.com/acme/dashboards/9"})
+	})
+
+	dashboard, err := client.PublishDashboard(t.Context(), 9)
+	require.NoError(t, err)
+	assert.Equal(t, 9, dashboard.ID)
+	assert.Equal(t, "Q1 Revenue", *dashboard.Title)
+}
+
 func TestListScheduledAgents(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`create` and `update` only ever write a dashboard's draft — publishing was UI-only, so a dashboard built or edited from the CLI (or an agent) couldn't go live without opening the app.

Adds `bruin cloud dashboards publish --dashboard-id <id>` + a `PublishDashboard` client method hitting `POST /api/v1/dashboards/{id}/publish` (cloud bruin-data/cloud#3161). Promotes the pending draft to the live state; errors when there's no draft.

Depends on the cloud endpoint being merged + deployed. Requires the new `dashboard:publish` token ability.