### PR TITLE
feat(cloud): dashboards get --state draft|published

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4829,7 +4829,7 @@ func cloudDashboardsList() *cli.Command {
 func cloudDashboardsGet() *cli.Command {
 	return &cli.Command{
 		Name:  "get",
-		Usage: "Get a dashboard including its published definition",
+		Usage: "Get a dashboard including its definition (published by default; use --state draft to fetch the unpublished draft)",
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
@@ -4838,10 +4838,20 @@ func cloudDashboardsGet() *cli.Command {
 				Usage:    "dashboard ID",
 				Required: true,
 			},
+			&cli.StringFlag{
+				Name:  "state",
+				Usage: "which state to fetch: 'draft' or 'published'. Default: the editable definition for editors, published for viewers. 'draft' needs edit access.",
+			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
 			output := c.String("output")
+
+			state := c.String("state")
+			if state != "" && state != "draft" && state != "published" {
+				printError(fmt.Errorf("invalid --state %q: use 'draft' or 'published'", state), output, "Invalid state")
+				return cli.Exit("", 1)
+			}
 
 			client, err := newCloudClient(c)
 			if err != nil {
@@ -4849,7 +4859,7 @@ func cloudDashboardsGet() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			dashboard, err := client.GetDashboard(ctx, c.Int("dashboard-id"))
+			dashboard, err := client.GetDashboard(ctx, c.Int("dashboard-id"), state)
 			if err != nil {
 				printError(err, output, "Failed to get dashboard")
 				return cli.Exit("", 1)
@@ -4866,6 +4876,16 @@ func cloudDashboardsGet() *cli.Command {
 				title = *dashboard.Title
 			}
 			infoPrinter.Printf("Dashboard %d: %s (visibility: %s)\n", dashboard.ID, title, dashboard.Visibility)
+
+			// Flag a pending draft so a draft-only dashboard isn't read as empty.
+			if dashboard.HasDraft != nil && *dashboard.HasDraft {
+				published := dashboard.IsPublished != nil && *dashboard.IsPublished
+				if published {
+					infoPrinter.Println("This dashboard has unpublished draft changes. Use --state draft to fetch them, --state published for the live version.")
+				} else {
+					infoPrinter.Println("This dashboard is an unpublished draft (nothing published yet).")
+				}
+			}
 
 			// Print the definition (state) as pretty JSON so it can be inspected or saved.
 			if len(dashboard.State) > 0 {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -850,10 +850,21 @@ bruin cloud dashboards list --output json
 
 #### `get`
 
-Get a single dashboard including its published definition (`state`):
+Get a single dashboard including its definition (`state`). By default the caller
+gets the editable definition if it has edit access (the draft if one is pending,
+otherwise the published state), and the published state otherwise. The response's
+`has_draft`/`is_published` flags report which states exist, so a dashboard that
+only has a pending draft isn't mistaken for empty.
+
+Use `--state draft` or `--state published` to fetch a specific one. `published` is
+open to any viewer; `draft` needs edit access (drafts aren't exposed to non-editors).
 
 ```bash
 bruin cloud dashboards get --dashboard-id 42
+
+# Fetch a specific state explicitly
+bruin cloud dashboards get --dashboard-id 42 --state draft
+bruin cloud dashboards get --dashboard-id 42 --state published
 
 # Full payload, incl. the definition, as JSON
 bruin cloud dashboards get --dashboard-id 42 --output json

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -876,9 +876,17 @@ func (c *APIClient) ListDashboards(ctx context.Context) ([]Dashboard, error) {
 	return resp.Dashboards, err
 }
 
-func (c *APIClient) GetDashboard(ctx context.Context, dashboardID int) (*Dashboard, error) {
+// GetDashboard returns a single dashboard. state selects which definition to
+// fetch: "draft", "published", or "" for the server default (the editable
+// definition for editors, published for viewers). The server gates "draft" to
+// callers with edit access.
+func (c *APIClient) GetDashboard(ctx context.Context, dashboardID int, state string) (*Dashboard, error) {
+	path := fmt.Sprintf("/dashboards/%d", dashboardID)
+	if state != "" {
+		path += "?state=" + url.QueryEscape(state)
+	}
 	var result Dashboard
-	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/dashboards/%d", dashboardID), nil, &result)
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1307,19 +1307,47 @@ func TestGetDashboard(t *testing.T) {
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/dashboards/3", r.URL.Path)
+		// No --state: the server default, so no query param.
+		assert.Empty(t, r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		writeJSON(t, w, map[string]any{
-			"id":         3,
-			"title":      "Revenue",
-			"visibility": "team",
-			"state":      map[string]any{"widgets": []any{}},
+			"id":           3,
+			"title":        "Revenue",
+			"visibility":   "team",
+			"state":        map[string]any{"widgets": []any{}},
+			"has_draft":    true,
+			"is_published": false,
 		})
 	})
 
-	dashboard, err := client.GetDashboard(t.Context(), 3)
+	dashboard, err := client.GetDashboard(t.Context(), 3, "")
 	require.NoError(t, err)
 	assert.Equal(t, 3, dashboard.ID)
 	assert.JSONEq(t, `{"widgets":[]}`, string(dashboard.State))
+	require.NotNil(t, dashboard.HasDraft)
+	assert.True(t, *dashboard.HasDraft)
+	require.NotNil(t, dashboard.IsPublished)
+	assert.False(t, *dashboard.IsPublished)
+}
+
+func TestGetDashboardWithState(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/dashboards/3", r.URL.Path)
+		// --state draft is passed through as ?state=draft.
+		assert.Equal(t, "draft", r.URL.Query().Get("state"))
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"id":         3,
+			"visibility": "team",
+			"state":      map[string]any{"draft": true},
+		})
+	})
+
+	dashboard, err := client.GetDashboard(t.Context(), 3, "draft")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"draft":true}`, string(dashboard.State))
 }
 
 func TestCreateDashboard(t *testing.T) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -334,15 +334,19 @@ type Skill struct {
 }
 
 // Dashboard represents a Bruin Cloud dashboard. State is only populated by the
-// single-dashboard endpoint and carries the published definition as raw JSON.
+// single-dashboard endpoint and carries the requested definition as raw JSON.
+// HasDraft/IsPublished are also only set by that endpoint and report which states
+// exist (so a draft-only dashboard isn't mistaken for empty).
 type Dashboard struct {
-	ID         int             `json:"id"`
-	Title      *string         `json:"title"`
-	Visibility string          `json:"visibility"`
-	UpdatedAt  *string         `json:"updated_at"`
-	URL        string          `json:"url"`
-	AgentID    *int            `json:"agent_id"`
-	State      json.RawMessage `json:"state,omitempty"`
+	ID          int             `json:"id"`
+	Title       *string         `json:"title"`
+	Visibility  string          `json:"visibility"`
+	UpdatedAt   *string         `json:"updated_at"`
+	URL         string          `json:"url"`
+	AgentID     *int            `json:"agent_id"`
+	State       json.RawMessage `json:"state,omitempty"`
+	HasDraft    *bool           `json:"has_draft,omitempty"`
+	IsPublished *bool           `json:"is_published,omitempty"`
 }
 
 // DashboardVersion is one version-history snapshot's metadata (no state blob).


### PR DESCRIPTION
Adds `--state` to `bruin cloud dashboards get`, passed through as `?state=` to fetch the draft or published definition explicitly. Surfaces `has_draft`/`is_published` and hints when a draft is pending, so a draft-only dashboard isn't read as empty. `draft` needs edit access.

Depends on the cloud endpoint (BRU-5875).