### PR TITLE
feat(vertica): add tlsmode, connection_load_balance, backup_server_node connection params

### DIFF
--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -5542,6 +5542,15 @@
         },
         "schema": {
           "type": "string"
+        },
+        "tlsmode": {
+          "type": "string"
+        },
+        "connection_load_balance": {
+          "type": "integer"
+        },
+        "backup_server_node": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -2249,6 +2249,10 @@ type VerticaConnection struct {
 	Port               int    `yaml:"port,omitempty"     json:"port" mapstructure:"port" jsonschema:"default=5433"`
 	Database           string `yaml:"database,omitempty" json:"database" mapstructure:"database"`
 	Schema             string `yaml:"schema,omitempty"   json:"schema,omitempty" mapstructure:"schema"`
+
+	TLSMode               string `yaml:"tlsmode,omitempty"                 json:"tlsmode,omitempty"                 mapstructure:"tlsmode"`
+	ConnectionLoadBalance *int   `yaml:"connection_load_balance,omitempty" json:"connection_load_balance,omitempty" mapstructure:"connection_load_balance"`
+	BackupServerNode      string `yaml:"backup_server_node,omitempty"      json:"backup_server_node,omitempty"      mapstructure:"backup_server_node"`
 }
 
 func (c VerticaConnection) GetName() string {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -4197,12 +4197,15 @@ func (m *Manager) AddVerticaConnectionFromConfig(connection *config.VerticaConne
 	m.mutex.Unlock()
 
 	client, err := vertica.NewDB(&vertica.Config{
-		Username: connection.Username,
-		Password: connection.Password,
-		Host:     connection.Host,
-		Port:     connection.Port,
-		Database: connection.Database,
-		Schema:   connection.Schema,
+		Username:              connection.Username,
+		Password:              connection.Password,
+		Host:                  connection.Host,
+		Port:                  connection.Port,
+		Database:              connection.Database,
+		Schema:                connection.Schema,
+		TLSMode:               connection.TLSMode,
+		ConnectionLoadBalance: connection.ConnectionLoadBalance,
+		BackupServerNode:      connection.BackupServerNode,
 	})
 	if err != nil {
 		return err

--- a/pkg/vertica/config.go
+++ b/pkg/vertica/config.go
@@ -3,6 +3,7 @@ package vertica
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 type Config struct {
@@ -26,7 +27,7 @@ func (c *Config) optionalQuery() url.Values {
 		query.Add("tlsmode", c.TLSMode)
 	}
 	if c.ConnectionLoadBalance != nil {
-		query.Add("connection_load_balance", fmt.Sprintf("%d", *c.ConnectionLoadBalance))
+		query.Add("connection_load_balance", strconv.Itoa(*c.ConnectionLoadBalance))
 	}
 	if c.BackupServerNode != "" {
 		query.Add("backup_server_node", c.BackupServerNode)

--- a/pkg/vertica/config.go
+++ b/pkg/vertica/config.go
@@ -6,16 +6,36 @@ import (
 )
 
 type Config struct {
-	Username string
-	Password string
-	Host     string
-	Port     int
-	Database string
-	Schema   string
+	Username              string
+	Password              string
+	Host                  string
+	Port                  int
+	Database              string
+	Schema                string
+	TLSMode               string
+	ConnectionLoadBalance *int
+	BackupServerNode      string
+}
+
+// optionalQuery returns the query parameters that are shared by both the native
+// and the ingestr connection URIs. These map directly onto the parameters
+// understood by the underlying vertica-sql-go driver.
+func (c *Config) optionalQuery() url.Values {
+	query := url.Values{}
+	if c.TLSMode != "" {
+		query.Add("tlsmode", c.TLSMode)
+	}
+	if c.ConnectionLoadBalance != nil {
+		query.Add("connection_load_balance", fmt.Sprintf("%d", *c.ConnectionLoadBalance))
+	}
+	if c.BackupServerNode != "" {
+		query.Add("backup_server_node", c.BackupServerNode)
+	}
+	return query
 }
 
 func (c *Config) ToDBConnectionURI() string {
-	query := url.Values{}
+	query := c.optionalQuery()
 	if c.Schema != "" {
 		query.Add("search_path", c.Schema)
 	}
@@ -33,10 +53,11 @@ func (c *Config) ToDBConnectionURI() string {
 
 func (c *Config) GetIngestrURI() string {
 	u := &url.URL{
-		Scheme: "vertica",
-		User:   url.UserPassword(c.Username, c.Password),
-		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
-		Path:   c.Database,
+		Scheme:   "vertica",
+		User:     url.UserPassword(c.Username, c.Password),
+		Host:     fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Path:     c.Database,
+		RawQuery: c.optionalQuery().Encode(),
 	}
 
 	return u.String()

--- a/pkg/vertica/config_test.go
+++ b/pkg/vertica/config_test.go
@@ -71,6 +71,60 @@ func TestConfig_ToDBConnectionURI(t *testing.T) {
 		// Password should be URL-encoded
 		assert.NotContains(t, uri, "p@ss w0rd!")
 	})
+
+	t.Run("connection URI with optional params", func(t *testing.T) {
+		t.Parallel()
+		loadBalance := 1
+		c := Config{
+			Username:              "user",
+			Password:              "password",
+			Host:                  "localhost",
+			Port:                  5433,
+			Database:              "mydb",
+			Schema:                "analytics",
+			TLSMode:               "server-strict",
+			ConnectionLoadBalance: &loadBalance,
+			BackupServerNode:      "backup1:5433,backup2:5433",
+		}
+
+		uri := c.ToDBConnectionURI()
+		assert.Contains(t, uri, "tlsmode=server-strict")
+		assert.Contains(t, uri, "connection_load_balance=1")
+		assert.Contains(t, uri, "backup_server_node=backup1%3A5433%2Cbackup2%3A5433")
+		assert.Contains(t, uri, "search_path=analytics")
+	})
+
+	t.Run("connection URI omits unset optional params", func(t *testing.T) {
+		t.Parallel()
+		c := Config{
+			Username: "user",
+			Password: "password",
+			Host:     "localhost",
+			Port:     5433,
+			Database: "mydb",
+		}
+
+		uri := c.ToDBConnectionURI()
+		assert.NotContains(t, uri, "tlsmode")
+		assert.NotContains(t, uri, "connection_load_balance")
+		assert.NotContains(t, uri, "backup_server_node")
+	})
+
+	t.Run("connection_load_balance can be disabled explicitly", func(t *testing.T) {
+		t.Parallel()
+		loadBalance := 0
+		c := Config{
+			Username:              "user",
+			Password:              "password",
+			Host:                  "localhost",
+			Port:                  5433,
+			Database:              "mydb",
+			ConnectionLoadBalance: &loadBalance,
+		}
+
+		uri := c.ToDBConnectionURI()
+		assert.Contains(t, uri, "connection_load_balance=0")
+	})
 }
 
 func TestConfig_GetIngestrURI(t *testing.T) {
@@ -105,5 +159,28 @@ func TestConfig_GetIngestrURI(t *testing.T) {
 		assert.Equal(t, "vertica://user:password@localhost:5433/mydb", uri)
 		assert.NotContains(t, uri, "search_path")
 		assert.NotContains(t, uri, "analytics")
+	})
+
+	t.Run("ingestr URI includes optional params", func(t *testing.T) {
+		t.Parallel()
+		loadBalance := 1
+		c := Config{
+			Username:              "user",
+			Password:              "password",
+			Host:                  "localhost",
+			Port:                  5433,
+			Database:              "mydb",
+			Schema:                "analytics",
+			TLSMode:               "server-strict",
+			ConnectionLoadBalance: &loadBalance,
+			BackupServerNode:      "backup1:5433,backup2:5433",
+		}
+
+		uri := c.GetIngestrURI()
+		assert.Contains(t, uri, "tlsmode=server-strict")
+		assert.Contains(t, uri, "connection_load_balance=1")
+		assert.Contains(t, uri, "backup_server_node=backup1%3A5433%2Cbackup2%3A5433")
+		// schema is still ignored for ingestr
+		assert.NotContains(t, uri, "search_path")
 	})
 }


### PR DESCRIPTION
## What

Adds the widely-used optional connection parameters supported by the underlying [`vertica-sql-go`](https://github.com/vertica/vertica-sql-go) driver to the Vertica connection:

| Param | Values | Purpose |
|---|---|---|
| `tlsmode` | `none` / `prefer` / `server` / `server-strict` | TLS negotiation mode |
| `connection_load_balance` | `0` / `1` | Enable native connection load balancing |
| `backup_server_node` | comma-separated `host:port` pairs | Failover hosts |