### PR TITLE
Support S3-compatible endpoints in S3 sensors

### DIFF
--- a/docs/ingestion/s3.md
+++ b/docs/ingestion/s3.md
@@ -24,6 +24,8 @@ To connect to S3, you need to add a configuration item to the connections sectio
 
 - `access_key_id` and `secret_access_key`: Used for accessing S3 bucket.
 
+The same `connections.s3` entry can also be used by native S3 sensors. See the [canonical S3 connection fields and B2, R2, and MinIO examples](/platforms/s3#s3-compatible-connections). The sensor-specific region, addressing, TLS, and session-token controls do not change ingestr's connection behavior.
+
 ### Step 2: Create an asset file for data ingestion
 
 To ingest data from S3, you need to create an [asset configuration](/assets/ingestr.html#asset-structure) file. This file defines the data flow from the source to the destination. Create a YAML file (e.g., s3_ingestion.yml) inside the assets folder and add the following content:

--- a/docs/platforms/s3.md
+++ b/docs/platforms/s3.md
@@ -8,7 +8,7 @@ S3 sensors allow you to monitor for the existence of specific objects in S3 buck
 
 ## Connection Configuration
 
-Add an AWS connection to your `bruin.yml` file:
+Sensors accept both `aws` and `s3` connections in `.bruin.yml`. Existing AWS connections continue to work:
 
 ```yaml
 connections:
@@ -18,6 +18,57 @@ connections:
       secret_key: "your-secret-key"
       region: "us-east-1"  # Optional - will be auto-discovered from bucket if not provided
 ```
+
+### S3-compatible connections
+
+Use the same `connections.s3` entry as [S3 ingestion](/ingestion/s3). Set the service endpoint, not an object URL; pass the bucket and key separately in the sensor asset. Bruin uses that endpoint for both object HEAD requests and wildcard listing, without AWS region discovery.
+
+| Field | Meaning |
+|---|---|
+| `name` | Connection name |
+| `access_key_id`, `secret_access_key` | Static credentials; provide both or neither |
+| `endpoint_url` | Custom HTTP(S) service URL, without credentials, query parameters, or fragment |
+| `region` | Sensor signing region; falls back to the AWS environment/profile region, then `us-east-1` for custom endpoints |
+| `url_style` | Sensor addressing: `path` or `vhost` (same vocabulary as DuckLake). Defaults to `path` for custom endpoints and virtual-hosted addressing for AWS |
+| `use_ssl` | Optional sensor transport assertion; must match the endpoint scheme. `false` requires an explicit `http://` endpoint |
+| `ca_bundle` | Path to a PEM CA bundle for sensors, resolved relative to the working directory |
+| `session_token` | Optional session token accompanying static sensor credentials |
+| `bucket_name`, `path_to_file`, `layout` | Ingestion destination settings; sensors use asset parameters instead |
+
+The region, addressing, TLS, and session-token options above configure the native sensor, not ingestr. Ingestion continues to use its existing endpoint and layout options.
+
+When static sensor credentials are omitted, the standard AWS credential chain is used (environment, shared profile, workload/instance role). HTTPS always verifies certificates; use `ca_bundle` for a private CA rather than bypassing verification. Explicit HTTP endpoints remain supported for local development and print a warning. `use_ssl` never silently changes the endpoint scheme. Sensor output includes the validated endpoint and addressing mode, not credentials.
+
+Example connection entries (place under your environment's `connections`):
+
+```yaml
+connections:
+  s3:
+    - name: raw-b2
+      access_key_id: your-b2-key-id
+      secret_access_key: your-b2-application-key
+      region: us-west-004
+      endpoint_url: https://s3.us-west-004.backblazeb2.com
+      url_style: path
+      use_ssl: true
+
+    - name: raw-r2
+      access_key_id: your-r2-access-key
+      secret_access_key: your-r2-secret-key
+      region: auto
+      endpoint_url: https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com
+      url_style: path
+
+    - name: local-minio
+      access_key_id: your-minio-access-key
+      secret_access_key: your-minio-secret-key
+      region: us-east-1
+      endpoint_url: http://localhost:9000
+      url_style: path
+      use_ssl: false  # Local development only
+```
+
+For HTTPS MinIO with a private CA, use an `https://` endpoint, `use_ssl: true`, and `ca_bundle: /path/to/minio-ca.pem`. To use virtual-hosted addressing, set `url_style: vhost` and ensure your provider's DNS and certificate support `BUCKET.ENDPOINT_HOST`.
 
 ## Sensor Configuration
 
@@ -38,6 +89,29 @@ parameters:
 - `bucket_name` (required): The name of the S3 bucket to monitor
 - `bucket_key` (required): The key/path of the object to wait for. Supports [wildcard patterns](#wildcard-patterns).
 - `timeout` (optional): How long to wait before the sensor fails. Uses single-unit duration syntax (`s`, `m`, `h`, `d`, `ms`, `ns`), e.g. `1h` or `90m`. Defaults to `24h`. See [Sensor Timeout](/assets/sensor#timeout).
+
+### Metadata comparisons
+
+Optional parameters apply to a specific key or to each wildcard candidate:
+
+- `etag`: Exact, case-sensitive comparison with an opaque ETag (surrounding HTTP quotes are ignored). Multipart and provider-specific ETags are **not** interpreted as MD5 hashes.
+- `min_size`: Minimum object size in bytes, inclusive; a non-negative integer.
+- `last_modified_after`: Exclusive lower bound for the object's last-modified time, as an RFC3339 timestamp.
+
+All supplied conditions must match the same object. Wildcards succeed when any candidate satisfies all conditions. Metadata filtering performs HEAD requests for matching keys; objects deleted between listing and HEAD are treated as missing. Permission errors are surfaced rather than treated as missing objects.
+
+```yaml
+name: wait_for_manifest
+type: s3.sensor.key_sensor
+connection: raw-b2
+parameters:
+  bucket_name: raw-inputs
+  bucket_key: manifests/*.json
+  min_size: 1
+  last_modified_after: "2026-01-01T00:00:00Z"
+  poke_interval: 10
+  timeout: 1h
+```
 
 ## Wildcard Patterns
 
@@ -74,8 +148,9 @@ bruin run path/to/your/sensor.asset.yml --sensor-mode wait
 
 ## Behavior
 
-- If the region is not specified in the connection, it will be auto-discovered from the bucket
+- For AWS endpoints, the region is discovered from the bucket only when neither the connection nor the AWS environment/profile specifies one. Custom endpoints never use AWS bucket-region discovery.
 - In wait  mode, the sensor polls every few seconds (configurable via `poke_interval`) as a parameter
+- SDK retries remain provider-neutral and can be configured with the standard `AWS_RETRY_MODE` and `AWS_MAX_ATTEMPTS` environment variables. `poke_interval` controls repeated checks for missing objects or unmet metadata conditions; `timeout` bounds polling and requests.
 - Default timeout is 24 hours for continuous polling. Override with the `timeout` parameter (single-unit duration syntax, e.g. `1h` or `90m`). See [Sensor Timeout](/assets/sensor#timeout).
 - Returns error if object is not found in `once` mode
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -4650,6 +4650,21 @@
         },
         "layout": {
           "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "url_style": {
+          "type": "string"
+        },
+        "use_ssl": {
+          "type": "boolean"
+        },
+        "ca_bundle": {
+          "type": "string"
+        },
+        "session_token": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -4670,13 +4670,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name",
-        "bucket_name",
-        "path_to_file",
-        "access_key_id",
-        "secret_access_key",
-        "endpoint_url",
-        "layout"
+        "name"
       ]
     },
     "SFTPConnection": {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1108,6 +1108,11 @@ type S3Connection struct {
 	SecretAccessKey    string `yaml:"secret_access_key,omitempty" json:"secret_access_key" mapstructure:"secret_access_key" sensitive:"true"`
 	EndpointURL        string `yaml:"endpoint_url,omitempty" json:"endpoint_url" mapstructure:"endpoint_url"`
 	Layout             string `yaml:"layout,omitempty" json:"layout" mapstructure:"layout"`
+	Region             string `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
+	URLStyle           string `yaml:"url_style,omitempty" json:"url_style,omitempty" mapstructure:"url_style"`
+	UseSSL             *bool  `yaml:"use_ssl,omitempty" json:"use_ssl,omitempty" mapstructure:"use_ssl"`
+	CABundle           string `yaml:"ca_bundle,omitempty" json:"ca_bundle,omitempty" mapstructure:"ca_bundle"`
+	SessionToken       string `yaml:"session_token,omitempty" json:"session_token,omitempty" mapstructure:"session_token" sensitive:"true"`
 }
 
 func (c S3Connection) GetName() string {

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1102,12 +1102,12 @@ func (c GenericConnection) GetName() string {
 
 type S3Connection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
-	BucketName         string `yaml:"bucket_name,omitempty" json:"bucket_name" mapstructure:"bucket_name"`
-	PathToFile         string `yaml:"path_to_file,omitempty" json:"path_to_file" mapstructure:"path_to_file"`
-	AccessKeyID        string `yaml:"access_key_id,omitempty" json:"access_key_id" mapstructure:"access_key_id" sensitive:"true"`
-	SecretAccessKey    string `yaml:"secret_access_key,omitempty" json:"secret_access_key" mapstructure:"secret_access_key" sensitive:"true"`
-	EndpointURL        string `yaml:"endpoint_url,omitempty" json:"endpoint_url" mapstructure:"endpoint_url"`
-	Layout             string `yaml:"layout,omitempty" json:"layout" mapstructure:"layout"`
+	BucketName         string `yaml:"bucket_name,omitempty" json:"bucket_name,omitempty" mapstructure:"bucket_name"`
+	PathToFile         string `yaml:"path_to_file,omitempty" json:"path_to_file,omitempty" mapstructure:"path_to_file"`
+	AccessKeyID        string `yaml:"access_key_id,omitempty" json:"access_key_id,omitempty" mapstructure:"access_key_id" sensitive:"true"`
+	SecretAccessKey    string `yaml:"secret_access_key,omitempty" json:"secret_access_key,omitempty" mapstructure:"secret_access_key" sensitive:"true"`
+	EndpointURL        string `yaml:"endpoint_url,omitempty" json:"endpoint_url,omitempty" mapstructure:"endpoint_url"`
+	Layout             string `yaml:"layout,omitempty" json:"layout,omitempty" mapstructure:"layout"`
 	Region             string `yaml:"region,omitempty" json:"region,omitempty" mapstructure:"region"`
 	URLStyle           string `yaml:"url_style,omitempty" json:"url_style,omitempty" mapstructure:"url_style"`
 	UseSSL             *bool  `yaml:"use_ssl,omitempty" json:"use_ssl,omitempty" mapstructure:"use_ssl"`

--- a/pkg/config/connections_test.go
+++ b/pkg/config/connections_test.go
@@ -33,3 +33,17 @@ func TestGoogleCloudPlatformConnection_AccessTokenRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(jsonBytes, &fromJSON))
 	require.Equal(t, "ya29.some-token", fromJSON["access_token"])
 }
+
+func TestS3ConnectionSchemaOnlyRequiresName(t *testing.T) {
+	t.Parallel()
+
+	schema, err := GetConnectionsSchema()
+	require.NoError(t, err)
+	var document struct {
+		Definitions map[string]struct {
+			Required []string `json:"required"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(schema), &document))
+	require.Equal(t, []string{"name"}, document.Definitions["S3Connection"].Required)
+}

--- a/pkg/s3/endpoint_test.go
+++ b/pkg/s3/endpoint_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestKeySensor_CustomEndpointHeadUsesPathRegionAndSessionToken(t *testing.T) {
+	t.Parallel()
+
 	var called atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called.Store(true)
@@ -52,6 +54,8 @@ func TestKeySensor_CustomEndpointHeadUsesPathRegionAndSessionToken(t *testing.T)
 }
 
 func TestKeySensor_CustomEndpointWildcardPagination(t *testing.T) {
+	t.Parallel()
+
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
@@ -73,6 +77,8 @@ func TestKeySensor_CustomEndpointWildcardPagination(t *testing.T) {
 }
 
 func TestKeySensor_CustomEndpointStatusHandling(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		status     int
@@ -83,6 +89,8 @@ func TestKeySensor_CustomEndpointStatusHandling(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.status)
 			}))
@@ -95,6 +103,8 @@ func TestKeySensor_CustomEndpointStatusHandling(t *testing.T) {
 }
 
 func TestKeySensor_CustomEndpointCABundle(t *testing.T) {
+	t.Parallel()
+
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/test-bucket/file.csv", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
@@ -118,6 +128,8 @@ func TestKeySensor_CustomEndpointCABundle(t *testing.T) {
 }
 
 func TestKeySensor_CustomEndpointValidationDoesNotLeakCredentials(t *testing.T) {
+	t.Parallel()
+
 	useHTTP := false
 	useHTTPS := true
 	tests := []struct {
@@ -136,6 +148,8 @@ func TestKeySensor_CustomEndpointValidationDoesNotLeakCredentials(t *testing.T) 
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			output := &bytes.Buffer{}
 			ctx := context.WithValue(t.Context(), executor.KeyPrinter, output)
 			err := runEndpointSensor(ctx, tt.connection, "file.csv")

--- a/pkg/s3/endpoint_test.go
+++ b/pkg/s3/endpoint_test.go
@@ -1,0 +1,216 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/executor"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeySensor_CustomEndpointHeadUsesPathRegionAndSessionToken(t *testing.T) {
+	var called atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		assert.Equal(t, http.MethodHead, r.Method)
+		assert.Equal(t, "/test-bucket/folder/file.csv", r.URL.EscapedPath())
+		assert.Contains(t, r.Header.Get("Authorization"), "Credential=test-access/", "request must use configured access key")
+		assert.Contains(t, r.Header.Get("Authorization"), "/eu-north-1/s3/aws4_request", "request must be signed for configured region")
+		assert.Equal(t, "test-session-token", r.Header.Get("X-Amz-Security-Token"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	output := &bytes.Buffer{}
+	ctx := context.WithValue(t.Context(), executor.KeyPrinter, output)
+	err := runEndpointSensor(ctx, config.S3Connection{
+		AccessKeyID:     "test-access",
+		SecretAccessKey: "test-secret",
+		SessionToken:    "test-session-token",
+		EndpointURL:     server.URL,
+		Region:          "eu-north-1",
+	}, "folder/file.csv")
+
+	require.NoError(t, err)
+	assert.True(t, called.Load())
+	assert.Contains(t, output.String(), "addressing: path")
+	assert.Contains(t, output.String(), "Warning: S3 HTTP endpoint disables TLS")
+	assert.NotContains(t, output.String(), "test-secret")
+	assert.NotContains(t, output.String(), "test-session-token")
+}
+
+func TestKeySensor_CustomEndpointWildcardPagination(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/test-bucket", r.URL.Path)
+		assert.Equal(t, "reports/", r.URL.Query().Get("prefix"))
+		w.Header().Set("Content-Type", "application/xml")
+		if r.URL.Query().Get("continuation-token") == "next-page" {
+			fmt.Fprint(w, `<ListBucketResult><Name>test-bucket</Name><IsTruncated>false</IsTruncated><Contents><Key>reports/result.csv</Key></Contents></ListBucketResult>`)
+			return
+		}
+		fmt.Fprint(w, `<ListBucketResult><Name>test-bucket</Name><IsTruncated>true</IsTruncated><NextContinuationToken>next-page</NextContinuationToken><Contents><Key>reports/result.txt</Key></Contents></ListBucketResult>`)
+	}))
+	defer server.Close()
+
+	err := runEndpointSensor(t.Context(), endpointConnection(server.URL), "reports/*.csv")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load())
+}
+
+func TestKeySensor_CustomEndpointStatusHandling(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		errorMatch string
+	}{
+		{name: "missing", status: http.StatusNotFound, errorMatch: "Sensor didn't return the expected result"},
+		{name: "forbidden", status: http.StatusForbidden, errorMatch: "failed to check object existence"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+
+			err := runEndpointSensor(t.Context(), endpointConnection(server.URL), "missing.csv")
+			require.ErrorContains(t, err, tt.errorMatch)
+		})
+	}
+}
+
+func TestKeySensor_CustomEndpointCABundle(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/test-bucket/file.csv", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	withoutBundle := endpointConnection(server.URL)
+	err := runEndpointSensor(t.Context(), withoutBundle, "file.csv")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+
+	certificate, err := x509.ParseCertificate(server.Certificate().Raw)
+	require.NoError(t, err)
+	bundle := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+	bundlePath := t.TempDir() + "/ca.pem"
+	require.NoError(t, os.WriteFile(bundlePath, bundle, 0o600))
+
+	withBundle := endpointConnection(server.URL)
+	withBundle.CABundle = bundlePath
+	require.NoError(t, runEndpointSensor(t.Context(), withBundle, "file.csv"))
+}
+
+func TestKeySensor_CustomEndpointValidationDoesNotLeakCredentials(t *testing.T) {
+	useHTTP := false
+	useHTTPS := true
+	tests := []struct {
+		name       string
+		connection config.S3Connection
+		message    string
+	}{
+		{name: "invalid endpoint", connection: config.S3Connection{EndpointURL: "://secret-access:secret-key@example.com"}, message: "endpoint_url must be an HTTP(S) URL"},
+		{name: "endpoint credentials", connection: config.S3Connection{EndpointURL: "https://secret-access:secret-key@example.com"}, message: "endpoint_url must be an HTTP(S) URL"},
+		{name: "invalid style", connection: config.S3Connection{URLStyle: "secret-style"}, message: "url_style must be 'path' or 'vhost'"},
+		{name: "https marked non SSL", connection: config.S3Connection{EndpointURL: "https://example.com", UseSSL: &useHTTP}, message: "use_ssl must agree"},
+		{name: "http marked SSL", connection: config.S3Connection{EndpointURL: "http://example.com", UseSSL: &useHTTPS}, message: "use_ssl must agree"},
+		{name: "non SSL without endpoint", connection: config.S3Connection{UseSSL: &useHTTP}, message: "requires an explicit HTTP endpoint_url"},
+		{name: "incomplete static credentials", connection: config.S3Connection{EndpointURL: "http://example.com", AccessKeyID: "secret-access"}, message: "access_key_id and secret_access_key must both be supplied"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			ctx := context.WithValue(t.Context(), executor.KeyPrinter, output)
+			err := runEndpointSensor(ctx, tt.connection, "file.csv")
+			require.ErrorContains(t, err, tt.message)
+			combined := err.Error() + output.String()
+			assert.NotContains(t, combined, "secret-access")
+			assert.NotContains(t, combined, "secret-key")
+		})
+	}
+}
+
+func TestKeySensor_CustomEndpointUsesDefaultCredentialChain(t *testing.T) {
+	// Environment mutation makes this test intentionally non-parallel.
+	t.Setenv("AWS_ACCESS_KEY_ID", "chain-access")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "chain-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "chain-token")
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Authorization"), "Credential=chain-access/")
+		assert.Contains(t, r.Header.Get("Authorization"), "/ap-southeast-2/s3/aws4_request")
+		assert.Equal(t, "chain-token", r.Header.Get("X-Amz-Security-Token"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conn := config.S3Connection{EndpointURL: server.URL}
+	require.NoError(t, runEndpointSensor(t.Context(), conn, "file.csv"))
+}
+
+func TestKeySensor_VirtualHostEndpoint(t *testing.T) {
+	// A subprocess isolates Go's cached proxy environment. The proxy captures the
+	// actual SDK request without DNS or any connection to an external provider.
+	if os.Getenv("BRUIN_S3_VHOST_TEST") == "1" {
+		conn := endpointConnection("http://objects.example.test")
+		conn.URLStyle = "vhost"
+		require.NoError(t, runEndpointSensor(t.Context(), conn, "folder/a b.csv"))
+		return
+	}
+	var called atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		assert.Equal(t, "test-bucket.objects.example.test", r.Host)
+		assert.Equal(t, "/folder/a%20b.csv", r.URL.EscapedPath())
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxy.Close()
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+	t.Setenv("BRUIN_S3_VHOST_TEST", "1")
+	command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestKeySensor_VirtualHostEndpoint$")
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	assert.True(t, called.Load())
+}
+
+func endpointConnection(endpoint string) config.S3Connection {
+	return config.S3Connection{
+		AccessKeyID:     "test-access",
+		SecretAccessKey: "test-secret",
+		EndpointURL:     endpoint,
+		Region:          "us-west-2",
+	}
+}
+
+func runEndpointSensor(ctx context.Context, connection config.S3Connection, key string) error {
+	connection.Name = "s3-test"
+	sensor := NewKeySensor(&mockConnectionGetter{details: &connection}, "once")
+	asset := &pipeline.Asset{
+		Connection: "s3-test",
+		Parameters: pipeline.ParameterMap{
+			"bucket_name": "test-bucket",
+			"bucket_key":  key,
+		},
+	}
+	return sensor.RunTask(ctx, &pipeline.Pipeline{}, asset)
+}

--- a/pkg/s3/metadata.go
+++ b/pkg/s3/metadata.go
@@ -37,7 +37,9 @@ func parseMetadataFilter(params pipeline.ParameterMap) (metadataFilter, error) {
 		}
 		f.minSize = size
 	}
-	if _, ok := params["last_modified_after"]; ok {
+	if timestamp, ok := params["last_modified_after"].(time.Time); ok {
+		f.modifiedAfter = timestamp
+	} else if _, ok := params["last_modified_after"]; ok {
 		value, _ := params.GetString("last_modified_after")
 		parsed, err := time.Parse(time.RFC3339, value)
 		if err != nil {

--- a/pkg/s3/metadata.go
+++ b/pkg/s3/metadata.go
@@ -1,0 +1,68 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/pkg/errors"
+)
+
+// Metadata constraints are optional and apply to each candidate object.
+type metadataFilter struct {
+	etag          string
+	minSize       int64
+	modifiedAfter time.Time
+}
+
+func parseMetadataFilter(params pipeline.ParameterMap) (metadataFilter, error) {
+	f := metadataFilter{}
+	if value, ok := params["etag"]; ok {
+		etag, valid := value.(string)
+		if !valid || strings.Trim(etag, "\"") == "" {
+			return f, errors.New("etag must be a non-empty string")
+		}
+		f.etag = strings.Trim(etag, "\"")
+	}
+	if _, ok := params["min_size"]; ok {
+		value, _ := params.GetString("min_size")
+		size, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || size < 0 {
+			return f, errors.New("min_size must be a non-negative integer in bytes")
+		}
+		f.minSize = size
+	}
+	if _, ok := params["last_modified_after"]; ok {
+		value, _ := params.GetString("last_modified_after")
+		parsed, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			return f, errors.New("last_modified_after must be an RFC3339 timestamp")
+		}
+		f.modifiedAfter = parsed
+	}
+	return f, nil
+}
+
+func (f metadataFilter) match(ctx context.Context, client *s3.Client, bucket, key string) (bool, error) {
+	obj, err := client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &bucket, Key: &key})
+	if err != nil {
+		var httpErr *smithyhttp.ResponseError
+		if errors.As(err, &httpErr) && httpErr.HTTPStatusCode() == http.StatusNotFound {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "failed to check object existence")
+	}
+	// Strip HTTP quoting only. ETags are opaque, not content hashes.
+	if f.etag != "" && (obj.ETag == nil || strings.Trim(*obj.ETag, "\"") != f.etag) {
+		return false, nil
+	}
+	if f.minSize > 0 && (obj.ContentLength == nil || *obj.ContentLength < f.minSize) {
+		return false, nil
+	}
+	return f.modifiedAfter.IsZero() || (obj.LastModified != nil && obj.LastModified.After(f.modifiedAfter)), nil
+}

--- a/pkg/s3/metadata_test.go
+++ b/pkg/s3/metadata_test.go
@@ -1,0 +1,108 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeySensor_Metadata(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, `<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>data/missing.csv</Key></Contents><Contents><Key>data/file.csv</Key></Contents></ListBucketResult>`)
+			return
+		}
+		if r.URL.Path == "/test-bucket/data/missing.csv" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"provider-opaque-multipart-7"`)
+		w.Header().Set("Content-Length", "42")
+		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+	}))
+	defer server.Close()
+	for _, key := range []string{"data/file.csv", "data/*.csv"} {
+		for _, tc := range []struct {
+			name    string
+			params  pipeline.ParameterMap
+			matches bool
+		}{
+			{"opaque etag", pipeline.ParameterMap{"etag": "provider-opaque-multipart-7"}, true},
+			{"quoted etag", pipeline.ParameterMap{"etag": `"provider-opaque-multipart-7"`}, true},
+			{"different etag", pipeline.ParameterMap{"etag": "other"}, false},
+			{"minimum size", pipeline.ParameterMap{"min_size": 42}, true},
+			{"too small", pipeline.ParameterMap{"min_size": 43}, false},
+			{"newer", pipeline.ParameterMap{"last_modified_after": "2006-01-01T00:00:00Z"}, true},
+			{"same timestamp", pipeline.ParameterMap{"last_modified_after": "2006-01-02T15:04:05Z"}, false},
+			{"all constraints", pipeline.ParameterMap{"etag": "provider-opaque-multipart-7", "min_size": "42", "last_modified_after": "2006-01-01T00:00:00Z"}, true},
+		} {
+			t.Run(key+"/"+tc.name, func(t *testing.T) {
+				conn := endpointConnection(server.URL)
+				sensor := NewKeySensor(&mockConnectionGetter{details: &conn}, "once")
+				tc.params["bucket_name"] = "test-bucket"
+				tc.params["bucket_key"] = key
+				err := sensor.RunTask(t.Context(), &pipeline.Pipeline{}, &pipeline.Asset{Connection: "s3-test", Parameters: tc.params})
+				if tc.matches {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, "Sensor didn't return the expected result")
+				}
+			})
+		}
+	}
+}
+
+func TestParseMetadataFilter_Invalid(t *testing.T) {
+	t.Parallel()
+	for _, params := range []pipeline.ParameterMap{
+		{"etag": 12},
+		{"etag": `""`},
+		{"min_size": -1},
+		{"min_size": 1.5},
+		{"min_size": nil},
+		{"last_modified_after": "yesterday"},
+	} {
+		_, err := parseMetadataFilter(params)
+		require.Error(t, err)
+	}
+}
+
+func TestKeySensor_WaitForMetadataAndTimeout(t *testing.T) {
+	t.Parallel()
+	for _, key := range []string{"file.csv", "*.csv"} {
+		t.Run(key, func(t *testing.T) {
+			var heads atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					fmt.Fprint(w, `<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>file.csv</Key></Contents></ListBucketResult>`)
+					return
+				}
+				if heads.Add(1) == 1 {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.Header().Set("ETag", `"ready"`)
+			}))
+			defer server.Close()
+			conn := endpointConnection(server.URL)
+			sensor := NewKeySensor(&mockConnectionGetter{details: &conn}, "wait")
+			asset := &pipeline.Asset{Connection: "s3-test", Parameters: pipeline.ParameterMap{
+				"bucket_name": "test-bucket", "bucket_key": key, "etag": "ready", "poke_interval": "0", "timeout": "5s",
+			}}
+			require.NoError(t, sensor.RunTask(t.Context(), &pipeline.Pipeline{}, asset))
+			require.Equal(t, int32(2), heads.Load())
+			asset.Parameters["etag"] = "not-ready"
+			asset.Parameters["poke_interval"] = "60"
+			asset.Parameters["timeout"] = "10ms"
+			err := sensor.RunTask(t.Context(), &pipeline.Pipeline{}, asset)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+	}
+}

--- a/pkg/s3/metadata_test.go
+++ b/pkg/s3/metadata_test.go
@@ -7,9 +7,11 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestKeySensor_Metadata(t *testing.T) {
@@ -27,7 +29,7 @@ func TestKeySensor_Metadata(t *testing.T) {
 		w.Header().Set("Content-Length", "42")
 		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 	for _, key := range []string{"data/file.csv", "data/*.csv"} {
 		for _, tc := range []struct {
 			name    string
@@ -44,6 +46,8 @@ func TestKeySensor_Metadata(t *testing.T) {
 			{"all constraints", pipeline.ParameterMap{"etag": "provider-opaque-multipart-7", "min_size": "42", "last_modified_after": "2006-01-01T00:00:00Z"}, true},
 		} {
 			t.Run(key+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				conn := endpointConnection(server.URL)
 				sensor := NewKeySensor(&mockConnectionGetter{details: &conn}, "once")
 				tc.params["bucket_name"] = "test-bucket"
@@ -74,10 +78,31 @@ func TestParseMetadataFilter_Invalid(t *testing.T) {
 	}
 }
 
+func TestParseMetadataFilter_YAMLTimestamps(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{
+		`"2024-01-01T00:00:00Z"`,
+		`2024-01-01T00:00:00Z`,
+		`2024-01-01T03:00:00+03:00`,
+	} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
+			var params pipeline.ParameterMap
+			require.NoError(t, yaml.Unmarshal([]byte("last_modified_after: "+value), &params))
+			filter, err := parseMetadataFilter(params)
+			require.NoError(t, err)
+			require.True(t, filter.modifiedAfter.Equal(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)))
+		})
+	}
+}
+
 func TestKeySensor_WaitForMetadataAndTimeout(t *testing.T) {
 	t.Parallel()
 	for _, key := range []string{"file.csv", "*.csv"} {
 		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
 			var heads atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == http.MethodGet {

--- a/pkg/s3/operator.go
+++ b/pkg/s3/operator.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
+	"net/url"
+	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/executor"
 	"github.com/bruin-data/bruin/pkg/helpers"
@@ -22,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func matchWildcard(ctx context.Context, client *s3.Client, bucket, key string) (bool, error) {
+func matchWildcard(ctx context.Context, client *s3.Client, bucket, key string, filter metadataFilter) (bool, error) {
 	prefix := objectpattern.ExtractPrefix(key)
 	re, err := regexp.Compile(objectpattern.WildcardToRegex(key))
 	if err != nil {
@@ -41,7 +42,13 @@ func matchWildcard(ctx context.Context, client *s3.Client, bucket, key string) (
 		}
 		for _, obj := range page.Contents {
 			if obj.Key != nil && re.MatchString(*obj.Key) {
-				return true, nil
+				if filter == (metadataFilter{}) {
+					return true, nil
+				}
+				matched, err := filter.match(ctx, client, bucket, *obj.Key)
+				if err != nil || matched {
+					return matched, err
+				}
 			}
 		}
 	}
@@ -80,6 +87,11 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 		return errors.New("S3 key sensor requires a parameter named 'bucket_key'")
 	}
 
+	filter, err := parseMetadataFilter(t.Parameters)
+	if err != nil {
+		return err
+	}
+
 	connName, err := p.GetConnectionNameForAsset(t)
 	if err != nil {
 		return err
@@ -90,7 +102,8 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 		return config.NewConnectionNotFoundError(ctx, "", connName)
 	}
 
-	var secretKey, accessKey, region, endpointURL string
+	var secretKey, accessKey, region, endpointURL, sessionToken, caBundle, urlStyle string
+	var useSSL *bool
 
 	awsConn, ok := connDetails.(*config.AwsConnection)
 	if ok {
@@ -105,17 +118,50 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 		secretKey = s3Conn.SecretAccessKey
 		accessKey = s3Conn.AccessKeyID
 		endpointURL = s3Conn.EndpointURL
+		region = s3Conn.Region
+		sessionToken = s3Conn.SessionToken
+		caBundle = s3Conn.CABundle
+		urlStyle = s3Conn.URLStyle
+		useSSL = s3Conn.UseSSL
 	}
 
-	// Load base config without forcing region
-	cfg, err := awsconfig.LoadDefaultConfig(
-		ctx,
-		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			accessKey, secretKey, "",
-		)),
-	)
+	if urlStyle != "" && urlStyle != "path" && urlStyle != "vhost" {
+		return errors.New("url_style must be 'path' or 'vhost'")
+	}
+	endpointURL = strings.TrimSpace(endpointURL)
+	if endpointURL != "" {
+		endpoint, parseErr := url.Parse(endpointURL)
+		if parseErr != nil || endpoint.Host == "" || (endpoint.Scheme != "https" && endpoint.Scheme != "http") || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+			return errors.New("endpoint_url must be an HTTP(S) URL without credentials, query, or fragment")
+		}
+		if useSSL != nil && *useSSL != (endpoint.Scheme == "https") {
+			return errors.New("use_ssl must agree with the endpoint_url scheme")
+		}
+	} else if useSSL != nil && !*useSSL {
+		return errors.New("use_ssl: false requires an explicit HTTP endpoint_url")
+	}
+
+	loadOptions := []func(*awsconfig.LoadOptions) error{}
+	if accessKey != "" || secretKey != "" || sessionToken != "" {
+		if accessKey == "" || secretKey == "" {
+			return errors.New("access_key_id and secret_access_key must both be supplied")
+		}
+		loadOptions = append(loadOptions, awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, sessionToken)))
+	}
+	if caBundle != "" {
+		bundle, readErr := os.Open(caBundle)
+		if readErr != nil {
+			return errors.Wrap(readErr, "failed to open S3 CA bundle")
+		}
+		defer bundle.Close()
+		loadOptions = append(loadOptions, awsconfig.WithCustomCABundle(bundle))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
 	if err != nil {
 		return errors.Wrap(err, "failed to load AWS config")
+	}
+	if region == "" {
+		region = cfg.Region
 	}
 
 	var s3Client *s3.Client
@@ -127,7 +173,7 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 		cfg.Region = region
 		s3Client = s3.NewFromConfig(cfg, func(o *s3.Options) {
 			o.BaseEndpoint = &endpointURL
-			o.UsePathStyle = true
+			o.UsePathStyle = urlStyle != "vhost"
 		})
 	} else {
 		// For AWS S3, discover region if not set
@@ -144,66 +190,57 @@ func (ks *KeySensor) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipel
 		}
 
 		cfg.Region = region
-		s3Client = s3.NewFromConfig(cfg)
+		s3Client = s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.UsePathStyle = urlStyle == "path"
+		})
 	}
 
 	printer, printerExists := ctx.Value(executor.KeyPrinter).(io.Writer)
 	if printerExists {
+		if endpointURL != "" {
+			style := "vhost"
+			if s3Client.Options().UsePathStyle {
+				style = "path"
+			}
+			fmt.Fprintln(printer, "S3 endpoint:", endpointURL, "addressing:", style)
+			if strings.HasPrefix(endpointURL, "http://") {
+				fmt.Fprintln(printer, "Warning: S3 HTTP endpoint disables TLS; use only for local development")
+			}
+		}
 		fmt.Fprintln(printer, "Poking S3:", bucketName+"/"+bucketKey)
 	}
 
 	isWildcard := objectpattern.ContainsWildcard(bucketKey)
 
 	sensorTimeout := helpers.GetSensorTimeout(t)
-	timeout := time.After(sensorTimeout)
+	ctx, cancel := context.WithTimeout(ctx, sensorTimeout)
+	defer cancel()
 	for {
-		select {
-		case <-timeout:
-			return errors.Errorf("Sensor timed out after %s", sensorTimeout)
-		default:
-			if isWildcard {
-				found, err := matchWildcard(ctx, s3Client, bucketName, bucketKey)
-				if err != nil {
-					return err
-				}
-				if found {
-					return nil
-				}
-
-				if ks.sensorMode == "once" || ks.sensorMode == "" {
-					return errors.New("Sensor didn't return the expected result")
-				}
-
-				pokeInterval := helpers.GetPokeInterval(ctx, t)
-				time.Sleep(time.Duration(pokeInterval) * time.Second)
-				if printerExists {
-					fmt.Fprintln(printer, "Info: No matching objects found, waiting for", pokeInterval, "seconds")
-				}
-				continue
-			}
-
-			_, err := s3Client.HeadObject(ctx, &s3.HeadObjectInput{
-				Bucket: &bucketName,
-				Key:    &bucketKey,
-			})
-			if err != nil {
-				var httpErr *smithyhttp.ResponseError
-				if errors.As(err, &httpErr) && httpErr.HTTPStatusCode() == http.StatusNotFound {
-					if ks.sensorMode == "once" || ks.sensorMode == "" {
-						return errors.New("Sensor didn't return the expected result")
-					}
-
-					pokeInterval := helpers.GetPokeInterval(ctx, t)
-					time.Sleep(time.Duration(pokeInterval) * time.Second)
-					if printerExists {
-						fmt.Fprintln(printer, "Info: Object not found, waiting for", pokeInterval, "seconds")
-					}
-					continue
-				}
-				return errors.Wrap(err, "failed to check object existence")
-			}
-
+		var found bool
+		if isWildcard {
+			found, err = matchWildcard(ctx, s3Client, bucketName, bucketKey, filter)
+		} else {
+			found, err = filter.match(ctx, s3Client, bucketName, bucketKey)
+		}
+		if err != nil {
+			return err
+		}
+		if found {
 			return nil
+		}
+		if ks.sensorMode == "once" || ks.sensorMode == "" {
+			return errors.New("Sensor didn't return the expected result")
+		}
+		pokeInterval := helpers.GetPokeInterval(ctx, t)
+		if printerExists {
+			fmt.Fprintln(printer, "Info: No matching objects found, waiting for", pokeInterval, "seconds")
+		}
+		timer := time.NewTimer(time.Duration(pokeInterval) * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return errors.Wrapf(ctx.Err(), "S3 sensor stopped (timeout %s)", sensorTimeout)
+		case <-timer.C:
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Closes #2622.

- Extend the canonical S3 connection with sensor region, path/virtual-host addressing, custom CA, TLS scheme assertion, and session-token options; use the AWS credential chain when static credentials are omitted.
- Keep exact-key, wildcard listing, and metadata requests on the configured endpoint. Add opaque ETag, minimum-size, and last-modified comparisons, with cancellable polling.
- Preserve existing AWS/custom-endpoint defaults, verify HTTPS certificates, warn for explicit development HTTP endpoints, and print endpoint/addressing diagnostics without credentials.
- Update the connection schema and document B2, R2, and MinIO examples. Ingestr behavior is unchanged.

## Verification
- `make format`: passed, 0 lint issues.
- `make test TEST_CONCURRENCY=1`: passed, including semantic-engine tests.
- `make build -o deps`: passed using the already-built Rust library.
- `make integration-test-light -o build`: passed using the verified binary.
- Generated `bruin internal connections` output matches the schema fixture.
- Both changed S3 documentation pages pass Markdown lint.

Local endpoint tests cover path/virtual-host routing, pagination, signing region and session tokens, credential-chain fallback, TLS trust and custom CA, missing/forbidden objects, metadata comparisons, and polling/timeouts. Live B2/R2 accounts were not exercised.

Verification used reduced Go parallelism/memory limits and an unoptimized local Rust library to fit the orb. Git signing was disabled only for test-process fixture commits; no repository build configuration was changed.