### PR TITLE
Add bruin cloud semantic-layers commands (BRU-6148)

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -42,6 +42,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudConnections(),
 			CloudConnectionSets(),
 			CloudDashboards(),
+			CloudSemanticLayers(),
 			CloudScheduledAgents(),
 			CloudSkills(),
 			CloudAuditLogs(),
@@ -4831,6 +4832,321 @@ func CloudDashboards() *cli.Command {
 			cloudDashboardsDelete(),
 		},
 	}
+}
+
+func CloudSemanticLayers() *cli.Command {
+	return &cli.Command{
+		Name:  "semantic-layers",
+		Usage: "Manage Bruin Cloud semantic layers",
+		Commands: []*cli.Command{
+			cloudSemanticLayersList(),
+			cloudSemanticLayersGet(),
+			cloudSemanticLayersCreate(),
+			cloudSemanticLayersUpdate(),
+			cloudSemanticLayersDelete(),
+		},
+	}
+}
+
+func cloudSemanticLayersList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List semantic layers",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			layers, err := client.ListSemanticLayers(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list semantic layers")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(layers, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Name", "Updated At"})
+			for _, l := range layers {
+				updated := ""
+				if l.UpdatedAt != nil {
+					updated = *l.UpdatedAt
+				}
+				t.AppendRow(table.Row{l.ID, l.Name, updated})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudSemanticLayersGet() *cli.Command {
+	return &cli.Command{
+		Name:  "get",
+		Usage: "Get a semantic layer including its model definition",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "semantic-layer-id",
+				Usage:    "semantic layer ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("semantic-layer-id") <= 0 {
+				printError(fmt.Errorf("--semantic-layer-id must be a positive integer, got %d", c.Int("semantic-layer-id")), output, "Invalid --semantic-layer-id")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			layer, err := client.GetSemanticLayer(ctx, c.Int("semantic-layer-id"))
+			if err != nil {
+				printError(err, output, "Failed to get semantic layer")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(layer, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			infoPrinter.Printf("Semantic layer %d: %s\n", layer.ID, layer.Name)
+			if len(layer.State) > 0 {
+				fmt.Println(string(layer.State))
+			}
+			return nil
+		},
+	}
+}
+
+func cloudSemanticLayersCreate() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a semantic layer from a name and model definition",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.StringFlag{
+				Name:     "name",
+				Usage:    "the semantic layer name",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "state",
+				Usage: "the model definition as a JSON or YAML string",
+			},
+			&cli.StringFlag{
+				Name:  "state-file",
+				Usage: "path to a file containing the model definition as JSON or YAML",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			state, err := parseSemanticStateFlags(c, output)
+			if err != nil {
+				return err
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			layer, err := client.CreateSemanticLayer(ctx, c.String("name"), state)
+			if err != nil {
+				printError(err, output, "Failed to create semantic layer")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(layer, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Created semantic layer %d (%s).\n", layer.ID, layer.Name)
+			return nil
+		},
+	}
+}
+
+func cloudSemanticLayersUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Update a semantic layer's name and/or model definition",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "semantic-layer-id",
+				Usage:    "semantic layer ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "name",
+				Usage: "a new name",
+			},
+			&cli.StringFlag{
+				Name:  "state",
+				Usage: "the model definition as a JSON or YAML string",
+			},
+			&cli.StringFlag{
+				Name:  "state-file",
+				Usage: "path to a file containing the model definition as JSON or YAML",
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("semantic-layer-id") <= 0 {
+				printError(fmt.Errorf("--semantic-layer-id must be a positive integer, got %d", c.Int("semantic-layer-id")), output, "Invalid --semantic-layer-id")
+				return cli.Exit("", 1)
+			}
+
+			fields := map[string]any{}
+			if c.IsSet("name") {
+				fields["name"] = c.String("name")
+			}
+			if c.IsSet("state") || c.IsSet("state-file") {
+				state, err := parseSemanticStateFlags(c, output)
+				if err != nil {
+					return err
+				}
+				fields["state"] = state
+			}
+			if len(fields) == 0 {
+				printError(errors.New("nothing to update: pass --name and/or --state/--state-file"), output, "No fields")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			layer, err := client.UpdateSemanticLayer(ctx, c.Int("semantic-layer-id"), fields)
+			if err != nil {
+				printError(err, output, "Failed to update semantic layer")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(layer, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			successPrinter.Printf("Updated semantic layer %d (%s).\n", layer.ID, layer.Name)
+			return nil
+		},
+	}
+}
+
+func cloudSemanticLayersDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a semantic layer",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+			&cli.IntFlag{
+				Name:     "semantic-layer-id",
+				Usage:    "semantic layer ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			if c.Int("semantic-layer-id") <= 0 {
+				printError(fmt.Errorf("--semantic-layer-id must be a positive integer, got %d", c.Int("semantic-layer-id")), output, "Invalid --semantic-layer-id")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			if err := client.DeleteSemanticLayer(ctx, c.Int("semantic-layer-id")); err != nil {
+				printError(err, output, "Failed to delete semantic layer")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				fmt.Println(`{"success": true}`)
+				return nil
+			}
+
+			successPrinter.Printf("Deleted semantic layer %d.\n", c.Int("semantic-layer-id"))
+			return nil
+		},
+	}
+}
+
+// parseSemanticStateFlags reads the model definition from --state or --state-file
+// (at most one). Returns nil when neither is set (name-only). Prints and returns
+// a cli.Exit error on failure. Accepts JSON or YAML (JSON is valid YAML).
+func parseSemanticStateFlags(c *cli.Command, output string) (map[string]any, error) {
+	if c.IsSet("state") && c.IsSet("state-file") {
+		printError(errors.New("pass only one of --state or --state-file"), output, "Ambiguous state")
+		return nil, cli.Exit("", 1)
+	}
+	if !c.IsSet("state") && !c.IsSet("state-file") {
+		return nil, nil
+	}
+
+	raw := c.String("state")
+	if file := c.String("state-file"); file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			printError(fmt.Errorf("failed to read --state-file: %w", err), output, "Invalid state file")
+			return nil, cli.Exit("", 1)
+		}
+		raw = string(data)
+	}
+
+	state, err := parseJSONOrYAMLObject([]byte(raw))
+	if err != nil {
+		printError(fmt.Errorf("invalid semantic model (expected a JSON or YAML object): %w", err), output, "Invalid state")
+		return nil, cli.Exit("", 1)
+	}
+	if state == nil {
+		printError(errors.New("semantic model must be a JSON or YAML object"), output, "Invalid state")
+		return nil, cli.Exit("", 1)
+	}
+	return state, nil
 }
 
 func cloudDashboardsList() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -328,7 +328,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 17)
+	assert.Len(t, cmd.Commands, 18)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -347,6 +347,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "connection-sets")
 	assert.Contains(t, subNames, "dashboards")
+	assert.Contains(t, subNames, "semantic-layers")
 	assert.Contains(t, subNames, "scheduled-agents")
 	assert.Contains(t, subNames, "skills")
 	assert.Contains(t, subNames, "audit-logs")

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -121,6 +121,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     {text: "Catalog", link: "/cloud/catalog"},
                     {text: "Insights", link: "/cloud/insights"},
                     {text: "Dashboards", link: "/cloud/dashboards"},
+                    {text: "Semantic Layers", link: "/cloud/semantic-layers"},
                     {
                         text: "AI Agents",
                         collapsed: true,

--- a/docs/cloud/overview.md
+++ b/docs/cloud/overview.md
@@ -33,6 +33,7 @@ From there:
 - [Catalog](/cloud/catalog): glossary, owners, and global lineage across pipelines.
 - [Insights](/cloud/insights): cost explorer, pipeline health, risk report, usage.
 - [Dashboards](/cloud/dashboards): AI-built dashboards your team can re-open without re-asking.
+- [Semantic Layers](/cloud/semantic-layers): reusable metric and dimension models that dashboards reference by name.
 - [AI Agents](/cloud/ai-agents/overview): create agents, chat with them, schedule them, deploy them to chat platforms.
 - [Integrations](/cloud/integrations/overview): connect agents to Slack, Microsoft Teams, Google Chat, Discord, WhatsApp, or Telegram.
 - [Notifications](/cloud/notifications): pipeline-level Slack, Teams, Discord, and webhook notifications.

--- a/docs/cloud/semantic-layers.md
+++ b/docs/cloud/semantic-layers.md
@@ -1,0 +1,23 @@
+# Semantic Layers
+
+A **semantic layer** in Bruin Cloud is a reusable model (a source table plus named metrics and dimensions) that your team's [dashboards](/cloud/dashboards) reference by name instead of hand-writing SQL. Define a metric like `total_revenue` once, and every widget that uses it stays consistent.
+
+Semantic layers live under **Catalog → Semantic Layers** in the top nav. They are shared across the team: every dashboard can reference them, so a change affects everything that uses the model.
+
+## Viewing
+
+The Semantic Layers page lists your team's models with their name, owner, and when each was last updated. Open a model to see its full definition as YAML.
+
+The page is **read-only**. You view models here. They are created and edited by an agent while it builds a dashboard, or with the CLI.
+
+## Access
+
+- **View**: anyone on your team can browse the list and open a model to read its full definition. Semantic layers are shared team state, so they are visible to everyone on the team.
+- **Create and edit**: team members whose role grants edit permissions can add new models and change existing ones. Members with view-only access cannot.
+- **Delete**: only the model's creator or a team admin can delete it. Because a model is shared, deleting one breaks any dashboard that still references it, so check usage first.
+
+## Related
+
+- [Semantic Layer](/core-concepts/semantic-layer): the model definition format (metrics, dimensions, joins).
+- [Dashboards](/cloud/dashboards): where semantic models are referenced.
+- [`bruin cloud semantic-layers`](/commands/cloud#semantic-layers): the CLI commands.

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -1033,6 +1033,55 @@ bruin cloud dashboards delete --dashboard-id 42
 
 ---
 
+### `semantic-layers`
+
+Manage the semantic layers in your Bruin Cloud team.
+
+#### `list`
+
+List the team's semantic layers (id, name, last updated):
+
+```bash
+bruin cloud semantic-layers list
+bruin cloud semantic-layers list --output json
+```
+
+#### `get`
+
+Get a single semantic layer including its definition:
+
+```bash
+bruin cloud semantic-layers get --semantic-layer-id 3
+bruin cloud semantic-layers get --semantic-layer-id 3 --output json
+```
+
+#### `create`
+
+Create a semantic layer from a name and a model definition (YAML or JSON). Names are unique within the team.
+
+```bash
+bruin cloud semantic-layers create --name sales --state-file model.yaml
+```
+
+#### `update`
+
+Update a semantic layer's name and/or definition. Only the flags you pass change; `--state`/`--state-file` replaces the whole definition.
+
+```bash
+bruin cloud semantic-layers update --semantic-layer-id 3 --name sales_v2
+bruin cloud semantic-layers update --semantic-layer-id 3 --state-file model.yaml
+```
+
+#### `delete`
+
+Delete a semantic layer:
+
+```bash
+bruin cloud semantic-layers delete --semantic-layer-id 3
+```
+
+---
+
 ### `scheduled-agents`
 
 Manage scheduled agents — cron-based recurring agent tasks.

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -979,6 +979,55 @@ func (c *APIClient) DeleteDashboard(ctx context.Context, dashboardID int) error 
 	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/dashboards/%d", dashboardID), nil, nil)
 }
 
+// ListSemanticLayers returns the team's semantic layers (metadata only, no state).
+func (c *APIClient) ListSemanticLayers(ctx context.Context) ([]SemanticLayer, error) {
+	var resp struct {
+		SemanticLayers []SemanticLayer `json:"semantic_layers"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/semantic-layers", nil, &resp)
+	return resp.SemanticLayers, err
+}
+
+// GetSemanticLayer returns a single semantic layer including its model definition.
+func (c *APIClient) GetSemanticLayer(ctx context.Context, id int) (*SemanticLayer, error) {
+	var result SemanticLayer
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/semantic-layers/%d", id), nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateSemanticLayer creates a semantic layer from a name and optional model
+// definition. Empty state is omitted so the server stores none.
+func (c *APIClient) CreateSemanticLayer(ctx context.Context, name string, state map[string]any) (*SemanticLayer, error) {
+	body := map[string]any{"name": name}
+	if state != nil {
+		body["state"] = state
+	}
+	var result SemanticLayer
+	err := c.doRequest(ctx, http.MethodPost, "/semantic-layers", body, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateSemanticLayer applies a partial update. Only the fields present change.
+func (c *APIClient) UpdateSemanticLayer(ctx context.Context, id int, fields map[string]any) (*SemanticLayer, error) {
+	var result SemanticLayer
+	err := c.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/semantic-layers/%d", id), fields, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteSemanticLayer permanently deletes a semantic layer. Requires an owner or team admin.
+func (c *APIClient) DeleteSemanticLayer(ctx context.Context, id int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/semantic-layers/%d", id), nil, nil)
+}
+
 // PublishDashboard promotes a dashboard's pending draft to the live state (create/update
 // only ever write the draft). Requires edit rights; errors when there's no draft.
 func (c *APIClient) PublishDashboard(ctx context.Context, dashboardID int) (*Dashboard, error) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1834,3 +1834,102 @@ func TestRunAgentQuery_PreservesLargeIntegerPrecision(t *testing.T) {
 	require.Len(t, res.Rows, 1)
 	assert.Equal(t, json.Number("9007199254740993"), res.Rows[0][0])
 }
+
+func TestListSemanticLayers(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/semantic-layers", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"semantic_layers": []map[string]any{
+				{"id": 3, "name": "sales", "updated_at": "2026-07-06T10:00:00+00:00"},
+			},
+		})
+	})
+
+	layers, err := client.ListSemanticLayers(t.Context())
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	assert.Equal(t, "sales", layers[0].Name)
+	require.NotNil(t, layers[0].UpdatedAt)
+	assert.Equal(t, "2026-07-06T10:00:00+00:00", *layers[0].UpdatedAt)
+}
+
+func TestGetSemanticLayer(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/semantic-layers/3", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, map[string]any{
+			"id": 3, "name": "sales", "state": map[string]any{"name": "sales", "source": map[string]any{"table": "raw.sales"}},
+		})
+	})
+
+	layer, err := client.GetSemanticLayer(t.Context(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, layer.ID)
+	assert.JSONEq(t, `{"name":"sales","source":{"table":"raw.sales"}}`, string(layer.State))
+}
+
+func TestCreateSemanticLayer(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/semantic-layers", r.URL.Path)
+
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "sales", body["name"])
+		assert.NotNil(t, body["state"])
+
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, SemanticLayer{ID: 9, Name: "sales", URL: "https://cloud.getbruin.com/acme/semantic-layers/9"})
+	})
+
+	layer, err := client.CreateSemanticLayer(t.Context(), "sales", map[string]any{"source": map[string]any{"table": "raw.sales"}})
+	require.NoError(t, err)
+	assert.Equal(t, 9, layer.ID)
+	assert.Equal(t, "https://cloud.getbruin.com/acme/semantic-layers/9", layer.URL)
+}
+
+func TestCreateSemanticLayerOmitsStateWhenNil(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "sales", body["name"])
+		_, hasState := body["state"]
+		assert.False(t, hasState)
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, SemanticLayer{ID: 9, Name: "sales"})
+	})
+
+	_, err := client.CreateSemanticLayer(t.Context(), "sales", nil)
+	require.NoError(t, err)
+}
+
+func TestUpdateSemanticLayer(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/semantic-layers/9", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		writeJSON(t, w, SemanticLayer{ID: 9, Name: "sales_v2"})
+	})
+
+	layer, err := client.UpdateSemanticLayer(t.Context(), 9, map[string]any{"name": "sales_v2"})
+	require.NoError(t, err)
+	assert.Equal(t, "sales_v2", layer.Name)
+}
+
+func TestDeleteSemanticLayer(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/semantic-layers/9", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	require.NoError(t, client.DeleteSemanticLayer(t.Context(), 9))
+}

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -349,6 +349,16 @@ type Dashboard struct {
 	IsPublished *bool           `json:"is_published,omitempty"`
 }
 
+// SemanticLayer is a team semantic model. State (the semantic.Model definition)
+// is only present on a single get.
+type SemanticLayer struct {
+	ID        int             `json:"id"`
+	Name      string          `json:"name"`
+	UpdatedAt *string         `json:"updated_at"`
+	URL       string          `json:"url"`
+	State     json.RawMessage `json:"state,omitempty"`
+}
+
 // DashboardVersion is one version-history snapshot's metadata (no state blob).
 type DashboardVersion struct {
 	ID         int    `json:"id"`


### PR DESCRIPTION
Adds `bruin cloud semantic-layers list/get/create/update/delete`, mirroring `bruin cloud dashboards`, against the `v1/semantic-layers` API. Includes the bruincloud API client methods + type, tests, and docs.