### PR TITLE
Add read-only ClickHouse connections

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,9 +130,6 @@ jobs:
         run: make integration-test
       - name: Run MSSQL developer environment integration test
         run: make integration-test-mssql
-      - name: Run ClickHouse read-only integration test
-        working-directory: integration-tests/cloud-integration-tests/clickhouse
-        run: go test -count=1 -timeout 10m -run '^TestReadOnlyConnection$' .
   dockerBuild:
     # Depot build for pushes and internally-created PRs. Fork PRs cannot
     # authenticate with Depot, so they are handled by dockerBuildFork instead.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -130,6 +130,9 @@ jobs:
         run: make integration-test
       - name: Run MSSQL developer environment integration test
         run: make integration-test-mssql
+      - name: Run ClickHouse read-only integration test
+        working-directory: integration-tests/cloud-integration-tests/clickhouse
+        run: go test -count=1 -timeout 10m -run '^TestReadOnlyConnection$' .
   dockerBuild:
     # Depot build for pushes and internally-created PRs. Fork PRs cannot
     # authenticate with Depot, so they are handled by dockerBuildFork instead.

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -23,7 +23,7 @@ connections:
 
 ### Read-only connections
 
-Set `read_only: true` to enable native read-only execution. The default is `false`. Bruin sends the native ClickHouse setting `readonly=1`, so the server rejects writes and changes to restricted settings.
+Set `read_only: true` to prevent SQL queries from modifying data. Defaults to `false`. Ingestr assets and seeds do not support this option.
 
 ## Ingestr Assets
 

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -25,12 +25,6 @@ connections:
 
 Set `read_only: true` to enable native read-only execution. The default is `false`. Bruin sends the native ClickHouse setting `readonly=1`, so the server rejects writes and changes to restricted settings.
 
-This option applies to Bruin's native SQL client. Ingestr assets and seed loading through ingestr return an error for these connections because they open a separate connection that does not preserve this setting. Use a separate connection with database-enforced read-only credentials for ingestion sources.
-
-Native read-only mode follows the database's transaction and permission rules; use database-enforced privileges when running untrusted SQL.
-
-Bruin uses `database` for direct ClickHouse assets and unqualified `clickhouse.seed` asset names. For an `ingestr` asset, the generated ClickHouse URI does not include this database: use `database.table` in the asset `name` when ClickHouse is the destination, or in `source_table` when it is the source. An unqualified ingestr table uses ClickHouse's `default` database.
-
 ## Ingestr Assets
 
 After adding a connection in `.bruin.yml`, create an [asset configuration](/assets/ingestr#asset-structure) file such as `stripe_ingestion.asset.yml` inside the `assets` directory. This file defines the flow from the source to the destination:

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -18,7 +18,16 @@ connections:
       database: "dev" # Default database for direct ClickHouse assets and unqualified seeds.
       http_port: 8443 # Optional; used only for ingestr and defaults to 8443.
       secure: 1 # Set to 1 for ClickHouse Cloud or another TLS connection.
+      read_only: false
 ```
+
+### Read-only connections
+
+Set `read_only: true` to enable native read-only execution. The default is `false`. Bruin sends the native ClickHouse setting `readonly=1`, so the server rejects writes and changes to restricted settings.
+
+This option applies to Bruin's native SQL client. Ingestr assets and seed loading through ingestr return an error for these connections because they open a separate connection that does not preserve this setting. Use a separate connection with database-enforced read-only credentials for ingestion sources.
+
+Native read-only mode follows the database's transaction and permission rules; use database-enforced privileges when running untrusted SQL.
 
 Bruin uses `database` for direct ClickHouse assets and unqualified `clickhouse.seed` asset names. For an `ingestr` asset, the generated ClickHouse URI does not include this database: use `database.table` in the asset `name` when ClickHouse is the destination, or in `source_table` when it is the source. An unqualified ingestr table uses ClickHouse's `default` database.
 
@@ -487,3 +496,15 @@ columns:
     type: "UInt32"
     description: "Time spent on the page in seconds"
 ```
+
+## Testing read-only connections
+
+The existing ClickHouse testcontainers suite starts a local server and exercises `bruin query` with writable and read-only connections. It verifies JSON results, rejects writes and attempts to disable read-only mode, and checks that the table is unchanged.
+
+```bash
+make build
+cd integration-tests/cloud-integration-tests/clickhouse
+go test -count=1 -v -run '^TestReadOnlyConnection$' .
+```
+
+Docker is required. `CLICKHOUSE_TEST_IMAGE` overrides the existing suite's default image.

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -23,7 +23,7 @@ connections:
 
 ### Read-only connections
 
-Set `read_only: true` to prevent SQL queries from modifying data. Defaults to `false`. Ingestr assets and seeds do not support this option.
+Set `read_only: true` to run SQL queries in read-only mode (default: `false`). Ingestr assets and seeds do not support this option.
 
 ## Ingestr Assets
 

--- a/docs/platforms/clickhouse.md
+++ b/docs/platforms/clickhouse.md
@@ -490,15 +490,3 @@ columns:
     type: "UInt32"
     description: "Time spent on the page in seconds"
 ```
-
-## Testing read-only connections
-
-The existing ClickHouse testcontainers suite starts a local server and exercises `bruin query` with writable and read-only connections. It verifies JSON results, rejects writes and attempts to disable read-only mode, and checks that the table is unchanged.
-
-```bash
-make build
-cd integration-tests/cloud-integration-tests/clickhouse
-go test -count=1 -v -run '^TestReadOnlyConnection$' .
-```
-
-Docker is required. `CLICKHOUSE_TEST_IMAGE` overrides the existing suite's default image.

--- a/integration-tests/cloud-integration-tests/clickhouse/read_only_test.go
+++ b/integration-tests/cloud-integration-tests/clickhouse/read_only_test.go
@@ -1,0 +1,63 @@
+package clickhouse_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnlyConnection(t *testing.T) {
+	host, port := startClickHouse(t)
+	writableConfig := writeClickHouseConfig(t, host, port)
+	binary := bruinBinary(t)
+	data, err := os.ReadFile(writableConfig)
+	require.NoError(t, err)
+	readonlyConfig := filepath.Join(t.TempDir(), ".bruin.yml")
+	data = append(data, []byte("          read_only: true\n")...)
+	require.NoError(t, os.WriteFile(readonlyConfig, data, 0o600))
+
+	runBruinQuery(t, binary, writableConfig, "CREATE TABLE readonly_rows (id Int32) ENGINE=Memory")
+	runBruinQuery(t, binary, writableConfig, "INSERT INTO readonly_rows VALUES (1)")
+
+	run := func(configPath, sql string) ([]byte, error) {
+		cmd := exec.CommandContext(t.Context(), binary, "query", "--config-file", configPath,
+			"--connection", connectionName, "--output", "json", "--query", sql)
+		cmd.Env = append(os.Environ(), "DISABLE_TELEMETRY=true")
+		return cmd.CombinedOutput()
+	}
+	assertCount := func(t *testing.T, configPath string, count float64) {
+		t.Helper()
+		output, err := run(configPath, "SELECT count(*) AS count FROM readonly_rows")
+		require.NoError(t, err, "%s", output)
+		var result struct {
+			Rows [][]float64 `json:"rows"`
+		}
+		require.NoError(t, json.Unmarshal(output, &result), "%s", output)
+		require.Equal(t, [][]float64{{count}}, result.Rows)
+	}
+	assertCount(t, readonlyConfig, 1)
+	for _, sql := range []string{
+		"INSERT INTO readonly_rows VALUES (2)",
+		"CREATE TABLE forbidden_rows (id Int32) ENGINE=Memory",
+		"DROP TABLE readonly_rows",
+		"TRUNCATE TABLE readonly_rows",
+		"ALTER TABLE readonly_rows ADD COLUMN value Int32",
+		"SET readonly=0",
+		"INSERT INTO readonly_rows SETTINGS readonly=0 VALUES (3)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			output, err := run(readonlyConfig, sql)
+			require.Error(t, err, "%s", output)
+			require.Contains(t, strings.ToLower(string(output)), "readonly mode")
+			assertCount(t, readonlyConfig, 1)
+			assertCount(t, writableConfig, 1)
+		})
+	}
+	runBruinQuery(t, binary, writableConfig, "INSERT INTO readonly_rows VALUES (4)")
+	assertCount(t, readonlyConfig, 2)
+}

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -810,6 +810,9 @@
         },
         "secure": {
           "type": "integer"
+        },
+        "read_only": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/clickhouse/config.go
+++ b/pkg/clickhouse/config.go
@@ -79,6 +79,6 @@ func (c *Config) GetDatabase() string {
 	return c.Database
 }
 
-func (c Config) IsReadOnly() bool {
+func (c *Config) IsReadOnly() bool {
 	return c.ReadOnly
 }

--- a/pkg/clickhouse/config.go
+++ b/pkg/clickhouse/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Database string
 	HTTPPort int
 	Secure   *int
+	ReadOnly bool
 }
 
 func (c *Config) ToClickHouseOptions() *click_house.Options {
@@ -48,6 +49,9 @@ func (c *Config) ToClickHouseOptions() *click_house.Options {
 			},
 		},
 	}
+	if c.ReadOnly {
+		opt.Settings = click_house.Settings{"readonly": 1}
+	}
 	return &opt
 }
 
@@ -73,4 +77,8 @@ func (c *Config) GetIngestrURI() string {
 
 func (c *Config) GetDatabase() string {
 	return c.Database
+}
+
+func (c Config) IsReadOnly() bool {
+	return c.ReadOnly
 }

--- a/pkg/clickhouse/config_test.go
+++ b/pkg/clickhouse/config_test.go
@@ -34,3 +34,18 @@ func TestConfig_ToClickHouseOptions(t *testing.T) {
 		t.Errorf("expected ClickHouse user agent to identify Bruin, got %s", userAgent)
 	}
 }
+
+func TestConfigReadOnly(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		c := Config{ReadOnly: readOnly}
+		options := c.ToClickHouseOptions()
+		if readOnly {
+			if options.Settings["readonly"] != 1 {
+				t.Fatalf("expected readonly=1, got %v", options.Settings)
+			}
+		} else if _, ok := options.Settings["readonly"]; ok {
+			t.Fatal("readonly should be unset by default")
+		}
+	}
+}

--- a/pkg/clickhouse/db.go
+++ b/pkg/clickhouse/db.go
@@ -75,6 +75,9 @@ func (c *Client) RunQueryWithoutResult(ctx context.Context, query *query.Query) 
 }
 
 func (c *Client) GetIngestrURI() (string, error) {
+	if cfg, ok := c.config.(interface{ IsReadOnly() bool }); ok && cfg.IsReadOnly() {
+		return "", errors.New("read_only connections cannot be used with ingestr")
+	}
 	return c.config.GetIngestrURI(), nil
 }
 

--- a/pkg/clickhouse/db.go
+++ b/pkg/clickhouse/db.go
@@ -49,6 +49,7 @@ type ClickHouseConfig interface {
 	ToClickHouseOptions() *click_house.Options
 	GetIngestrURI() string
 	GetDatabase() string
+	IsReadOnly() bool
 }
 
 type connection interface {
@@ -75,7 +76,7 @@ func (c *Client) RunQueryWithoutResult(ctx context.Context, query *query.Query) 
 }
 
 func (c *Client) GetIngestrURI() (string, error) {
-	if cfg, ok := c.config.(interface{ IsReadOnly() bool }); ok && cfg.IsReadOnly() {
+	if c.config.IsReadOnly() {
 		return "", errors.New("read_only connections cannot be used with ingestr")
 	}
 	return c.config.GetIngestrURI(), nil

--- a/pkg/config/clickhouse_read_only_test.go
+++ b/pkg/config/clickhouse_read_only_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestClickHouseConnectionReadOnlyRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, conn := range []any{&ClickHouseConnection{}} {
+		require.NoError(t, yaml.Unmarshal([]byte("name: reader\nread_only: true\n"), conn))
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+		var values map[string]any
+		require.NoError(t, json.Unmarshal(data, &values))
+		require.Equal(t, true, values["read_only"])
+		data, err = yaml.Marshal(conn)
+		require.NoError(t, err)
+		require.Contains(t, string(data), "read_only: true")
+		require.NoError(t, json.Unmarshal([]byte(`{"read_only":false}`), conn))
+		data, err = json.Marshal(conn)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "read_only")
+	}
+}
+
+func TestClickHouseConnectionReadOnlySchema(t *testing.T) {
+	t.Parallel()
+	schema, err := GetConnectionsSchema()
+	require.NoError(t, err)
+	var document struct {
+		Definitions map[string]struct {
+			Properties map[string]struct {
+				Type string `json:"type"`
+			} `json:"properties"`
+			Required []string `json:"required"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(schema), &document))
+	for _, name := range []string{"ClickHouseConnection"} {
+		def := document.Definitions[name]
+		require.Equal(t, "boolean", def.Properties["read_only"].Type)
+		require.NotContains(t, def.Required, "read_only")
+	}
+}

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1020,6 +1020,7 @@ type ClickHouseConnection struct {
 	Database           string `yaml:"database" json:"database" mapstructure:"database"`
 	HTTPPort           int    `yaml:"http_port,omitempty" json:"http_port,omitempty" mapstructure:"http_port"`
 	Secure             *int   `yaml:"secure,omitempty" json:"secure,omitempty" mapstructure:"secure"`
+	ReadOnly           bool   `yaml:"read_only,omitempty" json:"read_only,omitempty" mapstructure:"read_only"`
 }
 
 func (c ClickHouseConnection) GetName() string {

--- a/pkg/connection/clickhouse_read_only_test.go
+++ b/pkg/connection/clickhouse_read_only_test.go
@@ -1,0 +1,27 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerClickhouseReadOnly(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		m := Manager{availableConnections: map[string]any{}, AllConnectionDetails: map[string]any{}}
+		connection := &config.ClickHouseConnection{ConnectionMetadata: config.ConnectionMetadata{Name: "reader"}, Host: "localhost", ReadOnly: readOnly}
+		require.NoError(t, m.AddClickHouseConnectionFromConfig(connection))
+		client, ok := m.GetConnection("reader").(interface{ GetIngestrURI() (string, error) })
+		require.True(t, ok)
+		uri, err := client.GetIngestrURI()
+		if readOnly {
+			require.EqualError(t, err, "read_only connections cannot be used with ingestr")
+			require.Empty(t, uri)
+		} else {
+			require.NoError(t, err)
+			require.NotEmpty(t, uri)
+		}
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -2201,6 +2201,7 @@ func (m *Manager) AddClickHouseConnectionFromConfig(connection *config.ClickHous
 	m.mutex.Unlock()
 
 	client, err := clickhouse.NewClient(&clickhouse.Config{
+		ReadOnly: connection.ReadOnly,
 		Host:     connection.Host,
 		Port:     connection.Port,
 		Username: connection.Username,


### PR DESCRIPTION
Adds `read_only: true` to ClickHouse connections and sends the native `readonly=1` setting. Ingestr is rejected because its separate connection would not preserve this setting.

Extends the existing ClickHouse testcontainers suite with a CLI end-to-end test for local execution. The test verifies JSON reads, rejected writes and setting overrides, unchanged row counts after rejected queries, and continued reads after a writable connection inserts another row.

Validation: `make format`, `make test`, `make integration-test-light`, and `go test -count=1 -v -timeout 10m -run '^TestReadOnlyConnection$' .` in the existing ClickHouse integration module.
