### PR TITLE
feat: add Cloudflare Radar ingestr source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -298,6 +298,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                     {text: "Chess", link: "/ingestion/chess"},
                                     {text: "CleverTap", link: "/ingestion/clevertap"},
                                     {text: "ClickUp", link: "/ingestion/clickup"},
+                                    {text: "Cloudflare Radar", link: "/ingestion/cloudflare-radar"},
                                     {text: "Couchbase", link: "/ingestion/couchbase"},
                                     {text: "Cursor", link: "/ingestion/cursor"},
                                     {text: "Customer.io", link: "/ingestion/customerio"},

--- a/docs/ingestion/cloudflare-radar.md
+++ b/docs/ingestion/cloudflare-radar.md
@@ -4,6 +4,10 @@
 
 Bruin supports Cloudflare Radar as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Cloudflare Radar into your data warehouse.
 
+:::warning Requires a newer ingestr release
+The Cloudflare Radar source is not part of the ingestr version currently pinned by Bruin, so running an asset against it will fail with an unsupported-source error until Bruin bumps to an ingestr release that ships this source. If you need it before then, point Bruin at a local ingestr build that includes the source (for example with `bruin run --debug-ingestr-src <path-to-ingestr>`).
+:::
+
 To set up a Cloudflare Radar connection, add a configuration item to `.bruin.yml` and reference it from an ingestr asset. You need an API token that can read Cloudflare Radar data. Radar's data endpoints are global, so the Cloudflare account ID is not part of the connection.
 
 ## Set up a connection

--- a/docs/ingestion/cloudflare-radar.md
+++ b/docs/ingestion/cloudflare-radar.md
@@ -1,0 +1,139 @@
+# Cloudflare Radar
+
+[Cloudflare Radar](https://radar.cloudflare.com/) provides aggregated insights into Internet traffic, routing, connection quality, outages, bots, and Certificate Transparency data.
+
+Bruin supports Cloudflare Radar as a source for [Ingestr assets](/assets/ingestr), and you can use it to ingest data from Cloudflare Radar into your data warehouse.
+
+To set up a Cloudflare Radar connection, add a configuration item to `.bruin.yml` and reference it from an ingestr asset. You need an API token that can read Cloudflare Radar data. Radar's data endpoints are global, so the Cloudflare account ID is not part of the connection.
+
+## Set up a connection
+
+Cloudflare Radar connections are defined using the following properties:
+
+- `name`: The name to identify this connection.
+- `api_token`: Your Cloudflare API token with read access to Radar data (required).
+
+```yaml
+connections:
+  cloudflare_radar:
+    - name: my-cloudflare-radar
+      api_token: "your-api-token"
+```
+
+You can also use environment variables in `.bruin.yml` with the `${VAR_NAME}` syntax:
+
+```yaml
+connections:
+  cloudflare_radar:
+    - name: my-cloudflare-radar
+      api_token: ${CLOUDFLARE_RADAR_API_TOKEN}
+```
+
+Bruin uses the `cloudflare_radar` connection key in `.bruin.yml`. The underlying ingestr source URI scheme is `cloudflare-radar://`, as required by ingestr.
+
+## Ingesting data
+
+Create an [asset configuration](/assets/ingestr#asset-structure) file to define the data flow:
+
+```yaml
+name: public.cloudflare_radar_annotations
+type: ingestr
+
+parameters:
+  source_connection: my-cloudflare-radar
+  source_table: 'annotations'
+
+  destination: postgres
+```
+
+- `type`: Specifies the asset type. Set this to `ingestr` to use the ingestr data pipeline.
+- `source_connection`: The name of the Cloudflare Radar connection defined in `.bruin.yml`.
+- `source_table`: The Cloudflare Radar table to ingest. See [Available Source Tables](#available-source-tables) for options.
+- `destination`: The name of the destination platform.
+
+## Available Source Tables
+
+Cloudflare Radar exposes two kinds of source tables: a set of named catalog/event tables, and a generic `api:` syntax that gives you access to every Radar GET endpoint.
+
+### Named tables
+
+These provide convenient, automatically paginated aliases for commonly loaded catalog and event datasets.
+
+| Table | Primary Key | Inc Key | Inc Strategy | Description |
+|-------|-------------|---------|--------------|-------------|
+| `annotations` | `id` | `startDate` | merge | Internet events, outages, and traffic anomalies published by Radar. |
+| `autonomous_systems` | `asn` | - | replace | Autonomous systems known to Radar. |
+| `bgp_hijacks` | `id` | `min_hijack_ts` | merge | Detected BGP route hijack events. |
+| `bgp_leaks` | `id` | `detected_ts` | merge | Detected BGP route leak events. |
+| `bots` | `slug` | - | replace | Radar's catalog of known bots and their user-agent patterns. |
+| `certificate_authorities` | `sha256Fingerprint` | - | replace | Certificate authorities tracked through Certificate Transparency. |
+| `certificate_logs` | `slug` | - | replace | Certificate Transparency logs and their current states. |
+| `datasets` | `id` | - | replace | Downloadable Radar ranking and report datasets. |
+| `geolocations` | `geoId` | - | replace | Radar's geographic location catalog. |
+| `locations` | `alpha2` | - | replace | Countries and regions available as Radar filters. |
+| `outages` | `id` | `startDate` | merge | Internet outage annotations. |
+| `origins` | `slug` | - | replace | Origins available in Radar's origin metrics. |
+| `tlds` | `tld` | - | replace | Top-level domains and their managers. |
+| `traffic_anomalies` | `uuid` | `startDate` | merge | Recent Internet traffic anomalies. |
+
+```yaml
+name: public.cloudflare_radar_autonomous_systems
+type: ingestr
+
+parameters:
+  source_connection: my-cloudflare-radar
+  source_table: 'autonomous_systems'
+
+  destination: postgres
+```
+
+`annotations`, `outages`, `bgp_hijacks`, `bgp_leaks`, and `traffic_anomalies` accept `--interval-start` and `--interval-end`. Without an interval, `annotations` and `outages` cover the maximum API-supported trailing range of 364 days, BGP event tables return all events exposed by the API, and traffic anomalies cover the trailing seven days.
+
+### All Radar API endpoints
+
+Every GET endpoint in the [Cloudflare Radar API](https://developers.cloudflare.com/api/resources/radar/) is available as a dynamic table. Set `source_table` to `api:` followed by the endpoint path after `/radar/`, and append the endpoint's query parameters directly to the table name.
+
+For example, the API route `/radar/http/timeseries` becomes:
+
+```yaml
+name: public.cloudflare_radar_http_timeseries
+type: ingestr
+
+parameters:
+  source_connection: my-cloudflare-radar
+  source_table: 'api:http/timeseries?dateRange=7d&location=US'
+
+  destination: postgres
+```
+
+Parameterized route segments are filled in as part of the path:
+
+```yaml
+# /radar/http/summary/{dimension}
+source_table: 'api:http/summary/http_protocol?dateRange=7d'
+
+# /radar/entities/asns/{asn}
+source_table: 'api:entities/asns/13335'
+
+# /radar/ranking/domain/{domain}
+source_table: 'api:ranking/domain/cloudflare.com'
+```
+
+This covers all Radar families, including agent readiness, AI, annotations, AS112, attacks, BGP, bots, Certificate Transparency, datasets, DNS, email, entities, geolocations, HTTP, leaked credential checks, netflows, origins, post-quantum, quality, ranking, robots.txt, search, TCP resets and timeouts, TLDs, and traffic anomalies. Because the endpoint path and parameters are passed through, newly added Radar GET endpoints work without a connector release as long as they use Radar's standard JSON response envelope or return CSV.
+
+Repeated parameters are supported, for example `location=US&location=GB`. The `/radar/datasets/{alias}` download endpoint returns CSV, which the connector parses into one row per record.
+
+Dynamic list endpoints are automatically paginated when Radar exposes offset or page pagination. Analytics, top, detail, search, and other non-list endpoints make a single request using the supplied parameters.
+
+Dynamic tables default to the `replace` strategy. To merge them, provide the endpoint's stable key as the primary key and select the merge strategy. For endpoints that support date filters, `--interval-start` and `--interval-end` are forwarded as `dateStart` and `dateEnd` unless those parameters are already present in the source-table query string. Endpoints that only support `dateEnd` receive only the interval end.
+
+### Response rows
+
+Dynamic endpoint responses are converted to relational rows as follows:
+
+- list and top responses produce one row per item;
+- time-series responses produce one row per timestamp, with each metric as a column;
+- grouped or multiple series include `_series` when needed;
+- summary responses produce `dimension` and `value` columns;
+- detail responses produce one row;
+- nested values and Radar response metadata remain JSON columns.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -796,6 +796,25 @@
         "api_token"
       ]
     },
+    "CloudflareRadarConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "api_token": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "api_token"
+      ]
+    },
     "Connections": {
       "properties": {
         "aws": {
@@ -1215,6 +1234,12 @@
         "reddit_ads": {
           "items": {
             "$ref": "#/$defs/RedditAdsConnection"
+          },
+          "type": "array"
+        },
+        "cloudflare_radar": {
+          "items": {
+            "$ref": "#/$defs/CloudflareRadarConnection"
           },
           "type": "array"
         },

--- a/pkg/cloudflareradar/client.go
+++ b/pkg/cloudflareradar/client.go
@@ -1,0 +1,15 @@
+package cloudflareradar
+
+type Client struct {
+	config Config
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{
+		config: c,
+	}, nil
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}

--- a/pkg/cloudflareradar/config.go
+++ b/pkg/cloudflareradar/config.go
@@ -1,0 +1,21 @@
+package cloudflareradar
+
+import (
+	"errors"
+	"net/url"
+)
+
+type Config struct {
+	APIToken string `yaml:"api_token" json:"api_token" mapstructure:"api_token"`
+}
+
+func (c *Config) GetIngestrURI() (string, error) {
+	if c.APIToken == "" {
+		return "", errors.New("cloudflare_radar: api_token must be provided")
+	}
+
+	params := url.Values{}
+	params.Set("api_token", c.APIToken)
+
+	return "cloudflare-radar://?" + params.Encode(), nil
+}

--- a/pkg/cloudflareradar/config_test.go
+++ b/pkg/cloudflareradar/config_test.go
@@ -1,0 +1,60 @@
+package cloudflareradar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "valid api token",
+			config: Config{APIToken: "test-token"},
+			want:   "cloudflare-radar://?api_token=test-token",
+		},
+		{
+			name:   "token with special characters is escaped",
+			config: Config{APIToken: "a b&c"},
+			want:   "cloudflare-radar://?api_token=a+b%26c",
+		},
+		{
+			name:    "missing api token",
+			config:  Config{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.config.GetIngestrURI()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClient_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{APIToken: "test-token"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "cloudflare-radar://?api_token=test-token", uri)
+}

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1944,6 +1944,15 @@ func (c RedditAdsConnection) GetName() string {
 	return c.Name
 }
 
+type CloudflareRadarConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	APIToken           string `yaml:"api_token,omitempty" json:"api_token" mapstructure:"api_token" sensitive:"true"`
+}
+
+func (c CloudflareRadarConnection) GetName() string {
+	return c.Name
+}
+
 type ManifoldConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	QueryParams        map[string]string   `yaml:"query_params,omitempty" json:"query_params,omitempty" mapstructure:"query_params"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -95,6 +95,7 @@ type Connections struct {
 	AppleAds            []AppleAdsConnection            `yaml:"appleads,omitempty" json:"appleads,omitempty" mapstructure:"appleads"`
 	LinkedInAds         []LinkedInAdsConnection         `yaml:"linkedinads,omitempty" json:"linkedinads,omitempty" mapstructure:"linkedinads"`
 	RedditAds           []RedditAdsConnection           `yaml:"reddit_ads,omitempty" json:"reddit_ads,omitempty" mapstructure:"reddit_ads"`
+	CloudflareRadar     []CloudflareRadarConnection     `yaml:"cloudflare_radar,omitempty" json:"cloudflare_radar,omitempty" mapstructure:"cloudflare_radar"`
 	Mailchimp           []MailchimpConnection           `yaml:"mailchimp,omitempty" json:"mailchimp,omitempty" mapstructure:"mailchimp"`
 	Manifold            []ManifoldConnection            `yaml:"manifold,omitempty" json:"manifold,omitempty" mapstructure:"manifold"`
 	RevenueCat          []RevenueCatConnection          `yaml:"revenuecat,omitempty" json:"revenuecat,omitempty" mapstructure:"revenuecat"`
@@ -1306,6 +1307,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.RedditAds = append(env.Connections.RedditAds, conn)
+	case "cloudflare_radar":
+		var conn CloudflareRadarConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.CloudflareRadar = append(env.Connections.CloudflareRadar, conn)
 	case "revenuecat":
 		var conn RevenueCatConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -2060,6 +2068,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.LinkedInAds = removeConnection(env.Connections.LinkedInAds, connectionName)
 	case "reddit_ads":
 		env.Connections.RedditAds = removeConnection(env.Connections.RedditAds, connectionName)
+	case "cloudflare_radar":
+		env.Connections.CloudflareRadar = removeConnection(env.Connections.CloudflareRadar, connectionName)
 	case "linear":
 		env.Connections.Linear = removeConnection(env.Connections.Linear, connectionName)
 	case "gcs":
@@ -2382,6 +2392,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.AppleAds, source.AppleAds)
 	mergeConnectionList(&c.LinkedInAds, source.LinkedInAds)
 	mergeConnectionList(&c.RedditAds, source.RedditAds)
+	mergeConnectionList(&c.CloudflareRadar, source.CloudflareRadar)
 	mergeConnectionList(&c.Mailchimp, source.Mailchimp)
 	mergeConnectionList(&c.Manifold, source.Manifold)
 	mergeConnectionList(&c.RevenueCat, source.RevenueCat)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -966,6 +966,12 @@ func TestLoadFromFile(t *testing.T) {
 					RefreshToken:       "test-refresh-token",
 				},
 			},
+			CloudflareRadar: []CloudflareRadarConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "cloudflareradar-1"},
+					APIToken:           "test-api-token",
+				},
+			},
 			Espn: []EspnConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "espn-1"},
@@ -1746,6 +1752,16 @@ func TestConfig_AddConnection(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:     "Add Cloudflare Radar connection",
+			envName:  "default",
+			connType: "cloudflare_radar",
+			connName: "cloudflare-radar-conn",
+			creds: map[string]interface{}{
+				"api_token": "test-api-token",
+			},
+			expectedErr: false,
+		},
+		{
 			name:     "Add Intercom connection",
 			envName:  "default",
 			connType: "intercom",
@@ -1915,6 +1931,10 @@ func TestConfig_AddConnection(t *testing.T) {
 					assert.Len(t, env.Connections.Anthropic, 1)
 					assert.Equal(t, tt.connName, env.Connections.Anthropic[0].Name)
 					assert.Equal(t, tt.creds["api_key"], env.Connections.Anthropic[0].APIKey)
+				case "cloudflare_radar":
+					assert.Len(t, env.Connections.CloudflareRadar, 1)
+					assert.Equal(t, tt.connName, env.Connections.CloudflareRadar[0].Name)
+					assert.Equal(t, tt.creds["api_token"], env.Connections.CloudflareRadar[0].APIToken)
 				case "hostaway":
 					assert.Len(t, env.Connections.Hostaway, 1)
 					assert.Equal(t, tt.connName, env.Connections.Hostaway[0].Name)
@@ -2898,6 +2918,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				AppleAds:            []AppleAdsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "appleads1"}}},
 				LinkedInAds:         []LinkedInAdsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "linkedinads1"}}},
 				RedditAds:           []RedditAdsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "redditads1"}}},
+				CloudflareRadar:     []CloudflareRadarConnection{{ConnectionMetadata: ConnectionMetadata{Name: "cloudflareradar1"}}},
 				Mailchimp:           []MailchimpConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mailchimp1"}}},
 				Manifold:            []ManifoldConnection{{ConnectionMetadata: ConnectionMetadata{Name: "manifold1"}}},
 				RevenueCat:          []RevenueCatConnection{{ConnectionMetadata: ConnectionMetadata{Name: "revenuecat1"}}},
@@ -3038,6 +3059,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				AppleAds:            []AppleAdsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "appleads1"}}},
 				LinkedInAds:         []LinkedInAdsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "linkedinads1"}}},
 				RedditAds:           []RedditAdsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "redditads1"}}},
+				CloudflareRadar:     []CloudflareRadarConnection{{ConnectionMetadata: ConnectionMetadata{Name: "cloudflareradar1"}}},
 				Mailchimp:           []MailchimpConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mailchimp1"}}},
 				Manifold:            []ManifoldConnection{{ConnectionMetadata: ConnectionMetadata{Name: "manifold1"}}},
 				RevenueCat:          []RevenueCatConnection{{ConnectionMetadata: ConnectionMetadata{Name: "revenuecat1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -609,6 +609,9 @@ environments:
           client_id: "test-client-id"
           client_secret: "test-client-secret"
           refresh_token: "test-refresh-token"
+      cloudflare_radar:
+        - name: "cloudflareradar-1"
+          api_token: "test-api-token"
       espn:
         - name: "espn-1"
           sport: "football"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -610,6 +610,9 @@ environments:
           client_id: "test-client-id"
           client_secret: "test-client-secret"
           refresh_token: "test-refresh-token"
+      cloudflare_radar:
+        - name: "cloudflareradar-1"
+          api_token: "test-api-token"
       espn:
         - name: "espn-1"
           sport: "football"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -36,6 +36,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/clevertap"
 	"github.com/bruin-data/bruin/pkg/clickhouse"
 	"github.com/bruin-data/bruin/pkg/clickup"
+	"github.com/bruin-data/bruin/pkg/cloudflareradar"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/couchbase"
 	"github.com/bruin-data/bruin/pkg/cratedb"
@@ -228,6 +229,7 @@ type Manager struct {
 	Kalshi               map[string]*kalshi.Client
 	LinkedInAds          map[string]*linkedinads.Client
 	RedditAds            map[string]*redditads.Client
+	CloudflareRadar      map[string]*cloudflareradar.Client
 	Mailchimp            map[string]*mailchimp.Client
 	Manifold             map[string]*manifold.Client
 	Linear               map[string]*linear.Client
@@ -876,6 +878,29 @@ func (m *Manager) AddRedditAdsConnectionFromConfig(connection *config.RedditAdsC
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.RedditAds[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+
+	return nil
+}
+
+func (m *Manager) AddCloudflareRadarConnectionFromConfig(connection *config.CloudflareRadarConnection) error {
+	m.mutex.Lock()
+	if m.CloudflareRadar == nil {
+		m.CloudflareRadar = make(map[string]*cloudflareradar.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := cloudflareradar.NewClient(cloudflareradar.Config{
+		APIToken: connection.APIToken,
+	})
+	if err != nil {
+		return err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.CloudflareRadar[connection.Name] = client
 	m.availableConnections[connection.Name] = client
 	m.AllConnectionDetails[connection.Name] = connection
 
@@ -4278,6 +4303,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Kalshi, connectionManager.AddKalshiConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.LinkedInAds, connectionManager.AddLinkedInAdsConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.RedditAds, connectionManager.AddRedditAdsConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.CloudflareRadar, connectionManager.AddCloudflareRadarConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Mailchimp, connectionManager.AddMailchimpConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Manifold, connectionManager.AddManifoldConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.RevenueCat, connectionManager.AddRevenueCatConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -224,6 +224,25 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "tasks", PrimaryKey: "id", IncKey: "date_updated", IncStrategy: "merge"},
 	},
 
+	// Cloudflare Radar - Internet traffic, routing, and security insights
+	"cloudflare_radar": {
+		{Name: "annotations", PrimaryKey: "id", IncKey: "startDate", IncStrategy: "merge"},
+		{Name: "autonomous_systems", PrimaryKey: "asn", IncKey: "", IncStrategy: "replace"},
+		{Name: "bgp_hijacks", PrimaryKey: "id", IncKey: "min_hijack_ts", IncStrategy: "merge"},
+		{Name: "bgp_leaks", PrimaryKey: "id", IncKey: "detected_ts", IncStrategy: "merge"},
+		{Name: "bots", PrimaryKey: "slug", IncKey: "", IncStrategy: "replace"},
+		{Name: "certificate_authorities", PrimaryKey: "sha256Fingerprint", IncKey: "", IncStrategy: "replace"},
+		{Name: "certificate_logs", PrimaryKey: "slug", IncKey: "", IncStrategy: "replace"},
+		{Name: "datasets", PrimaryKey: "id", IncKey: "", IncStrategy: "replace"},
+		{Name: "geolocations", PrimaryKey: "geoId", IncKey: "", IncStrategy: "replace"},
+		{Name: "locations", PrimaryKey: "alpha2", IncKey: "", IncStrategy: "replace"},
+		{Name: "outages", PrimaryKey: "id", IncKey: "startDate", IncStrategy: "merge"},
+		{Name: "origins", PrimaryKey: "slug", IncKey: "", IncStrategy: "replace"},
+		{Name: "tlds", PrimaryKey: "tld", IncKey: "", IncStrategy: "replace"},
+		{Name: "traffic_anomalies", PrimaryKey: "uuid", IncKey: "startDate", IncStrategy: "merge"},
+		{Name: "api:<endpoint>?<params>", PrimaryKey: "", IncKey: "", IncStrategy: "replace"},
+	},
+
 	// Couchbase - NoSQL database (user-defined tables)
 	"couchbase": {},
 

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -301,6 +301,7 @@ var defaultMapping = map[string]string{
 	"quicksight":            "quicksight-default",
 	"rabbitmq":              "rabbitmq-default",
 	"reddit_ads":            "reddit_ads-default",
+	"cloudflare_radar":      "cloudflare_radar-default",
 	"revenuecat":            "revenuecat-default",
 	"sendgrid":              "sendgrid-default",
 	"sharepoint":            "sharepoint-default",


### PR DESCRIPTION
## What

Adds [Cloudflare Radar](https://radar.cloudflare.com/) as an ingestr source in Bruin. Cloudflare Radar exposes aggregated Internet traffic, routing, outage, bot, and Certificate Transparency data.