### PR TITLE
Add read-only Redshift connections

### DIFF
--- a/docs/platforms/redshift.md
+++ b/docs/platforms/redshift.md
@@ -23,11 +23,7 @@ Mind that, despite the connection being at all effects a Postgres connection, th
 
 ### Read-only connections
 
-Set `read_only: true` to enable native read-only execution. The default is `false`. Bruin runs each native SQL query in a `READ ONLY` transaction and rolls it back after reading the result. Multiple SQL statements in one query are rejected in this mode. See the [database transaction documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_BEGIN.html) for the native restrictions.
-
-This option applies to Bruin's native SQL client. Ingestr assets and seed loading through ingestr return an error for these connections because they open a separate connection that does not preserve this setting. Use a separate connection with database-enforced read-only credentials for ingestion sources.
-
-Native read-only mode follows the database's transaction and permission rules; use database-enforced privileges when running untrusted SQL.
+Set `read_only: true` to prevent SQL queries from modifying data. Defaults to `false`. Ingestr assets and seeds do not support this option.
 
 > [!NOTE]
 > `ssl_mode` should be one of the modes describe in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).

--- a/docs/platforms/redshift.md
+++ b/docs/platforms/redshift.md
@@ -18,7 +18,16 @@ Mind that, despite the connection being at all effects a Postgres connection, th
           database: "dev"
           schema: "schema_name" # optional
           ssl_mode: "allow" # optional
+          read_only: false
 ```
+
+### Read-only connections
+
+Set `read_only: true` to enable native read-only execution. The default is `false`. Bruin runs each native SQL query in a `READ ONLY` transaction and rolls it back after reading the result. Multiple SQL statements in one query are rejected in this mode. See the [database transaction documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_BEGIN.html) for the native restrictions.
+
+This option applies to Bruin's native SQL client. Ingestr assets and seed loading through ingestr return an error for these connections because they open a separate connection that does not preserve this setting. Use a separate connection with database-enforced read-only credentials for ingestion sources.
+
+Native read-only mode follows the database's transaction and permission rules; use database-enforced privileges when running untrusted SQL.
 
 > [!NOTE]
 > `ssl_mode` should be one of the modes describe in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).

--- a/docs/platforms/redshift.md
+++ b/docs/platforms/redshift.md
@@ -23,7 +23,7 @@ Mind that, despite the connection being at all effects a Postgres connection, th
 
 ### Read-only connections
 
-Set `read_only: true` to prevent SQL queries from modifying data. Defaults to `false`. Ingestr assets and seeds do not support this option.
+Set `read_only: true` to run SQL queries in read-only mode (default: `false`). Ingestr assets and seeds do not support this option.
 
 > [!NOTE]
 > `ssl_mode` should be one of the modes describe in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -4588,6 +4588,9 @@
         },
         "ssl_mode": {
           "type": "string"
+        },
+        "read_only": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -527,6 +527,7 @@ type RedshiftConnection struct {
 	Database           string `yaml:"database,omitempty" json:"database" mapstructure:"database"`
 	Schema             string `yaml:"schema,omitempty" json:"schema" mapstructure:"schema"`
 	SslMode            string `yaml:"ssl_mode,omitempty" json:"ssl_mode,omitempty" mapstructure:"ssl_mode" default:"allow"`
+	ReadOnly           bool   `yaml:"read_only,omitempty" json:"read_only,omitempty" mapstructure:"read_only"`
 }
 
 func (c RedshiftConnection) GetName() string {

--- a/pkg/config/redshift_read_only_test.go
+++ b/pkg/config/redshift_read_only_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRedshiftConnectionReadOnlyRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, conn := range []any{&RedshiftConnection{}} {
+		require.NoError(t, yaml.Unmarshal([]byte("name: reader\nread_only: true\n"), conn))
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+		var values map[string]any
+		require.NoError(t, json.Unmarshal(data, &values))
+		require.Equal(t, true, values["read_only"])
+		data, err = yaml.Marshal(conn)
+		require.NoError(t, err)
+		require.Contains(t, string(data), "read_only: true")
+		require.NoError(t, json.Unmarshal([]byte(`{"read_only":false}`), conn))
+		data, err = json.Marshal(conn)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "read_only")
+	}
+}
+
+func TestRedshiftConnectionReadOnlySchema(t *testing.T) {
+	t.Parallel()
+	schema, err := GetConnectionsSchema()
+	require.NoError(t, err)
+	var document struct {
+		Definitions map[string]struct {
+			Properties map[string]struct {
+				Type string `json:"type"`
+			} `json:"properties"`
+			Required []string `json:"required"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(schema), &document))
+	for _, name := range []string{"RedshiftConnection"} {
+		def := document.Definitions[name]
+		require.Equal(t, "boolean", def.Properties["read_only"].Type)
+		require.NotContains(t, def.Required, "read_only")
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -997,6 +997,7 @@ func (m *Manager) addRedshiftConnectionFromConfig(ctx context.Context, connectio
 	var client *postgres.Client
 	var err error
 	client, err = postgres.NewClient(ctx, postgres.RedShiftConfig{
+		ReadOnly: connection.ReadOnly,
 		Username: connection.Username,
 		Password: connection.Password,
 		Host:     connection.Host,

--- a/pkg/connection/redshift_read_only_test.go
+++ b/pkg/connection/redshift_read_only_test.go
@@ -1,0 +1,27 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerRedshiftReadOnly(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		m := Manager{availableConnections: map[string]any{}, AllConnectionDetails: map[string]any{}}
+		connection := &config.RedshiftConnection{ConnectionMetadata: config.ConnectionMetadata{Name: "reader"}, Host: "localhost", Port: 5432, SslMode: "disable", ReadOnly: readOnly}
+		require.NoError(t, m.AddRedshiftConnectionFromConfig(t.Context(), connection))
+		client, ok := m.GetConnection("reader").(interface{ GetIngestrURI() (string, error) })
+		require.True(t, ok)
+		uri, err := client.GetIngestrURI()
+		if readOnly {
+			require.EqualError(t, err, "read_only connections cannot be used with ingestr")
+			require.Empty(t, uri)
+		} else {
+			require.NoError(t, err)
+			require.NotEmpty(t, uri)
+		}
+	}
+}

--- a/pkg/postgres/config.go
+++ b/pkg/postgres/config.go
@@ -64,6 +64,7 @@ type RedShiftConfig struct {
 	Database string
 	Schema   string
 	SslMode  string
+	ReadOnly bool
 }
 
 // ToDBConnectionURI returns a connection URI to be used with the pgx package.

--- a/pkg/postgres/db.go
+++ b/pkg/postgres/db.go
@@ -44,8 +44,13 @@ func NewClient(ctx context.Context, c PgConfig) (*Client, error) {
 		return nil, err
 	}
 
+	var queryConn connection = conn
+	if cfg, ok := c.(interface{ IsReadOnly() bool }); ok && cfg.IsReadOnly() {
+		queryConn = &readOnlyConnection{pool: conn}
+	}
+
 	return &Client{
-		connection:    conn,
+		connection:    queryConn,
 		config:        c,
 		schemaCreator: ansisql.NewSchemaCreator(),
 		schemaCache:   &sync.Map{},
@@ -63,6 +68,9 @@ func (c *Client) RunQueryWithoutResult(ctx context.Context, query *query.Query) 
 }
 
 func (c *Client) GetIngestrURI() (string, error) {
+	if cfg, ok := c.config.(interface{ IsReadOnly() bool }); ok && cfg.IsReadOnly() {
+		return "", errors.New("read_only connections cannot be used with ingestr")
+	}
 	return c.config.GetIngestrURI(), nil
 }
 

--- a/pkg/postgres/read_only.go
+++ b/pkg/postgres/read_only.go
@@ -1,0 +1,71 @@
+package postgres
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pkg/errors"
+)
+
+type transactionPool interface {
+	BeginTx(ctx context.Context, options pgx.TxOptions) (pgx.Tx, error)
+}
+
+type readOnlyConnection struct {
+	pool transactionPool
+}
+
+func rollbackReadOnly(ctx context.Context, tx pgx.Tx) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	_ = tx.Rollback(ctx)
+}
+
+func (c *readOnlyConnection) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	rows, err := c.Query(ctx, sql, args...)
+	if err != nil {
+		return pgconn.CommandTag{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+	}
+	return rows.CommandTag(), rows.Err()
+}
+
+//nolint:ireturn
+func (c *readOnlyConnection) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	tx, err := c.pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start read-only transaction")
+	}
+	rows, err := tx.Query(ctx, sql, append([]any{pgx.QueryExecModeExec}, args...)...)
+	if err != nil {
+		rollbackReadOnly(ctx, tx)
+		return nil, err
+	}
+	return &readOnlyRows{Rows: rows, cleanup: func() { rollbackReadOnly(ctx, tx) }}, nil
+}
+
+type readOnlyRows struct {
+	pgx.Rows
+	cleanup   func()
+	closeOnce sync.Once
+}
+
+func (r *readOnlyRows) Close() {
+	r.closeOnce.Do(func() {
+		r.Rows.Close()
+		r.cleanup()
+	})
+}
+
+func (r *readOnlyRows) Next() bool {
+	if r.Rows.Next() {
+		return true
+	}
+	r.Close()
+	return false
+}

--- a/pkg/postgres/read_only_test.go
+++ b/pkg/postgres/read_only_test.go
@@ -1,0 +1,116 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnlyConnectionQuery(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"success", "query error", "row error", "early close", "canceled context"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+			mock.ExpectBeginTx(pgx.TxOptions{AccessMode: pgx.ReadOnly})
+			expected := mock.ExpectQuery("SELECT").WithArgs(pgx.QueryExecModeExec, 42)
+			if name == "query error" {
+				expected.WillReturnError(errors.New("query failed"))
+			} else {
+				rows := pgxmock.NewRows([]string{"value"}).AddRow(42).AddRow(43)
+				if name == "row error" {
+					rows.RowError(0, errors.New("row failed"))
+				}
+				expected.WillReturnRows(rows).RowsWillBeClosed()
+			}
+			mock.ExpectRollback()
+			conn := &readOnlyConnection{pool: mock}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			rows, err := conn.Query(ctx, "SELECT $1", 42)
+			if name == "query error" {
+				require.EqualError(t, err, "query failed")
+			} else {
+				require.NoError(t, err)
+				if name == "canceled context" {
+					cancel()
+				}
+				if name == "success" || name == "row error" {
+					for rows.Next() {
+						_, err := rows.Values()
+						if name == "row error" {
+							require.EqualError(t, err, "row failed")
+							break
+						}
+						require.NoError(t, err)
+					}
+					if name == "row error" {
+						require.EqualError(t, rows.Err(), "row failed")
+					} else {
+						require.NoError(t, rows.Err())
+					}
+				}
+				rows.Close()
+				rows.Close()
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestReadOnlyConnectionExec(t *testing.T) {
+	t.Parallel()
+	for _, fails := range []bool{false, true} {
+		t.Run(map[bool]string{false: "success", true: "write rejected"}[fails], func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+			mock.ExpectBeginTx(pgx.TxOptions{AccessMode: pgx.ReadOnly})
+			expected := mock.ExpectQuery("DELETE FROM items").WithArgs(pgx.QueryExecModeExec)
+			if fails {
+				expected.WillReturnError(errors.New("read-only transaction"))
+			} else {
+				expected.WillReturnRows(pgxmock.NewRows([]string{"value"}).AddRow(1)).RowsWillBeClosed()
+			}
+			mock.ExpectRollback()
+			client := &Client{connection: &readOnlyConnection{pool: mock}}
+			err = client.RunQueryWithoutResult(t.Context(), &query.Query{Query: "DELETE FROM items"})
+			if fails {
+				require.EqualError(t, err, "read-only transaction")
+			} else {
+				require.NoError(t, err)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestReadOnlyConnectionBeginFailure(t *testing.T) {
+	t.Parallel()
+	for _, exec := range []bool{false, true} {
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+		mock.ExpectBeginTx(pgx.TxOptions{AccessMode: pgx.ReadOnly}).WillReturnError(errors.New("unavailable"))
+		conn := &readOnlyConnection{pool: mock}
+		if exec {
+			_, err = conn.Exec(t.Context(), "SELECT 1")
+		} else {
+			rows, queryErr := conn.Query(t.Context(), "SELECT 1")
+			if rows != nil {
+				rows.Close()
+			}
+			err = queryErr
+		}
+		require.EqualError(t, err, "failed to start read-only transaction: unavailable")
+		require.NoError(t, mock.ExpectationsWereMet())
+	}
+}

--- a/pkg/postgres/redshift_read_only_config.go
+++ b/pkg/postgres/redshift_read_only_config.go
@@ -1,0 +1,5 @@
+package postgres
+
+func (c RedShiftConfig) IsReadOnly() bool {
+	return c.ReadOnly
+}


### PR DESCRIPTION
Adds `read_only: true` to Redshift connections. Queries use the shared pgx client with read-only transactions, deterministic rollback, and extended-protocol execution to reject multi-statement transaction escapes. Ingestr is rejected in this mode.

The pgx wrapper and its unit tests are shared unchanged with the separate PostgreSQL PR. This PR exposes the option only for Redshift and is based directly on `main`.

Validation: `make format`, `make test`, and `make integration-test-light`; unit tests cover transaction options, rollback/error paths, configuration serialization, and manager forwarding. Live Redshift validation is left for manual testing.
