### PR TITLE
fix: report plain CLI errors before exit (#2561)

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/bruin-data/bruin/cmd"
@@ -89,9 +92,21 @@ func main() {
 
 	err := app.Run(context.Background(), os.Args)
 	if err != nil {
+		printUnhandledError(err, os.Stderr)
 		cli.HandleExitCoder(err)
 		// Close the telemetry client manually as the defer is not called on os.Exit(1)
 		client.Close()
 		os.Exit(1) //nolint:gocritic
+	}
+}
+
+func printUnhandledError(err error, writer io.Writer) {
+	if err == nil {
+		return
+	}
+
+	var exitCoder cli.ExitCoder
+	if !errors.As(err, &exitCoder) {
+		_, _ = fmt.Fprintf(writer, "error: %v\n", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v3"
+)
+
+func TestPrintUnhandledError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "plain error",
+			err:      errors.New("something went wrong"),
+			expected: "error: something went wrong\n",
+		},
+		{
+			name: "exit coder",
+			err:  cli.Exit("already handled", 1),
+		},
+		{
+			name: "wrapped exit coder",
+			err:  fmt.Errorf("wrapped: %w", cli.Exit("already handled", 1)),
+		},
+		{
+			name: "nil error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			printUnhandledError(tt.err, &output)
+
+			assert.Equal(t, tt.expected, output.String())
+		})
+	}
+}


### PR DESCRIPTION
## What
Report plain CLI errors instead of exiting silently.

## Changes
- Print non-`ExitCoder` errors to stderr and add unit coverage.

## How to test
1. Run `./bin/bruin data-diff onlyonearg` and confirm the error is printed with exit code 1.

## Risk & rollback
- **Risk:** Low; only previously unhandled errors gain stderr output.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #2561