### PR TITLE
docs(templates): add scannable "At a glance" summaries

### DIFF
--- a/docs/getting-started/templates-docs/google-web-analytics-README.md
+++ b/docs/getting-started/templates-docs/google-web-analytics-README.md
@@ -1,5 +1,16 @@
 # Google Analytics and Search Console Reporting on BigQuery
 
+## At a glance
+
+- Reads your existing GA4 and Search Console exports in BigQuery
+- Ingests nothing — it starts from data you already have
+- Joins two Google products that never talk to each other
+- Cleans both exports into one tidy staging layer
+- Publishes nine reports on your organic search performance
+- Answers questions neither Google tool can answer alone
+- Ships as a starter template you edit for your business
+- **Builds the foundational search models and context an AI agent can analyze and act on**
+
 `google-web-analytics` turns the GA4 and Google Search Console exports you already
 have in BigQuery into an organic search reporting layer. It ingests nothing: both
 products export to BigQuery natively, so the template starts where those exports

--- a/docs/getting-started/templates-docs/google-web-analytics-README.md
+++ b/docs/getting-started/templates-docs/google-web-analytics-README.md
@@ -41,7 +41,8 @@ whose credentials can read both export datasets and write the three datasets thi
 pipeline creates.
 
 > Streaming export is required. See
-> [Scope: streaming export only](#scope-streaming-export-only) before your first run.
+> [Scope: streaming export only](#scope-streaming-export-only) in the appendix
+> before your first run.
 
 ## How it works
 
@@ -133,19 +134,9 @@ description.
 | `gsc_position_click_curve` | property × search type × position | The CTR your property actually earns at each position, measured from its own history. |
 | `gsc_export_log` | table × reporting date | When Google published each date, and whether it later restated it. |
 
-Both Search Console models keep the rows where Google withheld the query: the
-impressions and clicks are real, so dropping them would understate daily totals.
-They carry a NULL query and a `query_brand_type` of `anonymized`, and the
-query-grain reports exclude them explicitly.
-
-Every page-level report keeps `page_hostname` in its grain on purpose. A property
-that spans hosts routinely serves the same path on more than one, and a docs or
-blog subdomain is a different page from the marketing site even when both answer
-`/guide`. Joining on path alone would sum their impressions and value together.
-The cost is that when the two systems disagree about the canonical host, the page
-appears twice — once as `search_only`, once as `ga4_only` — instead of hiding the
-disagreement in a merged row. Aggregate over `page_hostname` in your own model if
-you would rather see one row per path.
+Two staging behaviours are worth knowing before you build on these — how rows with
+a withheld query are kept, and why page-level grains keep `page_hostname` — see
+[Staging model notes](#staging-model-notes) in the appendix.
 
 ### `web_analytics_reports`
 
@@ -161,180 +152,11 @@ you would rather see one row per path.
 | `ga4_gsc_query_value` | Which queries produce outcomes? | Google deliberately never passes the query to analytics. |
 | `ga4_gsc_intent_pipeline` | Does content marketing actually produce anything? | Needs query intent, page role, and post-click outcomes at once. None of the three exists in either product. |
 
-## Reading the reports
-
-### Start with `ga4_gsc_landing_page_performance`
-
-This is the join the other reports lean on. Each page carries its Search Console
-visibility next to what GA4 recorded afterwards, so the per-click and
-per-thousand-impression value columns rank pages by outcome rather than by traffic.
-
-It is a full outer join on purpose, and `coverage_status` explains every mismatch:
-
-| `coverage_status` | Meaning | Usual cause |
-| --- | --- | --- |
-| `matched` | Both systems agree the page gets Google search traffic. | |
-| `search_only` | Search Console reports clicks GA4 never recorded. | Missing or blocked tracking, a redirect chain, or bot filtering. |
-| `ga4_only` | GA4 recorded organic sessions Search Console has no data for. | Traffic from a non-Google engine, or a page excluded from the property. |
-| `session_shortfall` | GA4 saw fewer than half the reported clicks. | Consent-mode loss, slow tag load, or a redirect on entry. |
-
-The GA4 side is restricted to Google organic sessions, because Search Console has
-no visibility into other engines. `ga4_sessions` exposes both
-`is_organic_search_session` and the narrower `is_google_organic_session` so you can
-choose deliberately.
-
-### Opportunity sizing gives two different numbers
-
-`gsc_query_opportunities` answers two separate questions:
-
-- `clicks_at_expected_ctr` — what fixing the title and description alone would
-  return, holding position constant.
-- `clicks_at_top_three_ctr` — what ranking in the top three would return, holding
-  impressions constant.
-
-Both are estimates from your own observed behaviour, not forecasts; impressions
-move when position moves. `is_expected_ctr_reliable` tells you whether the
-click-curve bucket behind the comparison has enough impressions to trust.
-
-### `ga4_gsc_query_value` is modelled
-
-Google never passes the search query to analytics, so query-level outcomes cannot
-be measured — only allocated. Each page's GA4 outcomes are split across the queries
-that sent clicks to it, in proportion to those clicks. Within a page the weights
-sum to one, so page totals are preserved exactly and only the split between queries
-is estimated.
-
-The assumption is that every query sending traffic to a page converts at that
-page's average rate. That is wrong in a predictable direction: a high-intent query
-really does convert better than the page average, so its value is understated and a
-broad informational query's is overstated. Rank queries against each other with it;
-do not report the figure as measured.
-
-Clicks Google withheld are left out of the denominator, so their share of a page's
-outcome spreads across that page's disclosed queries. A page whose clicks were all
-withheld contributes nothing, which is why totals here fall short of those in
-`ga4_gsc_landing_page_performance`.
-
-## Scope and limitations
-
-Read this section before you quote a number from these tables to anyone.
-
-### Scope: streaming export only
-
-The template reads `events_intraday_*` and nothing else. It does not read the daily
-`events_YYYYMMDD` tables, `pseudonymous_users_*`, or `users_*`. Confirm your
-property produces intraday tables:
-
-```sql
-SELECT COUNTIF(REGEXP_CONTAINS(table_id, r'^events_intraday_')) AS intraday,
-       COUNTIF(REGEXP_CONTAINS(table_id, r'^events_[0-9]{8}$'))  AS daily
-FROM `your_project.your_ga4_dataset.__TABLES__`
-```
-
-`intraday > 0` and the template works as shipped. `intraday = 0` means every GA4
-model returns nothing — enable streaming export, or change the two GA4 models to
-read `events_*` instead. The failure is silent: empty tables, not an error.
-
-On a streaming-only property, intraday tables are a complete record of past days
-and are not cleaned up, so the wildcard covers your full history. The only partial
-day is today, which the default run window excludes and which whole-day replacement
-corrects on the next run.
-
-### GA4 session attribution is weaker in intraday tables
-
-Google does not populate session-scoped traffic source in intraday tables. Check
-your own property:
-
-```sql
-SELECT COUNT(*) AS events,
-       COUNTIF(session_traffic_source_last_click.cross_channel_campaign
-                 .default_channel_group IS NOT NULL) AS session_scoped,
-       COUNTIF(collected_traffic_source.manual_source IS NOT NULL) AS event_collected,
-       COUNTIF(traffic_source.source IS NOT NULL) AS user_first_touch
-FROM `your_project.your_ga4_dataset.events_intraday_*`
-WHERE _TABLE_SUFFIX >= '20260101'
-```
-
-Expect `session_scoped = 0`. `ga4_sessions` therefore falls back through
-`collected_traffic_source`, then the user-scoped `traffic_source`, and records
-which one it used in `traffic_source_basis`.
-
-Sessions where none of the three is populated get
-`traffic_source_basis = 'unavailable'` and a channel of `Unassigned`, and are never
-counted as organic. Expect that bucket to be large — two thirds of sessions on the
-property this was tested against.
-
-That sounds worse than it is. Checked against the GA4 interface, those
-`unavailable` sessions are almost exactly the ones GA4 itself labels **Direct**, so
-leaving them out of organic is mostly right rather than lost traffic. The real cost
-is narrower: organic sessions came in roughly 16% below what GA4 reported. Treat
-organic as a floor, not a total, but a close floor. Measure your own split before
-quoting any channel figure:
-
-```sql
-SELECT traffic_source_basis, COUNT(*) AS sessions
-FROM `your_project.web_analytics_staging.ga4_sessions`
-GROUP BY 1 ORDER BY sessions DESC
-```
-
-These numbers will not tie out to the GA4 interface, which applies its own
-attribution model on top of the same events.
-
-### Value columns are modelled, not recognized revenue
-
-Unless your site sends GA4 ecommerce revenue, all value in these reports comes from
-the weights you set in `key_event_values`. They exist to rank pages and queries
-against each other. They are not recognized revenue, bookings, or cash, and should
-not be reported as such.
-
-### The two systems will never tie out exactly
-
-Session counts and click counts come from different measurement systems.
-`session_per_click_ratio` sits near one on healthy pages; treat a low value as a
-tracking lead, not a bug in the report. Search Console dates are Pacific Time while
-GA4 `event_date` uses the property's reporting timezone, so where those differ a
-day's numbers are offset by a few hours of activity between the two systems.
-
-### Freshness, restatement, and window edges
-
-Search Console publishes with a two-to-three day delay and revises history in
-place. The staging models widen their read window by `source_lookback_days` and
-replace whole days, so late and restated data heals on the next run.
-`gsc_export_log` is where you confirm what Google actually published — a bumped
-`epoch_version` means Google restated a date rather than your site changing.
-
-Sessions that cross midnight span two daily export tables; a session split by the
-window edge is completed by the following run, because the lookback re-reads and
-replaces that day.
-
-The reports are rebuilt over a trailing `reporting_window_days` window, which
-bounds what each one scans. The trend reports need at least
-`2 × trend_window_days` of staged history before they say anything useful.
-
-### An event you do not send is a silently empty column
-
-The shipped `key_event_names` are placeholders. If your property does not fire
-them, the matching report columns are zero rather than an error. List what you
-actually send before configuring anything:
-
-```sql
-SELECT event_name, COUNT(*) AS events
-FROM `your_project.your_ga4_dataset.events_intraday_*`
-WHERE _TABLE_SUFFIX >= '20260101'
-GROUP BY 1 ORDER BY events DESC
-```
-
-### How closely this reconciles with Google's own interfaces
-
-Validated against both Google interfaces over a calendar month on a live property.
-
-Every Search Console figure matched exactly: clicks, impressions, CTR, and average
-position, and each of those again broken down by day, device, and country. The GA4
-side matched page views and users to within a fraction of a percent. Sessions came
-in about 2% below the interface, because the export itself holds slightly fewer
-sessions than GA4 reports — the models reproduce the export, and that residual gap
-is not something a transformation can close. Organic sessions are the one real gap,
-for the attribution reason above.
+For how to read each report — the `coverage_status` full outer join, opportunity
+sizing's two numbers, and why `ga4_gsc_query_value` is modelled — see
+[Reading the reports](#reading-the-reports). And before you quote any number from
+these tables to anyone, read [Scope and limitations](#scope-and-limitations). Both
+are in the appendix.
 
 ## Configure it
 
@@ -587,3 +409,196 @@ instead, replace `service_account_file` with
 Do not commit credentials. If either export lives in a different project from the
 one you write to, qualify the dataset variables with that project and grant read
 access there.
+
+## Appendix: notes, caveats & details
+
+### Staging model notes
+
+Both Search Console models keep the rows where Google withheld the query: the
+impressions and clicks are real, so dropping them would understate daily totals.
+They carry a NULL query and a `query_brand_type` of `anonymized`, and the
+query-grain reports exclude them explicitly.
+
+Every page-level report keeps `page_hostname` in its grain on purpose. A property
+that spans hosts routinely serves the same path on more than one, and a docs or
+blog subdomain is a different page from the marketing site even when both answer
+`/guide`. Joining on path alone would sum their impressions and value together.
+The cost is that when the two systems disagree about the canonical host, the page
+appears twice — once as `search_only`, once as `ga4_only` — instead of hiding the
+disagreement in a merged row. Aggregate over `page_hostname` in your own model if
+you would rather see one row per path.
+
+### Reading the reports
+
+#### Start with `ga4_gsc_landing_page_performance`
+
+This is the join the other reports lean on. Each page carries its Search Console
+visibility next to what GA4 recorded afterwards, so the per-click and
+per-thousand-impression value columns rank pages by outcome rather than by traffic.
+
+It is a full outer join on purpose, and `coverage_status` explains every mismatch:
+
+| `coverage_status` | Meaning | Usual cause |
+| --- | --- | --- |
+| `matched` | Both systems agree the page gets Google search traffic. | |
+| `search_only` | Search Console reports clicks GA4 never recorded. | Missing or blocked tracking, a redirect chain, or bot filtering. |
+| `ga4_only` | GA4 recorded organic sessions Search Console has no data for. | Traffic from a non-Google engine, or a page excluded from the property. |
+| `session_shortfall` | GA4 saw fewer than half the reported clicks. | Consent-mode loss, slow tag load, or a redirect on entry. |
+
+The GA4 side is restricted to Google organic sessions, because Search Console has
+no visibility into other engines. `ga4_sessions` exposes both
+`is_organic_search_session` and the narrower `is_google_organic_session` so you can
+choose deliberately.
+
+#### Opportunity sizing gives two different numbers
+
+`gsc_query_opportunities` answers two separate questions:
+
+- `clicks_at_expected_ctr` — what fixing the title and description alone would
+  return, holding position constant.
+- `clicks_at_top_three_ctr` — what ranking in the top three would return, holding
+  impressions constant.
+
+Both are estimates from your own observed behaviour, not forecasts; impressions
+move when position moves. `is_expected_ctr_reliable` tells you whether the
+click-curve bucket behind the comparison has enough impressions to trust.
+
+#### `ga4_gsc_query_value` is modelled
+
+Google never passes the search query to analytics, so query-level outcomes cannot
+be measured — only allocated. Each page's GA4 outcomes are split across the queries
+that sent clicks to it, in proportion to those clicks. Within a page the weights
+sum to one, so page totals are preserved exactly and only the split between queries
+is estimated.
+
+The assumption is that every query sending traffic to a page converts at that
+page's average rate. That is wrong in a predictable direction: a high-intent query
+really does convert better than the page average, so its value is understated and a
+broad informational query's is overstated. Rank queries against each other with it;
+do not report the figure as measured.
+
+Clicks Google withheld are left out of the denominator, so their share of a page's
+outcome spreads across that page's disclosed queries. A page whose clicks were all
+withheld contributes nothing, which is why totals here fall short of those in
+`ga4_gsc_landing_page_performance`.
+
+### Scope and limitations
+
+Read this section before you quote a number from these tables to anyone.
+
+#### Scope: streaming export only
+
+The template reads `events_intraday_*` and nothing else. It does not read the daily
+`events_YYYYMMDD` tables, `pseudonymous_users_*`, or `users_*`. Confirm your
+property produces intraday tables:
+
+```sql
+SELECT COUNTIF(REGEXP_CONTAINS(table_id, r'^events_intraday_')) AS intraday,
+       COUNTIF(REGEXP_CONTAINS(table_id, r'^events_[0-9]{8}$'))  AS daily
+FROM `your_project.your_ga4_dataset.__TABLES__`
+```
+
+`intraday > 0` and the template works as shipped. `intraday = 0` means every GA4
+model returns nothing — enable streaming export, or change the two GA4 models to
+read `events_*` instead. The failure is silent: empty tables, not an error.
+
+On a streaming-only property, intraday tables are a complete record of past days
+and are not cleaned up, so the wildcard covers your full history. The only partial
+day is today, which the default run window excludes and which whole-day replacement
+corrects on the next run.
+
+#### GA4 session attribution is weaker in intraday tables
+
+Google does not populate session-scoped traffic source in intraday tables. Check
+your own property:
+
+```sql
+SELECT COUNT(*) AS events,
+       COUNTIF(session_traffic_source_last_click.cross_channel_campaign
+                 .default_channel_group IS NOT NULL) AS session_scoped,
+       COUNTIF(collected_traffic_source.manual_source IS NOT NULL) AS event_collected,
+       COUNTIF(traffic_source.source IS NOT NULL) AS user_first_touch
+FROM `your_project.your_ga4_dataset.events_intraday_*`
+WHERE _TABLE_SUFFIX >= '20260101'
+```
+
+Expect `session_scoped = 0`. `ga4_sessions` therefore falls back through
+`collected_traffic_source`, then the user-scoped `traffic_source`, and records
+which one it used in `traffic_source_basis`.
+
+Sessions where none of the three is populated get
+`traffic_source_basis = 'unavailable'` and a channel of `Unassigned`, and are never
+counted as organic. Expect that bucket to be large — two thirds of sessions on the
+property this was tested against.
+
+That sounds worse than it is. Checked against the GA4 interface, those
+`unavailable` sessions are almost exactly the ones GA4 itself labels **Direct**, so
+leaving them out of organic is mostly right rather than lost traffic. The real cost
+is narrower: organic sessions came in roughly 16% below what GA4 reported. Treat
+organic as a floor, not a total, but a close floor. Measure your own split before
+quoting any channel figure:
+
+```sql
+SELECT traffic_source_basis, COUNT(*) AS sessions
+FROM `your_project.web_analytics_staging.ga4_sessions`
+GROUP BY 1 ORDER BY sessions DESC
+```
+
+These numbers will not tie out to the GA4 interface, which applies its own
+attribution model on top of the same events.
+
+#### Value columns are modelled, not recognized revenue
+
+Unless your site sends GA4 ecommerce revenue, all value in these reports comes from
+the weights you set in `key_event_values`. They exist to rank pages and queries
+against each other. They are not recognized revenue, bookings, or cash, and should
+not be reported as such.
+
+#### The two systems will never tie out exactly
+
+Session counts and click counts come from different measurement systems.
+`session_per_click_ratio` sits near one on healthy pages; treat a low value as a
+tracking lead, not a bug in the report. Search Console dates are Pacific Time while
+GA4 `event_date` uses the property's reporting timezone, so where those differ a
+day's numbers are offset by a few hours of activity between the two systems.
+
+#### Freshness, restatement, and window edges
+
+Search Console publishes with a two-to-three day delay and revises history in
+place. The staging models widen their read window by `source_lookback_days` and
+replace whole days, so late and restated data heals on the next run.
+`gsc_export_log` is where you confirm what Google actually published — a bumped
+`epoch_version` means Google restated a date rather than your site changing.
+
+Sessions that cross midnight span two daily export tables; a session split by the
+window edge is completed by the following run, because the lookback re-reads and
+replaces that day.
+
+The reports are rebuilt over a trailing `reporting_window_days` window, which
+bounds what each one scans. The trend reports need at least
+`2 × trend_window_days` of staged history before they say anything useful.
+
+#### An event you do not send is a silently empty column
+
+The shipped `key_event_names` are placeholders. If your property does not fire
+them, the matching report columns are zero rather than an error. List what you
+actually send before configuring anything:
+
+```sql
+SELECT event_name, COUNT(*) AS events
+FROM `your_project.your_ga4_dataset.events_intraday_*`
+WHERE _TABLE_SUFFIX >= '20260101'
+GROUP BY 1 ORDER BY events DESC
+```
+
+#### How closely this reconciles with Google's own interfaces
+
+Validated against both Google interfaces over a calendar month on a live property.
+
+Every Search Console figure matched exactly: clicks, impressions, CTR, and average
+position, and each of those again broken down by day, device, and country. The GA4
+side matched page views and users to within a fraction of a percent. Sessions came
+in about 2% below the interface, because the export itself holds slightly fewer
+sessions than GA4 reports — the models reproduce the export, and that residual gap
+is not something a transformation can close. Organic sessions are the one real gap,
+for the attribution reason above.

--- a/docs/getting-started/templates-docs/posthog-bigquery-README.md
+++ b/docs/getting-started/templates-docs/posthog-bigquery-README.md
@@ -1,6 +1,17 @@
 <!-- Generated from templates/posthog-bigquery/README.md. Do not edit directly; run `make sync-template-docs`. -->
 # PostHog Product Analytics to BigQuery
 
+## At a glance
+
+- Loads your PostHog events, people, and feature flags into BigQuery
+- Cleans them into a tidy staging layer that is easy to query
+- Merges each visitor's many IDs into one real person
+- Groups events into sessions with duration, bounce, and conversions
+- Builds four reports at the account and user-segment level
+- Skips duplicate rows, so re-running a day stays correct
+- Comes with a ready-made dashboard on top of the reports
+- **Builds the foundational product-analytics models and context an AI agent can analyze and act on**
+
 `posthog-bigquery` turns raw PostHog product analytics into warehouse-ready
 account intelligence in BigQuery.
 

--- a/docs/getting-started/templates-docs/posthog-bigquery-README.md
+++ b/docs/getting-started/templates-docs/posthog-bigquery-README.md
@@ -371,7 +371,7 @@ falling back to a default.
 
 Two of these are worth checking against your own data before you trust a
 ranking. `seat_denominator` decides whether the heaviest component measures
-rollout or licence coverage, which [Reports](#reports-posthog_reports) covers in
+rollout or licence coverage, which [Reports](#reports-posthog-reports) covers in
 full. And `depth_target_actions` sets where the depth component saturates: too
 high and it reads near-zero for everyone, too low and it stops separating
 accounts.

--- a/docs/getting-started/templates-docs/posthog-bigquery-README.md
+++ b/docs/getting-started/templates-docs/posthog-bigquery-README.md
@@ -19,6 +19,9 @@ It lands `events`, `persons`, and `feature_flags` in BigQuery, models them into
 a clean staging layer, and builds four reports — two at account grain, two
 segmented — with a dashboard on top. 13 assets across three layers.
 
+It complements the PostHog UI rather than replacing it — see
+[how this differs from PostHog out of the box](#how-this-differs-from-posthog-out-of-the-box).
+
 ## Features
 
 - **Identity resolution.** PostHog merges anonymous visitors into identified
@@ -44,26 +47,6 @@ segmented — with a dashboard on top. 13 assets across three layers.
 - **Typed schemas with quality checks.** Every column is declared and described;
   `metadata_push` sends those descriptions to BigQuery.
 - **A DAC dashboard** over the reports layer, filterable by plan and date range.
-
-## How this differs from PostHog out of the box
-
-PostHog is good at what it does, and a lot of this template's value is *not* that
-PostHog can't answer these questions — it's that the answers live in your
-warehouse, next to everything else.
-
-| | PostHog out of the box | This template |
-| --- | --- | --- |
-| **Account-level analysis** | Group Analytics, but only if you sent `$groups` on events at capture time. It cannot be applied retroactively, and it's a paid add-on. | Accounts are derived in SQL from person properties, so it works on events you already collected. If you never instrumented `$groups`, the account reports still build. |
-| **Getting data out** | Batch export to BigQuery delivers the raw event stream. | The same data, plus deduplication, identity resolution, sessionization, account rollup, and reports — modeling, not just export. |
-| **Joining to billing / CRM / support** | Not possible; PostHog only knows what you send it. | `posthog_stage.persons` exposes `company` and `email` as ordinary columns. Join them to your own tables and the reports gain real revenue context. |
-| **Custom metrics** | Trends, funnels, retention, paths and stickiness, plus HogQL for anything else — but only over data PostHog holds. | The same SQL freedom over the joined warehouse. The PQL and engagement scores are weighted CTEs you can rewrite. |
-| **Experiment readout** | Conversion per variant, with built-in significance testing. | The same exposure data crossed with plan, industry, and MRR — which variant won *among accounts worth money*. |
-| **History** | Bounded by your plan's retention window. | Bounded by your warehouse, which is usually cheaper per GB-year. |
-
-What PostHog still does better, and what this template does not replace: session
-replay and heatmaps, real-time dashboards, built-in experiment statistics, and
-requiring no pipeline to maintain. Run both — this is a complement to the PostHog
-UI, not a substitute for it.
 
 ## Project structure
 
@@ -117,62 +100,10 @@ checks are pinned in BigQuery rather than inferred from whatever a run happens
 to return. `metadata_push` is on in `pipeline.yml`, so those descriptions are
 pushed to the BigQuery table and column metadata.
 
-### Backfilling `events`: use one day per run
-
-This matters more than anything else in the template.
-
-PostHog's `/events` REST API — the endpoint ingestr reads — does not return a
-complete history for a multi-day window, and gives no indication that anything
-is missing. Measured against one project, `--full-refresh` each time, three
-repeats per window (the results are deterministic):
-
-| Window | Days | Events in PostHog | Events loaded | Days actually covered |
-| ------ | ---- | ----------------- | ------------- | --------------------- |
-| 3 days | 3 | 1,679 | 545 | 1 |
-| 7 days | 7 | 3,090 | 2,619 | 7, but 15% short |
-| 31 days | 31 | 16,925 | 673 | 1 |
-| 95 days | 95 | 42,354 | 1,551 | 4 |
-| 205 days, sparse | 205 | 141 | 141 | all — complete |
-| one day | 1 | exact | exact | 93 days tested, all exact |
-
-The loss is not a function of how wide the window is. A three-day window
-returned a single day while a seven-day window spanned all seven, and a
-205-day window over sparse data returned everything — so the limit tracks the
-volume of events in the window, not its width. There is no usable rule to
-exploit, because the seven-day case *looks* complete and is 15% short. **A
-single day is the only window that is reliably exact.**
-
-So backfill a day at a time. Note the end date is the *next* day: `bruin`
-parses a bare date as midnight, so `--start-date D --end-date D` is a
-zero-width interval and fails with `interval-start must be earlier than
-interval-end`.
-
-```bash
-d=2026-05-23
-while [ "$d" != "2026-08-22" ]; do
-  nxt=$(date -j -v+1d -f %Y-%m-%d $d +%Y-%m-%d)   # GNU: date -d "$d +1 day" +%F
-  bruin run assets/posthog_raw/events.asset.yml --start-date $d --end-date $nxt
-  d=$nxt
-done
-```
-
-The same off-by-one applies to any single-day run, including `persons` and
-`feature_flags`: `--end-date 2026-08-21` stops at midnight, so a profile edited
-at 06:50 that morning is outside the window.
-
-`extract_partition_by` does not help here. Ingestr rejects it for this source —
-"source table `events` does not support extract partitioning; supported sources
-are postgres, mysql, mssql, sqlite, and ADBC-backed SQL sources" — because it
-windows SQL extractions and PostHog is a REST source. It is also mutually
-exclusive with `--full-refresh`.
-
-Day-to-day scheduled runs are unaffected, since each one already covers a
-single day. Only wide backfills are at risk.
-
-`events` is also append-only, so re-running a day duplicates its rows. The
-staging layer deduplicates on `id`, which makes re-runs safe.
-
-`persons` and `feature_flags` merge on `id` and are unaffected by any of this.
+> **Backfill `events` one day at a time.** A wider window silently returns
+> partial data with no sign anything is missing, so backfilling multiple days at
+> once is the single biggest way to load wrong data
+> ([why, with measurements](#backfilling-events-use-one-day-per-run)).
 
 ### Staging: `posthog_stage`
 
@@ -188,25 +119,9 @@ never `posthog_raw` directly.
 | `posthog_stage.sessions` | Sessionized activity: duration, depth, entry/exit page, bounce, and whether the session converted. |
 | `posthog_stage.feature_flag_exposures` | One row per `$feature_flag_called` event, joined to the flag definition. |
 
-Three details worth knowing.
-
-`posthog_raw.events` is append-loaded, so re-running a day duplicates rows
-there; `posthog_stage.events` keeps only the most recently loaded copy of each
-event id, which makes re-runs safe. The tiebreaker on `timestamp` keeps that
-choice stable, so rebuilding from unchanged input gives an identical table.
-
-PostHog merges anonymous visitors into identified people over time, so a person
-owns several distinct IDs. `person_distinct_ids` is the single place that
-resolution happens: it collapses the map to one person per distinct ID and
-asserts that with a `unique` check, so no downstream join can quietly fan an
-event out across two persons and inflate every count built on it.
-
-`accounts` exists for the same reason. PostHog has no account entity unless
-`$groups` was instrumented at capture time, so the rollup — highest plan tier
-anyone holds, `MAX` of seats and MRR, modal industry — is derived once here
-instead of being copy-pasted into four reports that could then drift apart.
-An account whose people carry no recognized plan gets `unknown` rather than
-`NULL`, so it stays reachable from the dashboard's plan filter.
+For how re-runs stay safe, how identity resolution collapses to one person per
+distinct ID, and why the account rollup is derived once here, see
+[staging internals](#staging-internals).
 
 ### Reports: `posthog_reports`
 
@@ -222,45 +137,9 @@ activation, depth, breadth, session depth, and consistency; `pql_score` weights
 breadth, depth, seat activation, power users, and momentum. Adjust the weights —
 they encode assumptions about your product, not universal truths.
 
-Two things about those components are worth knowing before you trust a ranking.
-
-**Seat activation is the heaviest component and the easiest to get backwards.**
-It carries 30 engagement points and 20 PQL points, and its denominator —
-`posthog_stage.accounts.licensed_seats`, set by the `seat_denominator`
-variable — has to reconcile two different populations. `seats` comes from billing; the numerator counts people PostHog has
-seen, which means people an `identify` call has run for. An account that bought
-400 seats and rolled out to 40 reads as 10% activated, so left unqualified the
-component ranks small accounts above large ones and inverts the plan comparison.
-The default is therefore `LEAST(seats, known_users)`, which measures activation
-against the reachable team and treats the gap to the contract as a coverage
-question. Switch it back to `seats` in `accounts.sql` if your `identify`
-coverage matches your billing — that is what `seat_denominator: contracted`
-does. The seats information is not lost either way:
-`posthog_stage.accounts.seat_coverage` reports known users over contracted seats
-on its own, so a rollout that has not reached most of its licences shows up as a
-coverage number rather than as a low engagement score.
-
-**The score thresholds set queue length, not truth.** `pql_hot_score`,
-`pql_warm_score`, `pql_cool_score`, and `expansion_min_score` decide how many
-accounts land in front of a human, and the right numbers depend on how your
-scores actually spread. On a test project where nearly every account was active,
-the default `expansion_min_score` of 65 fired on a quarter of them — technically
-correct, operationally useless. Look at `COUNTIF(expansion_signal) / COUNT(*)`
-and the `pql_score` quartiles on your own data, then raise the thresholds rather
-than the headcount.
-
-**Breadth saturates.** It is a count out of `product_action_events`, so once an
-account has touched every event on the list the component stops discriminating —
-on one test project half the accounts sat at the ceiling. This is the one
-component with no variable to tune, because the fix is a different measure rather
-than a different constant: count distinct days per feature, or weight the rarer
-actions, instead of the plain distinct count.
-
-Account attributes come from `posthog_stage.accounts`, so the rollup rule is
-stated once: plan is the highest tier held by anyone at the company, seats and
-MRR are `MAX` (they repeat on every person row), industry is the modal value.
-`persons` is a current-state snapshot with no history, so today's plan is
-carried onto historical months.
+Before you trust a ranking, read the [scoring caveats](#scoring-caveats): seat
+activation is the heaviest component and the easiest to get backwards, the score
+thresholds set queue length rather than truth, and breadth saturates.
 
 ### Dashboard
 
@@ -309,12 +188,9 @@ by signup source.
 
 ![Retention](/posthog-retention.png)
 
-Two widget conventions are deliberate. The adoption widgets filter on
-`was_enabled`, so a boolean flag's `false` arm — everyone the rollout held out —
-is not counted as having adopted the feature; the "Enabled vs Held Out" table is
-where the two arms are compared. And the retention widgets filter on
-`is_complete_week`, which excludes weeks at either end of the event history that
-the warehouse cannot speak to.
+Two widget conventions — the adoption widgets filter on `was_enabled` and the
+retention widgets on `is_complete_week` — are deliberate
+([details](#dashboard-widget-conventions)).
 
 ## Adapt this to your project
 
@@ -360,19 +236,15 @@ numbers are bare and strings need quotes:
 bruin run --var pql_hot_score=85 --var seat_denominator='"contracted"' my-posthog-pipeline
 ```
 
-The `enum`, `minimum`, and `maximum` keywords on these variables are currently
-documentation rather than enforcement — Bruin validates that a variable has a
-default and little else, and `--var` overrides skip schema checks. Where getting
-a value wrong would silently produce plausible-but-wrong numbers rather than an
-obvious break, the SQL fails the run itself: an unrecognised `seat_denominator`
-stops `posthog_stage.accounts` with
-`seat_denominator must be "reachable" or "contracted", got …` instead of quietly
-falling back to a default.
+The `enum`, `minimum`, and `maximum` keywords on these variables document intent
+rather than enforce it, though the SQL still guards the values that would
+otherwise silently produce wrong numbers
+([details](#variable-validation-and-macro-loading)).
 
 Two of these are worth checking against your own data before you trust a
 ranking. `seat_denominator` decides whether the heaviest component measures
-rollout or licence coverage, which [Reports](#reports-posthog-reports) covers in
-full. And `depth_target_actions` sets where the depth component saturates: too
+rollout or licence coverage, which the [scoring caveats](#scoring-caveats) cover
+in full. And `depth_target_actions` sets where the depth component saturates: too
 high and it reads near-zero for everyone, too low and it stops separating
 accounts.
 
@@ -452,10 +324,9 @@ bruin validate my-posthog-pipeline
 bruin run my-posthog-pipeline
 ```
 
-`bruin validate` currently reports `in_string_list is not callable` for the
-assets that call the template's macros. The macros render correctly at run time;
-validation does not load the `macros/` folder
-([bruin#2588](https://github.com/bruin-data/bruin/issues/2588)).
+`bruin validate` reports a harmless `in_string_list is not callable` error for
+the assets that call the template's macros; the macros still render correctly at
+run time ([details](#variable-validation-and-macro-loading)).
 
 To load history, backfill `posthog_raw.events` with the one-day-per-run loop in
 [Backfilling `events`](#backfilling-events-use-one-day-per-run) — a wider window
@@ -489,3 +360,171 @@ bruin run --exclude-tag posthog_raw my-posthog-pipeline
 - [PostHog ingestion](https://getbruin.com/docs/bruin/ingestion/posthog.html)
 - [Ingestr assets](https://getbruin.com/docs/bruin/assets/ingestr.html)
 - [BigQuery platform](https://getbruin.com/docs/bruin/platforms/bigquery.html)
+
+## Appendix: notes, caveats & details
+
+### Backfilling `events`: use one day per run
+
+This matters more than anything else in the template.
+
+PostHog's `/events` REST API — the endpoint ingestr reads — does not return a
+complete history for a multi-day window, and gives no indication that anything
+is missing. Measured against one project, `--full-refresh` each time, three
+repeats per window (the results are deterministic):
+
+| Window | Days | Events in PostHog | Events loaded | Days actually covered |
+| ------ | ---- | ----------------- | ------------- | --------------------- |
+| 3 days | 3 | 1,679 | 545 | 1 |
+| 7 days | 7 | 3,090 | 2,619 | 7, but 15% short |
+| 31 days | 31 | 16,925 | 673 | 1 |
+| 95 days | 95 | 42,354 | 1,551 | 4 |
+| 205 days, sparse | 205 | 141 | 141 | all — complete |
+| one day | 1 | exact | exact | 93 days tested, all exact |
+
+The loss is not a function of how wide the window is. A three-day window
+returned a single day while a seven-day window spanned all seven, and a
+205-day window over sparse data returned everything — so the limit tracks the
+volume of events in the window, not its width. There is no usable rule to
+exploit, because the seven-day case *looks* complete and is 15% short. **A
+single day is the only window that is reliably exact.**
+
+So backfill a day at a time. Note the end date is the *next* day: `bruin`
+parses a bare date as midnight, so `--start-date D --end-date D` is a
+zero-width interval and fails with `interval-start must be earlier than
+interval-end`.
+
+```bash
+d=2026-05-23
+while [ "$d" != "2026-08-22" ]; do
+  nxt=$(date -j -v+1d -f %Y-%m-%d $d +%Y-%m-%d)   # GNU: date -d "$d +1 day" +%F
+  bruin run assets/posthog_raw/events.asset.yml --start-date $d --end-date $nxt
+  d=$nxt
+done
+```
+
+The same off-by-one applies to any single-day run, including `persons` and
+`feature_flags`: `--end-date 2026-08-21` stops at midnight, so a profile edited
+at 06:50 that morning is outside the window.
+
+`extract_partition_by` does not help here. Ingestr rejects it for this source —
+"source table `events` does not support extract partitioning; supported sources
+are postgres, mysql, mssql, sqlite, and ADBC-backed SQL sources" — because it
+windows SQL extractions and PostHog is a REST source. It is also mutually
+exclusive with `--full-refresh`.
+
+Day-to-day scheduled runs are unaffected, since each one already covers a
+single day. Only wide backfills are at risk.
+
+`events` is also append-only, so re-running a day duplicates its rows. The
+staging layer deduplicates on `id`, which makes re-runs safe.
+
+`persons` and `feature_flags` merge on `id` and are unaffected by any of this.
+
+### How this differs from PostHog out of the box
+
+PostHog is good at what it does, and a lot of this template's value is *not* that
+PostHog can't answer these questions — it's that the answers live in your
+warehouse, next to everything else.
+
+| | PostHog out of the box | This template |
+| --- | --- | --- |
+| **Account-level analysis** | Group Analytics, but only if you sent `$groups` on events at capture time. It cannot be applied retroactively, and it's a paid add-on. | Accounts are derived in SQL from person properties, so it works on events you already collected. If you never instrumented `$groups`, the account reports still build. |
+| **Getting data out** | Batch export to BigQuery delivers the raw event stream. | The same data, plus deduplication, identity resolution, sessionization, account rollup, and reports — modeling, not just export. |
+| **Joining to billing / CRM / support** | Not possible; PostHog only knows what you send it. | `posthog_stage.persons` exposes `company` and `email` as ordinary columns. Join them to your own tables and the reports gain real revenue context. |
+| **Custom metrics** | Trends, funnels, retention, paths and stickiness, plus HogQL for anything else — but only over data PostHog holds. | The same SQL freedom over the joined warehouse. The PQL and engagement scores are weighted CTEs you can rewrite. |
+| **Experiment readout** | Conversion per variant, with built-in significance testing. | The same exposure data crossed with plan, industry, and MRR — which variant won *among accounts worth money*. |
+| **History** | Bounded by your plan's retention window. | Bounded by your warehouse, which is usually cheaper per GB-year. |
+
+What PostHog still does better, and what this template does not replace: session
+replay and heatmaps, real-time dashboards, built-in experiment statistics, and
+requiring no pipeline to maintain. Run both — this is a complement to the PostHog
+UI, not a substitute for it.
+
+### Staging internals
+
+Three details worth knowing.
+
+`posthog_raw.events` is append-loaded, so re-running a day duplicates rows
+there; `posthog_stage.events` keeps only the most recently loaded copy of each
+event id, which makes re-runs safe. The tiebreaker on `timestamp` keeps that
+choice stable, so rebuilding from unchanged input gives an identical table.
+
+PostHog merges anonymous visitors into identified people over time, so a person
+owns several distinct IDs. `person_distinct_ids` is the single place that
+resolution happens: it collapses the map to one person per distinct ID and
+asserts that with a `unique` check, so no downstream join can quietly fan an
+event out across two persons and inflate every count built on it.
+
+`accounts` exists for the same reason. PostHog has no account entity unless
+`$groups` was instrumented at capture time, so the rollup — highest plan tier
+anyone holds, `MAX` of seats and MRR, modal industry — is derived once here
+instead of being copy-pasted into four reports that could then drift apart.
+An account whose people carry no recognized plan gets `unknown` rather than
+`NULL`, so it stays reachable from the dashboard's plan filter.
+
+### Scoring caveats
+
+Two things about those components are worth knowing before you trust a ranking.
+
+**Seat activation is the heaviest component and the easiest to get backwards.**
+It carries 30 engagement points and 20 PQL points, and its denominator —
+`posthog_stage.accounts.licensed_seats`, set by the `seat_denominator`
+variable — has to reconcile two different populations. `seats` comes from billing; the numerator counts people PostHog has
+seen, which means people an `identify` call has run for. An account that bought
+400 seats and rolled out to 40 reads as 10% activated, so left unqualified the
+component ranks small accounts above large ones and inverts the plan comparison.
+The default is therefore `LEAST(seats, known_users)`, which measures activation
+against the reachable team and treats the gap to the contract as a coverage
+question. Switch it back to `seats` in `accounts.sql` if your `identify`
+coverage matches your billing — that is what `seat_denominator: contracted`
+does. The seats information is not lost either way:
+`posthog_stage.accounts.seat_coverage` reports known users over contracted seats
+on its own, so a rollout that has not reached most of its licences shows up as a
+coverage number rather than as a low engagement score.
+
+**The score thresholds set queue length, not truth.** `pql_hot_score`,
+`pql_warm_score`, `pql_cool_score`, and `expansion_min_score` decide how many
+accounts land in front of a human, and the right numbers depend on how your
+scores actually spread. On a test project where nearly every account was active,
+the default `expansion_min_score` of 65 fired on a quarter of them — technically
+correct, operationally useless. Look at `COUNTIF(expansion_signal) / COUNT(*)`
+and the `pql_score` quartiles on your own data, then raise the thresholds rather
+than the headcount.
+
+**Breadth saturates.** It is a count out of `product_action_events`, so once an
+account has touched every event on the list the component stops discriminating —
+on one test project half the accounts sat at the ceiling. This is the one
+component with no variable to tune, because the fix is a different measure rather
+than a different constant: count distinct days per feature, or weight the rarer
+actions, instead of the plain distinct count.
+
+Account attributes come from `posthog_stage.accounts`, so the rollup rule is
+stated once: plan is the highest tier held by anyone at the company, seats and
+MRR are `MAX` (they repeat on every person row), industry is the modal value.
+`persons` is a current-state snapshot with no history, so today's plan is
+carried onto historical months.
+
+### Dashboard widget conventions
+
+Two widget conventions are deliberate. The adoption widgets filter on
+`was_enabled`, so a boolean flag's `false` arm — everyone the rollout held out —
+is not counted as having adopted the feature; the "Enabled vs Held Out" table is
+where the two arms are compared. And the retention widgets filter on
+`is_complete_week`, which excludes weeks at either end of the event history that
+the warehouse cannot speak to.
+
+### Variable validation and macro loading
+
+The `enum`, `minimum`, and `maximum` keywords on these variables are currently
+documentation rather than enforcement — Bruin validates that a variable has a
+default and little else, and `--var` overrides skip schema checks. Where getting
+a value wrong would silently produce plausible-but-wrong numbers rather than an
+obvious break, the SQL fails the run itself: an unrecognised `seat_denominator`
+stops `posthog_stage.accounts` with
+`seat_denominator must be "reachable" or "contracted", got …` instead of quietly
+falling back to a default.
+
+`bruin validate` currently reports `in_string_list is not callable` for the
+assets that call the template's macros. The macros render correctly at run time;
+validation does not load the `macros/` folder
+([bruin#2588](https://github.com/bruin-data/bruin/issues/2588)).

--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -55,27 +55,13 @@ stripe-bigquery/
 
 The `stripe_raw` dataset contains the six Stripe resources that underpin the billing models. Ingestr loads them with the shared `stripe-default` connection, and BigQuery is the destination.
 
-Each source asset uses ingestr's [incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading) (`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the Stripe object `id`, so a run only fetches the records created inside its own time window and upserts them.
-
-Incremental mode filters on Stripe's `created` timestamp and does not revisit records created in earlier windows. That matters for the mutable resources — a subscription cancelled or upgraded months after it was created, an invoice finalized, paid, or voided after its creation date. To pick those edits up, periodically re-run over a wider window:
-
-```bash
-bruin run --start-date 2023-01-01 --end-date $(date -u +%F) my-stripe-pipeline
-```
-
-Choose that cadence to match how current your reporting needs to be, or switch the mutable assets to `source_table: subscription` for [standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default), which reloads full history on every run. See [loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs) for the comparison.
-
-Each raw asset also declares its full column schema, which pins those columns into the destination table. That matters for fields Stripe leaves null on some accounts: `invoice.due_date` is only set for invoices collected with `send_invoice`, and a schema inferred purely from the data would drop the column and break the stage model.
+Each source asset uses ingestr's [incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading) (`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the Stripe object `id`, so a run only fetches the records created inside its own time window and upserts them. See [Incremental-loading trade-offs](#incremental-loading-trade-offs) for how mutable resources, re-run cadence, and column-schema pinning are handled.
 
 ### Conformed billing models
 
 The `stripe_stage` dataset exposes typed customer, product, price, subscription, subscription-item, invoice, and invoice-line-item models. It also builds daily snapshots of subscription items and customer MRR by native currency, stamped with the pipeline end date.
 
-Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`, so each run rebuilds its table from the current raw data. That keeps the pipeline idempotent and easy to reason about.
-
-The two daily snapshot assets are the exception. They use `delete+insert` on `snapshot_date`, so each run replaces only the day it observes and leaves earlier days in place. That accumulates the daily observation history the reports layer needs for month-over-month movement and retention, while keeping a re-run of any single date idempotent. Because `delete+insert` writes into an existing table, the first load has to create these two tables with `--full-refresh`; see [Run the pipeline](#run-the-pipeline).
-
-The snapshots record the Stripe state visible when the pipeline runs, so history builds up from the first run forward and cannot be backfilled from current Stripe records.
+Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`, so each run rebuilds its table from the current raw data. That keeps the pipeline idempotent and easy to reason about. The two daily snapshot assets are the exception; see [Snapshot & backfill mechanics](#snapshot-backfill-mechanics) for how they accumulate history and why the first load needs `--full-refresh`.
 
 ### Billing reports
 
@@ -85,6 +71,8 @@ The `stripe_reports` dataset provides four ready-to-query tables:
 - `monthly_mrr_movements` — customer-level new, reactivation, expansion, contraction, and churn movements.
 - `monthly_subscription_kpis` — recurring-revenue, retention, and customer-count metrics by currency.
 - `monthly_invoice_billings` — non-draft, non-void invoice billings by finalization month, with a labeled creation-date fallback.
+
+See [Metric policy & definitions](#metric-policy-definitions) for how these metrics are defined and the caveats that apply, and [Illustrative report rows](#illustrative-report-rows) for sample output from each table.
 
 ### Asset summary
 
@@ -112,55 +100,11 @@ All 19 assets materialize as tables. `create+replace` is the default when no inc
 | `stripe_reports` | `monthly_subscription_kpis` | table | `create+replace` | — | Recurring-revenue, retention, and customer-count scorecard |
 | `stripe_reports` | `monthly_invoice_billings` | table | `create+replace` | — | Invoice billings by finalization month and currency |
 
-The two snapshot assets are partitioned on `snapshot_date` because they accumulate indefinitely: their per-run `DELETE` prunes to the single day being replaced instead of scanning the whole history. The other assets are rebuilt in full each run, so partitioning would not save any scan.
+The two snapshot assets are partitioned on `snapshot_date`; see [Partitioning rationale](#partitioning-rationale) for why.
 
 ### Column-level documentation
 
 Every asset in all three layers declares its full column schema: each column carries a type, a description, and primary-key marks on the grain, so the reporting grain and the metric definitions are readable from the asset files themselves. `metadata_push` in `pipeline.yml` publishes those descriptions to the BigQuery table and column metadata, and `bruin docs my-stripe-pipeline` generates a browsable documentation site from the same schemas.
-
-## Example report rows
-
-The following illustrative rows use minor currency units: `9900` USD means $99.00. They show the shape of each table across several months, which fills in once the snapshots have accumulated that many months of history; see [Conformed billing models](#conformed-billing-models). Query the four tables in `stripe_reports` directly, then adapt the columns to the definitions used by your finance and revenue teams.
-
-### `monthly_mrr_by_customer`
-
-| metric_month | as_of_snapshot_date | stripe_customer_id | currency | active_subscription_count | ending_mrr_minor | run_rate_arr_minor |
-| --- | --- | --- | --- | ---: | ---: | ---: |
-| 2026-01-01 | 2026-01-31 | cus_acme | usd | 1 | 9900 | 118800 |
-| 2026-02-01 | 2026-02-28 | cus_acme | usd | 1 | 12900 | 154800 |
-| 2026-02-01 | 2026-02-28 | cus_pine | usd | 2 | 4900 | 58800 |
-
-### `monthly_mrr_movements`
-
-| metric_month | stripe_customer_id | currency | beginning_mrr_minor | ending_mrr_minor | expansion_mrr_minor | churned_mrr_minor | movement_type |
-| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| 2026-02-01 | cus_acme | usd | 9900 | 12900 | 3000 | 0 | expansion |
-| 2026-02-01 | cus_oak | usd | 2500 | 0 | 0 | 2500 | churn |
-| 2026-02-01 | cus_pine | usd | 0 | 4900 | 0 | 0 | new |
-
-### `monthly_subscription_kpis`
-
-| metric_month | currency | ending_mrr_minor | new_mrr_minor | expansion_mrr_minor | churned_mrr_minor | ending_active_customer_count | net_revenue_retention_rate_excluding_reactivation |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 2026-01-01 | usd | 12400 | 12400 | 0 | 0 | 2 | — |
-| 2026-02-01 | usd | 17800 | 4900 | 3000 | 2500 | 2 | 1.04 |
-| 2026-02-01 | eur | 8100 | 0 | 1100 | 0 | 1 | 1.16 |
-
-### `monthly_invoice_billings`
-
-| invoice_billing_month | invoice_billing_date_basis | currency | issued_invoice_count | subscription_invoice_count | invoiced_billings_minor | invoiced_subscription_billings_minor |
-| --- | --- | --- | ---: | ---: | ---: | ---: |
-| 2026-01-01 | invoice_finalized_at | usd | 14 | 12 | 139400 | 128700 |
-| 2026-02-01 | invoice_finalized_at | usd | 16 | 13 | 171800 | 160200 |
-| 2026-02-01 | invoice_created_at_fallback | eur | 2 | 2 | 16200 | 16200 |
-
-## Metric policy
-
-All monetary values in the `stripe_stage` and `stripe_reports` tables remain in each currency's minor units; only the dashboard converts to major units for display. Do not add amounts across currencies without an FX source and explicit conversion policy.
-
-MRR is a gross list-price run rate from active and past-due subscriptions with licensed recurring monthly or annual prices. Free, one-time, metered, and discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither measure is recognized revenue, bookings, cash, or a financial statement.
-
-The daily snapshots capture the Stripe state visible when the pipeline runs. They do not reconstruct prior daily MRR history from current Stripe records, so the accumulated history starts at the first run. Month-over-month movement and retention metrics need two contiguous monthly observations, so they stay empty until the snapshots span a second month.
 
 ## Configure connections
 
@@ -261,3 +205,71 @@ dac --config .bruin.yml serve --dir dashboards --port 8321
 This screenshot uses synthetic data solely to demonstrate the dashboard's layout and charts.
 
 MRR movement and retention metrics need two contiguous monthly snapshots, so they stay empty until the accumulated snapshot history spans a second month.
+
+## Appendix: notes, caveats & details
+
+### Incremental-loading trade-offs
+
+Incremental mode filters on Stripe's `created` timestamp and does not revisit records created in earlier windows. That matters for the mutable resources — a subscription cancelled or upgraded months after it was created, an invoice finalized, paid, or voided after its creation date. To pick those edits up, periodically re-run over a wider window:
+
+```bash
+bruin run --start-date 2023-01-01 --end-date $(date -u +%F) my-stripe-pipeline
+```
+
+Choose that cadence to match how current your reporting needs to be, or switch the mutable assets to `source_table: subscription` for [standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default), which reloads full history on every run. See [loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs) for the comparison.
+
+Each raw asset also declares its full column schema, which pins those columns into the destination table. That matters for fields Stripe leaves null on some accounts: `invoice.due_date` is only set for invoices collected with `send_invoice`, and a schema inferred purely from the data would drop the column and break the stage model.
+
+### Snapshot & backfill mechanics
+
+The two daily snapshot assets are the exception. They use `delete+insert` on `snapshot_date`, so each run replaces only the day it observes and leaves earlier days in place. That accumulates the daily observation history the reports layer needs for month-over-month movement and retention, while keeping a re-run of any single date idempotent. Because `delete+insert` writes into an existing table, the first load has to create these two tables with `--full-refresh`; see [Run the pipeline](#run-the-pipeline).
+
+The snapshots record the Stripe state visible when the pipeline runs, so history builds up from the first run forward and cannot be backfilled from current Stripe records.
+
+### Metric policy & definitions
+
+All monetary values in the `stripe_stage` and `stripe_reports` tables remain in each currency's minor units; only the dashboard converts to major units for display. Do not add amounts across currencies without an FX source and explicit conversion policy.
+
+MRR is a gross list-price run rate from active and past-due subscriptions with licensed recurring monthly or annual prices. Free, one-time, metered, and discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither measure is recognized revenue, bookings, cash, or a financial statement.
+
+The daily snapshots capture the Stripe state visible when the pipeline runs. They do not reconstruct prior daily MRR history from current Stripe records, so the accumulated history starts at the first run. Month-over-month movement and retention metrics need two contiguous monthly observations, so they stay empty until the snapshots span a second month.
+
+### Partitioning rationale
+
+The two snapshot assets are partitioned on `snapshot_date` because they accumulate indefinitely: their per-run `DELETE` prunes to the single day being replaced instead of scanning the whole history. The other assets are rebuilt in full each run, so partitioning would not save any scan.
+
+### Illustrative report rows
+
+The following illustrative rows use minor currency units: `9900` USD means $99.00. They show the shape of each table across several months, which fills in once the snapshots have accumulated that many months of history; see [Conformed billing models](#conformed-billing-models). Query the four tables in `stripe_reports` directly, then adapt the columns to the definitions used by your finance and revenue teams.
+
+#### `monthly_mrr_by_customer`
+
+| metric_month | as_of_snapshot_date | stripe_customer_id | currency | active_subscription_count | ending_mrr_minor | run_rate_arr_minor |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| 2026-01-01 | 2026-01-31 | cus_acme | usd | 1 | 9900 | 118800 |
+| 2026-02-01 | 2026-02-28 | cus_acme | usd | 1 | 12900 | 154800 |
+| 2026-02-01 | 2026-02-28 | cus_pine | usd | 2 | 4900 | 58800 |
+
+#### `monthly_mrr_movements`
+
+| metric_month | stripe_customer_id | currency | beginning_mrr_minor | ending_mrr_minor | expansion_mrr_minor | churned_mrr_minor | movement_type |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 2026-02-01 | cus_acme | usd | 9900 | 12900 | 3000 | 0 | expansion |
+| 2026-02-01 | cus_oak | usd | 2500 | 0 | 0 | 2500 | churn |
+| 2026-02-01 | cus_pine | usd | 0 | 4900 | 0 | 0 | new |
+
+#### `monthly_subscription_kpis`
+
+| metric_month | currency | ending_mrr_minor | new_mrr_minor | expansion_mrr_minor | churned_mrr_minor | ending_active_customer_count | net_revenue_retention_rate_excluding_reactivation |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2026-01-01 | usd | 12400 | 12400 | 0 | 0 | 2 | — |
+| 2026-02-01 | usd | 17800 | 4900 | 3000 | 2500 | 2 | 1.04 |
+| 2026-02-01 | eur | 8100 | 0 | 1100 | 0 | 1 | 1.16 |
+
+#### `monthly_invoice_billings`
+
+| invoice_billing_month | invoice_billing_date_basis | currency | issued_invoice_count | subscription_invoice_count | invoiced_billings_minor | invoiced_subscription_billings_minor |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| 2026-01-01 | invoice_finalized_at | usd | 14 | 12 | 139400 | 128700 |
+| 2026-02-01 | invoice_finalized_at | usd | 16 | 13 | 171800 | 160200 |
+| 2026-02-01 | invoice_created_at_fallback | eur | 2 | 2 | 16200 | 16200 |

--- a/docs/getting-started/templates-docs/stripe-bigquery-README.md
+++ b/docs/getting-started/templates-docs/stripe-bigquery-README.md
@@ -1,6 +1,17 @@
 <!-- Generated from templates/stripe-bigquery/README.md. Do not edit directly; run `make sync-template-docs`. -->
 # Stripe Billing Analytics to BigQuery
 
+## At a glance
+
+- Pulls your Stripe customers, subscriptions, invoices, and prices into BigQuery
+- Cleans that raw data into tidy, reusable billing tables
+- Publishes monthly reports on recurring revenue, churn, and invoices
+- Tracks MRR and ARR per customer and per currency
+- Saves a daily snapshot so month-over-month trends build up over time
+- Comes with a ready-made dashboard for revenue, retention, and billings
+- Safe to re-run, and easy to adapt to your own reporting
+- **Builds the foundational billing models and context an AI agent can analyze and act on**
+
 `stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery. It loads the customer, product, price, subscription, subscription-item, and invoice resources into `stripe_raw`; builds reusable billing models in `stripe_stage`; and publishes recurring-revenue and invoice-billing reports in `stripe_reports`.
 
 The template contains 19 assets across three layers. It is a practical starting point for analyzing Stripe subscription billing while keeping the data model small enough to adapt to your own reporting needs.

--- a/templates/posthog-bigquery/README.md
+++ b/templates/posthog-bigquery/README.md
@@ -18,6 +18,9 @@ It lands `events`, `persons`, and `feature_flags` in BigQuery, models them into
 a clean staging layer, and builds four reports — two at account grain, two
 segmented — with a dashboard on top. 13 assets across three layers.
 
+It complements the PostHog UI rather than replacing it — see
+[how this differs from PostHog out of the box](#how-this-differs-from-posthog-out-of-the-box).
+
 ## Features
 
 - **Identity resolution.** PostHog merges anonymous visitors into identified
@@ -43,26 +46,6 @@ segmented — with a dashboard on top. 13 assets across three layers.
 - **Typed schemas with quality checks.** Every column is declared and described;
   `metadata_push` sends those descriptions to BigQuery.
 - **A DAC dashboard** over the reports layer, filterable by plan and date range.
-
-## How this differs from PostHog out of the box
-
-PostHog is good at what it does, and a lot of this template's value is *not* that
-PostHog can't answer these questions — it's that the answers live in your
-warehouse, next to everything else.
-
-| | PostHog out of the box | This template |
-| --- | --- | --- |
-| **Account-level analysis** | Group Analytics, but only if you sent `$groups` on events at capture time. It cannot be applied retroactively, and it's a paid add-on. | Accounts are derived in SQL from person properties, so it works on events you already collected. If you never instrumented `$groups`, the account reports still build. |
-| **Getting data out** | Batch export to BigQuery delivers the raw event stream. | The same data, plus deduplication, identity resolution, sessionization, account rollup, and reports — modeling, not just export. |
-| **Joining to billing / CRM / support** | Not possible; PostHog only knows what you send it. | `posthog_stage.persons` exposes `company` and `email` as ordinary columns. Join them to your own tables and the reports gain real revenue context. |
-| **Custom metrics** | Trends, funnels, retention, paths and stickiness, plus HogQL for anything else — but only over data PostHog holds. | The same SQL freedom over the joined warehouse. The PQL and engagement scores are weighted CTEs you can rewrite. |
-| **Experiment readout** | Conversion per variant, with built-in significance testing. | The same exposure data crossed with plan, industry, and MRR — which variant won *among accounts worth money*. |
-| **History** | Bounded by your plan's retention window. | Bounded by your warehouse, which is usually cheaper per GB-year. |
-
-What PostHog still does better, and what this template does not replace: session
-replay and heatmaps, real-time dashboards, built-in experiment statistics, and
-requiring no pipeline to maintain. Run both — this is a complement to the PostHog
-UI, not a substitute for it.
 
 ## Project structure
 
@@ -116,62 +99,10 @@ checks are pinned in BigQuery rather than inferred from whatever a run happens
 to return. `metadata_push` is on in `pipeline.yml`, so those descriptions are
 pushed to the BigQuery table and column metadata.
 
-### Backfilling `events`: use one day per run
-
-This matters more than anything else in the template.
-
-PostHog's `/events` REST API — the endpoint ingestr reads — does not return a
-complete history for a multi-day window, and gives no indication that anything
-is missing. Measured against one project, `--full-refresh` each time, three
-repeats per window (the results are deterministic):
-
-| Window | Days | Events in PostHog | Events loaded | Days actually covered |
-| ------ | ---- | ----------------- | ------------- | --------------------- |
-| 3 days | 3 | 1,679 | 545 | 1 |
-| 7 days | 7 | 3,090 | 2,619 | 7, but 15% short |
-| 31 days | 31 | 16,925 | 673 | 1 |
-| 95 days | 95 | 42,354 | 1,551 | 4 |
-| 205 days, sparse | 205 | 141 | 141 | all — complete |
-| one day | 1 | exact | exact | 93 days tested, all exact |
-
-The loss is not a function of how wide the window is. A three-day window
-returned a single day while a seven-day window spanned all seven, and a
-205-day window over sparse data returned everything — so the limit tracks the
-volume of events in the window, not its width. There is no usable rule to
-exploit, because the seven-day case *looks* complete and is 15% short. **A
-single day is the only window that is reliably exact.**
-
-So backfill a day at a time. Note the end date is the *next* day: `bruin`
-parses a bare date as midnight, so `--start-date D --end-date D` is a
-zero-width interval and fails with `interval-start must be earlier than
-interval-end`.
-
-```bash
-d=2026-05-23
-while [ "$d" != "2026-08-22" ]; do
-  nxt=$(date -j -v+1d -f %Y-%m-%d $d +%Y-%m-%d)   # GNU: date -d "$d +1 day" +%F
-  bruin run assets/posthog_raw/events.asset.yml --start-date $d --end-date $nxt
-  d=$nxt
-done
-```
-
-The same off-by-one applies to any single-day run, including `persons` and
-`feature_flags`: `--end-date 2026-08-21` stops at midnight, so a profile edited
-at 06:50 that morning is outside the window.
-
-`extract_partition_by` does not help here. Ingestr rejects it for this source —
-"source table `events` does not support extract partitioning; supported sources
-are postgres, mysql, mssql, sqlite, and ADBC-backed SQL sources" — because it
-windows SQL extractions and PostHog is a REST source. It is also mutually
-exclusive with `--full-refresh`.
-
-Day-to-day scheduled runs are unaffected, since each one already covers a
-single day. Only wide backfills are at risk.
-
-`events` is also append-only, so re-running a day duplicates its rows. The
-staging layer deduplicates on `id`, which makes re-runs safe.
-
-`persons` and `feature_flags` merge on `id` and are unaffected by any of this.
+> **Backfill `events` one day at a time.** A wider window silently returns
+> partial data with no sign anything is missing, so backfilling multiple days at
+> once is the single biggest way to load wrong data
+> ([why, with measurements](#backfilling-events-use-one-day-per-run)).
 
 ### Staging: `posthog_stage`
 
@@ -187,25 +118,9 @@ never `posthog_raw` directly.
 | `posthog_stage.sessions` | Sessionized activity: duration, depth, entry/exit page, bounce, and whether the session converted. |
 | `posthog_stage.feature_flag_exposures` | One row per `$feature_flag_called` event, joined to the flag definition. |
 
-Three details worth knowing.
-
-`posthog_raw.events` is append-loaded, so re-running a day duplicates rows
-there; `posthog_stage.events` keeps only the most recently loaded copy of each
-event id, which makes re-runs safe. The tiebreaker on `timestamp` keeps that
-choice stable, so rebuilding from unchanged input gives an identical table.
-
-PostHog merges anonymous visitors into identified people over time, so a person
-owns several distinct IDs. `person_distinct_ids` is the single place that
-resolution happens: it collapses the map to one person per distinct ID and
-asserts that with a `unique` check, so no downstream join can quietly fan an
-event out across two persons and inflate every count built on it.
-
-`accounts` exists for the same reason. PostHog has no account entity unless
-`$groups` was instrumented at capture time, so the rollup — highest plan tier
-anyone holds, `MAX` of seats and MRR, modal industry — is derived once here
-instead of being copy-pasted into four reports that could then drift apart.
-An account whose people carry no recognized plan gets `unknown` rather than
-`NULL`, so it stays reachable from the dashboard's plan filter.
+For how re-runs stay safe, how identity resolution collapses to one person per
+distinct ID, and why the account rollup is derived once here, see
+[staging internals](#staging-internals).
 
 ### Reports: `posthog_reports`
 
@@ -221,45 +136,9 @@ activation, depth, breadth, session depth, and consistency; `pql_score` weights
 breadth, depth, seat activation, power users, and momentum. Adjust the weights —
 they encode assumptions about your product, not universal truths.
 
-Two things about those components are worth knowing before you trust a ranking.
-
-**Seat activation is the heaviest component and the easiest to get backwards.**
-It carries 30 engagement points and 20 PQL points, and its denominator —
-`posthog_stage.accounts.licensed_seats`, set by the `seat_denominator`
-variable — has to reconcile two different populations. `seats` comes from billing; the numerator counts people PostHog has
-seen, which means people an `identify` call has run for. An account that bought
-400 seats and rolled out to 40 reads as 10% activated, so left unqualified the
-component ranks small accounts above large ones and inverts the plan comparison.
-The default is therefore `LEAST(seats, known_users)`, which measures activation
-against the reachable team and treats the gap to the contract as a coverage
-question. Switch it back to `seats` in `accounts.sql` if your `identify`
-coverage matches your billing — that is what `seat_denominator: contracted`
-does. The seats information is not lost either way:
-`posthog_stage.accounts.seat_coverage` reports known users over contracted seats
-on its own, so a rollout that has not reached most of its licences shows up as a
-coverage number rather than as a low engagement score.
-
-**The score thresholds set queue length, not truth.** `pql_hot_score`,
-`pql_warm_score`, `pql_cool_score`, and `expansion_min_score` decide how many
-accounts land in front of a human, and the right numbers depend on how your
-scores actually spread. On a test project where nearly every account was active,
-the default `expansion_min_score` of 65 fired on a quarter of them — technically
-correct, operationally useless. Look at `COUNTIF(expansion_signal) / COUNT(*)`
-and the `pql_score` quartiles on your own data, then raise the thresholds rather
-than the headcount.
-
-**Breadth saturates.** It is a count out of `product_action_events`, so once an
-account has touched every event on the list the component stops discriminating —
-on one test project half the accounts sat at the ceiling. This is the one
-component with no variable to tune, because the fix is a different measure rather
-than a different constant: count distinct days per feature, or weight the rarer
-actions, instead of the plain distinct count.
-
-Account attributes come from `posthog_stage.accounts`, so the rollup rule is
-stated once: plan is the highest tier held by anyone at the company, seats and
-MRR are `MAX` (they repeat on every person row), industry is the modal value.
-`persons` is a current-state snapshot with no history, so today's plan is
-carried onto historical months.
+Before you trust a ranking, read the [scoring caveats](#scoring-caveats): seat
+activation is the heaviest component and the easiest to get backwards, the score
+thresholds set queue length rather than truth, and breadth saturates.
 
 ### Dashboard
 
@@ -308,12 +187,9 @@ by signup source.
 
 ![Retention](images/posthog-retention.png)
 
-Two widget conventions are deliberate. The adoption widgets filter on
-`was_enabled`, so a boolean flag's `false` arm — everyone the rollout held out —
-is not counted as having adopted the feature; the "Enabled vs Held Out" table is
-where the two arms are compared. And the retention widgets filter on
-`is_complete_week`, which excludes weeks at either end of the event history that
-the warehouse cannot speak to.
+Two widget conventions — the adoption widgets filter on `was_enabled` and the
+retention widgets on `is_complete_week` — are deliberate
+([details](#dashboard-widget-conventions)).
 
 ## Adapt this to your project
 
@@ -359,19 +235,15 @@ numbers are bare and strings need quotes:
 bruin run --var pql_hot_score=85 --var seat_denominator='"contracted"' my-posthog-pipeline
 ```
 
-The `enum`, `minimum`, and `maximum` keywords on these variables are currently
-documentation rather than enforcement — Bruin validates that a variable has a
-default and little else, and `--var` overrides skip schema checks. Where getting
-a value wrong would silently produce plausible-but-wrong numbers rather than an
-obvious break, the SQL fails the run itself: an unrecognised `seat_denominator`
-stops `posthog_stage.accounts` with
-`seat_denominator must be "reachable" or "contracted", got …` instead of quietly
-falling back to a default.
+The `enum`, `minimum`, and `maximum` keywords on these variables document intent
+rather than enforce it, though the SQL still guards the values that would
+otherwise silently produce wrong numbers
+([details](#variable-validation-and-macro-loading)).
 
 Two of these are worth checking against your own data before you trust a
 ranking. `seat_denominator` decides whether the heaviest component measures
-rollout or licence coverage, which [Reports](#reports-posthog-reports) covers in
-full. And `depth_target_actions` sets where the depth component saturates: too
+rollout or licence coverage, which the [scoring caveats](#scoring-caveats) cover
+in full. And `depth_target_actions` sets where the depth component saturates: too
 high and it reads near-zero for everyone, too low and it stops separating
 accounts.
 
@@ -451,10 +323,9 @@ bruin validate my-posthog-pipeline
 bruin run my-posthog-pipeline
 ```
 
-`bruin validate` currently reports `in_string_list is not callable` for the
-assets that call the template's macros. The macros render correctly at run time;
-validation does not load the `macros/` folder
-([bruin#2588](https://github.com/bruin-data/bruin/issues/2588)).
+`bruin validate` reports a harmless `in_string_list is not callable` error for
+the assets that call the template's macros; the macros still render correctly at
+run time ([details](#variable-validation-and-macro-loading)).
 
 To load history, backfill `posthog_raw.events` with the one-day-per-run loop in
 [Backfilling `events`](#backfilling-events-use-one-day-per-run) — a wider window
@@ -488,3 +359,171 @@ bruin run --exclude-tag posthog_raw my-posthog-pipeline
 - [PostHog ingestion](https://getbruin.com/docs/bruin/ingestion/posthog.html)
 - [Ingestr assets](https://getbruin.com/docs/bruin/assets/ingestr.html)
 - [BigQuery platform](https://getbruin.com/docs/bruin/platforms/bigquery.html)
+
+## Appendix: notes, caveats & details
+
+### Backfilling `events`: use one day per run
+
+This matters more than anything else in the template.
+
+PostHog's `/events` REST API — the endpoint ingestr reads — does not return a
+complete history for a multi-day window, and gives no indication that anything
+is missing. Measured against one project, `--full-refresh` each time, three
+repeats per window (the results are deterministic):
+
+| Window | Days | Events in PostHog | Events loaded | Days actually covered |
+| ------ | ---- | ----------------- | ------------- | --------------------- |
+| 3 days | 3 | 1,679 | 545 | 1 |
+| 7 days | 7 | 3,090 | 2,619 | 7, but 15% short |
+| 31 days | 31 | 16,925 | 673 | 1 |
+| 95 days | 95 | 42,354 | 1,551 | 4 |
+| 205 days, sparse | 205 | 141 | 141 | all — complete |
+| one day | 1 | exact | exact | 93 days tested, all exact |
+
+The loss is not a function of how wide the window is. A three-day window
+returned a single day while a seven-day window spanned all seven, and a
+205-day window over sparse data returned everything — so the limit tracks the
+volume of events in the window, not its width. There is no usable rule to
+exploit, because the seven-day case *looks* complete and is 15% short. **A
+single day is the only window that is reliably exact.**
+
+So backfill a day at a time. Note the end date is the *next* day: `bruin`
+parses a bare date as midnight, so `--start-date D --end-date D` is a
+zero-width interval and fails with `interval-start must be earlier than
+interval-end`.
+
+```bash
+d=2026-05-23
+while [ "$d" != "2026-08-22" ]; do
+  nxt=$(date -j -v+1d -f %Y-%m-%d $d +%Y-%m-%d)   # GNU: date -d "$d +1 day" +%F
+  bruin run assets/posthog_raw/events.asset.yml --start-date $d --end-date $nxt
+  d=$nxt
+done
+```
+
+The same off-by-one applies to any single-day run, including `persons` and
+`feature_flags`: `--end-date 2026-08-21` stops at midnight, so a profile edited
+at 06:50 that morning is outside the window.
+
+`extract_partition_by` does not help here. Ingestr rejects it for this source —
+"source table `events` does not support extract partitioning; supported sources
+are postgres, mysql, mssql, sqlite, and ADBC-backed SQL sources" — because it
+windows SQL extractions and PostHog is a REST source. It is also mutually
+exclusive with `--full-refresh`.
+
+Day-to-day scheduled runs are unaffected, since each one already covers a
+single day. Only wide backfills are at risk.
+
+`events` is also append-only, so re-running a day duplicates its rows. The
+staging layer deduplicates on `id`, which makes re-runs safe.
+
+`persons` and `feature_flags` merge on `id` and are unaffected by any of this.
+
+### How this differs from PostHog out of the box
+
+PostHog is good at what it does, and a lot of this template's value is *not* that
+PostHog can't answer these questions — it's that the answers live in your
+warehouse, next to everything else.
+
+| | PostHog out of the box | This template |
+| --- | --- | --- |
+| **Account-level analysis** | Group Analytics, but only if you sent `$groups` on events at capture time. It cannot be applied retroactively, and it's a paid add-on. | Accounts are derived in SQL from person properties, so it works on events you already collected. If you never instrumented `$groups`, the account reports still build. |
+| **Getting data out** | Batch export to BigQuery delivers the raw event stream. | The same data, plus deduplication, identity resolution, sessionization, account rollup, and reports — modeling, not just export. |
+| **Joining to billing / CRM / support** | Not possible; PostHog only knows what you send it. | `posthog_stage.persons` exposes `company` and `email` as ordinary columns. Join them to your own tables and the reports gain real revenue context. |
+| **Custom metrics** | Trends, funnels, retention, paths and stickiness, plus HogQL for anything else — but only over data PostHog holds. | The same SQL freedom over the joined warehouse. The PQL and engagement scores are weighted CTEs you can rewrite. |
+| **Experiment readout** | Conversion per variant, with built-in significance testing. | The same exposure data crossed with plan, industry, and MRR — which variant won *among accounts worth money*. |
+| **History** | Bounded by your plan's retention window. | Bounded by your warehouse, which is usually cheaper per GB-year. |
+
+What PostHog still does better, and what this template does not replace: session
+replay and heatmaps, real-time dashboards, built-in experiment statistics, and
+requiring no pipeline to maintain. Run both — this is a complement to the PostHog
+UI, not a substitute for it.
+
+### Staging internals
+
+Three details worth knowing.
+
+`posthog_raw.events` is append-loaded, so re-running a day duplicates rows
+there; `posthog_stage.events` keeps only the most recently loaded copy of each
+event id, which makes re-runs safe. The tiebreaker on `timestamp` keeps that
+choice stable, so rebuilding from unchanged input gives an identical table.
+
+PostHog merges anonymous visitors into identified people over time, so a person
+owns several distinct IDs. `person_distinct_ids` is the single place that
+resolution happens: it collapses the map to one person per distinct ID and
+asserts that with a `unique` check, so no downstream join can quietly fan an
+event out across two persons and inflate every count built on it.
+
+`accounts` exists for the same reason. PostHog has no account entity unless
+`$groups` was instrumented at capture time, so the rollup — highest plan tier
+anyone holds, `MAX` of seats and MRR, modal industry — is derived once here
+instead of being copy-pasted into four reports that could then drift apart.
+An account whose people carry no recognized plan gets `unknown` rather than
+`NULL`, so it stays reachable from the dashboard's plan filter.
+
+### Scoring caveats
+
+Two things about those components are worth knowing before you trust a ranking.
+
+**Seat activation is the heaviest component and the easiest to get backwards.**
+It carries 30 engagement points and 20 PQL points, and its denominator —
+`posthog_stage.accounts.licensed_seats`, set by the `seat_denominator`
+variable — has to reconcile two different populations. `seats` comes from billing; the numerator counts people PostHog has
+seen, which means people an `identify` call has run for. An account that bought
+400 seats and rolled out to 40 reads as 10% activated, so left unqualified the
+component ranks small accounts above large ones and inverts the plan comparison.
+The default is therefore `LEAST(seats, known_users)`, which measures activation
+against the reachable team and treats the gap to the contract as a coverage
+question. Switch it back to `seats` in `accounts.sql` if your `identify`
+coverage matches your billing — that is what `seat_denominator: contracted`
+does. The seats information is not lost either way:
+`posthog_stage.accounts.seat_coverage` reports known users over contracted seats
+on its own, so a rollout that has not reached most of its licences shows up as a
+coverage number rather than as a low engagement score.
+
+**The score thresholds set queue length, not truth.** `pql_hot_score`,
+`pql_warm_score`, `pql_cool_score`, and `expansion_min_score` decide how many
+accounts land in front of a human, and the right numbers depend on how your
+scores actually spread. On a test project where nearly every account was active,
+the default `expansion_min_score` of 65 fired on a quarter of them — technically
+correct, operationally useless. Look at `COUNTIF(expansion_signal) / COUNT(*)`
+and the `pql_score` quartiles on your own data, then raise the thresholds rather
+than the headcount.
+
+**Breadth saturates.** It is a count out of `product_action_events`, so once an
+account has touched every event on the list the component stops discriminating —
+on one test project half the accounts sat at the ceiling. This is the one
+component with no variable to tune, because the fix is a different measure rather
+than a different constant: count distinct days per feature, or weight the rarer
+actions, instead of the plain distinct count.
+
+Account attributes come from `posthog_stage.accounts`, so the rollup rule is
+stated once: plan is the highest tier held by anyone at the company, seats and
+MRR are `MAX` (they repeat on every person row), industry is the modal value.
+`persons` is a current-state snapshot with no history, so today's plan is
+carried onto historical months.
+
+### Dashboard widget conventions
+
+Two widget conventions are deliberate. The adoption widgets filter on
+`was_enabled`, so a boolean flag's `false` arm — everyone the rollout held out —
+is not counted as having adopted the feature; the "Enabled vs Held Out" table is
+where the two arms are compared. And the retention widgets filter on
+`is_complete_week`, which excludes weeks at either end of the event history that
+the warehouse cannot speak to.
+
+### Variable validation and macro loading
+
+The `enum`, `minimum`, and `maximum` keywords on these variables are currently
+documentation rather than enforcement — Bruin validates that a variable has a
+default and little else, and `--var` overrides skip schema checks. Where getting
+a value wrong would silently produce plausible-but-wrong numbers rather than an
+obvious break, the SQL fails the run itself: an unrecognised `seat_denominator`
+stops `posthog_stage.accounts` with
+`seat_denominator must be "reachable" or "contracted", got …` instead of quietly
+falling back to a default.
+
+`bruin validate` currently reports `in_string_list is not callable` for the
+assets that call the template's macros. The macros render correctly at run time;
+validation does not load the `macros/` folder
+([bruin#2588](https://github.com/bruin-data/bruin/issues/2588)).

--- a/templates/posthog-bigquery/README.md
+++ b/templates/posthog-bigquery/README.md
@@ -370,7 +370,7 @@ falling back to a default.
 
 Two of these are worth checking against your own data before you trust a
 ranking. `seat_denominator` decides whether the heaviest component measures
-rollout or licence coverage, which [Reports](#reports-posthog_reports) covers in
+rollout or licence coverage, which [Reports](#reports-posthog-reports) covers in
 full. And `depth_target_actions` sets where the depth component saturates: too
 high and it reads near-zero for everyone, too low and it stops separating
 accounts.

--- a/templates/posthog-bigquery/README.md
+++ b/templates/posthog-bigquery/README.md
@@ -1,5 +1,16 @@
 # PostHog Product Analytics to BigQuery
 
+## At a glance
+
+- Loads your PostHog events, people, and feature flags into BigQuery
+- Cleans them into a tidy staging layer that is easy to query
+- Merges each visitor's many IDs into one real person
+- Groups events into sessions with duration, bounce, and conversions
+- Builds four reports at the account and user-segment level
+- Skips duplicate rows, so re-running a day stays correct
+- Comes with a ready-made dashboard on top of the reports
+- **Builds the foundational product-analytics models and context an AI agent can analyze and act on**
+
 `posthog-bigquery` turns raw PostHog product analytics into warehouse-ready
 account intelligence in BigQuery.
 

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -1,5 +1,16 @@
 # Stripe Billing Analytics to BigQuery
 
+## At a glance
+
+- Pulls your Stripe customers, subscriptions, invoices, and prices into BigQuery
+- Cleans that raw data into tidy, reusable billing tables
+- Publishes monthly reports on recurring revenue, churn, and invoices
+- Tracks MRR and ARR per customer and per currency
+- Saves a daily snapshot so month-over-month trends build up over time
+- Comes with a ready-made dashboard for revenue, retention, and billings
+- Safe to re-run, and easy to adapt to your own reporting
+- **Builds the foundational billing models and context an AI agent can analyze and act on**
+
 `stripe-bigquery` is a focused Stripe billing analytics pipeline for BigQuery. It loads the customer, product, price, subscription, subscription-item, and invoice resources into `stripe_raw`; builds reusable billing models in `stripe_stage`; and publishes recurring-revenue and invoice-billing reports in `stripe_reports`.
 
 The template contains 19 assets across three layers. It is a practical starting point for analyzing Stripe subscription billing while keeping the data model small enough to adapt to your own reporting needs.

--- a/templates/stripe-bigquery/README.md
+++ b/templates/stripe-bigquery/README.md
@@ -54,27 +54,13 @@ stripe-bigquery/
 
 The `stripe_raw` dataset contains the six Stripe resources that underpin the billing models. Ingestr loads them with the shared `stripe-default` connection, and BigQuery is the destination.
 
-Each source asset uses ingestr's [incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading) (`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the Stripe object `id`, so a run only fetches the records created inside its own time window and upserts them.
-
-Incremental mode filters on Stripe's `created` timestamp and does not revisit records created in earlier windows. That matters for the mutable resources — a subscription cancelled or upgraded months after it was created, an invoice finalized, paid, or voided after its creation date. To pick those edits up, periodically re-run over a wider window:
-
-```bash
-bruin run --start-date 2023-01-01 --end-date $(date -u +%F) my-stripe-pipeline
-```
-
-Choose that cadence to match how current your reporting needs to be, or switch the mutable assets to `source_table: subscription` for [standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default), which reloads full history on every run. See [loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs) for the comparison.
-
-Each raw asset also declares its full column schema, which pins those columns into the destination table. That matters for fields Stripe leaves null on some accounts: `invoice.due_date` is only set for invoices collected with `send_invoice`, and a schema inferred purely from the data would drop the column and break the stage model.
+Each source asset uses ingestr's [incremental Stripe mode](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#incremental-loading) (`<endpoint>:sync:incremental`) with a `merge` materialization keyed on the Stripe object `id`, so a run only fetches the records created inside its own time window and upserts them. See [Incremental-loading trade-offs](#incremental-loading-trade-offs) for how mutable resources, re-run cadence, and column-schema pinning are handled.
 
 ### Conformed billing models
 
 The `stripe_stage` dataset exposes typed customer, product, price, subscription, subscription-item, invoice, and invoice-line-item models. It also builds daily snapshots of subscription items and customer MRR by native currency, stamped with the pipeline end date.
 
-Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`, so each run rebuilds its table from the current raw data. That keeps the pipeline idempotent and easy to reason about.
-
-The two daily snapshot assets are the exception. They use `delete+insert` on `snapshot_date`, so each run replaces only the day it observes and leaves earlier days in place. That accumulates the daily observation history the reports layer needs for month-over-month movement and retention, while keeping a re-run of any single date idempotent. Because `delete+insert` writes into an existing table, the first load has to create these two tables with `--full-refresh`; see [Run the pipeline](#run-the-pipeline).
-
-The snapshots record the Stripe state visible when the pipeline runs, so history builds up from the first run forward and cannot be backfilled from current Stripe records.
+Most stage and report assets are materialized as a `CREATE OR REPLACE TABLE`, so each run rebuilds its table from the current raw data. That keeps the pipeline idempotent and easy to reason about. The two daily snapshot assets are the exception; see [Snapshot & backfill mechanics](#snapshot-backfill-mechanics) for how they accumulate history and why the first load needs `--full-refresh`.
 
 ### Billing reports
 
@@ -84,6 +70,8 @@ The `stripe_reports` dataset provides four ready-to-query tables:
 - `monthly_mrr_movements` — customer-level new, reactivation, expansion, contraction, and churn movements.
 - `monthly_subscription_kpis` — recurring-revenue, retention, and customer-count metrics by currency.
 - `monthly_invoice_billings` — non-draft, non-void invoice billings by finalization month, with a labeled creation-date fallback.
+
+See [Metric policy & definitions](#metric-policy-definitions) for how these metrics are defined and the caveats that apply, and [Illustrative report rows](#illustrative-report-rows) for sample output from each table.
 
 ### Asset summary
 
@@ -111,55 +99,11 @@ All 19 assets materialize as tables. `create+replace` is the default when no inc
 | `stripe_reports` | `monthly_subscription_kpis` | table | `create+replace` | — | Recurring-revenue, retention, and customer-count scorecard |
 | `stripe_reports` | `monthly_invoice_billings` | table | `create+replace` | — | Invoice billings by finalization month and currency |
 
-The two snapshot assets are partitioned on `snapshot_date` because they accumulate indefinitely: their per-run `DELETE` prunes to the single day being replaced instead of scanning the whole history. The other assets are rebuilt in full each run, so partitioning would not save any scan.
+The two snapshot assets are partitioned on `snapshot_date`; see [Partitioning rationale](#partitioning-rationale) for why.
 
 ### Column-level documentation
 
 Every asset in all three layers declares its full column schema: each column carries a type, a description, and primary-key marks on the grain, so the reporting grain and the metric definitions are readable from the asset files themselves. `metadata_push` in `pipeline.yml` publishes those descriptions to the BigQuery table and column metadata, and `bruin docs my-stripe-pipeline` generates a browsable documentation site from the same schemas.
-
-## Example report rows
-
-The following illustrative rows use minor currency units: `9900` USD means $99.00. They show the shape of each table across several months, which fills in once the snapshots have accumulated that many months of history; see [Conformed billing models](#conformed-billing-models). Query the four tables in `stripe_reports` directly, then adapt the columns to the definitions used by your finance and revenue teams.
-
-### `monthly_mrr_by_customer`
-
-| metric_month | as_of_snapshot_date | stripe_customer_id | currency | active_subscription_count | ending_mrr_minor | run_rate_arr_minor |
-| --- | --- | --- | --- | ---: | ---: | ---: |
-| 2026-01-01 | 2026-01-31 | cus_acme | usd | 1 | 9900 | 118800 |
-| 2026-02-01 | 2026-02-28 | cus_acme | usd | 1 | 12900 | 154800 |
-| 2026-02-01 | 2026-02-28 | cus_pine | usd | 2 | 4900 | 58800 |
-
-### `monthly_mrr_movements`
-
-| metric_month | stripe_customer_id | currency | beginning_mrr_minor | ending_mrr_minor | expansion_mrr_minor | churned_mrr_minor | movement_type |
-| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| 2026-02-01 | cus_acme | usd | 9900 | 12900 | 3000 | 0 | expansion |
-| 2026-02-01 | cus_oak | usd | 2500 | 0 | 0 | 2500 | churn |
-| 2026-02-01 | cus_pine | usd | 0 | 4900 | 0 | 0 | new |
-
-### `monthly_subscription_kpis`
-
-| metric_month | currency | ending_mrr_minor | new_mrr_minor | expansion_mrr_minor | churned_mrr_minor | ending_active_customer_count | net_revenue_retention_rate_excluding_reactivation |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 2026-01-01 | usd | 12400 | 12400 | 0 | 0 | 2 | — |
-| 2026-02-01 | usd | 17800 | 4900 | 3000 | 2500 | 2 | 1.04 |
-| 2026-02-01 | eur | 8100 | 0 | 1100 | 0 | 1 | 1.16 |
-
-### `monthly_invoice_billings`
-
-| invoice_billing_month | invoice_billing_date_basis | currency | issued_invoice_count | subscription_invoice_count | invoiced_billings_minor | invoiced_subscription_billings_minor |
-| --- | --- | --- | ---: | ---: | ---: | ---: |
-| 2026-01-01 | invoice_finalized_at | usd | 14 | 12 | 139400 | 128700 |
-| 2026-02-01 | invoice_finalized_at | usd | 16 | 13 | 171800 | 160200 |
-| 2026-02-01 | invoice_created_at_fallback | eur | 2 | 2 | 16200 | 16200 |
-
-## Metric policy
-
-All monetary values in the `stripe_stage` and `stripe_reports` tables remain in each currency's minor units; only the dashboard converts to major units for display. Do not add amounts across currencies without an FX source and explicit conversion policy.
-
-MRR is a gross list-price run rate from active and past-due subscriptions with licensed recurring monthly or annual prices. Free, one-time, metered, and discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither measure is recognized revenue, bookings, cash, or a financial statement.
-
-The daily snapshots capture the Stripe state visible when the pipeline runs. They do not reconstruct prior daily MRR history from current Stripe records, so the accumulated history starts at the first run. Month-over-month movement and retention metrics need two contiguous monthly observations, so they stay empty until the snapshots span a second month.
 
 ## Configure connections
 
@@ -260,3 +204,71 @@ dac --config .bruin.yml serve --dir dashboards --port 8321
 This screenshot uses synthetic data solely to demonstrate the dashboard's layout and charts.
 
 MRR movement and retention metrics need two contiguous monthly snapshots, so they stay empty until the accumulated snapshot history spans a second month.
+
+## Appendix: notes, caveats & details
+
+### Incremental-loading trade-offs
+
+Incremental mode filters on Stripe's `created` timestamp and does not revisit records created in earlier windows. That matters for the mutable resources — a subscription cancelled or upgraded months after it was created, an invoice finalized, paid, or voided after its creation date. To pick those edits up, periodically re-run over a wider window:
+
+```bash
+bruin run --start-date 2023-01-01 --end-date $(date -u +%F) my-stripe-pipeline
+```
+
+Choose that cadence to match how current your reporting needs to be, or switch the mutable assets to `source_table: subscription` for [standard async loading](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#standard-async-loading-default), which reloads full history on every run. See [loading modes and trade-offs](https://getbruin.com/docs/ingestr/supported-sources/stripe.html#loading-modes-and-trade-offs) for the comparison.
+
+Each raw asset also declares its full column schema, which pins those columns into the destination table. That matters for fields Stripe leaves null on some accounts: `invoice.due_date` is only set for invoices collected with `send_invoice`, and a schema inferred purely from the data would drop the column and break the stage model.
+
+### Snapshot & backfill mechanics
+
+The two daily snapshot assets are the exception. They use `delete+insert` on `snapshot_date`, so each run replaces only the day it observes and leaves earlier days in place. That accumulates the daily observation history the reports layer needs for month-over-month movement and retention, while keeping a re-run of any single date idempotent. Because `delete+insert` writes into an existing table, the first load has to create these two tables with `--full-refresh`; see [Run the pipeline](#run-the-pipeline).
+
+The snapshots record the Stripe state visible when the pipeline runs, so history builds up from the first run forward and cannot be backfilled from current Stripe records.
+
+### Metric policy & definitions
+
+All monetary values in the `stripe_stage` and `stripe_reports` tables remain in each currency's minor units; only the dashboard converts to major units for display. Do not add amounts across currencies without an FX source and explicit conversion policy.
+
+MRR is a gross list-price run rate from active and past-due subscriptions with licensed recurring monthly or annual prices. Free, one-time, metered, and discounted amounts are excluded. Run-rate ARR is MRR multiplied by 12; neither measure is recognized revenue, bookings, cash, or a financial statement.
+
+The daily snapshots capture the Stripe state visible when the pipeline runs. They do not reconstruct prior daily MRR history from current Stripe records, so the accumulated history starts at the first run. Month-over-month movement and retention metrics need two contiguous monthly observations, so they stay empty until the snapshots span a second month.
+
+### Partitioning rationale
+
+The two snapshot assets are partitioned on `snapshot_date` because they accumulate indefinitely: their per-run `DELETE` prunes to the single day being replaced instead of scanning the whole history. The other assets are rebuilt in full each run, so partitioning would not save any scan.
+
+### Illustrative report rows
+
+The following illustrative rows use minor currency units: `9900` USD means $99.00. They show the shape of each table across several months, which fills in once the snapshots have accumulated that many months of history; see [Conformed billing models](#conformed-billing-models). Query the four tables in `stripe_reports` directly, then adapt the columns to the definitions used by your finance and revenue teams.
+
+#### `monthly_mrr_by_customer`
+
+| metric_month | as_of_snapshot_date | stripe_customer_id | currency | active_subscription_count | ending_mrr_minor | run_rate_arr_minor |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| 2026-01-01 | 2026-01-31 | cus_acme | usd | 1 | 9900 | 118800 |
+| 2026-02-01 | 2026-02-28 | cus_acme | usd | 1 | 12900 | 154800 |
+| 2026-02-01 | 2026-02-28 | cus_pine | usd | 2 | 4900 | 58800 |
+
+#### `monthly_mrr_movements`
+
+| metric_month | stripe_customer_id | currency | beginning_mrr_minor | ending_mrr_minor | expansion_mrr_minor | churned_mrr_minor | movement_type |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 2026-02-01 | cus_acme | usd | 9900 | 12900 | 3000 | 0 | expansion |
+| 2026-02-01 | cus_oak | usd | 2500 | 0 | 0 | 2500 | churn |
+| 2026-02-01 | cus_pine | usd | 0 | 4900 | 0 | 0 | new |
+
+#### `monthly_subscription_kpis`
+
+| metric_month | currency | ending_mrr_minor | new_mrr_minor | expansion_mrr_minor | churned_mrr_minor | ending_active_customer_count | net_revenue_retention_rate_excluding_reactivation |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2026-01-01 | usd | 12400 | 12400 | 0 | 0 | 2 | — |
+| 2026-02-01 | usd | 17800 | 4900 | 3000 | 2500 | 2 | 1.04 |
+| 2026-02-01 | eur | 8100 | 0 | 1100 | 0 | 1 | 1.16 |
+
+#### `monthly_invoice_billings`
+
+| invoice_billing_month | invoice_billing_date_basis | currency | issued_invoice_count | subscription_invoice_count | invoiced_billings_minor | invoiced_subscription_billings_minor |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| 2026-01-01 | invoice_finalized_at | usd | 14 | 12 | 139400 | 128700 |
+| 2026-02-01 | invoice_finalized_at | usd | 16 | 13 | 171800 | 160200 |
+| 2026-02-01 | invoice_created_at_fallback | eur | 2 | 2 | 16200 | 16200 |


### PR DESCRIPTION
## What

Adds a plain-language, bullet-point **At a glance** section to the top of three template docs so a reader can grasp what each template does and how — without wading through the dense intro prose.

Templates updated:
- `stripe-bigquery`
- `posthog-bigquery`
- `google-web-analytics`

Each summary uses short (5–15 word) bullets in everyday language and closes by emphasizing that the template builds the **foundational models and context layer an AI agent can analyze and act on**.

## How

- Stripe and PostHog pages are generated from their template READMEs — edited `templates/<name>/README.md` and regenerated with `make sync-template-docs`.
- `google-web-analytics` is a hand-maintained docs page (not in `SYNCED`), edited directly.

Docs-only change; no runtime/behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)