### PR TITLE
Add folder support to cloud dashboards commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4822,6 +4822,7 @@ func CloudDashboards() *cli.Command {
 		Usage: "Manage Bruin Cloud dashboards",
 		Commands: []*cli.Command{
 			cloudDashboardsList(),
+			cloudDashboardsFolders(),
 			cloudDashboardsGet(),
 			cloudDashboardsVersions(),
 			cloudDashboardsVersion(),
@@ -4865,17 +4866,63 @@ func cloudDashboardsList() *cli.Command {
 
 			t := table.NewWriter()
 			t.SetOutputMirror(os.Stdout)
-			t.AppendHeader(table.Row{"ID", "Title", "Visibility", "Updated At"})
+			t.AppendHeader(table.Row{"ID", "Title", "Visibility", "Folder", "Updated At"})
 			for _, d := range dashboards {
 				title := ""
 				if d.Title != nil {
 					title = *d.Title
 				}
+				folder := ""
+				if d.FolderName != nil {
+					folder = *d.FolderName
+				}
 				updated := ""
 				if d.UpdatedAt != nil {
 					updated = *d.UpdatedAt
 				}
-				t.AppendRow(table.Row{d.ID, title, d.Visibility, updated})
+				t.AppendRow(table.Row{d.ID, title, d.Visibility, folder, updated})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudDashboardsFolders() *cli.Command {
+	return &cli.Command{
+		Name:  "folders",
+		Usage: "List dashboard folders.",
+		Flags: []cli.Flag{
+			apiKeyFlag(),
+			outputFlag(),
+		},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			folders, err := client.ListDashboardFolders(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list dashboard folders")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(folders, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Name", "Dashboards"})
+			for _, f := range folders {
+				t.AppendRow(table.Row{f.ID, f.Name, f.DashboardCount})
 			}
 			t.Render()
 			return nil
@@ -4932,7 +4979,11 @@ func cloudDashboardsGet() *cli.Command {
 			if dashboard.Title != nil {
 				title = *dashboard.Title
 			}
-			infoPrinter.Printf("Dashboard %d: %s (visibility: %s)\n", dashboard.ID, title, dashboard.Visibility)
+			folder := "none"
+			if dashboard.FolderName != nil && *dashboard.FolderName != "" {
+				folder = *dashboard.FolderName
+			}
+			infoPrinter.Printf("Dashboard %d: %s (visibility: %s, folder: %s)\n", dashboard.ID, title, dashboard.Visibility, folder)
 
 			// Flag a pending draft so a draft-only dashboard isn't read as empty.
 			if dashboard.HasDraft != nil && *dashboard.HasDraft {
@@ -5164,6 +5215,10 @@ func cloudDashboardsCreate() *cli.Command {
 				Name:  "state-file",
 				Usage: "path to a file containing the dashboard definition as JSON or YAML",
 			},
+			&cli.StringFlag{
+				Name:  "folder",
+				Usage: "place the dashboard in this folder (by name; created if it doesn't exist)",
+			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
@@ -5228,7 +5283,7 @@ func cloudDashboardsCreate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			dashboard, err := client.CreateDashboard(ctx, c.String("title"), visibility, c.Int("agent-id"), state)
+			dashboard, err := client.CreateDashboard(ctx, c.String("title"), visibility, c.Int("agent-id"), c.String("folder"), state)
 			if err != nil {
 				printError(err, output, "Failed to create dashboard")
 				return cli.Exit("", 1)
@@ -5288,6 +5343,10 @@ func cloudDashboardsUpdate() *cli.Command {
 				Name:  "state-file",
 				Usage: "path to a file containing the dashboard definition as JSON or YAML",
 			},
+			&cli.StringFlag{
+				Name:  "folder",
+				Usage: "move the dashboard to this folder (by name; created if it doesn't exist); pass \"none\" to remove it from its folder",
+			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
@@ -5298,6 +5357,9 @@ func cloudDashboardsUpdate() *cli.Command {
 			fields := map[string]any{}
 			if c.IsSet("title") {
 				fields["title"] = c.String("title")
+			}
+			if c.IsSet("folder") {
+				fields["folder_name"] = c.String("folder")
 			}
 			if c.IsSet("visibility") {
 				visibility := c.String("visibility")
@@ -5339,7 +5401,7 @@ func cloudDashboardsUpdate() *cli.Command {
 			}
 
 			if len(fields) == 0 {
-				printError(errors.New("provide at least one of --title, --visibility, --state or --state-file"), output, "Nothing to update")
+				printError(errors.New("provide at least one of --title, --visibility, --state, --state-file or --folder"), output, "Nothing to update")
 				return cli.Exit("", 1)
 			}
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -640,7 +640,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	cmd := CloudDashboards()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "dashboards", cmd.Name)
-	require.Len(t, cmd.Commands, 8)
+	require.Len(t, cmd.Commands, 9)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -654,6 +654,7 @@ func TestCloudDashboardsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "update")
 	assert.Contains(t, subNames, "publish")
 	assert.Contains(t, subNames, "delete")
+	assert.Contains(t, subNames, "folders")
 }
 
 // cliRunMu serializes cli.Command.Run: urfave/cli's ensureHelp resets the

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -848,6 +848,15 @@ bruin cloud dashboards list
 bruin cloud dashboards list --output json
 ```
 
+#### `folders`
+
+Lists the team's dashboard folders with their id, name, and dashboard count.
+
+```bash
+bruin cloud dashboards folders
+bruin cloud dashboards folders --output json
+```
+
 #### `get`
 
 Get a single dashboard including its definition (`state`). By default the caller
@@ -897,12 +906,17 @@ Create a dashboard from a definition. The definition is written to the dashboard
 
 Pass `--agent-id` to bind the dashboard to an agent so its canvas chat and refresh work. If omitted, the server falls back to the agent encoded in a Cloud-CLI token; a generic team token has none, so the dashboard opens without a chat panel.
 
+Pass `--folder` to file the dashboard in a folder (by name; created if it doesn't exist). Folder names are unique per team. `dashboards list`/`get` return each dashboard's `folder_name`, and [`dashboards folders`](#folders) lists all folders.
+
 ```bash
 # Title only (empty draft)
 bruin cloud dashboards create --title "Q1 Revenue"
 
 # Bind an agent so the dashboard's chat works
 bruin cloud dashboards create --title "Q1 Revenue" --agent-id 7
+
+# File it in a folder (created if it doesn't exist)
+bruin cloud dashboards create --title "Q1 Revenue" --agent-id 7 --folder "Finance"
 
 # With a definition, inline or from a file
 bruin cloud dashboards create --title "Q1 Revenue" --visibility team --state '{"widgets":[]}'
@@ -1001,7 +1015,9 @@ Filters only act on `sql` widgets, so a dashboard built purely from inline data 
 
 #### `update`
 
-Update an existing dashboard's title, visibility, or definition. Only the flags you pass are changed. Like `create`, a new definition is written to the dashboard's **draft** — never published automatically; publish it with `dashboards publish` or from the Bruin Cloud UI. Changing visibility requires manage-access (the dashboard creator or a team admin).
+Update an existing dashboard's title, visibility, folder, or definition. Only the flags you pass are changed. Like `create`, a new definition is written to the dashboard's **draft** — never published automatically; publish it with `dashboards publish` or from the Bruin Cloud UI. Changing visibility requires manage-access (the dashboard creator or a team admin).
+
+Pass `--folder` to move the dashboard into a folder (created if it doesn't exist), or `--folder none` to remove it from its folder.
 
 ```bash
 # Rename
@@ -1013,6 +1029,10 @@ bruin cloud dashboards update --dashboard-id 42 --state-file ./dashboard.json
 
 # Change visibility
 bruin cloud dashboards update --dashboard-id 42 --visibility team
+
+# Move it to a folder (created if missing), or remove it from its folder
+bruin cloud dashboards update --dashboard-id 42 --folder "Finance"
+bruin cloud dashboards update --dashboard-id 42 --folder none
 ```
 
 #### `publish`

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -919,6 +919,16 @@ func (c *APIClient) ListDashboards(ctx context.Context) ([]Dashboard, error) {
 	return resp.Dashboards, err
 }
 
+// ListDashboardFolders returns the team's dashboard folders, including empty
+// ones (folders with no dashboards, which never surface in the dashboard list).
+func (c *APIClient) ListDashboardFolders(ctx context.Context) ([]DashboardFolder, error) {
+	var resp struct {
+		Folders []DashboardFolder `json:"folders"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/dashboard-folders", nil, &resp)
+	return resp.Folders, err
+}
+
 // GetDashboard returns a single dashboard. state selects which definition to
 // fetch: "draft", "published", or "" for the server default (the editable
 // definition for editors, published for viewers). The server gates "draft" to
@@ -939,10 +949,13 @@ func (c *APIClient) GetDashboard(ctx context.Context, dashboardID int, state str
 // CreateDashboard creates a dashboard from a definition. The server writes the
 // definition to the draft only (never published). Empty optional fields are
 // omitted so the server applies its defaults.
-func (c *APIClient) CreateDashboard(ctx context.Context, title, visibility string, agentID int, state map[string]any) (*Dashboard, error) {
+func (c *APIClient) CreateDashboard(ctx context.Context, title, visibility string, agentID int, folderName string, state map[string]any) (*Dashboard, error) {
 	body := map[string]any{"title": title}
 	if visibility != "" {
 		body["visibility"] = visibility
+	}
+	if folderName != "" {
+		body["folder_name"] = folderName
 	}
 	// Bind the dashboard to an agent so canvas chat and refresh work; omit to let
 	// the server fall back to the agent encoded in a Cloud-CLI token.

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1403,7 +1403,7 @@ func TestCreateDashboard(t *testing.T) {
 		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private", URL: "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", AgentID: &boundAgent})
 	})
 
-	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", 7, map[string]any{"widgets": []any{}})
+	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", 7, "", map[string]any{"widgets": []any{}})
 	require.NoError(t, err)
 	assert.Equal(t, 9, dashboard.ID)
 	assert.Equal(t, "https://cloud.getbruin.com/acme/dashboards/9?mode=edit", dashboard.URL)
@@ -1421,14 +1421,57 @@ func TestCreateDashboardOmitsAgentIDWhenZero(t *testing.T) {
 		// token-agent fallback rather than clearing the binding.
 		_, hasAgentID := body["agent_id"]
 		assert.False(t, hasAgentID)
+		// An empty folder name is omitted so the dashboard stays unfiled.
+		_, hasFolder := body["folder_name"]
+		assert.False(t, hasFolder)
 
 		w.WriteHeader(http.StatusCreated)
 		title := "New Dash"
 		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "team"})
 	})
 
-	_, err := client.CreateDashboard(t.Context(), "New Dash", "", 0, nil)
+	_, err := client.CreateDashboard(t.Context(), "New Dash", "", 0, "", nil)
 	require.NoError(t, err)
+}
+
+func TestCreateDashboardWithFolder(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		// A non-empty folder name is sent so the server files (or creates) the folder.
+		assert.Equal(t, "Finance", body["folder_name"])
+
+		w.WriteHeader(http.StatusCreated)
+		title := "New Dash"
+		folder := "Finance"
+		writeJSON(t, w, Dashboard{ID: 9, Title: &title, Visibility: "private", FolderName: &folder})
+	})
+
+	dashboard, err := client.CreateDashboard(t.Context(), "New Dash", "private", 0, "Finance", nil)
+	require.NoError(t, err)
+	require.NotNil(t, dashboard.FolderName)
+	assert.Equal(t, "Finance", *dashboard.FolderName)
+}
+
+func TestListDashboardFolders(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/dashboard-folders", r.URL.Path)
+
+		writeJSON(t, w, map[string]any{"folders": []DashboardFolder{
+			{ID: 1, Name: "Finance", DashboardCount: 2},
+			// An empty folder still comes back, with a zero count.
+			{ID: 2, Name: "Empty", DashboardCount: 0},
+		}})
+	})
+
+	folders, err := client.ListDashboardFolders(t.Context())
+	require.NoError(t, err)
+	require.Len(t, folders, 2)
+	assert.Equal(t, DashboardFolder{ID: 1, Name: "Finance", DashboardCount: 2}, folders[0])
+	assert.Equal(t, 0, folders[1].DashboardCount)
 }
 
 func TestUpdateDashboard(t *testing.T) {

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -344,9 +344,17 @@ type Dashboard struct {
 	UpdatedAt   *string         `json:"updated_at"`
 	URL         string          `json:"url"`
 	AgentID     *int            `json:"agent_id"`
+	FolderName  *string         `json:"folder_name"`
 	State       json.RawMessage `json:"state,omitempty"`
 	HasDraft    *bool           `json:"has_draft,omitempty"`
 	IsPublished *bool           `json:"is_published,omitempty"`
+}
+
+// DashboardFolder groups dashboards within a team.
+type DashboardFolder struct {
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	DashboardCount int    `json:"dashboard_count"`
 }
 
 // DashboardVersion is one version-history snapshot's metadata (no state blob).


### PR DESCRIPTION
Adds dashboard-folder support to `bruin cloud dashboards`.

- `--folder` flag on create and update
- folder shown per dashboard in list and get
- new `dashboards folders` subcommand that lists a team's folders with their dashboard counts

Depends on the matching cloud endpoint (bruin-data/cloud#3344).