### PR TITLE
Add --merge to bruin init to add template assets to an existing pipeline

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -265,9 +265,8 @@ var mergeableTemplateDirs = []string{"assets", "macros"}
 var mergeableTemplateFiles = []string{"requirements.txt", "pyproject.toml", "uv.lock"}
 
 // loadTemplateMergeFiles returns the mergeable files of every pipeline in a
-// template. Some templates wrap their pipeline in another directory, and some
-// contain more than one pipeline, so pipeline roots cannot be assumed to sit
-// directly below the template root.
+// template. Pipeline roots are found via their assets directory, because some
+// templates wrap or repeat their pipeline below the template root.
 func loadTemplateMergeFiles(templateName string) ([]templateMergeFile, error) {
 	assetRoots := make([]string, 0)
 	err := fs2.WalkDir(templates.Templates, templateName, func(entryPath string, d fs2.DirEntry, err error) error {
@@ -316,8 +315,8 @@ func loadTemplateMergeFiles(templateName string) ([]templateMergeFile, error) {
 	return sortedTemplateMergeFiles(filesByPath), nil
 }
 
-// collectTemplateMergeDir reads every file below root and records it under
-// prefix. A missing directory is not an error: most templates have no macros.
+// collectTemplateMergeDir records every file below root under prefix. A missing
+// directory is not an error: most templates have no macros.
 func collectTemplateMergeDir(templateName, root, prefix string, filesByPath map[string]templateMergeFile) error {
 	if _, err := fs2.Stat(templates.Templates, root); err != nil {
 		if errors.Is(err, fs2.ErrNotExist) {
@@ -421,6 +420,31 @@ func loadTemplateBruinConfig(templateName string) ([]byte, error) {
 	return content, nil
 }
 
+// writeFileAtomically replaces path in one step, so a failed write cannot leave
+// a truncated file behind.
+func writeFileAtomically(path string, content []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, path)
+}
+
 // mergeTemplateConfigIntoProject resolves the project from the destination
 // pipeline, then merges the template config into the project-level .bruin.yml.
 func mergeTemplateConfigIntoProject(pipelinePath string, templateBruinContent []byte) (initConfigSummary, error) {
@@ -449,7 +473,7 @@ func mergeTemplateConfigIntoProject(pipelinePath string, templateBruinContent []
 	if err != nil {
 		return initConfigSummary{}, fmt.Errorf("could not marshal .bruin.yml: %w", err)
 	}
-	if err := os.WriteFile(bruinYmlPath, configBytes, 0o644); err != nil { //nolint:gosec
+	if err := writeFileAtomically(bruinYmlPath, configBytes); err != nil {
 		return initConfigSummary{}, fmt.Errorf("could not write .bruin.yml file: %w", err)
 	}
 
@@ -498,11 +522,10 @@ func validateMergeDestination(pipelinePath string) error {
 	return nil
 }
 
-// findNonDirectoryParent walks the directories that relativePath needs, from
-// root downwards, and returns the first one that already exists as something
-// other than a directory. An empty result means the path is clear. Walking
-// top-down keeps every Lstat rooted at a known directory, so a conflict is
-// reported instead of a bare ENOTDIR.
+// findNonDirectoryParent returns the first directory relativePath needs that
+// already exists as something else, or "" when the path is clear. It walks
+// top-down so every Lstat is rooted at a known directory and cannot fail with a
+// bare ENOTDIR.
 func findNonDirectoryParent(root, relativePath string) (string, error) {
 	current := root
 	currentRelative := ""
@@ -531,8 +554,7 @@ func findNonDirectoryParent(root, relativePath string) (string, error) {
 }
 
 // collectMergeConflicts reports every destination path that is already taken. It
-// writes nothing, so callers can run it before any other part of the merge and
-// bail out with the project untouched.
+// writes nothing, so a conflict leaves the project untouched.
 func collectMergeConflicts(pipelinePath string, files []templateMergeFile) error {
 	if err := validateMergeDestination(pipelinePath); err != nil {
 		return err
@@ -546,9 +568,8 @@ func collectMergeConflicts(pipelinePath string, files []templateMergeFile) error
 			return fmt.Errorf("template contains an invalid file path %q", file.path)
 		}
 
-		// Parents are checked first: when one of them is a regular file, an
-		// Lstat of the full destination fails with ENOTDIR rather than
-		// reporting the actual conflict.
+		// Checked before the destination itself: a regular file in the parent
+		// chain makes the Lstat below fail with ENOTDIR instead of reporting it.
 		parentConflict, err := findNonDirectoryParent(destinationRoot, relativePath)
 		if err != nil {
 			return err
@@ -576,8 +597,8 @@ func collectMergeConflicts(pipelinePath string, files []templateMergeFile) error
 }
 
 // writeTemplateFiles copies the files into the pipeline. It must only run after
-// collectMergeConflicts has passed, which is what makes every destination path
-// safe to write and safe to remove again on failure.
+// collectMergeConflicts has passed: that is what makes each destination safe to
+// write and safe to remove again.
 func writeTemplateFiles(pipelinePath string, files []templateMergeFile) error {
 	destinationRoot := filepath.Clean(pipelinePath)
 	written := make([]string, 0, len(files))
@@ -604,8 +625,8 @@ func writeTemplateFile(destinationPath string, content []byte) error {
 	if err != nil {
 		return fmt.Errorf("could not create file %q: %w", destinationPath, err)
 	}
-	// The file exists from here on, so every failure path removes it: a stub left
-	// behind would be reported as a conflict on the next attempt.
+	// The file exists from here on, so every failure path removes it: a stub would
+	// be reported as a conflict on the next attempt.
 	if _, err := out.Write(content); err != nil {
 		_ = out.Close()
 		_ = os.Remove(destinationPath)
@@ -773,10 +794,8 @@ func Init() *cli.Command {
 					}
 				}
 
-				// Conflicts are collected first so that a destination clash aborts
-				// before the config is touched, and the config is merged before any
-				// file is copied. Both remaining steps are safe to repeat: the config
-				// merge is idempotent, and a failed copy removes what it wrote.
+				// Conflicts first so a clash aborts before anything is written, then
+				// the config, then the copy. Both writing steps are safe to repeat.
 				if err := collectMergeConflicts(inputPath, mergeFiles); err != nil {
 					errorPrinter.Printf("Could not merge template %s: %v\n", templateName, err)
 					return cli.Exit("", 1)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -421,8 +421,16 @@ func loadTemplateBruinConfig(templateName string) ([]byte, error) {
 }
 
 // writeFileAtomically replaces path in one step, so a failed write cannot leave
-// a truncated file behind.
+// a truncated file behind. An existing file keeps its own mode: .bruin.yml holds
+// credentials and may have been tightened to 0600 by hand.
 func writeFileAtomically(path string, content []byte) error {
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
 	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return err
@@ -434,7 +442,7 @@ func writeFileAtomically(path string, content []byte) error {
 		_ = tmp.Close()
 		return err
 	}
-	if err := tmp.Chmod(0o644); err != nil {
+	if err := tmp.Chmod(mode); err != nil {
 		_ = tmp.Close()
 		return err
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	fs2 "io/fs"
 	"os"
 	"os/exec"
+	fspath "path"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/config"
@@ -245,6 +248,390 @@ func mergeEnvironment(centralConfig *config.Config, templateEnvName string, temp
 	return nil
 }
 
+type templateMergeFile struct {
+	// path is relative to the template's pipeline root, e.g. "assets/orders.sql"
+	// or "macros/aggregations.sql".
+	path    string
+	content []byte
+}
+
+// mergeableTemplateDirs are the pipeline-level directories copied by merge mode.
+// Assets routinely call macros, so copying "assets" alone would produce a
+// pipeline that fails to render.
+var mergeableTemplateDirs = []string{"assets", "macros"}
+
+// mergeableTemplateFiles are the pipeline-root dependency files that Python
+// assets resolve by walking up from their own directory.
+var mergeableTemplateFiles = []string{"requirements.txt", "pyproject.toml", "uv.lock"}
+
+// loadTemplateMergeFiles returns the mergeable files of every pipeline in a
+// template. Some templates wrap their pipeline in another directory, and some
+// contain more than one pipeline, so pipeline roots cannot be assumed to sit
+// directly below the template root.
+func loadTemplateMergeFiles(templateName string) ([]templateMergeFile, error) {
+	assetRoots := make([]string, 0)
+	err := fs2.WalkDir(templates.Templates, templateName, func(entryPath string, d fs2.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() && d.Name() == "assets" {
+			assetRoots = append(assetRoots, entryPath)
+			return fs2.SkipDir
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not inspect template %s: %w", templateName, err)
+	}
+	if len(assetRoots) == 0 {
+		return nil, fmt.Errorf("template %q does not contain an assets directory", templateName)
+	}
+
+	filesByPath := make(map[string]templateMergeFile)
+	for _, assetRoot := range assetRoots {
+		pipelineRoot := fspath.Dir(assetRoot)
+
+		for _, dirName := range mergeableTemplateDirs {
+			if err := collectTemplateMergeDir(templateName, fspath.Join(pipelineRoot, dirName), dirName, filesByPath); err != nil {
+				return nil, err
+			}
+		}
+
+		for _, fileName := range mergeableTemplateFiles {
+			content, err := templates.Templates.ReadFile(fspath.Join(pipelineRoot, fileName))
+			if errors.Is(err, fs2.ErrNotExist) {
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("could not read %s from template %s: %w", fileName, templateName, err)
+			}
+			if err := addTemplateMergeFile(templateName, filesByPath, fileName, content); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return sortedTemplateMergeFiles(filesByPath), nil
+}
+
+// collectTemplateMergeDir reads every file below root and records it under
+// prefix. A missing directory is not an error: most templates have no macros.
+func collectTemplateMergeDir(templateName, root, prefix string, filesByPath map[string]templateMergeFile) error {
+	if _, err := fs2.Stat(templates.Templates, root); err != nil {
+		if errors.Is(err, fs2.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("could not inspect %s in template %s: %w", root, templateName, err)
+	}
+
+	err := fs2.WalkDir(templates.Templates, root, func(entryPath string, d fs2.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		content, err := templates.Templates.ReadFile(entryPath)
+		if err != nil {
+			return err
+		}
+
+		relativePath := fspath.Join(prefix, strings.TrimPrefix(entryPath, root+"/"))
+
+		return addTemplateMergeFile(templateName, filesByPath, relativePath, content)
+	})
+	if err != nil {
+		return fmt.Errorf("could not read %s from template %s: %w", prefix, templateName, err)
+	}
+
+	return nil
+}
+
+func addTemplateMergeFile(templateName string, filesByPath map[string]templateMergeFile, relativePath string, content []byte) error {
+	if !fs2.ValidPath(relativePath) || relativePath == "." {
+		return fmt.Errorf("template %q contains an invalid file path %q", templateName, relativePath)
+	}
+	if _, exists := filesByPath[relativePath]; exists {
+		return fmt.Errorf("template %q contains multiple files at %q", templateName, relativePath)
+	}
+
+	filesByPath[relativePath] = templateMergeFile{path: relativePath, content: content}
+
+	return nil
+}
+
+func sortedTemplateMergeFiles(filesByPath map[string]templateMergeFile) []templateMergeFile {
+	relativePaths := make([]string, 0, len(filesByPath))
+	for relativePath := range filesByPath {
+		relativePaths = append(relativePaths, relativePath)
+	}
+	sort.Strings(relativePaths)
+
+	files := make([]templateMergeFile, 0, len(relativePaths))
+	for _, relativePath := range relativePaths {
+		files = append(files, filesByPath[relativePath])
+	}
+
+	return files
+}
+
+func loadEcommerceMergeFiles(choices *EcommerceChoices) ([]templateMergeFile, error) {
+	generated, err := buildEcommerceFiles(choices)
+	if err != nil {
+		return nil, err
+	}
+
+	filesByPath := make(map[string]templateMergeFile)
+	for relativePath, content := range generated {
+		relativePath = filepath.ToSlash(relativePath)
+		if !isMergeableTemplatePath(relativePath) {
+			continue
+		}
+		if err := addTemplateMergeFile("ecommerce", filesByPath, relativePath, []byte(content)); err != nil {
+			return nil, err
+		}
+	}
+
+	return sortedTemplateMergeFiles(filesByPath), nil
+}
+
+func isMergeableTemplatePath(relativePath string) bool {
+	for _, dirName := range mergeableTemplateDirs {
+		if strings.HasPrefix(relativePath, dirName+"/") {
+			return true
+		}
+	}
+
+	return slices.Contains(mergeableTemplateFiles, relativePath)
+}
+
+func loadTemplateBruinConfig(templateName string) ([]byte, error) {
+	content, err := templates.Templates.ReadFile(templateName + "/.bruin.yml")
+	if errors.Is(err, fs2.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not read template config: %w", err)
+	}
+
+	return content, nil
+}
+
+// mergeTemplateConfigIntoProject resolves the project from the destination
+// pipeline, then merges the template config into the project-level .bruin.yml.
+func mergeTemplateConfigIntoProject(pipelinePath string, templateBruinContent []byte) (initConfigSummary, error) {
+	repoRoot, err := git.FindRepoFromPath(pipelinePath)
+	if err != nil {
+		return initConfigSummary{}, fmt.Errorf("could not locate the Git project containing pipeline %q: %w", pipelinePath, err)
+	}
+
+	bruinYmlPath := filepath.Join(repoRoot.Path, ".bruin.yml")
+	summary := initConfigSummary{
+		path:         bruinYmlPath,
+		existed:      fileExists(bruinYmlPath),
+		merged:       true,
+		locationNote: "This is your Git repo root, so it may sit several levels above the pipeline folder.",
+	}
+
+	centralConfig, err := config.LoadOrCreateWithoutPathAbsolutization(afero.NewOsFs(), bruinYmlPath)
+	if err != nil {
+		return initConfigSummary{}, fmt.Errorf("could not load .bruin.yml file: %w", err)
+	}
+	if err := mergeTemplateConfig(centralConfig, templateBruinContent); err != nil {
+		return initConfigSummary{}, err
+	}
+
+	configBytes, err := yaml.Marshal(centralConfig)
+	if err != nil {
+		return initConfigSummary{}, fmt.Errorf("could not marshal .bruin.yml: %w", err)
+	}
+	if err := os.WriteFile(bruinYmlPath, configBytes, 0o644); err != nil { //nolint:gosec
+		return initConfigSummary{}, fmt.Errorf("could not write .bruin.yml file: %w", err)
+	}
+
+	// Cosmetic, so a failure here must not abort a merge that has already
+	// written the config.
+	if err := ensureLocalDuckDBFilesAreIgnored(afero.NewOsFs(), bruinYmlPath, centralConfig); err != nil {
+		errorPrinter.Printf("Could not add the DuckDB database to .gitignore: %v\n", err)
+	}
+
+	return summary, nil
+}
+
+// projectConfigSummary describes the project-level .bruin.yml without touching
+// it, for templates that ship no config of their own. A pipeline outside a Git
+// repository yields an empty summary, which prints as "no config yet".
+func projectConfigSummary(pipelinePath string) initConfigSummary {
+	repoRoot, err := git.FindRepoFromPath(pipelinePath)
+	if err != nil {
+		return initConfigSummary{}
+	}
+
+	bruinYmlPath := filepath.Join(repoRoot.Path, ".bruin.yml")
+
+	return initConfigSummary{
+		path:         bruinYmlPath,
+		existed:      fileExists(bruinYmlPath),
+		locationNote: "This is your Git repo root, so it may sit several levels above the pipeline folder.",
+	}
+}
+
+// validateMergeDestination reports whether pipelinePath is an existing Bruin
+// pipeline. It runs before anything is written so that a bad destination cannot
+// leave a half-merged project behind.
+func validateMergeDestination(pipelinePath string) error {
+	info, err := os.Stat(pipelinePath)
+	if err != nil {
+		return fmt.Errorf("could not open pipeline path %q: %w", pipelinePath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("pipeline path %q is not a directory", pipelinePath)
+	}
+	if _, err := getPipelineDefinitionFullPath(pipelinePath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// findNonDirectoryParent walks the directories that relativePath needs, from
+// root downwards, and returns the first one that already exists as something
+// other than a directory. An empty result means the path is clear. Walking
+// top-down keeps every Lstat rooted at a known directory, so a conflict is
+// reported instead of a bare ENOTDIR.
+func findNonDirectoryParent(root, relativePath string) (string, error) {
+	current := root
+	currentRelative := ""
+	for _, part := range strings.Split(filepath.Dir(relativePath), string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+
+		current = filepath.Join(current, part)
+		currentRelative = filepath.Join(currentRelative, part)
+
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			// Nothing below a directory that does not exist yet can conflict.
+			return "", nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("could not inspect destination directory %q: %w", current, err)
+		}
+		if !info.IsDir() {
+			return currentRelative, nil
+		}
+	}
+
+	return "", nil
+}
+
+// collectMergeConflicts reports every destination path that is already taken. It
+// writes nothing, so callers can run it before any other part of the merge and
+// bail out with the project untouched.
+func collectMergeConflicts(pipelinePath string, files []templateMergeFile) error {
+	if err := validateMergeDestination(pipelinePath); err != nil {
+		return err
+	}
+
+	destinationRoot := filepath.Clean(pipelinePath)
+	conflicts := make([]string, 0)
+	for _, file := range files {
+		relativePath := filepath.FromSlash(file.path)
+		if !filepath.IsLocal(relativePath) {
+			return fmt.Errorf("template contains an invalid file path %q", file.path)
+		}
+
+		// Parents are checked first: when one of them is a regular file, an
+		// Lstat of the full destination fails with ENOTDIR rather than
+		// reporting the actual conflict.
+		parentConflict, err := findNonDirectoryParent(destinationRoot, relativePath)
+		if err != nil {
+			return err
+		}
+		if parentConflict != "" {
+			conflicts = append(conflicts, parentConflict)
+			continue
+		}
+
+		destinationPath := filepath.Join(destinationRoot, relativePath)
+		if _, err := os.Lstat(destinationPath); err == nil {
+			conflicts = append(conflicts, relativePath)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("could not inspect destination file %q: %w", destinationPath, err)
+		}
+	}
+
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		conflicts = slices.Compact(conflicts)
+		return fmt.Errorf("cannot merge template files because these paths already exist: %s", strings.Join(conflicts, ", "))
+	}
+
+	return nil
+}
+
+// writeTemplateFiles copies the files into the pipeline. It must only run after
+// collectMergeConflicts has passed, which is what makes every destination path
+// safe to write and safe to remove again on failure.
+func writeTemplateFiles(pipelinePath string, files []templateMergeFile) error {
+	destinationRoot := filepath.Clean(pipelinePath)
+	written := make([]string, 0, len(files))
+	for _, file := range files {
+		destinationPath := filepath.Join(destinationRoot, filepath.FromSlash(file.path))
+		if err := writeTemplateFile(destinationPath, file.content); err != nil {
+			// Roll back, otherwise a half-finished copy reports its own files as
+			// conflicts on the next attempt and the command can never succeed.
+			return errors.Join(err, removeTemplateFiles(written))
+		}
+
+		written = append(written, destinationPath)
+	}
+
+	return nil
+}
+
+func writeTemplateFile(destinationPath string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+		return fmt.Errorf("could not create directory %q: %w", filepath.Dir(destinationPath), err)
+	}
+
+	out, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644) //nolint:gosec // destination is validated as a local path below the requested pipeline
+	if err != nil {
+		return fmt.Errorf("could not create file %q: %w", destinationPath, err)
+	}
+	// The file exists from here on, so every failure path removes it: a stub left
+	// behind would be reported as a conflict on the next attempt.
+	if _, err := out.Write(content); err != nil {
+		_ = out.Close()
+		_ = os.Remove(destinationPath)
+		return fmt.Errorf("could not write file %q: %w", destinationPath, err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(destinationPath)
+		return fmt.Errorf("could not close file %q: %w", destinationPath, err)
+	}
+
+	return nil
+}
+
+// removeTemplateFiles deletes files a failed merge created. Directories are left
+// alone: an empty directory does not block a retry.
+func removeTemplateFiles(paths []string) error {
+	cleanupErrors := make([]error, 0)
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("could not remove %q while undoing the merge: %w", path, err))
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}
+
 // Init creates and returns the CLI command for initializing new Bruin pipelines from templates.
 func Init() *cli.Command {
 	folders, err := templates.Templates.ReadDir(".")
@@ -277,9 +664,28 @@ func Init() *cli.Command {
 				Name:  "in-place",
 				Usage: "initializes the template without creating a bruin repository parent folder",
 			},
+			&cli.BoolFlag{
+				Name:  "merge",
+				Usage: "merges the template's assets, macros and project config into an existing pipeline without overwriting existing files",
+			},
 		},
 		Action: func(ctx context.Context, c *cli.Command) error {
 			defer RecoverFromPanic()
+
+			inputPath := c.Args().Get(1)
+			merge := c.Bool("merge")
+			// Validated before the interactive template picker so a misuse of the
+			// flag fails immediately instead of after five prompts.
+			if merge {
+				if inputPath == "" {
+					errorPrinter.Printf("A path to an existing pipeline is required when using --merge.\n")
+					return cli.Exit("", 1)
+				}
+				if c.Bool("in-place") {
+					errorPrinter.Printf("--merge and --in-place cannot be used together.\n")
+					return cli.Exit("", 1)
+				}
+			}
 
 			templateName := c.Args().Get(0)
 			selectedViaInteractive := false
@@ -316,13 +722,109 @@ func Init() *cli.Command {
 				return cli.Exit("", 1)
 			}
 
-			inputPath := c.Args().Get(1)
 			if inputPath == "" {
 				if templateName == DefaultTemplate {
 					inputPath = DefaultFolderName
 				} else {
 					inputPath = templateName
 				}
+			}
+
+			if merge {
+				// Checked before the ecommerce stack picker so a bad destination
+				// fails immediately rather than after five prompts.
+				if err := validateMergeDestination(inputPath); err != nil {
+					errorPrinter.Printf("Could not merge template %s: %v\n", templateName, err)
+					return cli.Exit("", 1)
+				}
+
+				var (
+					mergeFiles           []templateMergeFile
+					templateBruinContent []byte
+					ecommerceChoices     *EcommerceChoices
+				)
+				if templateName == "ecommerce" {
+					ecommerceChoices, err = runEcommerceStackPicker()
+					if err != nil {
+						errorPrinter.Printf("Error during stack selection: %v\n", err)
+						return cli.Exit("", 1)
+					}
+					if ecommerceChoices == nil {
+						return nil
+					}
+
+					mergeFiles, err = loadEcommerceMergeFiles(ecommerceChoices)
+					if err != nil {
+						errorPrinter.Printf("Could not generate ecommerce assets: %v\n", err)
+						return cli.Exit("", 1)
+					}
+					templateBruinContent = []byte(generateBruinYML(ecommerceChoices))
+				} else {
+					mergeFiles, err = loadTemplateMergeFiles(templateName)
+					if err != nil {
+						errorPrinter.Printf("Could not load template assets: %v\n", err)
+						return cli.Exit("", 1)
+					}
+
+					templateBruinContent, err = loadTemplateBruinConfig(templateName)
+					if err != nil {
+						errorPrinter.Printf("Could not load template config: %v\n", err)
+						return cli.Exit("", 1)
+					}
+				}
+
+				// Conflicts are collected first so that a destination clash aborts
+				// before the config is touched, and the config is merged before any
+				// file is copied. Both remaining steps are safe to repeat: the config
+				// merge is idempotent, and a failed copy removes what it wrote.
+				if err := collectMergeConflicts(inputPath, mergeFiles); err != nil {
+					errorPrinter.Printf("Could not merge template %s: %v\n", templateName, err)
+					return cli.Exit("", 1)
+				}
+
+				configSummary := projectConfigSummary(inputPath)
+				if templateBruinContent != nil {
+					configSummary, err = mergeTemplateConfigIntoProject(inputPath, templateBruinContent)
+					if err != nil {
+						errorPrinter.Printf("Could not merge template config: %v\n", err)
+						return cli.Exit("", 1)
+					}
+				}
+
+				if err := writeTemplateFiles(inputPath, mergeFiles); err != nil {
+					errorPrinter.Printf("Could not copy the '%s' template files into %s: %v\n", templateName, inputPath, err)
+					return cli.Exit("", 1)
+				}
+
+				telemetryFields := map[string]interface{}{
+					"template_name": templateName,
+					"interactive":   selectedViaInteractive,
+					"merge":         true,
+				}
+				if ecommerceChoices != nil {
+					// The stack picker always runs, so this path is interactive
+					// regardless of how the template itself was chosen.
+					telemetryFields["interactive"] = true
+					telemetryFields["warehouse"] = ecommerceChoices.Warehouse
+					telemetryFields["payments"] = ecommerceChoices.Payments
+					telemetryFields["marketing"] = ecommerceChoices.Marketing
+					telemetryFields["ads"] = ecommerceChoices.Ads
+					telemetryFields["analytics"] = ecommerceChoices.Analytics
+				}
+				telemetry.SetTemplateName(templateName)
+				telemetry.SendEvent("template_selected", telemetryFields)
+
+				fileLabel := "files"
+				if len(mergeFiles) == 1 {
+					fileLabel = "file"
+				}
+				successPrinter.Printf("\n\nMerged %d %s from the '%s' template into pipeline '%s'.\n", len(mergeFiles), fileLabel, templateName, inputPath)
+				if ecommerceChoices != nil {
+					printEcommerceSummary(ecommerceChoices)
+				}
+				printInitSummary(configSummary, inputPath)
+
+				return nil
 			}
 
 			dir, _ := filepath.Split(inputPath)

--- a/cmd/init_merge_test.go
+++ b/cmd/init_merge_test.go
@@ -394,3 +394,34 @@ func TestWriteFileAtomicallyKeepsTheOriginalOnFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "keep me\n", string(content))
 }
+
+func TestWriteFileAtomicallyPreservesExistingPermissions(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("file modes are not meaningful on Windows")
+	}
+
+	targetRoot := t.TempDir()
+	path := filepath.Join(targetRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(path, []byte("old\n"), 0o600))
+
+	require.NoError(t, writeFileAtomically(path, []byte("new\n")))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteFileAtomicallyUsesDefaultPermissionsForNewFiles(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("file modes are not meaningful on Windows")
+	}
+
+	targetRoot := t.TempDir()
+	path := filepath.Join(targetRoot, ".bruin.yml")
+
+	require.NoError(t, writeFileAtomically(path, []byte("new\n")))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}

--- a/cmd/init_merge_test.go
+++ b/cmd/init_merge_test.go
@@ -1,0 +1,358 @@
+//nolint:paralleltest
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+// captureExitCode stops cli.Exit from tearing down the test binary and returns
+// the code the command asked for.
+func captureExitCode(t *testing.T) *int {
+	t.Helper()
+
+	original := cli.OsExiter
+	code := 0
+	cli.OsExiter = func(c int) { code = c }
+	t.Cleanup(func() { cli.OsExiter = original })
+
+	return &code
+}
+
+func initGitRepository(t *testing.T, root string) {
+	t.Helper()
+
+	gitInit := exec.CommandContext(t.Context(), "git", "init")
+	gitInit.Dir = root
+	output, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func createExistingPipeline(t *testing.T, root string) string {
+	t.Helper()
+
+	pipelinePath := filepath.Join(root, "pipelines", "existing")
+	require.NoError(t, os.MkdirAll(filepath.Join(pipelinePath, "assets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinePath, "pipeline.yml"), []byte("name: existing\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinePath, "README.md"), []byte("existing readme\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinePath, "assets", "existing.sql"), []byte("select 42\n"), 0o644))
+
+	return pipelinePath
+}
+
+func mergeFilePaths(files []templateMergeFile) []string {
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		paths = append(paths, file.path)
+	}
+
+	return paths
+}
+
+func TestInitMergeCopiesTemplateAssetsAndMergesConfig(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+	initGitRepository(t, targetRoot)
+	pipelinePath := createExistingPipeline(t, targetRoot)
+	configPath := filepath.Join(targetRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`default_environment: default
+environments:
+  default:
+    connections:
+      duckdb:
+        - name: existing-duckdb
+          path: existing.db
+        - name: duckdb-default
+          path: keep-existing.db
+`), 0o644))
+
+	err := Init().Run(t.Context(), []string{"init", "default", pipelinePath, "--merge"})
+	require.NoError(t, err)
+
+	pipelineContent, err := os.ReadFile(filepath.Join(pipelinePath, "pipeline.yml"))
+	require.NoError(t, err)
+	require.Equal(t, "name: existing\n", string(pipelineContent))
+
+	readmeContent, err := os.ReadFile(filepath.Join(pipelinePath, "README.md"))
+	require.NoError(t, err)
+	require.Equal(t, "existing readme\n", string(readmeContent))
+
+	existingAsset, err := os.ReadFile(filepath.Join(pipelinePath, "assets", "existing.sql"))
+	require.NoError(t, err)
+	require.Equal(t, "select 42\n", string(existingAsset))
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "player_stats.sql"))
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "my_python_asset.py"))
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "players.asset.yml"))
+
+	configContent, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Contains(t, string(configContent), "name: existing-duckdb")
+	require.Contains(t, string(configContent), "name: duckdb-default")
+	require.Contains(t, string(configContent), "path: keep-existing.db")
+	require.NotContains(t, string(configContent), "path: duckdb.db")
+	require.Contains(t, string(configContent), "name: chess-default")
+	require.NoDirExists(t, filepath.Join(targetRoot, "bruin"))
+}
+
+func TestInitMergeRequiresAPipelinePath(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+
+	exitCode := captureExitCode(t)
+	err := Init().Run(t.Context(), []string{"init", "default", "--merge"})
+	require.Error(t, err)
+	require.Equal(t, 1, *exitCode)
+	require.NoDirExists(t, filepath.Join(targetRoot, "default"))
+}
+
+func TestInitMergeRejectsInPlace(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+	initGitRepository(t, targetRoot)
+	pipelinePath := createExistingPipeline(t, targetRoot)
+
+	exitCode := captureExitCode(t)
+	err := Init().Run(t.Context(), []string{"init", "default", pipelinePath, "--merge", "--in-place"})
+	require.Error(t, err)
+	require.Equal(t, 1, *exitCode)
+	require.NoFileExists(t, filepath.Join(pipelinePath, "assets", "player_stats.sql"))
+	require.NoFileExists(t, filepath.Join(targetRoot, ".bruin.yml"))
+}
+
+func TestMergeTemplateConfigIntoProjectCreatesConfigAtRepoRoot(t *testing.T) {
+	targetRoot := t.TempDir()
+	initGitRepository(t, targetRoot)
+	pipelinePath := createExistingPipeline(t, targetRoot)
+	templateConfig, err := loadTemplateBruinConfig("default")
+	require.NoError(t, err)
+
+	summary, err := mergeTemplateConfigIntoProject(pipelinePath, templateConfig)
+	require.NoError(t, err)
+	require.False(t, summary.existed)
+	require.True(t, summary.merged)
+	require.Equal(t, filepath.Join(targetRoot, ".bruin.yml"), summary.path)
+
+	configContent, err := os.ReadFile(summary.path)
+	require.NoError(t, err)
+	require.Contains(t, string(configContent), "name: duckdb-default")
+}
+
+func TestInitMergeRejectsCollisionsBeforeWriting(t *testing.T) {
+	targetRoot := t.TempDir()
+	pipelinePath := createExistingPipeline(t, targetRoot)
+	collidingAssetPath := filepath.Join(pipelinePath, "assets", "player_stats.sql")
+	require.NoError(t, os.WriteFile(collidingAssetPath, []byte("select 'keep me'\n"), 0o644))
+
+	files, err := loadTemplateMergeFiles("default")
+	require.NoError(t, err)
+	err = collectMergeConflicts(pipelinePath, files)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), filepath.Join("assets", "player_stats.sql"))
+
+	collidingAsset, readErr := os.ReadFile(collidingAssetPath)
+	require.NoError(t, readErr)
+	require.Equal(t, "select 'keep me'\n", string(collidingAsset))
+	require.NoFileExists(t, filepath.Join(pipelinePath, "assets", "my_python_asset.py"))
+	require.NoFileExists(t, filepath.Join(pipelinePath, "assets", "players.asset.yml"))
+}
+
+func TestInitMergeReportsParentConflictsPipelineRelative(t *testing.T) {
+	targetRoot := t.TempDir()
+	pipelinePath := createExistingPipeline(t, targetRoot)
+	// A regular file where the template expects a directory.
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinePath, "assets", "stripe_raw"), []byte("not a directory\n"), 0o644))
+
+	files, err := loadTemplateMergeFiles("stripe-bigquery")
+	require.NoError(t, err)
+	err = collectMergeConflicts(pipelinePath, files)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), filepath.Join("assets", "stripe_raw"))
+	require.NotContains(t, err.Error(), targetRoot)
+	require.NoFileExists(t, filepath.Join(pipelinePath, "assets", "stripe_stage", "customers.sql"))
+}
+
+func TestInitMergeRequiresExistingPipeline(t *testing.T) {
+	targetRoot := t.TempDir()
+	targetPath := filepath.Join(targetRoot, "not-a-pipeline")
+	require.NoError(t, os.MkdirAll(targetPath, 0o755))
+
+	files, err := loadTemplateMergeFiles("default")
+	require.NoError(t, err)
+	err = collectMergeConflicts(targetPath, files)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no pipeline definition file")
+	require.NoDirExists(t, filepath.Join(targetPath, "assets"))
+}
+
+func TestMergeTemplateFilesPreservesNestedAssetDirectories(t *testing.T) {
+	targetRoot := t.TempDir()
+	pipelinePath := createExistingPipeline(t, targetRoot)
+
+	files, err := loadTemplateMergeFiles("stripe-bigquery")
+	require.NoError(t, err)
+	require.Contains(t, mergeFilePaths(files), "assets/stripe_raw/customer.asset.yml")
+	require.NoError(t, collectMergeConflicts(pipelinePath, files))
+	require.NoError(t, writeTemplateFiles(pipelinePath, files))
+
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "stripe_raw", "customer.asset.yml"))
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "stripe_reports", "monthly_subscription_kpis.sql"))
+	// Non-mergeable template files stay behind.
+	require.NoFileExists(t, filepath.Join(pipelinePath, "dashboards", "stripe-billing-analytics.yml"))
+}
+
+func TestLoadTemplateMergeFilesIncludesMacrosAndRequirements(t *testing.T) {
+	duckdbFiles, err := loadTemplateMergeFiles("duckdb")
+	require.NoError(t, err)
+	duckdbPaths := mergeFilePaths(duckdbFiles)
+	require.Contains(t, duckdbPaths, "assets/macro_example.sql")
+	// macro_example.sql calls count_by, which only exists in macros/.
+	require.Contains(t, duckdbPaths, "macros/aggregations.sql")
+	require.NotContains(t, duckdbPaths, "pipeline.yml")
+	require.NotContains(t, duckdbPaths, ".bruin.yml")
+
+	pythonFiles, err := loadTemplateMergeFiles("python")
+	require.NoError(t, err)
+	pythonPaths := mergeFilePaths(pythonFiles)
+	require.Contains(t, pythonPaths, "assets/python311/asset.py")
+	require.Contains(t, pythonPaths, "requirements.txt")
+}
+
+func TestMergeTemplateFilesCopiesMacros(t *testing.T) {
+	targetRoot := t.TempDir()
+	pipelinePath := createExistingPipeline(t, targetRoot)
+
+	files, err := loadTemplateMergeFiles("duckdb")
+	require.NoError(t, err)
+	require.NoError(t, collectMergeConflicts(pipelinePath, files))
+	require.NoError(t, writeTemplateFiles(pipelinePath, files))
+
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "macro_example.sql"))
+	require.FileExists(t, filepath.Join(pipelinePath, "macros", "aggregations.sql"))
+}
+
+func TestLoadTemplateMergeFilesIncludesWrappedPipelines(t *testing.T) {
+	files, err := loadTemplateMergeFiles("self-heal-demo")
+	require.NoError(t, err)
+
+	paths := mergeFilePaths(files)
+	require.Contains(t, paths, "assets/orders.asset.yml")
+	require.Contains(t, paths, "assets/daily_activity.sql")
+}
+
+func TestLoadEcommerceMergeFilesKeepsOnlyMergeablePaths(t *testing.T) {
+	choices := &EcommerceChoices{
+		Warehouse: warehouseClickHouse,
+		Payments:  paymentsStripe,
+		Marketing: marketingKlaviyo,
+		Ads:       []string{adsFacebook},
+		Analytics: analyticsGA4,
+	}
+
+	generated, err := buildEcommerceFiles(choices)
+	require.NoError(t, err)
+	require.Contains(t, generated, "pipeline.yml")
+
+	files, err := loadEcommerceMergeFiles(choices)
+	require.NoError(t, err)
+
+	paths := mergeFilePaths(files)
+	require.Contains(t, paths, "assets/raw/stripe_charges.asset.yml")
+	require.Contains(t, paths, "assets/raw/facebook_campaigns.asset.yml")
+	require.Contains(t, paths, "assets/raw/klaviyo_campaigns.asset.yml")
+	require.Contains(t, paths, "assets/raw/ga4_events.asset.yml")
+	// pipeline.yml is generated but deliberately not merged.
+	require.NotContains(t, paths, "pipeline.yml")
+	require.Len(t, files, len(generated)-1)
+}
+
+func TestInitMergeLeavesProjectUntouchedWhenAssetsCollide(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+	initGitRepository(t, targetRoot)
+	pipelinePath := createExistingPipeline(t, targetRoot)
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinePath, "assets", "player_stats.sql"), []byte("select 'keep me'\n"), 0o644))
+
+	exitCode := captureExitCode(t)
+	err := Init().Run(t.Context(), []string{"init", "default", pipelinePath, "--merge"})
+	require.Error(t, err)
+	require.Equal(t, 1, *exitCode)
+
+	// The config merge must not have run: a conflicting copy is aborted first.
+	require.NoFileExists(t, filepath.Join(targetRoot, ".bruin.yml"))
+	require.NoFileExists(t, filepath.Join(targetRoot, ".gitignore"))
+	require.NoFileExists(t, filepath.Join(pipelinePath, "assets", "my_python_asset.py"))
+}
+
+func TestProjectConfigSummaryReportsExistingConfig(t *testing.T) {
+	targetRoot := t.TempDir()
+	initGitRepository(t, targetRoot)
+	pipelinePath := createExistingPipeline(t, targetRoot)
+	configPath := filepath.Join(targetRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte("default_environment: default\n"), 0o644))
+
+	summary := projectConfigSummary(pipelinePath)
+	require.Equal(t, configPath, summary.path)
+	require.True(t, summary.existed)
+	require.False(t, summary.merged)
+	require.NotEmpty(t, summary.locationNote)
+}
+
+func TestProjectConfigSummaryIsEmptyOutsideAGitRepository(t *testing.T) {
+	targetRoot := t.TempDir()
+	pipelinePath := createExistingPipeline(t, targetRoot)
+
+	require.Equal(t, initConfigSummary{}, projectConfigSummary(pipelinePath))
+}
+
+func TestWriteTemplateFilesRemovesWhatItWroteOnFailure(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("directory permissions do not block file creation on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	targetRoot := t.TempDir()
+	pipelinePath := createExistingPipeline(t, targetRoot)
+
+	files, err := loadTemplateMergeFiles("stripe-bigquery")
+	require.NoError(t, err)
+	require.NoError(t, collectMergeConflicts(pipelinePath, files))
+
+	// A read-only directory makes the copy fail partway through, after the
+	// alphabetically earlier assets/stripe_raw files have been written.
+	blockedDir := filepath.Join(pipelinePath, "assets", "stripe_reports")
+	require.NoError(t, os.MkdirAll(blockedDir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(blockedDir, 0o755) })
+
+	require.Error(t, writeTemplateFiles(pipelinePath, files))
+
+	// Nothing the failed copy wrote is left behind, so a retry is still possible.
+	require.NoFileExists(t, filepath.Join(pipelinePath, "assets", "stripe_raw", "customer.asset.yml"))
+	require.NoError(t, os.Chmod(blockedDir, 0o755))
+	require.NoError(t, collectMergeConflicts(pipelinePath, files))
+	require.NoError(t, writeTemplateFiles(pipelinePath, files))
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "stripe_raw", "customer.asset.yml"))
+	require.FileExists(t, filepath.Join(pipelinePath, "assets", "stripe_reports", "monthly_subscription_kpis.sql"))
+}
+
+func TestInitMergeValidatesDestinationBeforeLoadingTheTemplate(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+	initGitRepository(t, targetRoot)
+	targetPath := filepath.Join(targetRoot, "not-a-pipeline")
+	require.NoError(t, os.MkdirAll(targetPath, 0o755))
+
+	exitCode := captureExitCode(t)
+	err := Init().Run(t.Context(), []string{"init", "default", targetPath, "--merge"})
+	require.Error(t, err)
+	require.Equal(t, 1, *exitCode)
+	require.NoDirExists(t, filepath.Join(targetPath, "assets"))
+	require.NoFileExists(t, filepath.Join(targetRoot, ".bruin.yml"))
+}

--- a/cmd/init_merge_test.go
+++ b/cmd/init_merge_test.go
@@ -356,3 +356,41 @@ func TestInitMergeValidatesDestinationBeforeLoadingTheTemplate(t *testing.T) {
 	require.NoDirExists(t, filepath.Join(targetPath, "assets"))
 	require.NoFileExists(t, filepath.Join(targetRoot, ".bruin.yml"))
 }
+
+func TestWriteFileAtomicallyLeavesNoTemporaryFiles(t *testing.T) {
+	targetRoot := t.TempDir()
+	path := filepath.Join(targetRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(path, []byte("old\n"), 0o644))
+
+	require.NoError(t, writeFileAtomically(path, []byte("new\n")))
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "new\n", string(content))
+
+	entries, err := os.ReadDir(targetRoot)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, ".bruin.yml", entries[0].Name())
+}
+
+func TestWriteFileAtomicallyKeepsTheOriginalOnFailure(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("directory permissions do not block file creation on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	targetRoot := t.TempDir()
+	path := filepath.Join(targetRoot, ".bruin.yml")
+	require.NoError(t, os.WriteFile(path, []byte("keep me\n"), 0o644))
+	require.NoError(t, os.Chmod(targetRoot, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(targetRoot, 0o755) })
+
+	require.Error(t, writeFileAtomically(path, []byte("truncated")))
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "keep me\n", string(content))
+}

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -9,7 +9,7 @@ You can use it to start a new data pipeline project quickly, or to add a new pip
 ## Usage
 
 ```bash
-bruin init [template] [folder] [--in-place]
+bruin init [template] [folder] [--in-place] [--merge]
 ```
 
 ### Examples
@@ -26,6 +26,9 @@ bruin init default --in-place
 
 # Create the self-healing DuckDB demo pipeline
 bruin init self-heal-demo
+
+# Add the default template's assets to an existing pipeline
+bruin init default pipelines/existing --merge
 ```
 
 ## How It Works
@@ -37,6 +40,18 @@ When you run `bruin init`, it:
 3. Merges any template-level `.bruin.yml` configuration into your existing (or newly created) root `.bruin.yml`.
 4. Optionally initializes a **Git repository** if none exists.
 5. Outputs next steps, such as validating or running your new pipeline.
+
+With `--merge`, Bruin instead adds the selected template's `assets/` and
+`macros/` files — plus a pipeline-level `requirements.txt`, `pyproject.toml` or
+`uv.lock` when the template ships one — to the existing pipeline at `folder`, and
+merges the template's `.bruin.yml` into the project-level config. It leaves the
+existing `pipeline.yml`, `README.md` and every other pipeline file unchanged.
+
+Because `pipeline.yml` is not merged, assets that rely on the template's own
+pipeline configuration may need a manual follow-up. For example
+`templates/default` sets `default_connections`, and `templates/stripe-bigquery`
+sets an ingestr `default:` block; copy the keys you need into the destination
+`pipeline.yml` if the merged assets fail to validate.
 
 ## Folder Structure
 
@@ -71,6 +86,10 @@ If Bruin detects no existing `.git` repository:
 * A new Git repository is created (via `git init`).
 * The pipeline is placed under `bruin/` unless `--in-place` is used.
 
+Merge mode does not create a Git repository. If the selected template contains
+`.bruin.yml`, the destination pipeline must already belong to a Git repository so
+Bruin can resolve the project-level config path.
+
 ### Configuration Merge
 
 If the selected template contains its own `.bruin.yml`, Bruin merges:
@@ -80,6 +99,14 @@ If the selected template contains its own `.bruin.yml`, Bruin merges:
 * **Default settings**
 
 into the existing `.bruin.yml` at your project root. This ensures shared environments (like `dev`, `prod`, etc.) stay consistent across pipelines.
+
+The same configuration merge is performed with `--merge`. Merge mode checks every
+destination path for conflicts first, then merges the config, then copies the
+files. A conflict aborts before anything is written, and a copy that fails partway
+removes the files it had already created, so a failed `--merge` is always safe to
+re-run. If the project does not have a `.bruin.yml` yet, Bruin creates it at the
+Git repository root. Templates without `.bruin.yml` leave the project config
+unchanged.
 
 ## Arguments
 
@@ -107,6 +134,25 @@ Initialize the pipeline directly in the current folder, instead of creating a `b
 
 * **Type:** `boolean`
 * **Default:** `false`
+
+### `merge`
+
+Merge the selected template's assets into an existing pipeline instead of creating
+a pipeline from the whole template.
+
+* **Type:** `boolean`
+* **Default:** `false`
+* **Requires:** an explicit `folder` containing `pipeline.yml` or `pipeline.yaml`
+
+The destination may be a nested or absolute path. Bruin preserves the directory
+structure beneath each template `assets/` and `macros/` folder and merges template
+connections into the project-level `.bruin.yml`. If any destination path already
+exists, the command stops before copying anything and lists the conflicts;
+existing files are never overwritten. `--merge` cannot be combined with
+`--in-place`.
+
+If a template contains more than one pipeline (for example `self-heal-demo`), the
+files of all of them are merged into the single destination pipeline.
 
 ## Example Output
 
@@ -169,5 +215,7 @@ The `shopify-clickhouse` template creates raw Shopify ingestion assets, conforme
 ## Notes
 
 * Traversing up/down the filesystem (e.g., `../pipeline`) is not allowed for safety.
+  This restriction does not apply to `--merge`, which must point to an existing pipeline.
 * `.bruin.yml` is automatically created or updated at your **project root** during initialization — the Git repository root when you are inside an existing repo, or a new `bruin/` folder for a fresh project.
+  Merge mode also updates it when the selected template provides configuration.
 * The command is safe to run multiple times — Bruin intelligently merges existing configuration.


### PR DESCRIPTION
## What

`bruin init <template> <path> --merge` adds a template's assets to a pipeline you already have, instead of scaffolding a whole new one. It copies `assets/`, `macros/` and pipeline-root `requirements.txt`/`pyproject.toml`/`uv.lock`, and merges the template's `.bruin.yml` into the project-level config. Nothing is ever overwritten: it collects every destination conflict first, merges the config next, copies files last, and a copy that fails partway removes what it wrote, so a failed merge is safe to re-run.

`macros/` and `requirements.txt` come along because several templates put asset dependencies there — `templates/duckdb`'s `macro_example.sql` calls `count_by`, which only exists in `macros/`, and `templates/python`'s asset imports `cowsay` from the pipeline-root `requirements.txt`.

## Changes

- `cmd/init.go` — new `--merge` flag; `loadTemplateMergeFiles` walks every `assets/` dir in a template (so wrapped and multi-pipeline templates work) and collects the mergeable files per pipeline root; `collectMergeConflicts` / `writeTemplateFiles` split so conflicts abort before anything is written; `mergeTemplateConfigIntoProject` resolves the project `.bruin.yml` from the Git root; `projectConfigSummary` for templates that ship no config. `--merge` rejects `--in-place` and a missing path before any interactive picker runs.
- `cmd/init_merge_test.go` — new; covers the happy path, nested asset dirs, macros/requirements, collision and parent-file conflicts, rollback, both guard rails, and the ecommerce merge path.
- `docs/commands/init.md` — documents the flag, what is and isn't merged (`pipeline.yml` isn't, so `default_connections` may need copying by hand), and the ordering guarantees.

## How to test

1. `make build`
2. `./bin/bruin init default pipelines/existing --merge` against a pipeline that already has a `pipeline.yml` — assets land in `assets/`, existing files are untouched, `.bruin.yml` is merged at the repo root.
3. Re-run it — the command lists the conflicting paths and writes nothing.
4. `./bin/bruin init duckdb <pipeline> --merge && ./bin/bruin validate <pipeline>` — the macro-using asset renders because `macros/` came along.

## Risk & rollback

- **Risk:** low — `--merge` is a new opt-in flag; the existing `bruin init` paths are unchanged.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test-light`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

Merge destinations are validated as local paths below the requested pipeline, files are created with `O_EXCL`, and symlinked `assets`/`macros` directories are reported as conflicts rather than followed.

## Related issues
