### PR TITLE
fix(pipeline): enforce variable enum, min, and max constraints

### DIFF
--- a/cmd/const_test.go
+++ b/cmd/const_test.go
@@ -214,4 +214,35 @@ func TestVariableOverridesMutator_VariantWinsOnOverlap(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `no such variable "nope"`)
 	})
+
+	t.Run("invalid enum --var is rejected", func(t *testing.T) {
+		t.Parallel()
+		p := &pipeline.Pipeline{
+			Variables: pipeline.Variables{
+				"seat_denominator": {"type": "string", "enum": []any{"reachable", "contracted"}, "default": "reachable"},
+			},
+		}
+
+		mutator := variableOverridesMutator([]string{`seat_denominator="Contracted"`})
+		_, err := mutator(t.Context(), p)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `invalid variable "seat_denominator"`)
+		assert.ErrorContains(t, err, "not one of the allowed values")
+		assert.Equal(t, "reachable", p.Variables["seat_denominator"]["default"])
+	})
+
+	t.Run("out of range --var is rejected", func(t *testing.T) {
+		t.Parallel()
+		p := &pipeline.Pipeline{
+			Variables: pipeline.Variables{
+				"forecast_days": {"type": "integer", "minimum": 7, "maximum": 90, "default": int64(30)},
+			},
+		}
+
+		mutator := variableOverridesMutator([]string{"forecast_days=0"})
+		_, err := mutator(t.Context(), p)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "below minimum")
+		assert.Equal(t, int64(30), p.Variables["forecast_days"]["default"])
+	})
 }

--- a/docs/getting-started/templates-docs/posthog-bigquery-README.md
+++ b/docs/getting-started/templates-docs/posthog-bigquery-README.md
@@ -515,12 +515,12 @@ the warehouse cannot speak to.
 
 ### Variable validation and macro loading
 
-The `enum`, `minimum`, and `maximum` keywords on these variables are currently
-documentation rather than enforcement — Bruin validates that a variable has a
-default and little else, and `--var` overrides skip schema checks. Where getting
+The `enum`, `minimum`, and `maximum` keywords on these variables are enforced
+on defaults, `--var` overrides, and variant values. A typo such as
+`--var seat_denominator='"Contracted"'` fails before any asset runs. Where getting
 a value wrong would silently produce plausible-but-wrong numbers rather than an
-obvious break, the SQL fails the run itself: an unrecognised `seat_denominator`
-stops `posthog_stage.accounts` with
+obvious break, the SQL still fails the run itself as a second line of defence: an
+unrecognised `seat_denominator` stops `posthog_stage.accounts` with
 `seat_denominator must be "reachable" or "contracted", got …` instead of quietly
 falling back to a default.
 

--- a/docs/pipelines/definition.md
+++ b/docs/pipelines/definition.md
@@ -488,6 +488,6 @@ variables:
 
 - **Type:** `Object (map[string]variable-schema)`
 
-Each variable must include a `default` value. Variables are defined using [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html) keywords.
+Each variable must include a `default` value. Variables are defined using [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html) keywords. Bruin validates `type`, `enum`, `const`, `minimum`, and `maximum` on defaults, `--var` overrides, and variant values.
 
 See the **[Variables reference](/variables/overview)** for the full list of supported types, keywords (`enum`, `minimum`, `pattern`, etc.), complex type examples, and runtime overrides.

--- a/docs/pipelines/variants.md
+++ b/docs/pipelines/variants.md
@@ -63,7 +63,7 @@ Rules:
 - **Variant name** must match `[a-zA-Z0-9_-]+`.
 - **Variable names** under each variant must reference variables already declared in the pipeline's `variables:` block. Unknown names fail validation with `references unknown variable "X"`.
 - A variant can override **any subset** of variables; unmentioned variables keep their `default` value.
-- Variant overrides must match the type of the underlying variable (e.g., a variable typed as `integer` cannot be overridden with a string).
+- Variant overrides must match the type of the underlying variable (e.g., a variable typed as `integer` cannot be overridden with a string) and any `enum`, `const`, `minimum`, or `maximum` constraints declared on that variable.
 
 ## Running a Variant
 

--- a/docs/variables/custom.md
+++ b/docs/variables/custom.md
@@ -29,7 +29,7 @@ variables:
 
 ## Supported JSON Schema Keywords
 
-Bruin accepts [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html) keywords in variable definitions. At parse time, it currently enforces that each variable has a `default` value; full schema validation is not yet enforced.
+Bruin accepts [JSON Schema draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html) keywords in variable definitions. At parse time it requires a `default` and checks that the default — and any `--var` or variant override — matches the declared `type`, `enum`, `const`, `minimum`, and `maximum`. Nested keywords such as `items`, `properties`, and `pattern` are stored for documentation and downstream tools but are not compiled as a full JSON Schema.
 
 | `type` value | Description | Example default |
 |--------------|-------------|-----------------|

--- a/pkg/pipeline/variables.go
+++ b/pkg/pipeline/variables.go
@@ -3,35 +3,24 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/xeipuuv/gojsonschema"
+	"reflect"
+	"sort"
 )
-
-func varSchemaLoader() *gojsonschema.SchemaLoader { //nolint:unused
-	loader := gojsonschema.NewSchemaLoader()
-	loader.Draft = gojsonschema.Draft7
-	loader.Validate = true
-	return loader
-}
 
 type Variables map[string]map[string]any
 
 func (v *Variables) Validate() error {
-	// TODO(turtledev):
-	// - validate the defaults actually satisfy the schema
-	// - make "properties" a required field for object types
-	//
-	// BUG: Schema compiler fetches the schema from the spec URL, which may break
-	// in environments where internet access is restricted.
+	if v == nil || *v == nil {
+		return nil
+	}
 
-	// TODO: Use a local copy of the schema.
-	// _, err := varSchemaLoader().Compile(gojsonschema.NewGoLoader(v.Schema()))
-	// if err != nil {
-	// 	return fmt.Errorf("invalid variables schema: %w", err)
-	// }
-	for key, value := range *v {
+	for _, key := range sortedVariableKeys(*v) {
+		value := (*v)[key]
 		if _, ok := value["default"]; !ok {
 			return fmt.Errorf("invalid variable %q: must have a default value", key)
+		}
+		if err := validateVariableValue(value["default"], value); err != nil {
+			return fmt.Errorf("invalid variable %q: %w", key, err)
 		}
 	}
 	return nil
@@ -70,13 +59,157 @@ func (v *Variables) Schema() any {
 }
 
 func (v *Variables) Merge(other map[string]any) error {
-	for key, value := range other {
-		if _, ok := (*v)[key]; !ok {
+	if len(other) == 0 {
+		return nil
+	}
+
+	for _, key := range sortedVariableKeys(other) {
+		schema, ok := (*v)[key]
+		if !ok {
 			return fmt.Errorf("no such variable %q", key)
+		}
+		if err := validateVariableValue(other[key], schema); err != nil {
+			return fmt.Errorf("invalid variable %q: %w", key, err)
+		}
+	}
+
+	for key, value := range other {
+		// An empty YAML body such as `foo:` decodes to a nil map, which cannot be assigned to.
+		if (*v)[key] == nil {
+			(*v)[key] = make(map[string]any, 1)
 		}
 		(*v)[key]["default"] = value
 	}
 	return nil
+}
+
+// validateVariableValue checks a default or override against the constraints
+// declared on the variable. Unknown `type` values are accepted so in-progress
+// templates (for example `type: TODO`) keep parsing. Nested keywords such as
+// `items`, `properties`, and `pattern` are stored but not compiled.
+func validateVariableValue(value any, schema map[string]any) error {
+	if err := validateOverrideType(value, schema); err != nil {
+		return err
+	}
+	if err := validateEnum(value, schema); err != nil {
+		return err
+	}
+	if err := validateConst(value, schema); err != nil {
+		return err
+	}
+	return validateNumericBounds(value, schema)
+}
+
+func validateEnum(value any, schema map[string]any) error {
+	allowed, ok := schemaSlice(schema, "enum")
+	if !ok {
+		return nil
+	}
+	for _, candidate := range allowed {
+		if jsonValuesEqual(value, candidate) {
+			return nil
+		}
+	}
+	return fmt.Errorf("value %v is not one of the allowed values %v", value, allowed)
+}
+
+func validateConst(value any, schema map[string]any) error {
+	expected, ok := schema["const"]
+	if !ok {
+		return nil
+	}
+	if jsonValuesEqual(value, expected) {
+		return nil
+	}
+	return fmt.Errorf("value %v does not match const %v", value, expected)
+}
+
+func validateNumericBounds(value any, schema map[string]any) error {
+	number, isNumber := asFloat64(value)
+	if !isNumber {
+		return nil
+	}
+
+	if minBound, ok := asFloat64(schema["minimum"]); ok && number < minBound {
+		return fmt.Errorf("value %v is below minimum %v", value, schema["minimum"])
+	}
+	if maxBound, ok := asFloat64(schema["maximum"]); ok && number > maxBound {
+		return fmt.Errorf("value %v is above maximum %v", value, schema["maximum"])
+	}
+	return nil
+}
+
+func schemaSlice(schema map[string]any, key string) ([]any, bool) {
+	raw, ok := schema[key]
+	if !ok || raw == nil {
+		return nil, false
+	}
+	switch values := raw.(type) {
+	case []any:
+		return values, true
+	default:
+		rv := reflect.ValueOf(raw)
+		if rv.Kind() != reflect.Slice {
+			return nil, false
+		}
+		out := make([]any, rv.Len())
+		for i := range rv.Len() {
+			out[i] = rv.Index(i).Interface()
+		}
+		return out, true
+	}
+}
+
+func jsonValuesEqual(a, b any) bool {
+	af, aNum := asFloat64(a)
+	bf, bNum := asFloat64(b)
+	if aNum && bNum {
+		return af == bf
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func asFloat64(value any) (float64, bool) {
+	switch n := value.(type) {
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func sortedVariableKeys[V any](variables map[string]V) []string {
+	keys := make([]string, 0, len(variables))
+	for key := range variables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // This ensures that when an empty object {} is provided, it clears the variables.

--- a/pkg/pipeline/variables_test.go
+++ b/pkg/pipeline/variables_test.go
@@ -7,23 +7,12 @@ import (
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestVariables(t *testing.T) {
 	t.Parallel()
 
-	// TODO: restore this test when meta-schema validation is implemented
-	// t.Run("Should return an error if the variables are not valid JSONSchema object", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	vars := pipeline.Variables{
-	// 		"user": {
-	// 			"type": "complex",
-	// 		},
-	// 	}
-	// 	err := vars.Validate()
-	// 	require.Error(t, err)
-	// 	assert.Contains(t, err.Error(), "invalid variables schema")
-	// })
 	t.Run("Should return an error if the default is not set", func(t *testing.T) {
 		t.Parallel()
 		vars := pipeline.Variables{
@@ -104,6 +93,143 @@ func TestVariables(t *testing.T) {
 			"active": true,
 		}
 		assert.Equal(t, expect, vars.Value())
+	})
+	t.Run("unknown type values stay permitted so in-progress templates still parse", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"taxi_types": map[string]any{
+				"type":    "TODO",
+				"default": "TODO",
+			},
+		}
+		require.NoError(t, vars.Validate())
+	})
+}
+
+func TestVariables_ValidateConstraints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects a default that is not in enum", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"seat_denominator": map[string]any{
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "Contracted",
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid variable "seat_denominator"`)
+		assert.Contains(t, err.Error(), "not one of the allowed values")
+	})
+
+	t.Run("accepts a default that is in enum", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"seat_denominator": map[string]any{
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "reachable",
+			},
+		}
+		require.NoError(t, vars.Validate())
+	})
+
+	t.Run("rejects a default below minimum", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"minimum": 7,
+				"maximum": 90,
+				"default": 0,
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "below minimum")
+	})
+
+	t.Run("rejects a default above maximum", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"minimum": 7,
+				"maximum": 90,
+				"default": 9999,
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "above maximum")
+	})
+
+	t.Run("accepts a default on the inclusive bounds", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"minimum": 7,
+				"maximum": 90,
+				"default": 7,
+			},
+		}
+		require.NoError(t, vars.Validate())
+	})
+
+	t.Run("rejects a default that does not match const", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"env": map[string]any{
+				"type":    "string",
+				"const":   "prod",
+				"default": "staging",
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match const")
+	})
+
+	t.Run("rejects a default with the wrong type", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"default": "30",
+			},
+		}
+		err := vars.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "type mismatch")
+		assert.Contains(t, err.Error(), "expected integer")
+	})
+
+	t.Run("treats whole-number floats as integers for JSON-decoded defaults", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"minimum": 7.0,
+				"maximum": 90.0,
+				"default": 30.0,
+			},
+		}
+		require.NoError(t, vars.Validate())
+	})
+
+	t.Run("treats integer and whole-number float enum members as equal", func(t *testing.T) {
+		t.Parallel()
+		vars := pipeline.Variables{
+			"tier": map[string]any{
+				"type":    "integer",
+				"enum":    []any{1, 2, 3},
+				"default": float64(2),
+			},
+		}
+		require.NoError(t, vars.Validate())
 	})
 }
 
@@ -299,5 +425,139 @@ func TestVariables_Merge(t *testing.T) {
 
 		assert.Equal(t, "string", vars["foo"]["type"])
 		assert.Equal(t, "new", vars["foo"]["default"])
+	})
+
+	t.Run("rejects an enum override that differs only by case", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"seat_denominator": map[string]any{
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "reachable",
+			},
+		}
+
+		err := vars.Merge(map[string]any{"seat_denominator": "Contracted"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid variable "seat_denominator"`)
+		assert.Contains(t, err.Error(), "not one of the allowed values")
+		assert.Equal(t, "reachable", vars["seat_denominator"]["default"], "invalid override must not replace the default")
+	})
+
+	t.Run("rejects an override outside numeric bounds", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"minimum": 7,
+				"maximum": 90,
+				"default": 30,
+			},
+		}
+
+		err := vars.Merge(map[string]any{"forecast_horizon_days": 0})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "below minimum")
+		assert.Equal(t, 30, vars["forecast_horizon_days"]["default"])
+
+		err = vars.Merge(map[string]any{"forecast_horizon_days": 9999})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "above maximum")
+		assert.Equal(t, 30, vars["forecast_horizon_days"]["default"])
+	})
+
+	t.Run("does not apply any override when one value is invalid", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"env": map[string]any{
+				"type":    "string",
+				"enum":    []any{"dev", "prod"},
+				"default": "dev",
+			},
+			"count": map[string]any{
+				"type":    "integer",
+				"minimum": 1,
+				"default": 1,
+			},
+		}
+
+		err := vars.Merge(map[string]any{
+			"env":   "staging",
+			"count": 5,
+		})
+		require.Error(t, err)
+		assert.Equal(t, "dev", vars["env"]["default"])
+		assert.Equal(t, 1, vars["count"]["default"])
+	})
+
+	t.Run("accepts a valid enum and integer override", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"seat_denominator": map[string]any{
+				"type":    "string",
+				"enum":    []any{"reachable", "contracted"},
+				"default": "reachable",
+			},
+			"forecast_horizon_days": map[string]any{
+				"type":    "integer",
+				"minimum": 7,
+				"maximum": 90,
+				"default": 30,
+			},
+		}
+
+		err := vars.Merge(map[string]any{
+			"seat_denominator":      "contracted",
+			"forecast_horizon_days": int64(14),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "contracted", vars["seat_denominator"]["default"])
+		assert.Equal(t, int64(14), vars["forecast_horizon_days"]["default"])
+	})
+
+	t.Run("does not panic when merging into an empty-bodied variable", func(t *testing.T) {
+		t.Parallel()
+
+		vars := pipeline.Variables{
+			"foo": nil,
+		}
+
+		err := vars.Merge(map[string]any{"foo": "bar"})
+		require.NoError(t, err)
+		assert.Equal(t, "bar", vars["foo"]["default"])
+	})
+}
+
+func TestVariables_ValidateYAMLPipeline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enforces enum and bounds from pipeline.yml", func(t *testing.T) {
+		t.Parallel()
+
+		var parsed struct {
+			Variables pipeline.Variables `yaml:"variables"`
+		}
+		err := yaml.Unmarshal([]byte(`
+variables:
+  seat_denominator:
+    type: string
+    enum: [reachable, contracted]
+    default: reachable
+  forecast_horizon_days:
+    type: integer
+    minimum: 7
+    maximum: 90
+    default: 30
+`), &parsed)
+		require.NoError(t, err)
+		require.NoError(t, parsed.Variables.Validate())
+
+		err = parsed.Variables.Merge(map[string]any{"seat_denominator": "Contracted"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not one of the allowed values")
 	})
 }

--- a/pkg/pipeline/variant.go
+++ b/pkg/pipeline/variant.go
@@ -42,7 +42,7 @@ func (vs VariantSet) Validate(vars Variables) error {
 			if !ok {
 				return fmt.Errorf("variant %q references unknown variable %q", name, key)
 			}
-			if err := validateOverrideType(value, schema); err != nil {
+			if err := validateVariableValue(value, schema); err != nil {
 				return fmt.Errorf("variant %q variable %q: %w", name, key, err)
 			}
 		}

--- a/pkg/pipeline/variant_test.go
+++ b/pkg/pipeline/variant_test.go
@@ -200,6 +200,47 @@ func TestVariantSet_Validate_TypeChecking(t *testing.T) {
 	})
 }
 
+func TestVariantSet_Validate_Constraints(t *testing.T) {
+	t.Parallel()
+
+	vars := pipeline.Variables{
+		"region": map[string]any{
+			"type":    "string",
+			"enum":    []any{"us", "eu", "ap"},
+			"default": "us",
+		},
+		"forecast_days": map[string]any{
+			"type":    "integer",
+			"minimum": 7,
+			"maximum": 90,
+			"default": 30,
+		},
+	}
+
+	t.Run("rejects enum override that differs only by case", func(t *testing.T) {
+		t.Parallel()
+		vs := pipeline.VariantSet{"client_alpha": {"region": "US"}}
+		err := vs.Validate(vars)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `variable "region"`)
+		assert.Contains(t, err.Error(), "not one of the allowed values")
+	})
+
+	t.Run("rejects override below minimum", func(t *testing.T) {
+		t.Parallel()
+		vs := pipeline.VariantSet{"client_alpha": {"forecast_days": 3}}
+		err := vs.Validate(vars)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "below minimum")
+	})
+
+	t.Run("accepts override on inclusive bounds and enum", func(t *testing.T) {
+		t.Parallel()
+		vs := pipeline.VariantSet{"client_alpha": {"region": "eu", "forecast_days": 7}}
+		require.NoError(t, vs.Validate(vars))
+	})
+}
+
 func TestPipeline_MaterializeVariant(t *testing.T) {
 	t.Parallel()
 

--- a/templates/posthog-bigquery/README.md
+++ b/templates/posthog-bigquery/README.md
@@ -514,12 +514,12 @@ the warehouse cannot speak to.
 
 ### Variable validation and macro loading
 
-The `enum`, `minimum`, and `maximum` keywords on these variables are currently
-documentation rather than enforcement — Bruin validates that a variable has a
-default and little else, and `--var` overrides skip schema checks. Where getting
+The `enum`, `minimum`, and `maximum` keywords on these variables are enforced
+on defaults, `--var` overrides, and variant values. A typo such as
+`--var seat_denominator='"Contracted"'` fails before any asset runs. Where getting
 a value wrong would silently produce plausible-but-wrong numbers rather than an
-obvious break, the SQL fails the run itself: an unrecognised `seat_denominator`
-stops `posthog_stage.accounts` with
+obvious break, the SQL still fails the run itself as a second line of defence: an
+unrecognised `seat_denominator` stops `posthog_stage.accounts` with
 `seat_denominator must be "reachable" or "contracted", got …` instead of quietly
 falling back to a default.
 


### PR DESCRIPTION
## What
Pipeline variables accept JSON Schema keywords like `enum`, `minimum`, and `maximum`, and the docs present them as working features — but until now only a missing `default` was rejected. A value such as `--var seat_denominator='"Contracted"'` was stored and the run succeeded, so Jinja branches silently took the wrong path.

This PR validates defaults, `--var` overrides, and variant values against `type`, `enum`, `const`, `minimum`, and `maximum` locally. It does not compile a full Draft-07 meta-schema (that approach was merged in #2599 and reverted in #2605), so in-progress templates such as zoomcamp's `type: TODO` keep parsing.

Closes #2587.

## Changes
- `pkg/pipeline/variables.go`: check defaults in `Validate` (used by `bruin validate`) and incoming values in `Merge` (used by `--var` and variant application). Overrides are applied only after every key is valid. Empty-bodied variables (`foo:`) no longer panic on merge.
- `pkg/pipeline/variant.go`: variant overrides go through the same constraint checks as `--var`.
- Tests for the reported enum typo, out-of-range integers, atomic merge, YAML pipeline.yml decoding, and `--var` mutator failures.
- Docs: custom variables, variants, pipeline definition, and the posthog-bigquery template now describe the enforced keywords.

## How to test
1. `go test -tags="no_duckdb_arrow" ./pkg/pipeline/ -run "TestVariables|TestVariantSet_Validate"`
2. `go test -tags="no_duckdb_arrow" ./cmd/ -run TestVariableOverridesMutator`
3. `make format` / `make test` if you have the full toolchain.
4. Manual: in a pipeline with `enum: [reachable, contracted]`, run `bruin run --var seat_denominator='"Contracted"'` and confirm it fails before assets execute. `reachable` / `contracted` still succeed. `forecast_horizon_days=0` fails when `minimum: 7`.

## Risk & rollback
- **Risk:** Medium. Previously accepted invalid variable values will now fail validation. Existing templates in this repo were checked; zoomcamp's placeholder `type: TODO` remains permitted because unknown types are not compiled as JSON Schema.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [ ] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Closes #2587
