### PR TITLE
feat(cloud): hidden `agents request-connection` command

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3864,12 +3864,8 @@ func cloudAgentsExportThread() *cli.Command {
 }
 
 // cloudAgentsRequestConnection surfaces an "add connection" card in the current
-// chat. It's internal (Hidden) and only meaningful inside a Bruin Cloud chat run:
-// the agent supplies just --reason and --connection-types, while --agent-id and
-// --thread-id come from the run's env (BRUIN_CLOUD_AGENT_ID / BRUIN_THREAD_ID) so
-// the agent can't address another thread and never handles the message pair —
-// the cloud endpoint resolves the in-flight pair itself. Absent that env it errors,
-// so a local run has nowhere to render a card and simply refuses.
+// chat. agent-id/thread-id are read straight from the run env, never flags, so an
+// agent can't point the card at another chat.
 func cloudAgentsRequestConnection() *cli.Command {
 	return &cli.Command{
 		Name:   "request-connection",
@@ -3878,16 +3874,6 @@ func cloudAgentsRequestConnection() *cli.Command {
 		Flags: []cli.Flag{
 			apiKeyFlag(),
 			outputFlag(),
-			&cli.IntFlag{
-				Name:    "agent-id",
-				Usage:   "agent ID (defaults to BRUIN_CLOUD_AGENT_ID)",
-				Sources: cli.EnvVars("BRUIN_CLOUD_AGENT_ID"),
-			},
-			&cli.IntFlag{
-				Name:    "thread-id",
-				Usage:   "thread ID (defaults to BRUIN_THREAD_ID)",
-				Sources: cli.EnvVars("BRUIN_THREAD_ID"),
-			},
 			&cli.StringFlag{
 				Name:     "reason",
 				Usage:    "short, user-facing reason the connection is needed",
@@ -3902,7 +3888,8 @@ func cloudAgentsRequestConnection() *cli.Command {
 			defer RecoverFromPanic()
 			output := c.String("output")
 
-			agentID, threadID := c.Int("agent-id"), c.Int("thread-id")
+			agentID, _ := strconv.Atoi(os.Getenv("BRUIN_CLOUD_AGENT_ID"))
+			threadID, _ := strconv.Atoi(os.Getenv("BRUIN_THREAD_ID"))
 			if agentID <= 0 || threadID <= 0 {
 				printError(errors.New("request-connection only works inside a Bruin Cloud chat run (BRUIN_CLOUD_AGENT_ID and BRUIN_THREAD_ID must be set)"), output, "Not in a cloud chat")
 				return cli.Exit("", 1)

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -2434,6 +2434,7 @@ func CloudAgents() *cli.Command {
 			cloudAgentsSetMemory(),
 			cloudAgentsClearMemory(),
 			cloudAgentsExportThread(),
+			cloudAgentsRequestConnection(),
 			cloudAgentsConnections(),
 			cloudAgentsMcp(),
 		},
@@ -3857,6 +3858,74 @@ func cloudAgentsExportThread() *cli.Command {
 			}
 
 			fmt.Println(string(pretty))
+			return nil
+		},
+	}
+}
+
+// cloudAgentsRequestConnection surfaces an "add connection" card in the current
+// chat. It's internal (Hidden) and only meaningful inside a Bruin Cloud chat run:
+// the agent supplies just --reason and --connection-types, while --agent-id and
+// --thread-id come from the run's env (BRUIN_CLOUD_AGENT_ID / BRUIN_THREAD_ID) so
+// the agent can't address another thread and never handles the message pair —
+// the cloud endpoint resolves the in-flight pair itself. Absent that env it errors,
+// so a local run has nowhere to render a card and simply refuses.
+func cloudAgentsRequestConnection() *cli.Command {
+	return &cli.Command{
+		Name:   "request-connection",
+		Usage:  "Surface an 'add connection' card in the current chat (internal; used by agent runs)",
+		Hidden: true,
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:    "agent-id",
+				Usage:   "agent ID (defaults to BRUIN_CLOUD_AGENT_ID)",
+				Sources: cli.EnvVars("BRUIN_CLOUD_AGENT_ID"),
+			},
+			&cli.IntFlag{
+				Name:    "thread-id",
+				Usage:   "thread ID (defaults to BRUIN_THREAD_ID)",
+				Sources: cli.EnvVars("BRUIN_THREAD_ID"),
+			},
+			&cli.StringFlag{
+				Name:     "reason",
+				Usage:    "short, user-facing reason the connection is needed",
+				Required: true,
+			},
+			&cli.StringSliceFlag{
+				Name:  "connection-types",
+				Usage: "likely connection type(s), e.g. snowflake,postgres; repeat or comma-separate",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			agentID, threadID := c.Int("agent-id"), c.Int("thread-id")
+			if agentID <= 0 || threadID <= 0 {
+				printError(errors.New("request-connection only works inside a Bruin Cloud chat run (BRUIN_CLOUD_AGENT_ID and BRUIN_THREAD_ID must be set)"), output, "Not in a cloud chat")
+				return cli.Exit("", 1)
+			}
+
+			reason := strings.TrimSpace(c.String("reason"))
+			if reason == "" {
+				printError(errors.New("--reason is required"), output, "Missing --reason")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.RequestConnection(ctx, agentID, threadID, reason, c.StringSlice("connection-types")); err != nil {
+				printError(err, output, "Failed to request connection")
+				return cli.Exit("", 1)
+			}
+
+			printSuccessForOutput(output, "Connection request surfaced in the chat. Ask the user to add the connection there, then re-send their message.")
 			return nil
 		},
 	}

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -533,7 +533,7 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	cmd := CloudAgents()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "agents", cmd.Name)
-	require.Len(t, cmd.Commands, 18)
+	require.Len(t, cmd.Commands, 19)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -547,6 +547,61 @@ func TestCloudAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "set-memory")
 	assert.Contains(t, subNames, "clear-memory")
 	assert.Contains(t, subNames, "export-thread")
+	assert.Contains(t, subNames, "request-connection")
+}
+
+// runRequestConnection runs "cloud agents request-connection" against a stub
+// server, returning the request path it hit (empty if never called) and the JSON
+// body it received.
+func runRequestConnection(t *testing.T, args ...string) (path string, body map[string]any, runErr error) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"status":"ok","message_pair_id":99}`))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("BRUIN_CLOUD_BASE_URL", server.URL)
+	t.Setenv("BRUIN_CLOUD_API_KEY", "test-key")
+	t.Setenv("BRUIN_CLOUD_TEAM", "")
+	t.Chdir(writeTempConfigRepo(t, configWithoutCloudYML))
+
+	isDebug := false
+	cmd := Cloud(&isDebug)
+	// A cli.Exit from the action would otherwise os.Exit and kill the test binary;
+	// neutralize the handler so Run returns the error for us to assert on.
+	cmd.ExitErrHandler = func(context.Context, *cli.Command, error) {}
+	runErr = cmd.Run(t.Context(), append([]string{"cloud", "agents", "request-connection"}, args...))
+	return path, body, runErr
+}
+
+func TestCloudAgentsRequestConnection_UsesEnvIDsAndBody(t *testing.T) { //nolint:paralleltest // uses t.Chdir/t.Setenv
+	t.Setenv("BRUIN_CLOUD_AGENT_ID", "7")
+	t.Setenv("BRUIN_THREAD_ID", "42")
+
+	path, body, err := runRequestConnection(t,
+		"--reason", "need snowflake",
+		"--connection-types", "snowflake", "--connection-types", "postgres",
+	)
+	require.NoError(t, err)
+	// agent + thread come from the run's env, never from the agent's own flags.
+	assert.Equal(t, "/agents/7/threads/42/connection-request", path)
+	assert.Equal(t, "need snowflake", body["reason"])
+	assert.Equal(t, []any{"snowflake", "postgres"}, body["connection_types"])
+}
+
+func TestCloudAgentsRequestConnection_RefusesOutsideCloudChat(t *testing.T) { //nolint:paralleltest // uses t.Chdir/t.Setenv
+	// No thread in the env → nothing to render a card on; the command refuses
+	// instead of calling the API.
+	t.Setenv("BRUIN_CLOUD_AGENT_ID", "0")
+	t.Setenv("BRUIN_THREAD_ID", "0")
+
+	path, _, err := runRequestConnection(t, "--reason", "need snowflake")
+	require.Error(t, err)
+	assert.Empty(t, path, "the API must not be called without a thread")
 }
 
 func TestCloudAgentsThreadsCommand_Help(t *testing.T) {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -582,7 +582,8 @@ func TestCloudAgentsRequestConnection_UsesEnvIDsAndBody(t *testing.T) { //nolint
 	t.Setenv("BRUIN_CLOUD_AGENT_ID", "7")
 	t.Setenv("BRUIN_THREAD_ID", "42")
 
-	path, body, err := runRequestConnection(t,
+	path, body, err := runRequestConnection(
+		t,
 		"--reason", "need snowflake",
 		"--connection-types", "snowflake", "--connection-types", "postgres",
 	)

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -605,6 +605,17 @@ func TestCloudAgentsRequestConnection_RefusesOutsideCloudChat(t *testing.T) { //
 	assert.Empty(t, path, "the API must not be called without a thread")
 }
 
+func TestCloudAgentsRequestConnection_HasNoIDFlagsToOverrideTheRunBinding(t *testing.T) { //nolint:paralleltest // uses t.Chdir/t.Setenv
+	// The ids come only from the env; there is no --agent-id flag for an agent to
+	// pass, so it can't redirect the card to another thread.
+	t.Setenv("BRUIN_CLOUD_AGENT_ID", "7")
+	t.Setenv("BRUIN_THREAD_ID", "42")
+
+	path, _, err := runRequestConnection(t, "--reason", "x", "--agent-id", "999")
+	require.Error(t, err) // unknown flag
+	assert.Empty(t, path, "the API must not be called")
+}
+
 func TestCloudAgentsThreadsCommand_Help(t *testing.T) {
 	t.Parallel()
 	cmd := cloudAgentsThreads()

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -547,6 +547,17 @@ func (c *APIClient) AddAgentConnection(ctx context.Context, agentID int, connTyp
 	return resp.Connections, err
 }
 
+// RequestConnection posts an "add connection" card to the thread's in-flight
+// message pair. The cloud endpoint resolves the pair itself, so only the thread
+// is addressed here. connectionTypes may be empty.
+func (c *APIClient) RequestConnection(ctx context.Context, agentID, threadID int, reason string, connectionTypes []string) error {
+	body := map[string]any{"reason": reason}
+	if len(connectionTypes) > 0 {
+		body["connection_types"] = connectionTypes
+	}
+	return c.doRequest(ctx, http.MethodPost, fmt.Sprintf("/agents/%d/threads/%d/connection-request", agentID, threadID), body, nil)
+}
+
 // CreateAgent creates a new agent. Optional fields are omitted when empty so the
 // server applies its defaults (null description/prompt, "team" visibility).
 func (c *APIClient) CreateAgent(ctx context.Context, name, description, systemPrompt, visibility string) (*Agent, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -603,6 +603,40 @@ func TestAddAgentConnection(t *testing.T) {
 	assert.Equal(t, "postgres", connections[0].Type)
 }
 
+func TestRequestConnection(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/agents/7/threads/42/connection-request", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "need snowflake", body["reason"])
+		assert.Equal(t, []any{"snowflake", "postgres"}, body["connection_types"])
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, map[string]any{"status": "ok", "message_pair_id": 99})
+	})
+
+	require.NoError(t, client.RequestConnection(t.Context(), 7, 42, "need snowflake", []string{"snowflake", "postgres"}))
+}
+
+func TestRequestConnectionOmitsEmptyTypes(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "just reason", body["reason"])
+		_, hasTypes := body["connection_types"]
+		assert.False(t, hasTypes) // omitted, not sent as an empty array
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, map[string]any{"status": "ok"})
+	})
+
+	require.NoError(t, client.RequestConnection(t.Context(), 1, 2, "just reason", nil))
+}
+
 func TestListConnectionSets(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds a hidden `bruin cloud agents request-connection` command that posts an "add connection" request to the current chat via the Cloud API. Agent and thread ids come from the run environment; the caller passes only `--reason` and `--connection-types`. Includes client and command tests.