### PR TITLE
fix: fetch schema_prefix summaries on cache miss

### DIFF
--- a/pkg/devenv/modifier.go
+++ b/pkg/devenv/modifier.go
@@ -77,17 +77,20 @@ func (d *DevEnvQueryModifier) Modify(ctx context.Context, p *pipeline.Pipeline, 
 	d.connSchemaCacheLock.Lock()
 	if d.connSchemaCache == nil {
 		d.connSchemaCache = make(map[string]*ansisql.DBDatabase)
+	}
 
+	if dbSummary = d.connSchemaCache[connName]; dbSummary != nil {
+		d.connSchemaCacheLock.Unlock()
+	} else {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			dbSummary, dbSummaryErr = dbFetcherConn.GetDatabaseSummary(ctx)
-			d.connSchemaCache[connName] = dbSummary
+			if dbSummaryErr == nil && dbSummary != nil {
+				d.connSchemaCache[connName] = dbSummary
+			}
 			d.connSchemaCacheLock.Unlock()
 		}()
-	} else {
-		dbSummary = d.connSchemaCache[connName]
-		d.connSchemaCacheLock.Unlock()
 	}
 
 	wg.Wait()
@@ -97,6 +100,9 @@ func (d *DevEnvQueryModifier) Modify(ctx context.Context, p *pipeline.Pipeline, 
 
 	if dbSummaryErr != nil {
 		return nil, dbSummaryErr
+	}
+	if dbSummary == nil {
+		return nil, fmt.Errorf("database summary for connection '%s' is unavailable", connName)
 	}
 
 	crossCatalogTables := make([]string, 0)

--- a/pkg/devenv/modifier_test.go
+++ b/pkg/devenv/modifier_test.go
@@ -44,7 +44,8 @@ type mockConnectionInstance struct {
 
 func (m *mockConnectionInstance) GetDatabaseSummary(ctx context.Context) (*ansisql.DBDatabase, error) {
 	args := m.Called(ctx)
-	return args.Get(0).(*ansisql.DBDatabase), args.Error(1)
+	summary, _ := args.Get(0).(*ansisql.DBDatabase)
+	return summary, args.Error(1)
 }
 
 type mockTableCheckingConnectionInstance struct {
@@ -795,6 +796,132 @@ func TestTableExistsInDatabasePrefersMetadataChecker(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 	connection.AssertExpectations(t)
+}
+
+func TestDevEnvQueryModifier_Modify_FetchesSummaryOnSecondConnection(t *testing.T) {
+	t.Parallel()
+
+	pipelineA := &pipeline.Pipeline{
+		DefaultConnections: map[string]string{"postgres": "conn-a"},
+	}
+	pipelineB := &pipeline.Pipeline{
+		DefaultConnections: map[string]string{"postgres": "conn-b"},
+	}
+	asset := &pipeline.Asset{
+		Name: "dev_schema1.table1",
+		Type: pipeline.AssetTypePostgresQuery,
+	}
+
+	connA := new(mockConnectionInstance)
+	connA.On("GetDatabaseSummary", mock.Anything).Return(&ansisql.DBDatabase{
+		Name: "db_a",
+		Schemas: []*ansisql.DBSchema{
+			{
+				Name: "dev_schema1",
+				Tables: []*ansisql.DBTable{
+					{Name: "table1"},
+				},
+			},
+		},
+	}, nil).Once()
+
+	connB := new(mockConnectionInstance)
+	connB.On("GetDatabaseSummary", mock.Anything).Return(&ansisql.DBDatabase{
+		Name:    "db_b",
+		Schemas: []*ansisql.DBSchema{},
+	}, nil).Once()
+
+	connectionFetcher := new(mockConnectionFetcher)
+	connectionFetcher.On("GetConnection", "conn-a").Return(connA)
+	connectionFetcher.On("GetConnection", "conn-b").Return(connB)
+
+	sqlParser := new(mockSQLParser)
+	queryA := "SELECT * FROM schema1.table1"
+	sqlParser.On("UsedTables", queryA, "postgres").Return([]string{"schema1.table1"}, nil)
+	sqlParser.On("RenameTables", queryA, "postgres", map[string]string{
+		"schema1.table1": "dev_schema1.table1",
+	}).Return("SELECT * FROM dev_schema1.table1", nil)
+
+	queryB := "SELECT * FROM otherdb.schema1.table1"
+	sqlParser.On("UsedTables", queryB, "postgres").Return([]string{"otherdb.schema1.table1"}, nil)
+	sqlParser.On("RenameTables", queryB, "postgres", map[string]string{
+		"schema1.table1": "dev_schema1.table1",
+	}).Return("SELECT * FROM otherdb.schema1.table1", nil)
+
+	modifier := &DevEnvQueryModifier{
+		Dialect: "postgres",
+		Conn:    connectionFetcher,
+		Parser:  sqlParser,
+	}
+	ctx := context.WithValue(t.Context(), config.EnvironmentContextKey, &config.Environment{SchemaPrefix: "dev_"})
+
+	gotA, err := modifier.Modify(ctx, pipelineA, asset, &query.Query{Query: queryA})
+	require.NoError(t, err)
+	require.Equal(t, &query.Query{Query: "SELECT * FROM dev_schema1.table1"}, gotA)
+
+	gotB, err := modifier.Modify(ctx, pipelineB, asset, &query.Query{Query: queryB})
+	require.NoError(t, err)
+	require.Equal(t, &query.Query{Query: queryB}, gotB)
+	sqlParser.AssertExpectations(t)
+	connA.AssertExpectations(t)
+	connB.AssertExpectations(t)
+}
+
+func TestDevEnvQueryModifier_Modify_DoesNotCacheFailedSummary(t *testing.T) {
+	t.Parallel()
+
+	p := &pipeline.Pipeline{
+		DefaultConnections: map[string]string{"postgres": "conn-a"},
+	}
+	asset := &pipeline.Asset{
+		Name: "dev_schema1.table1",
+		Type: pipeline.AssetTypePostgresQuery,
+	}
+
+	connA := new(mockConnectionInstance)
+	connA.On("GetDatabaseSummary", mock.Anything).
+		Return(nil, errors.New("failed to get db summary")).
+		Once()
+	connA.On("GetDatabaseSummary", mock.Anything).Return(&ansisql.DBDatabase{
+		Name: "db_a",
+		Schemas: []*ansisql.DBSchema{
+			{
+				Name: "dev_schema1",
+				Tables: []*ansisql.DBTable{
+					{Name: "table1"},
+				},
+			},
+		},
+	}, nil).Once()
+
+	connectionFetcher := new(mockConnectionFetcher)
+	connectionFetcher.On("GetConnection", "conn-a").Return(connA)
+
+	sqlParser := new(mockSQLParser)
+	queryA := "SELECT * FROM schema1.table1"
+	sqlParser.On("UsedTables", queryA, "postgres").Return([]string{"schema1.table1"}, nil)
+
+	queryB := "SELECT * FROM otherdb.schema.table"
+	sqlParser.On("UsedTables", queryB, "postgres").Return([]string{"otherdb.schema.table"}, nil)
+	sqlParser.On("RenameTables", queryB, "postgres", map[string]string{
+		"schema1.table1": "dev_schema1.table1",
+	}).Return("SELECT * FROM otherdb.schema.table", nil)
+
+	modifier := &DevEnvQueryModifier{
+		Dialect: "postgres",
+		Conn:    connectionFetcher,
+		Parser:  sqlParser,
+	}
+	ctx := context.WithValue(t.Context(), config.EnvironmentContextKey, &config.Environment{SchemaPrefix: "dev_"})
+
+	_, err := modifier.Modify(ctx, p, asset, &query.Query{Query: queryA})
+	require.EqualError(t, err, "failed to get db summary")
+
+	got, err := modifier.Modify(ctx, p, asset, &query.Query{Query: queryB})
+	require.NoError(t, err)
+	require.Equal(t, &query.Query{Query: queryB}, got)
+	sqlParser.AssertExpectations(t)
+	connA.AssertExpectations(t)
 }
 
 func TestDevEnvQueryModifierBatchesCrossCatalogTableChecks(t *testing.T) {


### PR DESCRIPTION
## What
`DevEnvQueryModifier` is reused for the whole run (including `--downstream`). Database summaries are cached by connection name, but a fetch only happened when the cache map itself was first created.

After the first asset succeeded, a second asset on a different connection took the "map already exists" path, got a nil summary, and panicked on `dbSummary.Name` when the query had a 3-part table (`database.schema.table`). A 2-part-only query can hide this because `len(parts) != 3` skips that read.

Failed `GetDatabaseSummary` calls also stored nil, so a later `Modify` on the same connection could panic instead of fetching again or returning the error.

## Changes
- `pkg/devenv/modifier.go` — initialize the map if needed; fetch whenever this connection has no usable summary; store only a non-nil success; return a clear error instead of dereferencing nil. `RenameTables` / 3-part rewrite behavior is unchanged.
- `pkg/devenv/modifier_test.go` — sequential two-connection test (`conn-a` then `conn-b`, second query uses `otherdb.schema1.table1`); failed summary is not treated as a cache hit.

## How to test
1. `go test -tags="no_duckdb_arrow" ./pkg/devenv -count=1`
2. Confirm `TestDevEnvQueryModifier_Modify_FetchesSummaryOnSecondConnection` and `TestDevEnvQueryModifier_Modify_DoesNotCacheFailedSummary` pass.

## Risk & rollback
- **Risk:** low — cache lookup only; query rewrite policy is unchanged.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make format`; `make test`)
- [ ] Integration tests pass if affected (`make integration-test`) — not run; this is unit-level `Modify` only
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)