### PR TITLE
ci: reduce docs checkout overhead and cache locked dependencies

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          # VitePress lastUpdated is disabled; pages and sitemap need no history.
+          fetch-depth: 1
       # - uses: pnpm/action-setup@v2 # Uncomment this if you're using pnpm
       # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
       - name: Setup Node

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -5,10 +5,20 @@ on:
     branches: [ main ]
     paths:
       - 'docs/**'
+      - '.github/workflows/docs-build.yml'
+      - '.github/workflows/deploy-docs.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.npmrc'
   pull_request:
     branches: [ main ]
     paths:
       - 'docs/**'
+      - '.github/workflows/docs-build.yml'
+      - '.github/workflows/deploy-docs.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.npmrc'
 
 jobs:
   docs-build:
@@ -20,16 +30,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          fetch-depth: 0
+          # VitePress lastUpdated is disabled; pages and sitemap need no history.
+          fetch-depth: 1
 
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22.14.0'
+          cache: npm
 
       - name: Install dependencies with npm@11 (for min-release-age support)
-        run: npx npm@11.10.0 install
+        run: npx npm@11.10.0 ci
 
 
       - name: Build documentation


### PR DESCRIPTION
## Summary

- Use depth-one checkout for docs validation and Pages builds. VitePress `lastUpdated` is disabled, and neither the config nor custom docs code consumes Git history. VitePress only adds sitemap `lastmod` from enabled page timestamps.
- Cache npm downloads for docs validation and use pinned `npm@11.10.0 ci`, matching the existing deployment install. Keep the lockfile and seven-day minimum-release-age policy unchanged.
- Validate changes to both docs workflows, package manifests/lockfile, and `.npmrc`, not just `docs/**`.

No test/OS/race/lint coverage, deployment triggers/permissions/concurrency, or documentation appearance is changed.

## Validation

- `npx --yes npm@11.10.0 ci`: 326 packages installed, zero audit vulnerabilities, no lockfile edits.
- `npm run docs:build`: successful (37.07s locally).
- Rebuilt an identical docs tree outside any Git repository: successful (35.84s). Sitemap byte comparison and all generated HTML text comparison pass. Generated asset hashes/random code-tab IDs prevent a raw byte-for-byte bundle comparison.
- actionlint v1.7.7 passes for both workflows with the existing Depot runner label declared in a temporary config (shellcheck unavailable).
- `git diff --check` passes. Full Go format/test targets are not run locally for workflow-only changes, per repository guidance; the PR still triggers the unchanged cross-OS CI Checks workflow.

## Evidence and follow-up

The 24–30 August review found Docs Build p50 69s, p95 623s, with checkout as high as 832s. Revalidation against the six latest successful first-attempt PR docs jobs on September 5 shows a much healthier current baseline: creation-to-last-job wall times 46, 48, 67, 49, 49, 47s (median 48.5s); checkout 8, 9, 13, 9, 8, 8s (median 8.5s); install median 6s. The old tail is historical evidence, not the current median or a promised saving.

All six historical lint failures are actual lint diagnostics (noctx, gci, copyloopvar/dupword/predeclared, nilerr, perfsprint), not demonstrated flakes. A current successful core run has warm Go/Rust caches, full lint 8s, Linux tests 95s, Windows tests 135s, and zero Wait-for-R delay. A preceding failure reports a test data race. These do not support blanket sharding or duplicate caches, so core CI is unchanged.

CI measurements will be added after natural PR checks finish. Compare docs and core workflows separately, successful first attempts only, using creation-to-last-job wall time including waits; report sample counts and cancelled/action-required outcomes separately. No manual benchmark rerun batches or deployment are requested by this PR.
