### PR TITLE
docs: surface the cloud command in the Bruin Cloud section

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -175,6 +175,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             {text: "Audit Logs", link: "/cloud/audit-logs"},
                         ],
                     },
+                    {text: "Cloud Command", link: "/commands/cloud"},
                     {text: "Cloud MCP", link: "/cloud/mcp-setup"},
                     {text: "FAQ", link: "/cloud/faq"},
                 ],

--- a/docs/cloud/overview.md
+++ b/docs/cloud/overview.md
@@ -41,6 +41,7 @@ From there:
 - [Instance Types](/cloud/instance-types): sizing assets at run time.
 - [Security](/cloud/security): network access and dedicated egress IPs for allowlisting.
 - [Team Settings](/cloud/team-settings), [API Tokens](/cloud/api-tokens), [Audit Logs](/cloud/audit-logs): team administration.
+- [`cloud` command](/commands/cloud): list projects, check runs, diagnose failures, and drive Bruin Cloud from your terminal.
 - [Cloud MCP](/cloud/mcp-setup): talk to Bruin Cloud from Cursor, Claude Code, or Codex.
 - [FAQ](/cloud/faq): short answers to common questions, including patterns that look plausible but are not real features.
 


### PR DESCRIPTION
## What

The `bruin cloud` CLI reference (`/commands/cloud`) was only reachable from the **Commands** sidebar section, so people browsing the **Bruin Cloud** docs had a hard time finding it.

Per the feedback ("it's part of the CLI, but maybe add redundant pages that link the same page in multiple places"), this keeps the page where it is and adds redundant entry points into it:

- **Sidebar**: new `Cloud Command` entry in the Bruin Cloud section pointing at `/commands/cloud` (the existing entry in the Commands section stays — same page, two locations).
- **Overview**: inline link to the `` `cloud` `` command in the Bruin Cloud overview page list.

No pages moved and no content was duplicated.

## Terminology

Labels match existing usage across the docs — the page title `` `cloud` Command ``, the command's own Related Topics widget ("Cloud Command"), and the backticked `` [`cloud` command] `` form already used in `api-tokens.md` and `mcp-setup.md`.

## Testing

Docs-only change. Built the site locally with `vitepress dev`; both `/cloud/overview` and `/commands/cloud` resolve and the new sidebar/inline links point at the command reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)