### PR TITLE
Document notification destination setup

### DIFF
--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -68,7 +68,7 @@ A rule can send to multiple destinations and can include multiple recipients or 
 
 Enter multiple values on separate lines or separate them with commas.
 
-To find a Microsoft Teams channel ID, copy the channel link. The encoded value after `/channel/` is the channel ID. Replace `%3A` with `:` and `%40` with `@`. For example, `19%3Aabc%40thread.tacv2` becomes `19:abc@thread.tacv2`.
+To find a Microsoft Teams channel ID, copy the channel link. The encoded value between `/channel/` and the next `/` is the channel ID. Replace `%3A` with `:` and `%40` with `@`. For example, `19%3Aabc%40thread.tacv2` becomes `19:abc@thread.tacv2`.
 
 <a href="notifications/notification-rule-destinations.png" target="_blank">
   <img class="docs-screenshot" src="/cloud/notifications/notification-rule-destinations.png" alt="Email and Slack destinations in a notification rule">

--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -63,10 +63,12 @@ A rule can send to multiple destinations and can include multiple recipients or 
 | --- | --- | --- |
 | Email | No connection is required. | One or more email addresses. |
 | Slack | [Connect Slack to Bruin](/cloud/integrations/slack). | A channel name or ID. |
-| Microsoft Teams | [Add the Bruin bot to Teams](/cloud/integrations/teams). | The full conversation ID, starting with `19:`. |
-| Discord | [Connect the Bruin bot to Discord](/cloud/integrations/discord). | A numeric channel ID the bot can access. |
+| Microsoft Teams | [Add the Bruin bot to Teams](/cloud/integrations/teams). | The full channel ID, starting with `19:`. Connection names are not supported. |
+| Discord | [Connect the Bruin bot to Discord](/cloud/integrations/discord). | A numeric channel ID the bot can access. Connection names are not supported. |
 
 Enter multiple values on separate lines or separate them with commas.
+
+To find a Microsoft Teams channel ID, copy the channel link. The encoded value after `/channel/` is the channel ID. Replace `%3A` with `:` and `%40` with `@`. For example, `19%3Aabc%40thread.tacv2` becomes `19:abc@thread.tacv2`.
 
 <a href="notifications/notification-rule-destinations.png" target="_blank">
   <img class="docs-screenshot" src="/cloud/notifications/notification-rule-destinations.png" alt="Email and Slack destinations in a notification rule">

--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -59,12 +59,14 @@ Choose **all** to require every condition in a group, or **any** to require at l
 
 A rule can send to multiple destinations and can include multiple recipients or channels for a destination.
 
-| Destination | Value |
-| --- | --- |
-| Email | One or more email addresses. |
-| Slack | A Slack channel name or ID. |
-| Microsoft Teams | A Teams conversation ID. |
-| Discord | A Discord channel ID. |
+| Destination | Setup | Value |
+| --- | --- | --- |
+| Email | No connection is required. | One or more email addresses. |
+| Slack | [Connect Slack to Bruin](/cloud/integrations/slack). | A channel name or ID. |
+| Microsoft Teams | [Add the Bruin bot to Teams](/cloud/integrations/teams). | The full conversation ID, starting with `19:`. |
+| Discord | [Connect the Bruin bot to Discord](/cloud/integrations/discord). | A numeric channel ID the bot can access. |
+
+Saved Microsoft Teams and Discord webhook connections are used only by [legacy notifications](/cloud/legacy-notifications), not by notification rules.
 
 Enter multiple values on separate lines or separate them with commas.
 

--- a/docs/cloud/notifications.md
+++ b/docs/cloud/notifications.md
@@ -66,8 +66,6 @@ A rule can send to multiple destinations and can include multiple recipients or 
 | Microsoft Teams | [Add the Bruin bot to Teams](/cloud/integrations/teams). | The full conversation ID, starting with `19:`. |
 | Discord | [Connect the Bruin bot to Discord](/cloud/integrations/discord). | A numeric channel ID the bot can access. |
 
-Saved Microsoft Teams and Discord webhook connections are used only by [legacy notifications](/cloud/legacy-notifications), not by notification rules.
-
 Enter multiple values on separate lines or separate them with commas.
 
 <a href="notifications/notification-rule-destinations.png" target="_blank">


### PR DESCRIPTION
## Summary
- document setup and accepted values for Email, Slack, Microsoft Teams, and Discord notification rules
- distinguish new notification destinations from legacy Teams and Discord webhook connections

## Verification
- `npm run docs:build`
- `git diff --check`

Markdown lint reports existing errors elsewhere in the documentation; `docs/cloud/notifications.md` has no reported errors.