### PR TITLE
Add read-only PostgreSQL connections

### DIFF
--- a/docs/platforms/postgres.md
+++ b/docs/platforms/postgres.md
@@ -18,10 +18,13 @@ In order to set up a PostgreSQL connection, you need to add a configuration item
           ssl_mode: "allow" # optional
           schema: "schema_name" # optional
           pool_max_conns: 5 # optional
+          read_only: true # optional, defaults to false
 ```
 
 > [!NOTE]
 > `ssl_mode` should be one of the modes describe in the [documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).
+
+When `read_only` is `true`, Bruin starts PostgreSQL sessions with `default_transaction_read_only` enabled. Write statements will fail unless the session explicitly overrides that setting. For strict access control, also grant the connection's PostgreSQL role read-only permissions.
 
 ## PostgreSQL Assets
 

--- a/integration-tests/cloud-integration-tests/postgres/postgres_test.go
+++ b/integration-tests/cloud-integration-tests/postgres/postgres_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -677,6 +678,8 @@ func TestPostgresIndividualTasks(t *testing.T) {
 }
 
 func TestPostgresReadOnlyConnection(t *testing.T) {
+	t.Parallel()
+
 	currentFolder, err := os.Getwd()
 	require.NoError(t, err)
 
@@ -703,32 +706,32 @@ parameters:
   destination: postgres
   strategy: replace
 `), 0o600))
-	gitInit := exec.Command("git", "init")
+	gitInit := exec.CommandContext(t.Context(), "git", "init")
 	gitInit.Dir = tempDir
 	output, err := gitInit.CombinedOutput()
 	require.NoError(t, err, "failed to initialize test repository: %s", output)
 
-	cleanupTable := func(tableName string) {
-		cleanup := exec.Command(binary, "query", "--config-file", sourceConfigPath, "--connection", "postgres-default", "--query", "DROP TABLE IF EXISTS "+tableName+";") //nolint:gosec
+	cleanupTable := func(ctx context.Context, tableName string) {
+		cleanup := exec.CommandContext(ctx, binary, "query", "--config-file", sourceConfigPath, "--connection", "postgres-default", "--query", "DROP TABLE IF EXISTS "+tableName+";") //nolint:gosec
 		_ = cleanup.Run()
 	}
-	cleanupTable("public.bruin_read_only_native_probe")
-	cleanupTable("public.bruin_read_only_ingestr_probe")
+	cleanupTable(t.Context(), "public.bruin_read_only_native_probe")
+	cleanupTable(t.Context(), "public.bruin_read_only_ingestr_probe")
 	t.Cleanup(func() {
-		cleanupTable("public.bruin_read_only_native_probe")
-		cleanupTable("public.bruin_read_only_ingestr_probe")
+		cleanupTable(context.Background(), "public.bruin_read_only_native_probe")
+		cleanupTable(context.Background(), "public.bruin_read_only_ingestr_probe")
 	})
 
-	output, err = exec.Command(binary, "query", "--config-file", readOnlyConfigPath, "--connection", "postgres-readonly", "--output", "csv", "--query", "SHOW default_transaction_read_only;").CombinedOutput() //nolint:gosec
+	output, err = exec.CommandContext(t.Context(), binary, "query", "--config-file", readOnlyConfigPath, "--connection", "postgres-readonly", "--output", "csv", "--query", "SHOW default_transaction_read_only;").CombinedOutput() //nolint:gosec
 	require.NoError(t, err, "read query failed: %s", output)
 	normalizedOutput := strings.ReplaceAll(strings.ToLower(string(output)), "\r\n", "\n")
 	require.Contains(t, normalizedOutput, "\non\n")
 
-	output, err = exec.Command(binary, "query", "--config-file", readOnlyConfigPath, "--connection", "postgres-readonly", "--query", "CREATE TABLE public.bruin_read_only_native_probe (id integer);").CombinedOutput() //nolint:gosec
+	output, err = exec.CommandContext(t.Context(), binary, "query", "--config-file", readOnlyConfigPath, "--connection", "postgres-readonly", "--query", "CREATE TABLE public.bruin_read_only_native_probe (id integer);").CombinedOutput() //nolint:gosec
 	require.Error(t, err, "write unexpectedly succeeded: %s", output)
 	require.Contains(t, strings.ToLower(string(output)), "read-only transaction")
 
-	output, err = exec.Command(binary, "run", "--config-file", readOnlyConfigPath, "--env", "default", assetPath).CombinedOutput() //nolint:gosec
+	output, err = exec.CommandContext(t.Context(), binary, "run", "--config-file", readOnlyConfigPath, "--env", "default", assetPath).CombinedOutput() //nolint:gosec
 	require.Error(t, err, "ingestr write unexpectedly succeeded: %s", output)
 	require.Contains(t, strings.ToLower(string(output)), "read-only transaction")
 }

--- a/integration-tests/cloud-integration-tests/postgres/postgres_test.go
+++ b/integration-tests/cloud-integration-tests/postgres/postgres_test.go
@@ -3,12 +3,15 @@ package postgres
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/bruin-data/bruin/pkg/config"
 	"github.com/bruin-data/bruin/pkg/e2e"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestPostgresWorkflows(t *testing.T) {
@@ -671,6 +674,115 @@ func TestPostgresIndividualTasks(t *testing.T) {
 			t.Logf("Task '%s' completed successfully", task.Name)
 		})
 	}
+}
+
+func TestPostgresReadOnlyConnection(t *testing.T) {
+	currentFolder, err := os.Getwd()
+	require.NoError(t, err)
+
+	projectRoot := filepath.Join(currentFolder, "../../../")
+	binary := filepath.Join(projectRoot, "bin/bruin")
+	sourceConfigPath := filepath.Join(projectRoot, "integration-tests/cloud-integration-tests/.bruin.cloud.yml")
+	tempDir := t.TempDir()
+	readOnlyConfigPath := filepath.Join(tempDir, ".bruin.yml")
+	csvPath := filepath.Join(tempDir, "source.csv")
+	assetDir := filepath.Join(tempDir, "assets")
+	assetPath := filepath.Join(assetDir, "readonly.asset.yml")
+
+	require.NoError(t, os.MkdirAll(assetDir, 0o755))
+	require.NoError(t, os.WriteFile(csvPath, []byte("id,name\n1,test\n"), 0o600))
+	writeReadOnlyPostgresConfig(t, sourceConfigPath, readOnlyConfigPath, csvPath)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "pipeline.yml"), []byte("name: postgres-read-only-test\n"), 0o600))
+	require.NoError(t, os.WriteFile(assetPath, []byte(`name: public.bruin_read_only_ingestr_probe
+type: ingestr
+connection: postgres-readonly
+
+parameters:
+  source_connection: csv-readonly-source
+  source_table: sample
+  destination: postgres
+  strategy: replace
+`), 0o600))
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = tempDir
+	output, err := gitInit.CombinedOutput()
+	require.NoError(t, err, "failed to initialize test repository: %s", output)
+
+	cleanupTable := func(tableName string) {
+		cleanup := exec.Command(binary, "query", "--config-file", sourceConfigPath, "--connection", "postgres-default", "--query", "DROP TABLE IF EXISTS "+tableName+";") //nolint:gosec
+		_ = cleanup.Run()
+	}
+	cleanupTable("public.bruin_read_only_native_probe")
+	cleanupTable("public.bruin_read_only_ingestr_probe")
+	t.Cleanup(func() {
+		cleanupTable("public.bruin_read_only_native_probe")
+		cleanupTable("public.bruin_read_only_ingestr_probe")
+	})
+
+	output, err = exec.Command(binary, "query", "--config-file", readOnlyConfigPath, "--connection", "postgres-readonly", "--output", "csv", "--query", "SHOW default_transaction_read_only;").CombinedOutput() //nolint:gosec
+	require.NoError(t, err, "read query failed: %s", output)
+	normalizedOutput := strings.ReplaceAll(strings.ToLower(string(output)), "\r\n", "\n")
+	require.Contains(t, normalizedOutput, "\non\n")
+
+	output, err = exec.Command(binary, "query", "--config-file", readOnlyConfigPath, "--connection", "postgres-readonly", "--query", "CREATE TABLE public.bruin_read_only_native_probe (id integer);").CombinedOutput() //nolint:gosec
+	require.Error(t, err, "write unexpectedly succeeded: %s", output)
+	require.Contains(t, strings.ToLower(string(output)), "read-only transaction")
+
+	output, err = exec.Command(binary, "run", "--config-file", readOnlyConfigPath, "--env", "default", assetPath).CombinedOutput() //nolint:gosec
+	require.Error(t, err, "ingestr write unexpectedly succeeded: %s", output)
+	require.Contains(t, strings.ToLower(string(output)), "read-only transaction")
+}
+
+func writeReadOnlyPostgresConfig(t *testing.T, sourcePath, destinationPath, csvPath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+
+	var sourceConfig config.Config
+	require.NoError(t, yaml.Unmarshal(data, &sourceConfig))
+
+	environmentName := sourceConfig.DefaultEnvironmentName
+	if environmentName == "" {
+		environmentName = "default"
+	}
+	environment, ok := sourceConfig.Environments[environmentName]
+	require.True(t, ok, "environment %q not found", environmentName)
+	require.NotNil(t, environment.Connections)
+
+	var readOnlyConnection config.PostgresConnection
+	found := false
+	for _, connection := range environment.Connections.Postgres {
+		if connection.Name == "postgres-default" {
+			connection.Name = "postgres-readonly"
+			connection.ReadOnly = true
+			readOnlyConnection = connection
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "postgres-default connection not found")
+
+	testConfig := config.Config{
+		DefaultEnvironmentName: "default",
+		Environments: map[string]config.Environment{
+			"default": {
+				Connections: &config.Connections{
+					Postgres: []config.PostgresConnection{readOnlyConnection},
+					CSV: []config.CSVConnection{
+						{
+							ConnectionMetadata: config.ConnectionMetadata{Name: "csv-readonly-source"},
+							Path:               csvPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	encoded, err := yaml.Marshal(testConfig)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(destinationPath, encoded, 0o600))
 }
 
 func readQueryFromFile(filePath string) string {

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -4344,6 +4344,9 @@
         },
         "ssl_mode": {
           "type": "string"
+        },
+        "read_only": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -512,6 +512,7 @@ type PostgresConnection struct {
 	Schema             string `yaml:"schema,omitempty" json:"schema,omitempty" mapstructure:"schema"`
 	PoolMaxConns       int    `yaml:"pool_max_conns,omitempty" json:"pool_max_conns,omitempty" mapstructure:"pool_max_conns" default:"10"`
 	SslMode            string `yaml:"ssl_mode,omitempty" json:"ssl_mode,omitempty" mapstructure:"ssl_mode" default:"allow"`
+	ReadOnly           bool   `yaml:"read_only,omitempty" json:"read_only,omitempty" mapstructure:"read_only"`
 }
 
 func (c PostgresConnection) GetName() string {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -70,6 +70,7 @@ func TestLoadFromFile(t *testing.T) {
 					Port:               5432,
 					PoolMaxConns:       5,
 					SslMode:            "require",
+					ReadOnly:           true,
 				},
 			},
 			RedShift: []RedshiftConnection{
@@ -4052,6 +4053,7 @@ func TestGetConnectionFieldsForTypeIncludesMaxConcurrentAssets(t *testing.T) {
 	}
 
 	assert.Contains(t, names, "max_concurrent_assets")
+	assert.Contains(t, names, "read_only")
 	assert.NotContains(t, names, "name")
 }
 

--- a/pkg/config/testdata/simple.yml
+++ b/pkg/config/testdata/simple.yml
@@ -29,6 +29,7 @@ environments:
           schema: "non_public_schema"
           pool_max_conns: 5
           ssl_mode: "require"
+          read_only: true
 
       redshift:
         - name: conn4

--- a/pkg/config/testdata/simple_win.yml
+++ b/pkg/config/testdata/simple_win.yml
@@ -29,6 +29,7 @@ environments:
           schema: "non_public_schema"
           pool_max_conns: 5
           ssl_mode: "require"
+          read_only: true
 
       redshift:
         - name: conn4

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1052,6 +1052,7 @@ func (m *Manager) addPgLikeConnectionFromConfig(ctx context.Context, connection 
 			Schema:       connection.Schema,
 			PoolMaxConns: poolMaxConns,
 			SslMode:      connection.SslMode,
+			ReadOnly:     connection.ReadOnly,
 		})
 	}
 

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -140,14 +140,20 @@ func TestManager_AddPgConnectionFromConfig(t *testing.T) {
 		Port:               15432,
 		SslMode:            "disable",
 		PoolMaxConns:       10,
+		ReadOnly:           true,
 	}
 
 	err := m.AddPgConnectionFromConfig(t.Context(), configuration)
 	require.NoError(t, err)
 
-	res, ok := m.GetConnection("test").(postgres.PgClient)
-	assert.True(t, ok)
-	assert.NotNil(t, res)
+	pgClient, ok := m.GetConnection("test").(*postgres.Client)
+	require.True(t, ok)
+	require.NotNil(t, pgClient)
+
+	uri, err := pgClient.GetIngestrURI()
+	require.NoError(t, err)
+	assert.Equal(t, "postgresql://user:pass@somehost:15432/db?sslmode=disable&options=-c+default_transaction_read_only%3Don", uri)
+	assert.Equal(t, configuration, m.GetConnectionDetails("test"))
 }
 
 func TestManager_AddRedshiftConnectionFromConfig(t *testing.T) {

--- a/pkg/postgres/config.go
+++ b/pkg/postgres/config.go
@@ -5,7 +5,10 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 )
+
+const readOnlySessionOption = "-c default_transaction_read_only=on"
 
 type Config struct {
 	Username     string
@@ -16,6 +19,7 @@ type Config struct {
 	Schema       string
 	PoolMaxConns int
 	SslMode      string
+	ReadOnly     bool
 }
 
 // ToDBConnectionURI returns a connection URI to be used with the pgx package.
@@ -32,6 +36,9 @@ func (c Config) ToDBConnectionURI() string {
 	if c.Schema != "" {
 		connectionURI += "&search_path=" + c.Schema
 	}
+	if c.ReadOnly {
+		connectionURI += "&options=" + url.QueryEscape(readOnlySessionOption)
+	}
 
 	return connectionURI
 }
@@ -45,8 +52,15 @@ func (c Config) GetIngestrURI() string {
 		c.Database,
 	)
 
+	queryParams := make([]string, 0, 2)
 	if c.SslMode != "" {
-		connString += "?sslmode=" + c.SslMode
+		queryParams = append(queryParams, "sslmode="+url.QueryEscape(c.SslMode))
+	}
+	if c.ReadOnly {
+		queryParams = append(queryParams, "options="+url.QueryEscape(readOnlySessionOption))
+	}
+	if len(queryParams) > 0 {
+		connString += "?" + strings.Join(queryParams, "&")
 	}
 
 	return connString

--- a/pkg/postgres/config_test.go
+++ b/pkg/postgres/config_test.go
@@ -8,32 +8,80 @@ import (
 
 func TestConfig_ToDBConnectionURI(t *testing.T) {
 	t.Parallel()
-	c := Config{
-		Username:     "user",
-		Password:     "password",
-		Host:         "localhost",
-		Port:         5432,
-		Database:     "database",
-		Schema:       "schema",
-		PoolMaxConns: 10,
-		SslMode:      "disable",
+
+	tests := []struct {
+		name     string
+		readOnly bool
+		expected string
+	}{
+		{
+			name:     "read-write",
+			readOnly: false,
+			expected: "postgres://user:password@localhost:5432/database?sslmode=disable&pool_max_conns=10&search_path=schema",
+		},
+		{
+			name:     "read-only",
+			readOnly: true,
+			expected: "postgres://user:password@localhost:5432/database?sslmode=disable&pool_max_conns=10&search_path=schema&options=-c+default_transaction_read_only%3Don",
+		},
 	}
 
-	assert.Equal(t, "postgres://user:password@localhost:5432/database?sslmode=disable&pool_max_conns=10&search_path=schema", c.ToDBConnectionURI())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := Config{
+				Username:     "user",
+				Password:     "password",
+				Host:         "localhost",
+				Port:         5432,
+				Database:     "database",
+				Schema:       "schema",
+				PoolMaxConns: 10,
+				SslMode:      "disable",
+				ReadOnly:     tt.readOnly,
+			}
+
+			assert.Equal(t, tt.expected, c.ToDBConnectionURI())
+		})
+	}
 }
 
 func TestConfig_ToIngestr(t *testing.T) {
 	t.Parallel()
-	c := Config{
-		Username:     "user",
-		Password:     "password",
-		Host:         "localhost",
-		Port:         5432,
-		Database:     "database",
-		Schema:       "schema",
-		PoolMaxConns: 10,
-		SslMode:      "disable",
+
+	tests := []struct {
+		name     string
+		readOnly bool
+		expected string
+	}{
+		{
+			name:     "read-write",
+			readOnly: false,
+			expected: "postgresql://user:password@localhost:5432/database?sslmode=disable",
+		},
+		{
+			name:     "read-only",
+			readOnly: true,
+			expected: "postgresql://user:password@localhost:5432/database?sslmode=disable&options=-c+default_transaction_read_only%3Don",
+		},
 	}
 
-	assert.Equal(t, "postgresql://user:password@localhost:5432/database?sslmode=disable", c.GetIngestrURI())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := Config{
+				Username:     "user",
+				Password:     "password",
+				Host:         "localhost",
+				Port:         5432,
+				Database:     "database",
+				Schema:       "schema",
+				PoolMaxConns: 10,
+				SslMode:      "disable",
+				ReadOnly:     tt.readOnly,
+			}
+
+			assert.Equal(t, tt.expected, c.GetIngestrURI())
+		})
+	}
 }


### PR DESCRIPTION
## What
Add an optional `read_only` flag for PostgreSQL connections.

## Changes
- Enforce `default_transaction_read_only` for pgx and ingestr sessions, with config schema, tests, and docs.

## How to test
1. Set `read_only: true` on a PostgreSQL connection and verify reads work while writes fail.

## Risk & rollback
- **Risk:** Low; the new behavior is opt-in.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [x] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
N/A