### PR TITLE
fix(test): clone ADBC-scanned checksum in academy determinism test

### DIFF
--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -872,6 +872,9 @@ func academySQLBeginnerChecksums(t *testing.T, dbPath string) map[string]academy
 
 		var snapshot academyTableSnapshot
 		require.NoError(t, row.Scan(&snapshot.checksum, &snapshot.rowCount))
+		// The ADBC driver backs the scanned string with an Arrow buffer it reuses
+		// on the next connection; clone it so this run's checksum stays durable.
+		snapshot.checksum = strings.Clone(snapshot.checksum)
 		snapshots[name] = snapshot
 	}
 


### PR DESCRIPTION
## Problem

`TestAcademySqlBeginnerGeneratorsAreDeterministic` fails flakily. It runs the six generators into two DuckDB files and compares checksums (`first` vs `second`). On failure the `first` map's checksums are **uninitialized/aliased memory** (raw `\x00` bytes, a stray `"r_id"` fragment, live pointer bytes like `\xb9\x7f\x00\x00`) while `second`'s are valid 32-char MD5 hex — and the row counts match, so the generators are deterministic.

## Cause

The test opens DuckDB via the ADBC driver (`sql.Open(duck.ADBCDriverName(), …)`). The ADBC driver backs a scanned string with an Arrow buffer that it reuses when the next connection opens. `first`'s checksum strings alias that buffer, so once `second`'s connection runs, `first`'s values get clobbered — hence the corrupted bytes.

## Fix

`strings.Clone` the checksum right after `Scan`, forcing a durable Go allocation independent of the driver buffer.

## Verification

`go test ./cmd/ -run TestAcademySqlBeginnerGeneratorsAreDeterministic -count=1` passes; `gofmt`, `golangci-lint` clean.