### PR TITLE
fix(academy-sql-beginner): update programme name and un-flatten Reviewing work list

### DIFF
--- a/templates/academy-sql-beginner/AGENTS.md
+++ b/templates/academy-sql-beginner/AGENTS.md
@@ -36,19 +36,22 @@ model answers, the hands-on task, and the rubric. Then:
 ### Reviewing work
 
 1. Get the artifact the lesson asks for. When it names a file (a query, a findings
-file), read it from disk - do not accept "I did it". When the artifact is a spoken or
-written answer (the discussion lessons), the student's actual answer in the
-conversation is the artifact - grade that, do not demand a file the lesson never asked
-for. 2. Run it yourself with `bruin query` if it is a query. 3. Check it against the
-lesson's rubric, point by point, naming what is right before what is wrong. 4. On a
-pass, update `course/progress.md` and prompt `next lesson`. On a fail, give one
-concrete fix and stop. Never mark a lesson done that the student has not actually
-completed.
+   file), read it from disk - do not accept "I did it". When the artifact is a spoken or
+   written answer (the discussion lessons), the student's actual answer in the
+   conversation is the artifact - grade that, do not demand a file the lesson never asked
+   for.
+2. Run it yourself with `bruin query` if it is a query.
+3. Check it against the lesson's rubric, point by point, naming what is right before what
+   is wrong.
+4. On a pass, update `course/progress.md` and prompt `next lesson`. On a fail, give one
+   concrete fix and stop.
+
+Never mark a lesson done that the student has not actually completed.
 
 ## Your role
 
 You are a SQL instructor working inside a Bruin project. Your student is taking the
-beginner course in the Agentic Data Analysis series on getbruin.com/learn.
+Ask the Data course in the SQL in the Age of AI series on getbruin.com/learn/sql-ai-beginner.
 
 Your job is to make the student able to read and audit SQL without you. It is not to
 produce correct queries as fast as possible.

--- a/templates/academy-sql-beginner/README.md
+++ b/templates/academy-sql-beginner/README.md
@@ -1,6 +1,6 @@
 # academy-sql-beginner
 
-The starter project for the beginner course in the **Agentic Data Analysis**
+The starter project for the beginner course in the **SQL in the Age of AI**
 series on [getbruin.com/learn](https://getbruin.com/learn). It gives you a small,
 realistic retail dataset to learn SQL on - and to learn how to *audit* SQL, which
 is the real point of the course.


### PR DESCRIPTION
## What

Three fixes to the `templates/academy-sql-beginner/` template, which is a live, agent-led interactive SQL course. `AGENTS.md` is the instruction set that turns a student's coding agent into an instructor, so errors in it degrade teaching directly.

1. **Stale programme name.** The programme was renamed from *Agentic Data Analysis* to **SQL in the Age of AI** (course **Ask the Data**, at `getbruin.com/learn/sql-ai-beginner`). Updated the `## Your role` sentence in `AGENTS.md` and the matching reference in `README.md`.
2. **Flattened numbered list in `### Reviewing work`.** This is the procedure that decides whether a lesson is marked complete. Steps 2–4 began mid-line, so only step 1 rendered as a list item and the rest collapsed into one paragraph. Re-broken into four list items with **no wording changes**; the trailing "Never mark a lesson done…" line is preserved.
3. **Audited the rest of `AGENTS.md`.** `### Commands` and `### Teaching a lesson` were checked and are cleanly structured; no other flattened lists or headings.

## Out of scope / left untouched
- 7 `pipeline/assets/*.sql` files still reference the old programme name in comments — left because `pipeline/` was excluded from this change.

## Verification
- Non-application (template markdown) change; this template is **not** in `SYNCED`, so no docs-page regeneration.
- An agent followed `AGENTS.md` end-to-end and ran `next lesson` and `review my work` once each against the template: both commands are followable, `### Reviewing work` now parses as four distinct steps plus the final line, and no ambiguity was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)