### PR TITLE
feat: add 2Checkout (Verifone) ingestr source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -278,6 +278,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                                 text: "Sources",
                                 collapsed: false,
                                 items: [
+                                    {text: "2Checkout", link: "/ingestion/twocheckout"},
                                     {text: "Adapty", link: "/ingestion/adapty"},
                                     {text: "Adjust", link: "/ingestion/adjust"},
                                     {text: "Airtable", link: "/ingestion/airtable"},

--- a/docs/ingestion/twocheckout.md
+++ b/docs/ingestion/twocheckout.md
@@ -1,0 +1,73 @@
+# 2Checkout (Verifone)
+
+[2Checkout](https://www.2checkout.com/) (now part of Verifone) is a payment and subscription platform that handles online sales, recurring billing, and global payments for software and digital goods businesses.
+
+Bruin supports 2Checkout as a source for [Ingestr assets](/assets/ingestr). You can ingest data from 2Checkout into your data platform.
+
+To set up a 2Checkout connection, add a configuration item in the `.bruin.yml` file and in your asset file. You authenticate with your `merchant_code` and API `secret_key`, both found under **Integrations > Webhooks & API** in the 2Checkout Control Panel.
+
+Follow these steps to set up 2Checkout and run ingestion.
+
+## Configuration
+
+### Step 1: Add a connection to the .bruin.yml file
+
+```yaml
+connections:
+  twocheckout:
+    - name: "twocheckout"
+      merchant_code: "your-merchant-code"
+      secret_key: "your-secret-key"
+```
+
+- `merchant_code`: (Required) Your 2Checkout merchant code.
+- `secret_key`: (Required) Your 2Checkout API secret key.
+- `base_url`: (Optional) Override the default REST API host (`https://api.2checkout.com`).
+
+::: tip
+Authentication signs each request with an HMAC-SHA256 signature that embeds a UTC timestamp, so the host clock must be accurate — clock skew of more than a few minutes results in `401` errors.
+:::
+
+### Step 2: Create an asset file for data ingestion
+
+Create an [asset configuration](/assets/ingestr#asset-structure) file (e.g., `twocheckout_ingestion.yml`) inside the assets folder with the following content:
+
+```yaml
+name: public.twocheckout
+type: ingestr
+
+parameters:
+  source_connection: twocheckout
+  source_table: 'orders'
+
+  destination: postgres
+```
+
+- `name`: The name of the asset.
+- `type`: Always `ingestr` for 2Checkout.
+- `source_connection`: The 2Checkout connection name defined in `.bruin.yml`.
+- `source_table`: Name of the 2Checkout table to ingest.
+- `destination`: The destination connection name.
+
+## Available Source Tables
+
+| Table | PK | Inc Strategy | Details |
+|-------|----|--------------|---------|
+| orders | ref_no, status | merge | Orders with line items, payments, and refunds. Filtered server-side by the run's date interval. The key is `(ref_no, status)` so status transitions (e.g. `COMPLETE` → `REFUND`) are preserved as distinct rows rather than overwriting each other. |
+| subscriptions | subscription_reference | merge | Recurring subscriptions, including status, billing period, and pricing. Filtered on `ModifiedAfter`, so it captures subscriptions that changed within the interval. |
+| products | product_code | merge | Products in your catalog, including pricing and settings. Full snapshot each run. |
+| promotions | code | merge | Promotions and their discount configuration. Full snapshot each run. |
+
+`orders` and `subscriptions` support incremental date-range loads: the run's date interval — set with `--start-date` / `--end-date` (see [run](/commands/run)) — filters records to that window. `products` and `promotions` are full snapshots on every run.
+
+::: warning
+2Checkout only returns the first 200 pages of results per query (a hard 20,000-record ceiling). To load more than that from `orders` or `subscriptions`, narrow the run's date interval so each query stays under the ceiling. There is no dedicated customers table — customer data arrives embedded in `orders` and `subscriptions`.
+:::
+
+### Step 3: [Run](/commands/run) asset to ingest data
+
+```bash
+bruin run assets/twocheckout_ingestion.yml
+```
+
+Running this command ingests data from 2Checkout into your Postgres database.

--- a/docs/ingestion/twocheckout.md
+++ b/docs/ingestion/twocheckout.md
@@ -55,8 +55,8 @@ parameters:
 |-------|----|--------------|---------|
 | orders | ref_no, status | merge | Orders with line items, payments, and refunds. Filtered server-side by the run's date interval. The key is `(ref_no, status)` so status transitions (e.g. `COMPLETE` → `REFUND`) are preserved as distinct rows rather than overwriting each other. |
 | subscriptions | subscription_reference | merge | Recurring subscriptions, including status, billing period, and pricing. Filtered on `ModifiedAfter`, so it captures subscriptions that changed within the interval. |
-| products | product_code | merge | Products in your catalog, including pricing and settings. Full snapshot each run. |
-| promotions | code | merge | Promotions and their discount configuration. Full snapshot each run. |
+| products | product_code | replace | Products in your catalog, including pricing and settings. Full snapshot each run. |
+| promotions | code | replace | Promotions and their discount configuration. Full snapshot each run. |
 
 `orders` and `subscriptions` support incremental date-range loads: the run's date interval — set with `--start-date` / `--end-date` (see [run](/commands/run)) — filters records to that window. `products` and `promotions` are full snapshots on every run.
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -1308,6 +1308,12 @@
           },
           "type": "array"
         },
+        "twocheckout": {
+          "items": {
+            "$ref": "#/$defs/TwoCheckoutConnection"
+          },
+          "type": "array"
+        },
         "payrails": {
           "items": {
             "$ref": "#/$defs/PayrailsConnection"
@@ -5407,6 +5413,32 @@
       "required": [
         "name",
         "account_sid"
+      ]
+    },
+    "TwoCheckoutConnection": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "max_concurrent_assets": {
+          "type": "integer"
+        },
+        "merchant_code": {
+          "type": "string"
+        },
+        "secret_key": {
+          "type": "string"
+        },
+        "base_url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "merchant_code",
+        "secret_key"
       ]
     },
     "TypeformConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1417,6 +1417,17 @@ func (c FastspringConnection) GetName() string {
 	return c.Name
 }
 
+type TwoCheckoutConnection struct {
+	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
+	MerchantCode       string `yaml:"merchant_code,omitempty" json:"merchant_code" mapstructure:"merchant_code"`
+	SecretKey          string `yaml:"secret_key,omitempty" json:"secret_key" mapstructure:"secret_key" sensitive:"true"`
+	BaseURL            string `yaml:"base_url,omitempty" json:"base_url,omitempty" mapstructure:"base_url"`
+}
+
+func (c TwoCheckoutConnection) GetName() string {
+	return c.Name
+}
+
 type PayrailsConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	ClientID           string `yaml:"client_id,omitempty" json:"client_id" mapstructure:"client_id"`

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -110,6 +110,7 @@ type Connections struct {
 	Mixpanel            []MixpanelConnection            `yaml:"mixpanel,omitempty" json:"mixpanel,omitempty" mapstructure:"mixpanel"`
 	Amplitude           []AmplitudeConnection           `yaml:"amplitude,omitempty" json:"amplitude,omitempty" mapstructure:"amplitude"`
 	Fastspring          []FastspringConnection          `yaml:"fastspring,omitempty" json:"fastspring,omitempty" mapstructure:"fastspring"`
+	TwoCheckout         []TwoCheckoutConnection         `yaml:"twocheckout,omitempty" json:"twocheckout,omitempty" mapstructure:"twocheckout"`
 	Payrails            []PayrailsConnection            `yaml:"payrails,omitempty" json:"payrails,omitempty" mapstructure:"payrails"`
 	Clickup             []ClickupConnection             `yaml:"clickup,omitempty" json:"clickup,omitempty" mapstructure:"clickup"`
 	Jobtread            []JobtreadConnection            `yaml:"jobtread,omitempty" json:"jobtread,omitempty" mapstructure:"jobtread"`
@@ -1439,6 +1440,13 @@ func (c *Config) AddConnection(environmentName, name, connType string, creds map
 		}
 		conn.Name = name
 		env.Connections.Fastspring = append(env.Connections.Fastspring, conn)
+	case "twocheckout":
+		var conn TwoCheckoutConnection
+		if err := mapstructure.Decode(creds, &conn); err != nil {
+			return fmt.Errorf("failed to decode credentials: %w", err)
+		}
+		conn.Name = name
+		env.Connections.TwoCheckout = append(env.Connections.TwoCheckout, conn)
 	case "payrails":
 		var conn PayrailsConnection
 		if err := mapstructure.Decode(creds, &conn); err != nil {
@@ -2096,6 +2104,8 @@ func (c *Config) DeleteConnection(environmentName, connectionName string) error 
 		env.Connections.Amplitude = removeConnection(env.Connections.Amplitude, connectionName)
 	case "fastspring":
 		env.Connections.Fastspring = removeConnection(env.Connections.Fastspring, connectionName)
+	case "twocheckout":
+		env.Connections.TwoCheckout = removeConnection(env.Connections.TwoCheckout, connectionName)
 	case "payrails":
 		env.Connections.Payrails = removeConnection(env.Connections.Payrails, connectionName)
 	case "pinterest":
@@ -2397,6 +2407,7 @@ func (c *Connections) MergeFrom(source *Connections) error {
 	mergeConnectionList(&c.Mixpanel, source.Mixpanel)
 	mergeConnectionList(&c.Amplitude, source.Amplitude)
 	mergeConnectionList(&c.Fastspring, source.Fastspring)
+	mergeConnectionList(&c.TwoCheckout, source.TwoCheckout)
 	mergeConnectionList(&c.Payrails, source.Payrails)
 	mergeConnectionList(&c.Clickup, source.Clickup)
 	mergeConnectionList(&c.Jobtread, source.Jobtread)

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -664,6 +664,13 @@ func TestLoadFromFile(t *testing.T) {
 					Password:           "pass-123",
 				},
 			},
+			TwoCheckout: []TwoCheckoutConnection{
+				{
+					ConnectionMetadata: ConnectionMetadata{Name: "twocheckout-1"},
+					MerchantCode:       "merchant-123",
+					SecretKey:          "secret-123",
+				},
+			},
 			Payrails: []PayrailsConnection{
 				{
 					ConnectionMetadata: ConnectionMetadata{Name: "payrails-1"},
@@ -1777,6 +1784,17 @@ func TestConfig_AddConnection(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:     "Add 2Checkout connection",
+			envName:  "default",
+			connType: "twocheckout",
+			connName: "twocheckout-conn",
+			creds: map[string]interface{}{
+				"merchant_code": "merchant-123",
+				"secret_key":    "secret-123",
+			},
+			expectedErr: false,
+		},
+		{
 			name:     "Add Trello connection",
 			envName:  "default",
 			connType: "trello",
@@ -2035,6 +2053,25 @@ func TestDeleteConnection(t *testing.T) {
 							Connections: &Connections{
 								Fabric: []FabricConnection{
 									{ConnectionMetadata: ConnectionMetadata{Name: "fabric-conn"}, Host: "fabric.example", Database: "warehouse", ClientID: "client-id"},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectedErr: false,
+		},
+		{
+			name:     "Delete existing 2Checkout connection",
+			envName:  "default",
+			connName: "twocheckout-conn",
+			setupConfig: func() *Config {
+				return &Config{
+					Environments: map[string]Environment{
+						"default": {
+							Connections: &Connections{
+								TwoCheckout: []TwoCheckoutConnection{
+									{ConnectionMetadata: ConnectionMetadata{Name: "twocheckout-conn"}, MerchantCode: "merchant-123", SecretKey: "secret-123"},
 								},
 							},
 						},
@@ -2912,6 +2949,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
 				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
 				Fastspring:          []FastspringConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fastspring1"}}},
+				TwoCheckout:         []TwoCheckoutConnection{{ConnectionMetadata: ConnectionMetadata{Name: "twocheckout1"}}},
 				Payrails:            []PayrailsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "payrails1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},
@@ -3052,6 +3090,7 @@ func TestConnections_MergeFrom(t *testing.T) {
 				Mixpanel:            []MixpanelConnection{{ConnectionMetadata: ConnectionMetadata{Name: "mixpanel1"}}},
 				Amplitude:           []AmplitudeConnection{{ConnectionMetadata: ConnectionMetadata{Name: "amplitude1"}}},
 				Fastspring:          []FastspringConnection{{ConnectionMetadata: ConnectionMetadata{Name: "fastspring1"}}},
+				TwoCheckout:         []TwoCheckoutConnection{{ConnectionMetadata: ConnectionMetadata{Name: "twocheckout1"}}},
 				Payrails:            []PayrailsConnection{{ConnectionMetadata: ConnectionMetadata{Name: "payrails1"}}},
 				Clickup:             []ClickupConnection{{ConnectionMetadata: ConnectionMetadata{Name: "clickup1"}}},
 				Jobtread:            []JobtreadConnection{{ConnectionMetadata: ConnectionMetadata{Name: "jobtread1"}}},

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -409,6 +409,10 @@ environments:
         - name: "fastspring-1"
           username: "user-123"
           password: "pass-123"
+      twocheckout:
+        - name: "twocheckout-1"
+          merchant_code: "merchant-123"
+          secret_key: "secret-123"
       payrails:
         - name: "payrails-1"
           client_id: "client-123"

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -411,6 +411,10 @@ environments:
         - name: "fastspring-1"
           username: "user-123"
           password: "pass-123"
+      twocheckout:
+        - name: "twocheckout-1"
+          merchant_code: "merchant-123"
+          secret_key: "secret-123"
       payrails:
         - name: "payrails-1"
           client_id: "client-123"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -146,6 +146,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/trino"
 	"github.com/bruin-data/bruin/pkg/trustpilot"
 	"github.com/bruin-data/bruin/pkg/twilio"
+	"github.com/bruin-data/bruin/pkg/twocheckout"
 	"github.com/bruin-data/bruin/pkg/typeform"
 	"github.com/bruin-data/bruin/pkg/vertica"
 	"github.com/bruin-data/bruin/pkg/vitess"
@@ -243,6 +244,7 @@ type Manager struct {
 	Mixpanel             map[string]*mixpanel.Client
 	Amplitude            map[string]*amplitude.Client
 	Fastspring           map[string]*fastspring.Client
+	TwoCheckout          map[string]*twocheckout.Client
 	Payrails             map[string]*payrails.Client
 	Clickup              map[string]*clickup.Client
 	Jobtread             map[string]*jobtread.Client
@@ -3077,6 +3079,29 @@ func (m *Manager) AddFastspringConnectionFromConfig(connection *config.Fastsprin
 	return nil
 }
 
+func (m *Manager) AddTwoCheckoutConnectionFromConfig(connection *config.TwoCheckoutConnection) error {
+	m.mutex.Lock()
+	if m.TwoCheckout == nil {
+		m.TwoCheckout = make(map[string]*twocheckout.Client)
+	}
+	m.mutex.Unlock()
+
+	client, err := twocheckout.NewClient(twocheckout.Config{
+		MerchantCode: connection.MerchantCode,
+		SecretKey:    connection.SecretKey,
+		BaseURL:      connection.BaseURL,
+	})
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.TwoCheckout[connection.Name] = client
+	m.availableConnections[connection.Name] = client
+	m.AllConnectionDetails[connection.Name] = connection
+	return nil
+}
+
 func (m *Manager) AddPayrailsConnectionFromConfig(connection *config.PayrailsConnection) error {
 	m.mutex.Lock()
 	if m.Payrails == nil {
@@ -4295,6 +4320,7 @@ func NewManagerFromConfigWithContext(ctx context.Context, cm *config.Config) (co
 	processConnections(cm.SelectedEnvironment.Connections.Mixpanel, connectionManager.AddMixpanelConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Amplitude, connectionManager.AddAmplitudeConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Fastspring, connectionManager.AddFastspringConnectionFromConfig, &wg, &errList, &mu)
+	processConnections(cm.SelectedEnvironment.Connections.TwoCheckout, connectionManager.AddTwoCheckoutConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Payrails, connectionManager.AddPayrailsConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Pinterest, connectionManager.AddPinterestConnectionFromConfig, &wg, &errList, &mu)
 	processConnections(cm.SelectedEnvironment.Connections.Trustpilot, connectionManager.AddTrustpilotConnectionFromConfig, &wg, &errList, &mu)

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -717,6 +717,17 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 		{Name: "revenue_report", PrimaryKey: "order_id, transaction_date", IncKey: "syncdate", IncStrategy: "merge"},
 	},
 
+	// 2Checkout (Verifone) - Payments & Subscriptions
+	// The source filters server-side on the run interval (StartDate/EndDate for
+	// orders, ModifiedAfter for subscriptions) and serves products/promotions as
+	// snapshots, so it owns incrementality and no per-row cursor column is used.
+	"twocheckout": {
+		{Name: "orders", PrimaryKey: "ref_no, status", IncStrategy: "merge"},
+		{Name: "subscriptions", PrimaryKey: "subscription_reference", IncStrategy: "merge"},
+		{Name: "products", PrimaryKey: "product_code", IncStrategy: "merge"},
+		{Name: "promotions", PrimaryKey: "code", IncStrategy: "merge"},
+	},
+
 	// Mixpanel - Analytics
 	"mixpanel": {
 		{Name: "events", PrimaryKey: "distinct_id", IncKey: "time", IncStrategy: "merge"},

--- a/pkg/ingestr/sources.go
+++ b/pkg/ingestr/sources.go
@@ -724,8 +724,8 @@ var SourceTablesRegistry = map[string][]*SourceTable{
 	"twocheckout": {
 		{Name: "orders", PrimaryKey: "ref_no, status", IncStrategy: "merge"},
 		{Name: "subscriptions", PrimaryKey: "subscription_reference", IncStrategy: "merge"},
-		{Name: "products", PrimaryKey: "product_code", IncStrategy: "merge"},
-		{Name: "promotions", PrimaryKey: "code", IncStrategy: "merge"},
+		{Name: "products", PrimaryKey: "product_code", IncStrategy: "replace"},
+		{Name: "promotions", PrimaryKey: "code", IncStrategy: "replace"},
 	},
 
 	// Mixpanel - Analytics

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -284,6 +284,7 @@ var defaultMapping = map[string]string{
 	"linkedinads":           "linkedinads-default",
 	"amplitude":             "amplitude-default",
 	"fastspring":            "fastspring-default",
+	"twocheckout":           "twocheckout-default",
 	"payrails":              "payrails-default",
 	"mailchimp":             "mailchimp-default",
 	"manifold":              "manifold-default",

--- a/pkg/twocheckout/client.go
+++ b/pkg/twocheckout/client.go
@@ -1,0 +1,13 @@
+package twocheckout
+
+type Client struct {
+	config Config
+}
+
+func (c *Client) GetIngestrURI() (string, error) {
+	return c.config.GetIngestrURI()
+}
+
+func NewClient(c Config) (*Client, error) {
+	return &Client{c}, nil
+}

--- a/pkg/twocheckout/config.go
+++ b/pkg/twocheckout/config.go
@@ -1,0 +1,47 @@
+package twocheckout
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Config describes credentials for a 2Checkout (Verifone) connection.
+type Config struct {
+	MerchantCode string `yaml:"merchant_code" json:"merchant_code" mapstructure:"merchant_code"`
+	SecretKey    string `yaml:"secret_key" json:"secret_key" mapstructure:"secret_key"`
+	// BaseURL overrides the default 2Checkout REST API host. Optional.
+	BaseURL string `yaml:"base_url" json:"base_url" mapstructure:"base_url"`
+}
+
+type requiredField struct {
+	key   string
+	value string
+}
+
+// GetIngestrURI builds the 2Checkout ingestr URI.
+//
+// The scheme is `twocheckout`, not `2checkout`: RFC 3986 requires a URI scheme
+// to begin with a letter, and a leading digit breaks url.Parse.
+func (c *Config) GetIngestrURI() (string, error) {
+	params := url.Values{}
+
+	requiredFields := []requiredField{
+		{"merchant_code", c.MerchantCode},
+		{"secret_key", c.SecretKey},
+	}
+
+	for _, field := range requiredFields {
+		field.value = strings.TrimSpace(field.value)
+		if field.value == "" {
+			return "", fmt.Errorf("twocheckout: %s must be provided", field.key)
+		}
+		params.Set(field.key, field.value)
+	}
+
+	if baseURL := strings.TrimSpace(c.BaseURL); baseURL != "" {
+		params.Set("base_url", baseURL)
+	}
+
+	return "twocheckout://?" + params.Encode(), nil
+}

--- a/pkg/twocheckout/config_test.go
+++ b/pkg/twocheckout/config_test.go
@@ -1,0 +1,64 @@
+package twocheckout
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetIngestrURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "required fields set",
+			config: Config{MerchantCode: "MERCHANT123", SecretKey: "secret"},
+			want:   "twocheckout://?merchant_code=MERCHANT123&secret_key=secret",
+		},
+		{
+			name:   "with base_url",
+			config: Config{MerchantCode: "MERCHANT123", SecretKey: "secret", BaseURL: "https://api.example.com"},
+			want:   "twocheckout://?base_url=https%3A%2F%2Fapi.example.com&merchant_code=MERCHANT123&secret_key=secret",
+		},
+		{
+			name:    "missing merchant_code",
+			config:  Config{SecretKey: "secret"},
+			wantErr: true,
+		},
+		{
+			name:    "missing secret_key",
+			config:  Config{MerchantCode: "MERCHANT123"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.config.GetIngestrURI()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{MerchantCode: "MERCHANT123", SecretKey: "secret"})
+	require.NoError(t, err)
+
+	uri, err := client.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "twocheckout://?merchant_code=MERCHANT123&secret_key=secret", uri)
+}


### PR DESCRIPTION
## What

Adds Bruin connection support for the **2Checkout (Verifone)** ingestr source (scheme: `twocheckout` — not `2checkout`, since RFC 3986 forbids a leading-digit URI scheme).


## URI parameters

Verified against the ingestr `v1.1.43` URI parser — these are the complete set:

| Param | Required | Sensitive |
|-------|----------|-----------|
| `merchant_code` | yes | no |
| `secret_key` | yes | yes |
| `base_url` | no | no |
