### PR TITLE
fix(lineage): resolve assets that have no explicit name

### DIFF
--- a/cmd/lineage.go
+++ b/cmd/lineage.go
@@ -71,7 +71,9 @@ func (r *LineageCommand) Run(ctx context.Context, assetPath string, fullLineage 
 		return cli.Exit("", 1)
 	}
 
-	opts := []pipeline.CreatePipelineOption{}
+	// mutating the pipeline is what fills in the derived fields of the assets, most notably the names
+	// of the assets that don't have an explicit name given, therefore we need it to resolve the lineage.
+	opts := []pipeline.CreatePipelineOption{pipeline.WithMutate()}
 	if variantName != "" {
 		opts = append(opts, pipeline.WithVariant(variantName))
 	}

--- a/cmd/lineage_test.go
+++ b/cmd/lineage_test.go
@@ -119,6 +119,73 @@ Asset has no downstream dependencies.
 `,
 			wantErr: assert.NoError,
 		},
+		{
+			name: "nameless asset gets its name resolved from its path",
+			args: args{
+				assetPath: path.AbsPathForTests(t, "./testdata/lineage-nameless/assets/nameless.sql"),
+			},
+			want: `
+Lineage: 'nameless'
+
+Upstream Dependencies
+========================
+Asset has no upstream dependencies.
+
+
+Downstream Dependencies
+========================
+- nested.nameless_nested (assets/nested/nameless_nested.sql)
+
+Total: 1
+`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "nested nameless asset resolves both its nameless upstream and its named downstream",
+			args: args{
+				assetPath: path.AbsPathForTests(t, "./testdata/lineage-nameless/assets/nested/nameless_nested.sql"),
+			},
+			want: `
+Lineage: 'nested.nameless_nested'
+
+Upstream Dependencies
+========================
+- nameless (assets/nameless.sql)
+
+Total: 1
+
+
+Downstream Dependencies
+========================
+- dashboard.named (assets/named.sql)
+
+Total: 1
+`,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "named asset resolves its full upstream through the nameless assets",
+			args: args{
+				assetPath: path.AbsPathForTests(t, "./testdata/lineage-nameless/assets/named.sql"),
+				full:      true,
+			},
+			want: `
+Lineage: 'dashboard.named'
+
+Upstream Dependencies
+========================
+- nested.nameless_nested (assets/nested/nameless_nested.sql)
+- nameless (assets/nameless.sql)
+
+Total: 2
+
+
+Downstream Dependencies
+========================
+Asset has no downstream dependencies.
+`,
+			wantErr: assert.NoError,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/testdata/lineage-nameless/assets/named.sql
+++ b/cmd/testdata/lineage-nameless/assets/named.sql
@@ -1,0 +1,11 @@
+/* @bruin
+
+name: dashboard.named
+type: bq.sql
+
+depends:
+  - nested.nameless_nested
+
+@bruin */
+
+select 3 as three

--- a/cmd/testdata/lineage-nameless/assets/nameless.sql
+++ b/cmd/testdata/lineage-nameless/assets/nameless.sql
@@ -1,0 +1,7 @@
+/* @bruin
+
+type: bq.sql
+
+@bruin */
+
+select 1 as one

--- a/cmd/testdata/lineage-nameless/assets/nested/nameless_nested.sql
+++ b/cmd/testdata/lineage-nameless/assets/nested/nameless_nested.sql
@@ -1,0 +1,10 @@
+/* @bruin
+
+type: bq.sql
+
+depends:
+  - nameless
+
+@bruin */
+
+select 2 as two

--- a/cmd/testdata/lineage-nameless/pipeline.yml
+++ b/cmd/testdata/lineage-nameless/pipeline.yml
@@ -1,0 +1,3 @@
+name: lineage-nameless
+schedule: daily
+start_date: "2024-01-01"


### PR DESCRIPTION
## What
`bruin lineage <path>` built the pipeline without mutation, so the `SetNameFromPath` asset mutator never ran — assets with no explicit `name:` kept an empty name, printed as `Lineage: ''`, and registered under `""` in the pipeline's name lookup, so no dependency edge pointing at them resolved in either direction.

## Changes
- `cmd/lineage.go`: seed the pipeline build options with `pipeline.WithMutate()`, matching every other command that walks assets (`run`, `lint`, `patch`, `import`, `fetch`, `internal parse-pipeline`).
- `cmd/lineage_test.go`: three cases covering a nameless asset's name being derived from its path, a nested nameless asset resolving upstream and downstream, and `--full` traversal through two nameless assets.
- `cmd/testdata/lineage-nameless/`: fixture pipeline with the chain `nameless.sql` → `nested/nameless_nested.sql` → `named.sql`, the nested one covering dotted path-derived names.

## How to test
1. `go test ./cmd/ -run TestLineageCommand_Run` — the three new cases fail on `main` (`Lineage: ''`, empty dependency lists) and pass with this change.
2. Or manually: create a pipeline with a SQL asset whose `@bruin` block omits `name:`, plus another asset that depends on it by its path-derived name, then run `bruin lineage` on both files and confirm the name and both directions of the edge appear.

## Risk & rollback
- **Risk:** low — `lineage` is read-only, and the mutators it now runs (glossary enrichment, pipeline defaults, secret injection, retry translation, name-from-path) are the same set already applied by `lint` and `internal parse-pipeline` on the same pipelines.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
<!-- none -->