### PR TITLE
docs: add Cloud Semantic Layers page

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -121,6 +121,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     {text: "Catalog", link: "/cloud/catalog"},
                     {text: "Insights", link: "/cloud/insights"},
                     {text: "Dashboards", link: "/cloud/dashboards"},
+                    {text: "Semantic Layers", link: "/cloud/semantic-layers"},
                     {
                         text: "AI Agents",
                         collapsed: true,

--- a/docs/cloud/catalog.md
+++ b/docs/cloud/catalog.md
@@ -1,6 +1,6 @@
 # Catalog
 
-The **Catalog** dropdown in the top nav covers everything you need to navigate, document, and trace your data: **Pipelines**, **Assets**, **Lineage**, and **Glossary**. **Owners** is a per-owner profile reached by clicking an owner name anywhere in the product.
+The **Catalog** dropdown in the top nav covers everything you need to navigate, document, and trace your data: **Pipelines**, **Assets**, **Lineage**, **Glossary**, and **Semantic Layers**. **Owners** is a per-owner profile reached by clicking an owner name anywhere in the product.
 
 This page covers Glossary, Owners, and the global Lineage view. For the per-asset and per-pipeline pages, see [Assets](/cloud/assets) and [Pipelines](/cloud/pipelines).
 

--- a/docs/cloud/semantic-layers.md
+++ b/docs/cloud/semantic-layers.md
@@ -23,7 +23,7 @@ This is meant for pruning models that were removed from the repo but still linge
 ## Access
 
 - **View**: controlled by the `semantic:list` permission. Members with a role that grants it can browse the list and open a model to read its definition.
-- **Delete**: controlled by the `semantic:delete` permission, granted to team leads by default.
+- **Delete**: controlled by the `semantic:delete` permission, granted to team admins by default.
 
 ## Related
 

--- a/docs/cloud/semantic-layers.md
+++ b/docs/cloud/semantic-layers.md
@@ -1,0 +1,31 @@
+# Semantic Layers
+
+A **semantic layer** in Bruin Cloud is a reusable model (a source table plus named metrics and dimensions) that your team's [dashboards](/cloud/dashboards) reference by name instead of hand-writing SQL. Define a metric like `total_revenue` once, and every widget that uses it stays consistent.
+
+Semantic models are defined in your Git repository as YAML files and picked up by Bruin Cloud when it syncs the repo. They live under **Catalog → Semantic Layers** in the top nav.
+
+## Viewing
+
+The Semantic Layers page lists the models defined in your repo, each with its name and project. Open a model to see its full definition as YAML.
+
+The page is **read-only**. You view models here; you create and change them by editing the YAML in your repo and pushing the change. On the next sync the updated definition shows up here.
+
+## Validation errors
+
+If a model fails schema validation during a sync, it is not listed as a usable model. Instead its errors appear in a banner at the top of the page so you can find and fix the definition in your repo. Use **Clear** to dismiss an error; if the model is still invalid on the next sync, the error comes back.
+
+## Deleting
+
+Deleting a model from this page removes it from the Bruin Cloud catalog. It does **not** touch your repo.
+
+This is meant for pruning models that were removed from the repo but still linger in the catalog. If a model you delete still exists in your repo, it reappears the next time Bruin Cloud syncs that repo, because the repo remains the source of truth. To remove a model for good, delete its YAML from the repo.
+
+## Access
+
+- **View**: controlled by the `semantic:list` permission. Members with a role that grants it can browse the list and open a model to read its definition.
+- **Delete**: controlled by the `semantic:delete` permission, granted to team leads by default.
+
+## Related
+
+- [Semantic Layer](/core-concepts/semantic-layer): the model definition format (metrics, dimensions, joins).
+- [Dashboards](/cloud/dashboards): where semantic models are referenced.


### PR DESCRIPTION
Documents the repo-defined Semantic Layers viewer in Bruin Cloud: viewing, validation errors, deleting (with the reappear-on-sync caveat), and permission-based access. Adds the Catalog sidebar entry so the page is reachable in the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)