### PR TITLE
feat(lint): forbid destination_table on queryable ingestr destinations

### DIFF
--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -170,6 +170,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			ApplicableLevels: []Level{LevelAsset},
 		},
 		&SimpleRule{
+			Identifier:       "ingestr-destination-table-on-queryable",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			AssetValidator:   EnsureIngestrDestinationTableNotSetForQueryable,
+			ApplicableLevels: []Level{LevelAsset},
+		},
+		&SimpleRule{
 			Identifier:       "valid-pipeline-start-date",
 			Fast:             true,
 			Severity:         ValidatorSeverityCritical,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -400,7 +400,7 @@ func EnsureIngestrDestinationTableNotSetForQueryable(ctx context.Context, p *pip
 
 	return []*Issue{{
 		Task:        asset,
-		Description: "'destination_table' is not supported for queryable destinations: it only redirects the ingestion, while checks, column lineage, and table creation still target the asset name. Name the asset after the destination table instead.",
+		Description: "'destination_table' is not supported for queryable destinations; name the asset after the destination table instead.",
 	}}, nil
 }
 

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -377,11 +377,8 @@ func WarnIngestrCDCModeDeprecated(ctx context.Context, p *pipeline.Pipeline, ass
 	}}, nil
 }
 
-// EnsureIngestrDestinationTableNotSetForQueryable forbids a `destination_table` override
-// on an ingestr asset whose destination is a queryable SQL warehouse, where it desyncs the
-// ingestion target from checks, lineage, and table-creation DDL (which key off asset.Name).
-// The override exists for non-queryable targets (e.g. CleverTap) whose destination string
-// cannot be a valid asset name; on a warehouse the asset should be named after the table.
+// EnsureIngestrDestinationTableNotSetForQueryable forbids a `destination_table` override on a
+// queryable ingestr destination, where it desyncs ingestion from name-keyed checks/lineage/DDL.
 func EnsureIngestrDestinationTableNotSetForQueryable(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
 	if asset.Type != pipeline.AssetTypeIngestr || asset.Parameters == nil {
 		return nil, nil

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -400,7 +400,7 @@ func EnsureIngestrDestinationTableNotSetForQueryable(ctx context.Context, p *pip
 
 	return []*Issue{{
 		Task:        asset,
-		Description: "'destination_table' is not supported for queryable destinations; name the asset after the destination table instead.",
+		Description: "'destination_table' is not supported for queryable destinations; set the asset `name` to the target table instead.",
 	}}, nil
 }
 

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -377,6 +377,36 @@ func WarnIngestrCDCModeDeprecated(ctx context.Context, p *pipeline.Pipeline, ass
 	}}, nil
 }
 
+// EnsureIngestrDestinationTableNotSetForQueryable forbids a `destination_table` override
+// on an ingestr asset whose destination is a queryable SQL warehouse, where it desyncs the
+// ingestion target from checks, lineage, and table-creation DDL (which key off asset.Name).
+// The override exists for non-queryable targets (e.g. CleverTap) whose destination string
+// cannot be a valid asset name; on a warehouse the asset should be named after the table.
+func EnsureIngestrDestinationTableNotSetForQueryable(ctx context.Context, p *pipeline.Pipeline, asset *pipeline.Asset) ([]*Issue, error) {
+	if asset.Type != pipeline.AssetTypeIngestr || asset.Parameters == nil {
+		return nil, nil
+	}
+
+	destTable, ok := asset.Parameters.GetString("destination_table")
+	if !ok || destTable == "" || destTable == asset.Name {
+		return nil, nil
+	}
+
+	destType, err := helpers.GetIngestrDestinationType(asset)
+	if err != nil {
+		// Unknown or unset destination: nothing to warn about here.
+		return nil, nil //nolint:nilerr
+	}
+	if !pipeline.IsSQLAssetType(destType) {
+		return nil, nil
+	}
+
+	return []*Issue{{
+		Task:        asset,
+		Description: "'destination_table' is not supported for queryable destinations: it only redirects the ingestion, while checks, column lineage, and table creation still target the asset name. Name the asset after the destination table instead.",
+	}}, nil
+}
+
 func validateIngestrMaterialization(asset *pipeline.Asset, effectiveStrategy string) ([]*Issue, string) {
 	issues := make([]*Issue, 0)
 	mat := asset.Materialization

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -2800,6 +2800,81 @@ func TestWarnIngestrCDCModeDeprecated(t *testing.T) {
 	}
 }
 
+func TestEnsureIngestrDestinationTableNotSetForQueryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		asset    *pipeline.Asset
+		wantWarn bool
+	}{
+		{
+			name: "non-ingestr asset is ignored",
+			asset: &pipeline.Asset{
+				Type:       pipeline.AssetTypePython,
+				Parameters: pipeline.ParameterMap{"destination_table": "other_table"},
+			},
+		},
+		{
+			name: "no destination_table is fine",
+			asset: &pipeline.Asset{
+				Name:       "asset_name",
+				Type:       pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{"destination": "bigquery"},
+			},
+		},
+		{
+			name: "destination_table equal to the asset name is fine",
+			asset: &pipeline.Asset{
+				Name:       "public.users",
+				Type:       pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{"destination": "bigquery", "destination_table": "public.users"},
+			},
+		},
+		{
+			name: "non-queryable destination (gsheets) is not flagged",
+			asset: &pipeline.Asset{
+				Name:       "sheet_export",
+				Type:       pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{"destination": "gsheets", "destination_table": "some_tab"},
+			},
+		},
+		{
+			name: "unknown destination is not flagged",
+			asset: &pipeline.Asset{
+				Name:       "clevertap_profiles",
+				Type:       pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{"destination": "clevertap", "destination_table": "profiles?identity_column=email"},
+			},
+		},
+		{
+			name: "diverging destination_table on a queryable destination warns",
+			asset: &pipeline.Asset{
+				Name:       "asset_name",
+				Type:       pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{"destination": "bigquery", "destination_table": "public.other_table"},
+			},
+			wantWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &pipeline.Pipeline{Assets: []*pipeline.Asset{tt.asset}}
+			got, err := EnsureIngestrDestinationTableNotSetForQueryable(t.Context(), p, tt.asset)
+			require.NoError(t, err)
+			if tt.wantWarn {
+				assert.Len(t, got, 1)
+				assert.Contains(t, got[0].Description, "destination_table")
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}
+
 func TestEnsurePipelineStartDateIsValid(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds a lint rule (`ingestr-destination-table-on-queryable`, **critical**) that fails validation when an ingestr asset sets `destination_table` to a value differing from the asset name **and** its destination resolves to a queryable SQL warehouse (BigQuery, Snowflake, Postgres, Redshift, DuckDB, Databricks, MSSQL, ClickHouse, …).

## Why

The `destination_table` parameter overrides only the ingestion target (`--dest-table` handed to ingestr). Everything else in bruin that concerns the destination table still resolves against `asset.Name`:

- **Quality checks** (`ti.GetAsset().Name` interpolated straight into `SELECT ... FROM <table>`)
- **Column lineage** (nodes are keyed by asset name)
- **Schema/table-creation DDL** (`tablename.SchemaToCreate(asset.Name)` / `ContainerToCreate(asset.Name)`)

So on a queryable destination, setting `destination_table` to a genuinely different real table makes ingestion write to the override while checks/lineage/DDL target the asset name — a **silent desync**.

`asset.Name` is the physical-table identity across ~55 check call sites (18 files), ~324 materialization references (20 files), the DDL helpers, and name-keyed lineage — there is no single resolution layer to thread an override through. Making name ≠ table first-class would be a large, high-risk refactor for a use case that does not exist today (the only consumer, CleverTap, is non-queryable, so its checks are NoOp and there is nothing to desync). This rule closes the footgun instead: it forbids the one configuration that silently corrupts checks/lineage/DDL.