### PR TITLE
Add read-only MotherDuck connections

### DIFF
--- a/docs/platforms/motherduck.md
+++ b/docs/platforms/motherduck.md
@@ -12,12 +12,14 @@ Bruin supports connecting to MotherDuck databases using your MotherDuck token.
         - name: "connection_name"
           token: "your_motherduck_token"
           database: "database_name"  # optional
+          read_only: false
 ```
 
 **Parameters**:
 
 - `token`: Your MotherDuck authentication token (required)
 - `database`: The specific database to connect to in your MotherDuck account (optional)
+- `read_only`: Run SQL queries in read-only mode (default: `false`). Requires a MotherDuck read-scaling token. Ingestr assets and seeds do not support this option.
 
 If no database is specified, you'll connect to your default MotherDuck database.
 

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -3748,6 +3748,9 @@
         },
         "database": {
           "type": "string"
+        },
+        "read_only": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -1005,6 +1005,7 @@ type MotherduckConnection struct {
 	ConnectionMetadata `yaml:",inline" mapstructure:",squash"`
 	Token              string `yaml:"token,omitempty" json:"token" mapstructure:"token" sensitive:"true"`
 	Database           string `yaml:"database,omitempty" json:"database,omitempty" mapstructure:"database"`
+	ReadOnly           bool   `yaml:"read_only,omitempty" json:"read_only,omitempty" mapstructure:"read_only"`
 }
 
 func (m MotherduckConnection) GetName() string {

--- a/pkg/config/motherduck_read_only_test.go
+++ b/pkg/config/motherduck_read_only_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMotherduckConnectionReadOnlyRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, conn := range []any{&MotherduckConnection{}} {
+		require.NoError(t, yaml.Unmarshal([]byte("name: reader\nread_only: true\n"), conn))
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+		var values map[string]any
+		require.NoError(t, json.Unmarshal(data, &values))
+		require.Equal(t, true, values["read_only"])
+		data, err = yaml.Marshal(conn)
+		require.NoError(t, err)
+		require.Contains(t, string(data), "read_only: true")
+		require.NoError(t, json.Unmarshal([]byte(`{"read_only":false}`), conn))
+		data, err = json.Marshal(conn)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "read_only")
+	}
+}
+
+func TestMotherduckConnectionReadOnlySchema(t *testing.T) {
+	t.Parallel()
+	schema, err := GetConnectionsSchema()
+	require.NoError(t, err)
+	var document struct {
+		Definitions map[string]struct {
+			Properties map[string]struct {
+				Type string `json:"type"`
+			} `json:"properties"`
+			Required []string `json:"required"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(schema), &document))
+	for _, name := range []string{"MotherduckConnection"} {
+		def := document.Definitions[name]
+		require.Equal(t, "boolean", def.Properties["read_only"].Type)
+		require.NotContains(t, def.Required, "read_only")
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -2178,6 +2178,7 @@ func (m *Manager) AddMotherduckConnectionFromConfig(connection *config.Motherduc
 	client, err := duck.NewClient(duck.MotherDuckConfig{
 		Token:    connection.Token,
 		Database: connection.Database,
+		ReadOnly: connection.ReadOnly,
 	})
 	if err != nil {
 		return err

--- a/pkg/connection/motherduck_read_only_test.go
+++ b/pkg/connection/motherduck_read_only_test.go
@@ -1,0 +1,27 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerMotherduckReadOnly(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		m := Manager{availableConnections: map[string]any{}, AllConnectionDetails: map[string]any{}}
+		connection := &config.MotherduckConnection{ConnectionMetadata: config.ConnectionMetadata{Name: "reader"}, Token: "test-token", ReadOnly: readOnly}
+		require.NoError(t, m.AddMotherduckConnectionFromConfig(connection))
+		client, ok := m.GetConnection("reader").(interface{ GetIngestrURI() (string, error) })
+		require.True(t, ok)
+		uri, err := client.GetIngestrURI()
+		if readOnly {
+			require.EqualError(t, err, "read_only MotherDuck connections cannot be used with ingestr")
+			require.Empty(t, uri)
+		} else {
+			require.NoError(t, err)
+			require.NotEmpty(t, uri)
+		}
+	}
+}

--- a/pkg/duckdb/config.go
+++ b/pkg/duckdb/config.go
@@ -1,6 +1,10 @@
 package duck
 
-import "github.com/bruin-data/bruin/pkg/config"
+import (
+	"net/url"
+
+	"github.com/bruin-data/bruin/pkg/config"
+)
 
 type Config struct {
 	Path      string
@@ -35,20 +39,32 @@ func (c Config) GetLakehouseAlias() string {
 }
 
 type MotherDuckConfig struct {
+	ReadOnly bool
 	Token    string
 	Database string
 }
 
 func (c MotherDuckConfig) ToDBConnectionURI() string {
 	if c.Database != "" {
-		return "md:" + c.Database + "?motherduck_token=" + c.Token
+		return "md:" + c.Database + "?motherduck_token=" + url.QueryEscape(c.Token)
 	}
-	return "md:?motherduck_token=" + c.Token
+	return "md:?motherduck_token=" + url.QueryEscape(c.Token)
 }
 
 func (c MotherDuckConfig) GetIngestrURI() string {
 	if c.Database != "" {
-		return "motherduck://" + c.Database + "?token=" + c.Token
+		return "motherduck://" + c.Database + "?token=" + url.QueryEscape(c.Token)
 	}
-	return "motherduck://?token=" + c.Token
+	return "motherduck://?token=" + url.QueryEscape(c.Token)
+}
+
+func isReadOnlyMotherDuck(c DuckDBConfig) bool {
+	switch cfg := c.(type) {
+	case MotherDuckConfig:
+		return cfg.ReadOnly
+	case *MotherDuckConfig:
+		return cfg.ReadOnly
+	default:
+		return false
+	}
 }

--- a/pkg/duckdb/db.go
+++ b/pkg/duckdb/db.go
@@ -200,7 +200,7 @@ func (w *sqlxWrapper) QueryRowContext(ctx context.Context, query string, args ..
 }
 
 func NewClient(c DuckDBConfig) (*Client, error) {
-	readOnly := false
+	readOnly := isReadOnlyMotherDuck(c)
 	if cfg, ok := c.(Config); ok {
 		readOnly = cfg.ReadOnly
 	}
@@ -248,6 +248,9 @@ func (c *Client) RunQueryWithoutResult(ctx context.Context, query *query.Query) 
 }
 
 func (c *Client) GetIngestrURI() (string, error) {
+	if isReadOnlyMotherDuck(c.config) {
+		return "", errors.New("read_only MotherDuck connections cannot be used with ingestr")
+	}
 	return c.config.GetIngestrURI(), nil
 }
 

--- a/pkg/duckdb/ephemeral_db.go
+++ b/pkg/duckdb/ephemeral_db.go
@@ -38,15 +38,7 @@ func NewEphemeralConnection(c DuckDBConfig) (*EphemeralConnection, error) {
 //
 //nolint:ireturn
 func (e *EphemeralConnection) openADBC(ctx context.Context) (adbc.Database, adbc.Connection, error) {
-	path := e.config.ToDBConnectionURI()
-	opts := map[string]string{
-		"driver": "duckdb",
-		"path":   path,
-	}
-
-	if cfg, ok := e.config.(Config); ok && cfg.ReadOnly {
-		opts["access_mode"] = "read_only"
-	}
+	opts := e.databaseOptions()
 
 	var drv drivermgr.Driver
 	adb, err := drv.NewDatabase(opts)
@@ -589,4 +581,20 @@ func convertAssign(dest, src any) error {
 	}
 
 	return fmt.Errorf("cannot assign %T to %T", src, dest)
+}
+
+func (e *EphemeralConnection) databaseOptions() map[string]string {
+	opts := map[string]string{
+		"driver": "duckdb",
+		"path":   e.config.ToDBConnectionURI(),
+	}
+
+	if cfg, ok := e.config.(Config); ok && cfg.ReadOnly {
+		opts["access_mode"] = "read_only"
+	}
+
+	if isReadOnlyMotherDuck(e.config) {
+		opts["access_mode"] = "read_only"
+	}
+	return opts
 }

--- a/pkg/duckdb/motherduck_read_only_test.go
+++ b/pkg/duckdb/motherduck_read_only_test.go
@@ -1,0 +1,61 @@
+//go:build !bruin_no_duckdb
+
+package duck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMotherDuckReadOnlyOptions(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name     string
+		config   DuckDBConfig
+		readOnly bool
+	}{
+		{"motherduck default", MotherDuckConfig{Database: "analytics", Token: "token"}, false},
+		{"motherduck readonly", MotherDuckConfig{Database: "analytics", Token: "token", ReadOnly: true}, true},
+		{"motherduck pointer", &MotherDuckConfig{ReadOnly: true}, true},
+		{"duckdb default", Config{Path: "test.db"}, false},
+		{"duckdb readonly", Config{Path: "test.db", ReadOnly: true}, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			connection := &EphemeralConnection{config: test.config}
+			options := connection.databaseOptions()
+			require.Equal(t, test.config.ToDBConnectionURI(), options["path"])
+			if test.readOnly {
+				require.Equal(t, "read_only", options["access_mode"])
+			} else {
+				require.NotContains(t, options, "access_mode")
+			}
+		})
+	}
+}
+
+func TestMotherDuckReadOnlyClient(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		client, err := NewClient(MotherDuckConfig{Token: "test-token", Database: "analytics", ReadOnly: readOnly})
+		require.NoError(t, err)
+		require.Equal(t, readOnly, client.readOnly)
+		uri, err := client.GetIngestrURI()
+		if readOnly {
+			require.EqualError(t, err, "read_only MotherDuck connections cannot be used with ingestr")
+			require.Empty(t, uri)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, "motherduck://analytics?token=test-token", uri)
+		}
+		client.Close()
+	}
+}
+
+func TestMotherDuckTokenEscaping(t *testing.T) {
+	t.Parallel()
+	config := MotherDuckConfig{Database: "analytics", Token: "a&access_mode=read_write"}
+	require.Equal(t, "md:analytics?motherduck_token=a%26access_mode%3Dread_write", config.ToDBConnectionURI())
+	require.Equal(t, "motherduck://analytics?token=a%26access_mode%3Dread_write", config.GetIngestrURI())
+}


### PR DESCRIPTION
Adds `read_only: true` to MotherDuck connections. Bruin forwards the option to the DuckDB ADBC driver as `access_mode=read_only` and keeps connection locking consistent with read-only execution. Ingestr is rejected for these connections. Tokens are URL-encoded when building connection URIs.

This mode requires a MotherDuck read-scaling token, consistent with [MotherDuck's own read-only client guidance](https://github.com/motherduckdb/mcp-server-motherduck#duckdb--motherduck-local-mcp-server). Live MotherDuck validation is left for manual testing.

Validation: `make format`, `make test`, `make integration-test-light`, and full lint on the changed packages. Tests cover connection configuration serialization, schema exposure, manager forwarding, driver options, ingestr rejection, and token escaping.
