### PR TITLE
feat(iceberg): add r2 catalog type for Cloudflare R2 Data Catalog

### DIFF
--- a/docs/ingestion/iceberg.md
+++ b/docs/ingestion/iceberg.md
@@ -11,7 +11,7 @@ Bruin supports Iceberg as a **destination** for [Ingestr assets](/assets/ingestr
 
 | Catalog (`catalog.type`) | Storage (`storage.type`) |
 |---|---|
-| `glue`, `sqlite`, `postgres`, `rest`, `hive`, `hadoop`, `sql` | `s3`, `gcs`, `local` |
+| `glue`, `sqlite`, `postgres`, `rest`, `hive`, `hadoop`, `sql`, `r2` | `s3`, `gcs`, `local` |
 
 Table data is written to AWS S3 or any S3-compatible store (MinIO, Cloudflare R2, GCS interop), to Google Cloud Storage natively, or to the local filesystem.
 
@@ -69,6 +69,18 @@ Each catalog type takes different fields. Use the matching `catalog:` block belo
 > [!TIP]
 > A REST catalog is a **running server** you start and configure yourself — it holds its own warehouse location, storage backend, and credentials, and usually writes the table metadata to storage. Your connection's `storage` block still supplies the credentials Bruin uses to write the **data files**.
 > OAuth2 options such as `oauth2-server-uri` and `scope` go in the top-level [`properties`](#table-options) block.
+
+**Cloudflare R2 Data Catalog**
+```yaml
+          catalog:
+            type: r2                          # required
+            catalog_id: "<account_id>"        # required — Cloudflare account id
+            database: "<bucket>"              # required — R2 bucket with Data Catalog enabled
+            token: "${R2_TOKEN}"              # required — R2 API token (Admin Read & Write)
+```
+
+> [!TIP]
+> R2 Data Catalog is a managed Iceberg REST catalog. It vends the S3 storage credentials through the catalog, so **no `storage` block is needed** — the account id and bucket build the connection.
 
 **Hive**
 ```yaml

--- a/pkg/config/iceberg.go
+++ b/pkg/config/iceberg.go
@@ -13,6 +13,7 @@ const (
 	IcebergCatalogHive     IcebergCatalogType = "hive"
 	IcebergCatalogHadoop   IcebergCatalogType = "hadoop"
 	IcebergCatalogSQL      IcebergCatalogType = "sql"
+	IcebergCatalogR2       IcebergCatalogType = "r2"
 )
 
 type IcebergStorageType string
@@ -36,7 +37,8 @@ type IcebergAuth struct {
 }
 
 // IcebergCatalog describes the Iceberg catalog backend. Which fields apply depends
-// on Type (glue: catalog_id/region; sqlite/hadoop: path; postgres/rest/hive: host).
+// on Type (glue: catalog_id/region; sqlite/hadoop: path; postgres/rest/hive: host;
+// r2: catalog_id/database/token).
 type IcebergCatalog struct {
 	Type      IcebergCatalogType `yaml:"type" json:"type" mapstructure:"type"`
 	CatalogID string             `yaml:"catalog_id,omitempty" json:"catalog_id,omitempty" mapstructure:"catalog_id"`

--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -150,12 +150,10 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 	case config.IcebergCatalogR2:
 		// Cloudflare R2 Data Catalog: account id + bucket build the URI, and R2 vends
 		// the S3 storage credentials through the catalog, so no storage block is needed.
-		if cat.CatalogID == "" || cat.Database == "" {
-			return "", nil, fmt.Errorf("iceberg: r2 catalog requires %q (account id) and %q (bucket)", "catalog_id", "database")
+		if cat.CatalogID == "" || cat.Database == "" || cat.Token == "" {
+			return "", nil, fmt.Errorf("iceberg: r2 catalog requires %q (account id), %q (bucket), and %q (R2 API token)", "catalog_id", "database", "token")
 		}
-		if cat.Token != "" {
-			q.Set("token", cat.Token)
-		}
+		q.Set("token", cat.Token)
 		return "iceberg+r2://" + cat.CatalogID + "/" + cat.Database, q, nil
 	case config.IcebergCatalogHive:
 		if cat.Host == "" {

--- a/pkg/iceberg/config.go
+++ b/pkg/iceberg/config.go
@@ -21,6 +21,7 @@ var supportedCatalogTypes = []config.IcebergCatalogType{
 	config.IcebergCatalogHive,
 	config.IcebergCatalogHadoop,
 	config.IcebergCatalogSQL,
+	config.IcebergCatalogR2,
 }
 
 type Config struct {
@@ -146,6 +147,16 @@ func icebergCatalogURI(cat config.IcebergCatalog) (string, url.Values, error) {
 			q.Set("token", cat.Token)
 		}
 		return "iceberg+rest://" + hostPort(cat.Host, cat.Port), q, nil
+	case config.IcebergCatalogR2:
+		// Cloudflare R2 Data Catalog: account id + bucket build the URI, and R2 vends
+		// the S3 storage credentials through the catalog, so no storage block is needed.
+		if cat.CatalogID == "" || cat.Database == "" {
+			return "", nil, fmt.Errorf("iceberg: r2 catalog requires %q (account id) and %q (bucket)", "catalog_id", "database")
+		}
+		if cat.Token != "" {
+			q.Set("token", cat.Token)
+		}
+		return "iceberg+r2://" + cat.CatalogID + "/" + cat.Database, q, nil
 	case config.IcebergCatalogHive:
 		if cat.Host == "" {
 			return "", nil, fmt.Errorf("iceberg: hive catalog requires %q", "host")

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -275,16 +275,18 @@ func TestConfig_GetIngestrURI_R2Catalog(t *testing.T) {
 	assert.Empty(t, q.Get("warehouse"), "R2 derives the warehouse from the account/bucket in the URI")
 }
 
-func TestConfig_GetIngestrURI_R2CatalogRequiresAccountAndBucket(t *testing.T) {
+func TestConfig_GetIngestrURI_R2CatalogRequiresAccountBucketToken(t *testing.T) {
 	t.Parallel()
 
-	_, err := Config{Catalog: config.IcebergCatalog{Type: config.IcebergCatalogR2, Database: "b"}}.GetIngestrURI()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "r2 catalog requires")
-
-	_, err = Config{Catalog: config.IcebergCatalog{Type: config.IcebergCatalogR2, CatalogID: "acct"}}.GetIngestrURI()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "r2 catalog requires")
+	for _, cat := range []config.IcebergCatalog{
+		{Type: config.IcebergCatalogR2, Database: "b", Token: "t"},
+		{Type: config.IcebergCatalogR2, CatalogID: "acct", Token: "t"},
+		{Type: config.IcebergCatalogR2, CatalogID: "acct", Database: "b"},
+	} {
+		_, err := Config{Catalog: cat}.GetIngestrURI()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "r2 catalog requires")
+	}
 }
 
 func TestConfig_GetIngestrURI_HadoopAndHive(t *testing.T) {

--- a/pkg/iceberg/config_test.go
+++ b/pkg/iceberg/config_test.go
@@ -252,6 +252,41 @@ func TestConfig_GetIngestrURI_RESTCatalog(t *testing.T) {
 	assert.Equal(t, "https://auth.internal/token", q.Get("oauth2-server-uri"))
 }
 
+func TestConfig_GetIngestrURI_R2Catalog(t *testing.T) {
+	t.Parallel()
+
+	// R2 needs no storage block: the catalog vends the S3 credentials.
+	c := Config{
+		Catalog: config.IcebergCatalog{
+			Type:      config.IcebergCatalogR2,
+			CatalogID: "a430f6cbf157ff5d1518cdab0cba50aa",
+			Database:  "ingestr-r2-test",
+			Token:     "cfat_secret",
+		},
+	}
+
+	got, err := c.GetIngestrURI()
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, "iceberg+r2://a430f6cbf157ff5d1518cdab0cba50aa/ingestr-r2-test?"), "got: %s", got)
+
+	scheme, q := parseQuery(t, got)
+	assert.Equal(t, "iceberg+r2", scheme)
+	assert.Equal(t, "cfat_secret", q.Get("token"))
+	assert.Empty(t, q.Get("warehouse"), "R2 derives the warehouse from the account/bucket in the URI")
+}
+
+func TestConfig_GetIngestrURI_R2CatalogRequiresAccountAndBucket(t *testing.T) {
+	t.Parallel()
+
+	_, err := Config{Catalog: config.IcebergCatalog{Type: config.IcebergCatalogR2, Database: "b"}}.GetIngestrURI()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "r2 catalog requires")
+
+	_, err = Config{Catalog: config.IcebergCatalog{Type: config.IcebergCatalogR2, CatalogID: "acct"}}.GetIngestrURI()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "r2 catalog requires")
+}
+
 func TestConfig_GetIngestrURI_HadoopAndHive(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds `r2` as an Iceberg catalog type, mapping to ingestr's `iceberg+r2://` shorthand (added in ingestr [#1109-follow-up]). Cloudflare R2 Data Catalog is a managed Iceberg REST catalog that vends S3 storage credentials through the catalog itself, so no `storage` block is required.

## Config

```yaml
connections:
  iceberg:
    - name: my-r2
      catalog:
        type: r2
        catalog_id: "<account_id>"   # Cloudflare account id
        database: "<bucket>"          # R2 bucket with Data Catalog enabled
        token: "${R2_TOKEN}"          # R2 API token (Admin Read & Write)
```

Produces `iceberg+r2://<account_id>/<bucket>?token=<token>`.