### PR TITLE
Add read-only BigQuery connections

### DIFF
--- a/docs/platforms/bigquery.md
+++ b/docs/platforms/bigquery.md
@@ -96,6 +96,25 @@ access_token: "ya29...."
 
 **Note:** Access-token connections cannot be used for ingestr assets — use a service account for those.
 
+### Read-only connections
+
+Set `read_only: true` with a service account file or inline service account JSON:
+
+```yaml
+connections:
+  google_cloud_platform:
+    - name: bigquery-reader
+      project_id: my-project
+      service_account_file: /path/to/service-account.json
+      read_only: true
+```
+
+Bruin obtains OAuth tokens with only the `https://www.googleapis.com/auth/bigquery.readonly` scope. Queries and dry runs use the [jobs.query API](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query), which accepts this scope. Tokens are reused and refreshed automatically. The default is `read_only: false`.
+
+Read-only connections require `service_account_file` or `service_account_json`. Bruin rejects ADC, pre-minted access tokens, and preconfigured credential objects because it cannot restrict their existing scopes. Ingestr and BigQuery Data Transfer are also rejected for read-only connections.
+
+Configured query cost limits still apply. Read-only dry runs return byte estimates and schema, but do not return statement types or referenced table lists. BigQuery assigns query job IDs in this mode instead of Bruin's usual job ID prefix.
+
 ## BigQuery Assets
 
 ### `bq.sql`

--- a/docs/platforms/bigquery.md
+++ b/docs/platforms/bigquery.md
@@ -109,11 +109,7 @@ connections:
       read_only: true
 ```
 
-Bruin obtains OAuth tokens with only the `https://www.googleapis.com/auth/bigquery.readonly` scope. Queries and dry runs use the [jobs.query API](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query), which accepts this scope. Tokens are reused and refreshed automatically. The default is `read_only: false`.
-
-Read-only connections require `service_account_file` or `service_account_json`. Bruin rejects ADC, pre-minted access tokens, and preconfigured credential objects because it cannot restrict their existing scopes. Ingestr and BigQuery Data Transfer are also rejected for read-only connections.
-
-Configured query cost limits still apply. Read-only dry runs return byte estimates and schema, but do not return statement types or referenced table lists. BigQuery assigns query job IDs in this mode instead of Bruin's usual job ID prefix.
+Read-only mode requires `service_account_file` or `service_account_json`; ADC and access tokens are not supported. Ingestr and BigQuery Data Transfer are unavailable in this mode. Defaults to `false`.
 
 ## BigQuery Assets
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -2920,6 +2920,9 @@
         },
         "max_query_cost_soft": {
           "type": "number"
+        },
+        "read_only": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/bigquery/auth.go
+++ b/pkg/bigquery/auth.go
@@ -12,13 +12,13 @@ import (
 
 const readOnlyScope = "https://www.googleapis.com/auth/bigquery.readonly"
 
-func (c *Config) clientOptions(ctx context.Context) ([]option.ClientOption, error) {
+func (c Config) clientOptions(ctx context.Context) ([]option.ClientOption, error) {
 	if c.ReadOnly {
-		tokenSource, err := c.readOnlyTokenSource(ctx)
+		credentials, err := c.readOnlyCredentials(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return []option.ClientOption{option.WithTokenSource(tokenSource)}, nil
+		return []option.ClientOption{option.WithTokenSource(credentials.TokenSource)}, nil
 	}
 
 	options := []option.ClientOption{option.WithScopes(scopes...)}
@@ -40,7 +40,7 @@ func (c *Config) clientOptions(ctx context.Context) ([]option.ClientOption, erro
 	return options, nil
 }
 
-func (c *Config) readOnlyTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+func (c Config) readOnlyCredentials(ctx context.Context) (*google.Credentials, error) {
 	if c.UseApplicationDefaultCredentials || c.AccessToken != "" || c.Credentials != nil {
 		return nil, errors.New("read_only requires service_account_json or service_account_file; ADC, access_token, and preconfigured credentials are not supported")
 	}
@@ -59,5 +59,5 @@ func (c *Config) readOnlyTokenSource(ctx context.Context) (oauth2.TokenSource, e
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create read-only BigQuery credentials")
 	}
-	return credentials.TokenSource, nil
+	return credentials, nil
 }

--- a/pkg/bigquery/auth.go
+++ b/pkg/bigquery/auth.go
@@ -1,0 +1,63 @@
+package bigquery
+
+import (
+	"context"
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+)
+
+const readOnlyScope = "https://www.googleapis.com/auth/bigquery.readonly"
+
+func (c *Config) clientOptions(ctx context.Context) ([]option.ClientOption, error) {
+	if c.ReadOnly {
+		tokenSource, err := c.readOnlyTokenSource(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return []option.ClientOption{option.WithTokenSource(tokenSource)}, nil
+	}
+
+	options := []option.ClientOption{option.WithScopes(scopes...)}
+	if c.UseApplicationDefaultCredentials {
+		return options, nil
+	}
+	switch {
+	case c.CredentialsJSON != "":
+		options = append(options, option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(c.CredentialsJSON)))
+	case c.CredentialsFilePath != "":
+		options = append(options, option.WithAuthCredentialsFile(option.ServiceAccount, c.CredentialsFilePath))
+	case c.AccessToken != "":
+		options = append(options, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.AccessToken})))
+	case c.Credentials != nil:
+		options = append(options, option.WithCredentials(c.Credentials))
+	default:
+		return nil, errors.New("no credentials provided")
+	}
+	return options, nil
+}
+
+func (c *Config) readOnlyTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	if c.UseApplicationDefaultCredentials || c.AccessToken != "" || c.Credentials != nil {
+		return nil, errors.New("read_only requires service_account_json or service_account_file; ADC, access_token, and preconfigured credentials are not supported")
+	}
+	data := []byte(c.CredentialsJSON)
+	if len(data) == 0 {
+		if c.CredentialsFilePath == "" {
+			return nil, errors.New("read_only requires service_account_json or service_account_file")
+		}
+		var err error
+		data, err = os.ReadFile(c.CredentialsFilePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read read-only BigQuery credentials")
+		}
+	}
+	credentials, err := google.CredentialsFromJSONWithType(ctx, data, google.ServiceAccount, readOnlyScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create read-only BigQuery credentials")
+	}
+	return credentials.TokenSource, nil
+}

--- a/pkg/bigquery/config.go
+++ b/pkg/bigquery/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	MaxQueryCost                     *float64
 	MaxBillableBytesSoft             *int64
 	MaxQueryCostSoft                 *float64
+	ReadOnly                         bool
 }
 
 func (c Config) IsValid() bool {
@@ -34,6 +35,9 @@ func (c Config) IsValid() bool {
 }
 
 func (c Config) GetConnectionURI() (string, error) {
+	if c.ReadOnly {
+		return "", errors.New("read_only connections cannot be used with ingestr")
+	}
 	// If using Application Default Credentials, return simple URI
 	// ingestr will use ADC automatically when no credentials are in the URI
 	if c.UseApplicationDefaultCredentials {

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/conc/pool"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	bigqueryapi "google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -82,60 +83,22 @@ func WithSoftQueryLimits(ctx context.Context) context.Context {
 }
 
 type Client struct {
-	client      *bigquery.Client
-	config      *Config
-	typeMapper  *diff.DatabaseTypeMapper
-	clientMutex sync.Mutex // Protects lazy client creation
+	client          *bigquery.Client
+	readOnlyService *bigqueryapi.Service
+	config          *Config
+	typeMapper      *diff.DatabaseTypeMapper
+	clientMutex     sync.Mutex // Protects lazy client creation
 }
 
 func NewDB(c *Config) (*Client, error) {
-	options := []option.ClientOption{
-		option.WithScopes(scopes...),
+	d := &Client{config: c, typeMapper: diff.NewBigQueryTypeMapper()}
+	if c.UseApplicationDefaultCredentials && !c.ReadOnly {
+		return d, nil
 	}
-
-	// If ADC is enabled, create the client lazily (when it's actually used)
-	// This allows pipelines without BigQuery assets to run even if ADC is not configured
-	if c.UseApplicationDefaultCredentials {
-		return &Client{
-			client:     nil, // Will be created lazily when ensureClientInitialized is called
-			config:     c,
-			typeMapper: diff.NewBigQueryTypeMapper(),
-		}, nil
+	if err := d.createClient(context.Background()); err != nil {
+		return nil, err
 	}
-
-	// For explicit credentials, create the client immediately
-	switch {
-	case c.CredentialsJSON != "":
-		options = append(options, option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(c.CredentialsJSON)))
-	case c.CredentialsFilePath != "":
-		options = append(options, option.WithAuthCredentialsFile(option.ServiceAccount, c.CredentialsFilePath))
-	case c.AccessToken != "":
-		options = append(options, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.AccessToken})))
-	case c.Credentials != nil:
-		options = append(options, option.WithCredentials(c.Credentials))
-	default:
-		return nil, errors.New("no credentials provided")
-	}
-
-	client, err := bigquery.NewClient(
-		context.Background(),
-		c.ProjectID,
-		options...,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create bigquery client")
-	}
-
-	// Set location if specified (used for query execution region)
-	if c.Location != "" {
-		client.Location = c.Location
-	}
-
-	return &Client{
-		client:     client,
-		config:     c,
-		typeMapper: diff.NewBigQueryTypeMapper(),
-	}, nil
+	return d, nil
 }
 
 func (d *Client) GetIngestrURI() (string, error) {
@@ -165,24 +128,9 @@ func (d *Client) createClient(ctx context.Context) error {
 		return nil
 	}
 
-	options := []option.ClientOption{
-		option.WithScopes(scopes...),
-	}
-
-	// If ADC is enabled, no explicit credentials are needed
-	if !d.config.UseApplicationDefaultCredentials {
-		switch {
-		case d.config.CredentialsJSON != "":
-			options = append(options, option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(d.config.CredentialsJSON)))
-		case d.config.CredentialsFilePath != "":
-			options = append(options, option.WithAuthCredentialsFile(option.ServiceAccount, d.config.CredentialsFilePath))
-		case d.config.AccessToken != "":
-			options = append(options, option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: d.config.AccessToken})))
-		case d.config.Credentials != nil:
-			options = append(options, option.WithCredentials(d.config.Credentials))
-		default:
-			return errors.New("no credentials provided")
-		}
+	options, err := d.config.clientOptions(ctx)
+	if err != nil {
+		return err
 	}
 
 	client, err := bigquery.NewClient(
@@ -199,6 +147,14 @@ func (d *Client) createClient(ctx context.Context) error {
 		client.Location = d.config.Location
 	}
 
+	if d.config.ReadOnly {
+		service, err := bigqueryapi.NewService(ctx, options...)
+		if err != nil {
+			_ = client.Close()
+			return errors.Wrap(err, "failed to create read-only BigQuery service")
+		}
+		d.readOnlyService = service
+	}
 	d.client = client
 	return nil
 }
@@ -214,6 +170,9 @@ func (d *Client) ensureClientInitialized(ctx context.Context) error {
 }
 
 func (d *Client) NewDataTransferClient(ctx context.Context) (*datatransfer.Client, error) {
+	if d.config.ReadOnly {
+		return nil, errors.New("read_only connections cannot be used with BigQuery Data Transfer")
+	}
 	options := []option.ClientOption{
 		option.WithScopes(scopes...),
 	}
@@ -267,6 +226,10 @@ func (d *Client) IsValid(ctx context.Context, query *query.Query) (bool, error) 
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return false, err
 	}
+	if d.isReadOnly() {
+		_, err := d.readOnlyDryRun(ctx, query.ToDryRunQuery())
+		return err == nil, err
+	}
 	q := d.queryForExecution(ctx, query.ToDryRunQuery())
 	q.DryRun = true
 
@@ -316,13 +279,17 @@ func (d *Client) RunQueryWithoutResult(ctx context.Context, q *query.Query) erro
 		return err
 	}
 	bqQuery := d.queryForExecution(ctx, q.String())
-	job, err := bqQuery.Run(ctx)
+	job, rows, err := d.startQuery(ctx, bqQuery)
 	if err != nil {
 		return formatError(err)
 	}
 	defer cancelJobOnContextCancellation(ctx, job)
-	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
-	_, err = job.Read(ctx)
+	if job != nil {
+		query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
+	}
+	if rows == nil {
+		_, err = job.Read(ctx)
+	}
 	if err != nil {
 		return formatError(err)
 	}
@@ -338,13 +305,17 @@ func (d *Client) Select(ctx context.Context, q *query.Query) ([][]interface{}, e
 		return nil, err
 	}
 	bqQuery := d.queryForExecution(ctx, q.String())
-	job, err := bqQuery.Run(ctx)
+	job, rows, err := d.startQuery(ctx, bqQuery)
 	if err != nil {
 		return nil, formatError(err)
 	}
 	defer cancelJobOnContextCancellation(ctx, job)
-	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
-	rows, err := job.Read(ctx)
+	if job != nil {
+		query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
+	}
+	if rows == nil {
+		rows, err = job.Read(ctx)
+	}
 	if err != nil {
 		return nil, formatError(err)
 	}
@@ -379,13 +350,17 @@ func (d *Client) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*
 		return nil, err
 	}
 	bqQuery := d.queryForExecution(ctx, queryObj.String())
-	job, err := bqQuery.Run(ctx)
+	job, rows, err := d.startQuery(ctx, bqQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run query: %w", formatError(err))
 	}
 	defer cancelJobOnContextCancellation(ctx, job)
-	query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
-	rows, err := job.Read(ctx)
+	if job != nil {
+		query.LogOrSinkQueryID(ctx, "BigQuery", job.ID())
+	}
+	if rows == nil {
+		rows, err = job.Read(ctx)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read query results: %w", formatError(err))
 	}
@@ -428,7 +403,7 @@ func (d *Client) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*
 
 	// Store the column types in the result
 	result.ColumnTypes = columnTypes
-	if len(result.Rows) == 0 && !query.IsLikelyResultQuery(queryObj.String()) {
+	if job != nil && len(result.Rows) == 0 && !query.IsLikelyResultQuery(queryObj.String()) {
 		summary := d.queryExecutionSummary(ctx, job)
 		if query.IsNonResultStatement(summary) {
 			result.Execution = summary
@@ -537,7 +512,11 @@ func (d *Client) queryForExecution(ctx context.Context, queryString string) *big
 	if d.config != nil && d.config.MaxBillableBytes != nil {
 		bqQuery.MaxBytesBilled = *d.config.MaxBillableBytes
 	}
-	applyJobIDPrefix(ctx, bqQuery)
+	if d.isReadOnly() {
+		bqQuery.Location = d.client.Location
+	} else {
+		applyJobIDPrefix(ctx, bqQuery)
+	}
 	return bqQuery
 }
 
@@ -590,6 +569,9 @@ func formatBigQueryCostUSD(cost float64) string {
 func (d *Client) QueryDryRun(ctx context.Context, queryObj *query.Query) (*bigquery.QueryStatistics, error) {
 	if err := d.ensureClientInitialized(ctx); err != nil {
 		return nil, err
+	}
+	if d.isReadOnly() {
+		return d.readOnlyDryRun(ctx, queryObj.String())
 	}
 	q := d.queryForExecution(ctx, queryObj.String())
 	q.DryRun = true

--- a/pkg/bigquery/read_only.go
+++ b/pkg/bigquery/read_only.go
@@ -44,7 +44,7 @@ func (d *Client) readOnlyDryRun(ctx context.Context, sql string) (*bigquery.Quer
 		return nil, errors.New(resp.Errors[0].Message)
 	}
 	stats := &bigquery.QueryStatistics{
-		TotalBytesProcessed: int64(resp.TotalBytesProcessed),
+		TotalBytesProcessed: resp.TotalBytesProcessed,
 		TotalBytesBilled:    resp.TotalBytesBilled,
 		CacheHit:            resp.CacheHit,
 	}

--- a/pkg/bigquery/read_only.go
+++ b/pkg/bigquery/read_only.go
@@ -1,0 +1,62 @@
+package bigquery
+
+import (
+	"context"
+	"encoding/json"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/pkg/errors"
+	bigqueryapi "google.golang.org/api/bigquery/v2"
+)
+
+func (d *Client) isReadOnly() bool {
+	return d.config != nil && d.config.ReadOnly
+}
+
+func (d *Client) startQuery(ctx context.Context, q *bigquery.Query) (*bigquery.Job, *bigquery.RowIterator, error) {
+	if !d.isReadOnly() {
+		job, err := q.Run(ctx)
+		return job, nil, err
+	}
+	rows, err := q.Read(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rows.SourceJob(), rows, nil
+}
+
+func (d *Client) readOnlyDryRun(ctx context.Context, sql string) (*bigquery.QueryStatistics, error) {
+	useLegacySQL := false
+	req := &bigqueryapi.QueryRequest{
+		Query:        sql,
+		DryRun:       true,
+		UseLegacySql: &useLegacySQL,
+		Location:     d.config.Location,
+	}
+	if d.config.MaxBillableBytes != nil {
+		req.MaximumBytesBilled = *d.config.MaxBillableBytes
+	}
+	resp, err := d.readOnlyService.Jobs.Query(d.config.ProjectID, req).Context(ctx).Do()
+	if err != nil {
+		return nil, formatError(err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, errors.New(resp.Errors[0].Message)
+	}
+	stats := &bigquery.QueryStatistics{
+		TotalBytesProcessed: int64(resp.TotalBytesProcessed),
+		TotalBytesBilled:    resp.TotalBytesBilled,
+		CacheHit:            resp.CacheHit,
+	}
+	if resp.Schema != nil {
+		data, err := json.Marshal(resp.Schema.Fields)
+		if err != nil {
+			return nil, err
+		}
+		stats.Schema, err = bigquery.SchemaFromJSON(data)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return stats, nil
+}

--- a/pkg/bigquery/read_only_test.go
+++ b/pkg/bigquery/read_only_test.go
@@ -38,15 +38,23 @@ func TestReadOnlyBigQuery(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				if r.URL.Path == "/token" {
-					require.NoError(t, r.ParseForm())
+					if !assert.NoError(t, r.ParseForm()) {
+						return
+					}
 					parts := strings.Split(r.Form.Get("assertion"), ".")
-					require.Len(t, parts, 3)
+					if !assert.Len(t, parts, 3) {
+						return
+					}
 					data, err := base64.RawURLEncoding.DecodeString(parts[1])
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 					var claims struct {
 						Scope string `json:"scope"`
 					}
-					require.NoError(t, json.Unmarshal(data, &claims))
+					if !assert.NoError(t, json.Unmarshal(data, &claims)) {
+						return
+					}
 					assert.Equal(t, "https://www.googleapis.com/auth/bigquery.readonly", claims.Scope)
 					tokens.Add(1)
 					_, _ = w.Write([]byte(`{"access_token":"readonly-token","token_type":"Bearer","expires_in":3600}`))
@@ -59,7 +67,9 @@ func TestReadOnlyBigQuery(t *testing.T) {
 					return
 				}
 				var req bigqueryapi.QueryRequest
-				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+					return
+				}
 				assert.Equal(t, "EU", req.Location)
 				assert.Equal(t, expectedMaxBytes.Load(), req.MaximumBytesBilled)
 				if strings.HasPrefix(req.Query, "DELETE") {

--- a/pkg/bigquery/read_only_test.go
+++ b/pkg/bigquery/read_only_test.go
@@ -1,0 +1,171 @@
+package bigquery
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/google"
+	bigqueryapi "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
+)
+
+func TestReadOnlyBigQuery(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	for _, fromFile := range []bool{false, true} {
+		t.Run(fmt.Sprintf("file=%t", fromFile), func(t *testing.T) {
+			t.Parallel()
+			var tokens, queries, dryRuns atomic.Int32
+			var expectedMaxBytes atomic.Int64
+			expectedMaxBytes.Store(100)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/token" {
+					require.NoError(t, r.ParseForm())
+					parts := strings.Split(r.Form.Get("assertion"), ".")
+					require.Len(t, parts, 3)
+					data, err := base64.RawURLEncoding.DecodeString(parts[1])
+					require.NoError(t, err)
+					var claims struct {
+						Scope string `json:"scope"`
+					}
+					require.NoError(t, json.Unmarshal(data, &claims))
+					assert.Equal(t, "https://www.googleapis.com/auth/bigquery.readonly", claims.Scope)
+					tokens.Add(1)
+					_, _ = w.Write([]byte(`{"access_token":"readonly-token","token_type":"Bearer","expires_in":3600}`))
+					return
+				}
+				assert.Equal(t, "Bearer readonly-token", r.Header.Get("Authorization"))
+				if r.Method != http.MethodPost || r.URL.Path != "/projects/test-project/queries" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.Error(w, "unexpected API", http.StatusBadRequest)
+					return
+				}
+				var req bigqueryapi.QueryRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				assert.Equal(t, "EU", req.Location)
+				assert.Equal(t, expectedMaxBytes.Load(), req.MaximumBytesBilled)
+				if strings.HasPrefix(req.Query, "DELETE") {
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"error":{"code":403,"message":"insufficient authentication scopes"}}`))
+					return
+				}
+				if req.DryRun {
+					dryRuns.Add(1)
+					_, _ = w.Write([]byte(`{"jobComplete":true,"totalBytesProcessed":"10","schema":{"fields":[{"name":"value","type":"INTEGER"}]}}`))
+					return
+				}
+				queries.Add(1)
+				_, _ = w.Write([]byte(`{"jobComplete":true,"jobReference":{"projectId":"test-project","jobId":"readonly-job","location":"EU"},"schema":{"fields":[{"name":"value","type":"INTEGER"}]},"totalRows":"1","rows":[{"f":[{"v":"42"}]}]}`))
+			}))
+			defer server.Close()
+			data, err := json.Marshal(map[string]string{
+				"type": "service_account", "project_id": "test-project", "client_email": "test@test-project.iam.gserviceaccount.com",
+				"private_key": string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})),
+				"token_uri":   server.URL + "/token",
+			})
+			require.NoError(t, err)
+			maxBytes := int64(100)
+			cfg := &Config{ProjectID: "test-project", Location: "EU", CredentialsJSON: string(data), ReadOnly: true, MaxBillableBytes: &maxBytes}
+			if fromFile {
+				path := filepath.Join(t.TempDir(), "credentials.json")
+				require.NoError(t, os.WriteFile(path, data, 0o600))
+				cfg.CredentialsJSON = ""
+				cfg.CredentialsFilePath = path
+			}
+			initialized, err := NewDB(cfg)
+			require.NoError(t, err)
+			require.NotNil(t, initialized.readOnlyService)
+			_, err = initialized.GetIngestrURI()
+			require.ErrorContains(t, err, "read_only connections cannot be used")
+			_, err = initialized.NewDataTransferClient(t.Context())
+			require.ErrorContains(t, err, "read_only connections cannot be used")
+			require.Equal(t, "EU", initialized.client.Location)
+			require.NoError(t, initialized.client.Close())
+			opts, err := cfg.clientOptions(t.Context())
+			require.NoError(t, err)
+			opts = append(opts, option.WithEndpoint(server.URL))
+			bq, err := bigquery.NewClient(t.Context(), cfg.ProjectID, opts...)
+			require.NoError(t, err)
+			defer bq.Close()
+			bq.Location = cfg.Location
+			service, err := bigqueryapi.NewService(t.Context(), opts...)
+			require.NoError(t, err)
+			client := &Client{client: bq, config: cfg, readOnlyService: service}
+			ctx := query.WithQueryType(t.Context(), "test")
+			q := &query.Query{Query: "SELECT 42 AS value"}
+			rows, err := client.Select(ctx, q)
+			require.NoError(t, err)
+			require.Equal(t, [][]interface{}{{int64(42)}}, rows)
+			result, err := client.SelectWithSchema(ctx, q)
+			require.NoError(t, err)
+			require.Equal(t, []string{"value"}, result.Columns)
+			require.Equal(t, []string{"INTEGER"}, result.ColumnTypes)
+			require.Equal(t, rows, result.Rows)
+			require.NoError(t, client.RunQueryWithoutResult(ctx, q))
+			valid, err := client.IsValid(ctx, q)
+			require.NoError(t, err)
+			require.True(t, valid)
+			stats, err := client.QueryDryRun(ctx, q)
+			require.NoError(t, err)
+			require.Equal(t, int64(10), stats.TotalBytesProcessed)
+			require.Len(t, stats.Schema, 1)
+			_, err = client.Select(ctx, &query.Query{Query: "DELETE FROM dataset.items"})
+			require.ErrorContains(t, err, "insufficient authentication scopes")
+			require.Equal(t, int32(1), tokens.Load())
+			require.Equal(t, int32(3), queries.Load())
+			require.GreaterOrEqual(t, dryRuns.Load(), int32(5))
+			maxBytes = 5
+			expectedMaxBytes.Store(5)
+			_, err = client.Select(ctx, q)
+			require.ErrorContains(t, err, "exceeds max_billable_bytes")
+			require.Equal(t, int32(3), queries.Load())
+		})
+	}
+}
+
+func TestReadOnlyRejectsUnsupportedCredentials(t *testing.T) {
+	t.Parallel()
+	for name, cfg := range map[string]Config{
+		"missing":         {},
+		"ADC":             {UseApplicationDefaultCredentials: true},
+		"token":           {AccessToken: "existing-token"},
+		"credentials":     {Credentials: &google.Credentials{}},
+		"ADC with JSON":   {UseApplicationDefaultCredentials: true, CredentialsJSON: `{"type":"service_account"}`},
+		"token with JSON": {AccessToken: "existing-token", CredentialsJSON: `{"type":"service_account"}`},
+		"authorized user": {CredentialsJSON: `{"type":"authorized_user"}`},
+		"invalid JSON":    {CredentialsJSON: `invalid`},
+		"missing file":    {CredentialsFilePath: filepath.Join(t.TempDir(), "missing.json")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg.ReadOnly = true
+			cfg.ProjectID = "test-project"
+			_, err := NewDB(&cfg)
+			require.Error(t, err)
+			client := &Client{config: &cfg}
+			require.Error(t, client.createClient(t.Context()))
+			_, err = client.NewDataTransferClient(t.Context())
+			require.ErrorContains(t, err, "read_only connections cannot be used")
+			_, err = client.GetIngestrURI()
+			require.ErrorContains(t, err, "read_only connections cannot be used")
+		})
+	}
+}

--- a/pkg/config/bigquery_read_only_test.go
+++ b/pkg/config/bigquery_read_only_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGoogleCloudPlatformConnectionReadOnlyRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, conn := range []any{&GoogleCloudPlatformConnection{}} {
+		require.NoError(t, yaml.Unmarshal([]byte("name: reader\nread_only: true\n"), conn))
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+		var values map[string]any
+		require.NoError(t, json.Unmarshal(data, &values))
+		require.Equal(t, true, values["read_only"])
+		data, err = yaml.Marshal(conn)
+		require.NoError(t, err)
+		require.Contains(t, string(data), "read_only: true")
+		require.NoError(t, json.Unmarshal([]byte(`{"read_only":false}`), conn))
+		data, err = json.Marshal(conn)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "read_only")
+	}
+}
+
+func TestGoogleCloudPlatformConnectionReadOnlySchema(t *testing.T) {
+	t.Parallel()
+	schema, err := GetConnectionsSchema()
+	require.NoError(t, err)
+	var document struct {
+		Definitions map[string]struct {
+			Properties map[string]struct {
+				Type string `json:"type"`
+			} `json:"properties"`
+			Required []string `json:"required"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(schema), &document))
+	for _, name := range []string{"GoogleCloudPlatformConnection"} {
+		def := document.Definitions[name]
+		require.Equal(t, "boolean", def.Properties["read_only"].Type)
+		require.NotContains(t, def.Required, "read_only")
+	}
+}

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -76,6 +76,7 @@ type GoogleCloudPlatformConnection struct { //nolint:recvcheck
 	MaxQueryCost                     *float64 `yaml:"max_query_cost,omitempty" json:"max_query_cost,omitempty" mapstructure:"max_query_cost"`
 	MaxBillableBytesSoft             *int64   `yaml:"max_billable_bytes_soft,omitempty" json:"max_billable_bytes_soft,omitempty" mapstructure:"max_billable_bytes_soft"`
 	MaxQueryCostSoft                 *float64 `yaml:"max_query_cost_soft,omitempty" json:"max_query_cost_soft,omitempty" mapstructure:"max_query_cost_soft"`
+	ReadOnly                         bool     `yaml:"read_only,omitempty" json:"read_only,omitempty" mapstructure:"read_only"`
 	rawCredentials                   *google.Credentials
 }
 
@@ -96,6 +97,9 @@ func (c GoogleCloudPlatformConnection) MarshalYAML() (interface{}, error) {
 
 	if c.UseApplicationDefaultCredentials {
 		m["use_application_default_credentials"] = c.UseApplicationDefaultCredentials
+	}
+	if c.ReadOnly {
+		m["read_only"] = true
 	}
 	if c.MaxBillableBytes != nil {
 		m["max_billable_bytes"] = *c.MaxBillableBytes
@@ -149,6 +153,9 @@ func (c GoogleCloudPlatformConnection) MarshalJSON() ([]byte, error) {
 	}
 	if c.AccessToken != "" {
 		payload["access_token"] = c.AccessToken
+	}
+	if c.ReadOnly {
+		payload["read_only"] = true
 	}
 	addConnectionMetadataToMap(c.ConnectionMetadata, payload)
 	if c.MaxBillableBytes != nil {

--- a/pkg/connection/bigquery_read_only_test.go
+++ b/pkg/connection/bigquery_read_only_test.go
@@ -1,0 +1,29 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerBigQueryReadOnlyRejectsADC(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		m := Manager{availableConnections: map[string]any{}, AllConnectionDetails: map[string]any{}}
+		connection := &config.GoogleCloudPlatformConnection{
+			ConnectionMetadata:               config.ConnectionMetadata{Name: "reader"},
+			ProjectID:                        "test-project",
+			UseApplicationDefaultCredentials: true,
+			ReadOnly:                         readOnly,
+		}
+		err := m.AddBqConnectionFromConfig(connection)
+		if readOnly {
+			require.ErrorContains(t, err, "read_only requires service_account_json or service_account_file")
+			require.Nil(t, m.GetConnection("reader"))
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, m.GetConnection("reader"))
+		}
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -410,6 +410,7 @@ func (m *Manager) AddBqConnectionFromConfig(connection *config.GoogleCloudPlatfo
 	// Note: ADC validation is deferred - it will only happen when the client is actually used.
 	// This allows pipelines without BigQuery assets to run even if ADC is not configured.
 	db, err := bigquery.NewDB(&bigquery.Config{
+		ReadOnly:                         connection.ReadOnly,
 		ProjectID:                        connection.ProjectID,
 		CredentialsFilePath:              connection.ServiceAccountFile,
 		CredentialsJSON:                  connection.ServiceAccountJSON,


### PR DESCRIPTION
Adds `read_only: true` to BigQuery connections using a service account JSON file or inline JSON. OAuth tokens request only `bigquery.readonly`; queries and dry runs use `jobs.query`, preserving location and query cost limits.

ADC, existing access tokens, preconfigured credentials, ingestr, and Data Transfer are rejected in this mode. Read-only dry runs expose estimates and schema; BigQuery supplies job IDs.

Validation: `make format`, `make test`, `make integration-test-light`, and OAuth/API tests for scope restriction, configuration round trips, reads, dry runs, and cost limits. Live BigQuery validation is left for manual testing.
