### PR TITLE
Add read-only Snowflake connections

### DIFF
--- a/docs/platforms/snowflake.md
+++ b/docs/platforms/snowflake.md
@@ -13,6 +13,30 @@ Snowflake connections support two authentication methods:
 
 Both methods use the same Snowflake account, database, schema, warehouse, role, and region fields. Choose one authentication method and configure it as shown below.
 
+### Read-only connections
+
+Set `read_only: true` on a Snowflake connection to validate SQL with SQLGlot before Bruin sends it to Snowflake:
+
+```yaml
+environments:
+  default:
+    connections:
+      snowflake:
+        - name: snowflake-default
+          account: your-account
+          username: your-user
+          password: your-password
+          warehouse: your-warehouse
+          database: your-database
+          read_only: true
+```
+
+The default is `false`. With this option enabled, Bruin allows SELECT queries (including CTEs and set operations), SHOW, DESCRIBE, and EXPLAIN of read queries. Every statement in a multi-statement query must pass validation before any statement executes.
+
+Bruin rejects writes, session changes, procedure calls, SELECT INTO, locking reads, sequence references, unknown or user-defined function calls, and SQL that cannot be parsed or classified. Unknown functions are rejected even when they happen to be read-only. Parser failures also prevent execution. Ingestr URI export is disabled for these connections because ingestr executes outside this validation path.
+
+This is a conservative SQL syntax check. SQLGlot cannot inspect view definitions or prove the absence of side effects in database objects. Use a Snowflake role with restricted privileges as well; `read_only` does not change server-side permissions.
+
 ### Connection Parameters
 
 Each parameter has a short heading for the page outline. Expand the details below a parameter to see where to find it in Snowflake and how to get it with a command or query.

--- a/integration-tests/expectations/expected_connections_schema.json
+++ b/integration-tests/expectations/expected_connections_schema.json
@@ -5079,6 +5079,9 @@
         "private_key": {
           "type": "string"
         },
+        "read_only": {
+          "type": "boolean"
+        },
         "token": {
           "type": "string"
         }

--- a/pkg/config/connections.go
+++ b/pkg/config/connections.go
@@ -545,6 +545,7 @@ type SnowflakeConnection struct {
 	Warehouse          string `yaml:"warehouse,omitempty" json:"warehouse,omitempty" mapstructure:"warehouse"`
 	PrivateKeyPath     string `yaml:"private_key_path,omitempty" json:"private_key_path,omitempty" jsonschema:"oneof_required=private_key_path" mapstructure:"private_key_path" sensitive_file:"true"`
 	PrivateKey         string `yaml:"private_key,omitempty" json:"private_key,omitempty" jsonschema:"oneof_required=private_key" mapstructure:"private_key" sensitive:"true"`
+	ReadOnly           bool   `yaml:"read_only,omitempty" json:"read_only,omitempty" mapstructure:"read_only"`
 	Token              string `yaml:"token,omitempty" json:"token,omitempty" jsonschema:"oneof_required=token" mapstructure:"token" sensitive:"true"`
 }
 
@@ -573,6 +574,9 @@ func (c SnowflakeConnection) MarshalJSON() ([]byte, error) {
 		"warehouse":   c.Warehouse,
 		"private_key": c.PrivateKey,
 		"token":       c.Token,
+	}
+	if c.ReadOnly {
+		payload["read_only"] = true
 	}
 	addConnectionMetadataToMap(c.ConnectionMetadata, payload)
 
@@ -678,6 +682,14 @@ func (c SnowflakeConnection) MarshalYAML() (interface{}, error) {
 			node.Content,
 			&yaml.Node{Kind: yaml.ScalarNode, Value: "token"},
 			&yaml.Node{Kind: yaml.ScalarNode, Value: c.Token},
+		)
+	}
+
+	if c.ReadOnly {
+		node.Content = append(
+			node.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "read_only"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
 		)
 	}
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -4191,3 +4191,25 @@ environments:
 	require.Equal(t, "gs://bucket/warehouse", remote.Storage.Path)
 	require.Equal(t, filepath.Join(configLocation, "creds/sa.json"), remote.Storage.KeyFile)
 }
+
+func TestSnowflakeReadOnlySerialization(t *testing.T) {
+	t.Parallel()
+	for _, readOnly := range []bool{false, true} {
+		conn := SnowflakeConnection{ConnectionMetadata: ConnectionMetadata{Name: "sf"}, Account: "account", ReadOnly: readOnly}
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+		var jsonConn SnowflakeConnection
+		require.NoError(t, json.Unmarshal(data, &jsonConn))
+		require.Equal(t, readOnly, jsonConn.ReadOnly)
+		data, err = yaml.Marshal(conn)
+		require.NoError(t, err)
+		var yamlConn SnowflakeConnection
+		require.NoError(t, yaml.Unmarshal(data, &yamlConn))
+		require.Equal(t, readOnly, yamlConn.ReadOnly)
+		if readOnly {
+			require.Contains(t, string(data), "read_only: true")
+		} else {
+			require.NotContains(t, string(data), "read_only")
+		}
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -456,6 +456,7 @@ func newSnowflakeDBFromConnection(connection *config.SnowflakeConnection) (*snow
 	}
 
 	return snowflake.NewDB(&snowflake.Config{
+		ReadOnly:   connection.ReadOnly,
 		Account:    connection.Account,
 		Username:   connection.Username,
 		Password:   connection.Password,

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1288,3 +1288,13 @@ func TestManagerMapsStayPaired(t *testing.T) {
 		}
 	}
 }
+
+func TestSnowflakeReadOnlyConnection(t *testing.T) {
+	t.Parallel()
+	db, err := newSnowflakeDBFromConnection(&config.SnowflakeConnection{
+		Account: "test", Username: "test", Password: "test", ReadOnly: true,
+	})
+	require.NoError(t, err)
+	_, err = db.GetIngestrURI()
+	require.ErrorContains(t, err, "read-only")
+}

--- a/pkg/snowflake/config.go
+++ b/pkg/snowflake/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Config struct {
+	ReadOnly   bool
 	Account    string
 	Username   string
 	Password   string
@@ -60,6 +61,10 @@ func (c Config) DSN() (string, error) {
 }
 
 func (c Config) GetIngestrURI() (string, error) {
+	if c.ReadOnly {
+		return "", errors.New("read-only Snowflake connections cannot be used with ingestr because SQL validation cannot be enforced")
+	}
+
 	u := &url.URL{
 		Scheme: "snowflake",
 		Path:   c.Database,

--- a/pkg/snowflake/db.go
+++ b/pkg/snowflake/db.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bruin-data/bruin/pkg/diff"
 	"github.com/bruin-data/bruin/pkg/pipeline"
 	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/bruin-data/bruin/pkg/sqlparser"
 	"github.com/bruin-data/bruin/pkg/tablename"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
@@ -213,6 +214,10 @@ func (db *DB) Select(ctx context.Context, query *query.Query) ([][]interface{}, 
 }
 
 func (db *DB) selectOnce(ctx context.Context, query *query.Query, requestID *gosnowflake.UUID) ([][]interface{}, error) {
+	if err := db.validateReadOnlyQuery(query.String()); err != nil {
+		return nil, err
+	}
+
 	if err := db.initializeDB(ctx); err != nil {
 		return nil, err
 	}
@@ -284,6 +289,10 @@ func (db *DB) SelectOnlyLastResult(ctx context.Context, query *query.Query) ([][
 }
 
 func (db *DB) selectOnlyLastResultOnce(ctx context.Context, query *query.Query, requestID *gosnowflake.UUID) ([][]interface{}, error) {
+	if err := db.validateReadOnlyQuery(query.String()); err != nil {
+		return nil, err
+	}
+
 	if err := db.initializeDB(ctx); err != nil {
 		return nil, err
 	}
@@ -368,6 +377,10 @@ func (db *DB) IsValid(ctx context.Context, query *query.Query) (bool, error) {
 }
 
 func (db *DB) isValidOnce(ctx context.Context, query *query.Query, requestID *gosnowflake.UUID) (bool, error) {
+	if err := db.validateReadOnlyQuery(query.ToExplainQuery()); err != nil {
+		return false, err
+	}
+
 	if err := db.initializeDB(ctx); err != nil {
 		return false, err
 	}
@@ -448,6 +461,10 @@ func (db *DB) SelectWithSchema(ctx context.Context, queryObj *query.Query) (*que
 }
 
 func (db *DB) selectWithSchemaOnce(ctx context.Context, queryObj *query.Query, requestID *gosnowflake.UUID) (*query.QueryResult, error) {
+	if err := db.validateReadOnlyQuery(queryObj.String()); err != nil {
+		return nil, err
+	}
+
 	if err := db.initializeDB(ctx); err != nil {
 		return nil, err
 	}
@@ -1475,4 +1492,11 @@ func (db *DB) BuildTableExistsQuery(tableName string) (string, error) {
 	)
 
 	return strings.TrimSpace(query), nil
+}
+
+func (db *DB) validateReadOnlyQuery(query string) error {
+	if db.config == nil || !db.config.ReadOnly {
+		return nil
+	}
+	return sqlparser.ValidateReadOnlyQuery(query, "snowflake")
 }

--- a/pkg/snowflake/readonly_test.go
+++ b/pkg/snowflake/readonly_test.go
@@ -1,0 +1,71 @@
+package snowflake
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBReadOnly(t *testing.T) {
+	methods := []struct {
+		name    string
+		run     func(*DB, *query.Query) error
+		explain bool
+	}{
+		{name: "Select", run: func(db *DB, q *query.Query) error { _, err := db.Select(t.Context(), q); return err }},
+		{name: "SelectOnlyLastResult", run: func(db *DB, q *query.Query) error { _, err := db.SelectOnlyLastResult(t.Context(), q); return err }},
+		{name: "SelectWithSchema", run: func(db *DB, q *query.Query) error { _, err := db.SelectWithSchema(t.Context(), q); return err }},
+		{name: "RunQueryWithoutResult", run: func(db *DB, q *query.Query) error { return db.RunQueryWithoutResult(t.Context(), q) }},
+		{name: "IsValid", explain: true, run: func(db *DB, q *query.Query) error { _, err := db.IsValid(t.Context(), q); return err }},
+		{name: "DryRunQuery", explain: true, run: func(db *DB, q *query.Query) error { _, err := db.DryRunQuery(t.Context(), q); return err }},
+	}
+	for _, method := range methods {
+		t.Run(method.name, func(t *testing.T) {
+			for _, sql := range []string{"DELETE FROM t", "SELECT 1; DROP TABLE t", "SELECT FROM", "SELECT SYSTEM$CANCEL_QUERY('id')"} {
+				db := &DB{config: &Config{ReadOnly: true}, connect: func(context.Context) (*sqlx.DB, error) {
+					t.Fatal("read-only validation must reject the query before connecting")
+					return nil, nil
+				}}
+				require.ErrorContains(t, method.run(db, &query.Query{Query: sql}), "read-only")
+			}
+			mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			require.NoError(t, err)
+			defer mockDB.Close()
+			db := &DB{config: &Config{ReadOnly: true}, conn: sqlx.NewDb(mockDB, "sqlmock")}
+			sql := "SELECT 1"
+			if method.explain {
+				sql = "EXPLAIN SELECT 1;"
+			}
+			mock.ExpectQuery(sql).WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+			require.NoError(t, method.run(db, &query.Query{Query: "SELECT 1"}))
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestDBReadOnlyDisabledAllowsWrites(t *testing.T) {
+	t.Parallel()
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer mockDB.Close()
+	db := &DB{config: &Config{}, conn: sqlx.NewDb(mockDB, "sqlmock")}
+	mock.ExpectQuery("DELETE FROM t").WillReturnRows(sqlmock.NewRows([]string{"rows"}).AddRow(1))
+	require.NoError(t, db.RunQueryWithoutResult(t.Context(), &query.Query{Query: "DELETE FROM t"}))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDBReadOnlyExplainVariableDefinitions(t *testing.T) {
+	db := &DB{config: &Config{ReadOnly: true}}
+	_, err := db.IsValid(t.Context(), &query.Query{Query: "SELECT 1", VariableDefinitions: []string{"DELETE FROM t"}})
+	require.ErrorContains(t, err, "read-only")
+}
+
+func TestReadOnlyIngestrURI(t *testing.T) {
+	t.Parallel()
+	_, err := (Config{ReadOnly: true}).GetIngestrURI()
+	require.ErrorContains(t, err, "read-only")
+}

--- a/pkg/sqlparser/readonly.go
+++ b/pkg/sqlparser/readonly.go
@@ -1,0 +1,55 @@
+package sqlparser
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	readOnlyParserOnce sync.Once
+	readOnlyParser     *SQLParser
+	readOnlyParserErr  error
+)
+
+func ValidateReadOnlyQuery(query, dialect string) error {
+	readOnlyParserOnce.Do(func() {
+		readOnlyParser, readOnlyParserErr = NewSQLParserCached()
+	})
+	if readOnlyParserErr != nil {
+		return fmt.Errorf("read-only query validation failed: %w", readOnlyParserErr)
+	}
+	readOnly, err := readOnlyParser.IsReadOnlyQuery(query, dialect)
+	if err != nil {
+		return fmt.Errorf("read-only query validation failed: %w", err)
+	}
+	if !readOnly {
+		return errors.New("query is not allowed on a read-only connection")
+	}
+	return nil
+}
+
+func (s *SQLParser) IsReadOnlyQuery(query, dialect string) (bool, error) {
+	if err := s.Start(); err != nil {
+		return false, fmt.Errorf("failed to start sql parser: %w", err)
+	}
+	payload, err := s.sendCommand(&parserCommand{
+		Command:  "is-read-only",
+		Contents: map[string]interface{}{"query": query, "dialect": dialect},
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to validate read-only query: %w", err)
+	}
+	var response struct {
+		ReadOnly bool   `json:"is_read_only"`
+		Error    string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(payload), &response); err != nil {
+		return false, fmt.Errorf("failed to unmarshal read-only response: %w", err)
+	}
+	if response.Error != "" {
+		return false, fmt.Errorf("cannot determine whether query is read-only: %s", response.Error)
+	}
+	return response.ReadOnly, nil
+}

--- a/pkg/sqlparser/readonly_test.go
+++ b/pkg/sqlparser/readonly_test.go
@@ -1,0 +1,73 @@
+package sqlparser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLParserIsReadOnlyQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		dialect string
+		want    bool
+		wantErr bool
+	}{
+		{name: "select", query: "SELECT 1", want: true},
+		{name: "CTE and aggregation", query: "WITH x AS (SELECT amount FROM orders) SELECT SUM(amount) FROM x", want: true},
+		{name: "union", query: "SELECT 1 UNION ALL SELECT 2", want: true},
+		{name: "multiple reads", query: "SELECT 1; SELECT 2;", want: true},
+		{name: "comments and literals", query: "/* DELETE FROM t ->> */ SELECT 'DROP TABLE t; ->>'; -- INSERT INTO t", want: true},
+		{name: "show", query: "SHOW TABLES", want: true},
+		{name: "describe", query: "DESCRIBE TABLE orders", want: true},
+		{name: "explain", query: "EXPLAIN SELECT COUNT(*) FROM orders", want: true},
+		{name: "insert", query: "INSERT INTO t VALUES (1)"},
+		{name: "update", query: "UPDATE t SET a = 1"},
+		{name: "delete", query: "DELETE FROM t"},
+		{name: "merge", query: "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE"},
+		{name: "create", query: "CREATE TABLE t AS SELECT 1"},
+		{name: "drop", query: "DROP TABLE t"},
+		{name: "alter", query: "ALTER TABLE t ADD COLUMN a INT"},
+		{name: "truncate", query: "TRUNCATE TABLE t"},
+		{name: "copy out", query: "COPY INTO @stage FROM t"},
+		{name: "call", query: "CALL write_data()"},
+		{name: "execute immediate", query: "EXECUTE IMMEDIATE 'DELETE FROM t'"},
+		{name: "session change", query: "ALTER SESSION SET QUERY_TAG = 'test'"},
+		{name: "use", query: "USE ROLE ACCOUNTADMIN"},
+		{name: "trailing write", query: "SELECT 1; DROP TABLE t"},
+		{name: "leading write", query: "DELETE FROM t; SELECT 1"},
+		{name: "select into", query: "SELECT * INTO backup FROM t"},
+		{name: "write CTE", query: "WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x", dialect: "postgres"},
+		{name: "lock", query: "SELECT * FROM t FOR UPDATE", dialect: "postgres"},
+		{name: "sequence", query: "SELECT seq.NEXTVAL"},
+		{name: "sequence function", query: "SELECT * FROM TABLE(GETNEXTVAL(seq))"},
+		{name: "system function", query: "SELECT SYSTEM$CANCEL_QUERY('id')"},
+		{name: "unknown function", query: "SELECT my_udf(1)"},
+		{name: "qualified function", query: "SELECT db.schema.ABS(1)"},
+		{name: "explain write", query: "EXPLAIN DELETE FROM t"},
+		{name: "explain trailing write", query: "EXPLAIN SELECT 1; DELETE FROM t"},
+		{name: "Snowflake flow operator", query: "SELECT 1 ->> DELETE FROM t"},
+		{name: "empty", query: "", wantErr: true},
+		{name: "only comments", query: "-- SELECT 1", wantErr: true},
+		{name: "malformed", query: "SELECT FROM", wantErr: true},
+		{name: "unknown dialect", query: "SELECT 1", dialect: "unknown", wantErr: true},
+		{name: "long write", query: "SELECT '" + strings.Repeat("a", 11000) + "'; DELETE FROM t"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialect := tt.dialect
+			if dialect == "" {
+				dialect = "snowflake"
+			}
+			got, err := sharedSQLParser.IsReadOnlyQuery(tt.query, dialect)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pythonsrc/main.py
+++ b/pythonsrc/main.py
@@ -12,6 +12,7 @@ from parser.main import (
     get_column_lineage,
     get_tables,
     is_single_select_query,
+    is_read_only_query,
     select_cte,
 )
 
@@ -62,6 +63,9 @@ def main():
                 logging.info("got add-limit command")
                 c = cmd["contents"]
                 result = add_limit(c["query"], c["limit"], c["dialect"])
+            elif cmd["command"] == "is-read-only":
+                c = cmd["contents"]
+                result = is_read_only_query(c["query"], c["dialect"])
             elif cmd["command"] == "is-single-select":
                 logging.info("got is-single-select command")
                 c = cmd["contents"]

--- a/pythonsrc/parser/main.py
+++ b/pythonsrc/parser/main.py
@@ -1,10 +1,11 @@
 import logging
 from dataclasses import dataclass
 
-from sqlglot import exp, lineage, parse, parse_one
+from sqlglot import exp, lineage, parse, parse_one, tokenize
 from sqlglot.lineage import Node
 from sqlglot.optimizer import optimize
 from sqlglot.optimizer.scope import build_scope, find_all_in_scope
+from sqlglot.tokens import TokenType
 
 
 def normalize_sqlglot_dialect(dialect: str | None) -> str | None:
@@ -817,3 +818,86 @@ def add_ctes(query: str, dialect: str = None, ctes: list = None) -> dict:
         return {"error": str(e)}
 
     return {"query": parsed.sql(dialect=dialect or None)}
+
+
+def is_read_only_query(query: str, dialect: str = None) -> dict:
+    dialect = normalize_sqlglot_dialect(dialect)
+    try:
+        if dialect == "snowflake" and any(
+            token.token_type == TokenType.DARROW
+            for token in tokenize(query, dialect=dialect)
+        ):
+            return {"is_read_only": False, "error": ""}
+        statements = [
+            stmt
+            for stmt in parse(query, dialect=dialect)
+            if stmt is not None and not isinstance(stmt, exp.Semicolon)
+        ]
+        if not statements:
+            return {"is_read_only": False, "error": "cannot parse empty query"}
+        for statement in statements:
+            if not _is_read_only_statement(statement, dialect):
+                return {"is_read_only": False, "error": ""}
+        return {"is_read_only": True, "error": ""}
+    except Exception as e:
+        return {"is_read_only": False, "error": str(e)}
+
+
+def _is_read_only_statement(statement: exp.Expr, dialect: str | None) -> bool:
+    if isinstance(statement, exp.Command) and dialect == "snowflake":
+        if statement.name.upper() != "EXPLAIN" or not isinstance(
+            statement.expression, exp.Literal
+        ):
+            return False
+        explained = parse(statement.expression.this, dialect=dialect)
+        return (
+            len(explained) == 1
+            and isinstance(explained[0], exp.Query)
+            and _is_read_only_statement(explained[0], dialect)
+        )
+
+    if not isinstance(
+        statement,
+        (
+            exp.Select,
+            exp.Union,
+            exp.Intersect,
+            exp.Except,
+            exp.Subquery,
+            exp.Show,
+            exp.Describe,
+        ),
+    ):
+        return False
+
+    for node in statement.walk():
+        if isinstance(
+            node,
+            (
+                exp.DDL,
+                exp.DML,
+                exp.Drop,
+                exp.Alter,
+                exp.TruncateTable,
+                exp.Grant,
+                exp.Revoke,
+                exp.Execute,
+                exp.Transaction,
+                exp.Commit,
+                exp.Rollback,
+                exp.Use,
+                exp.Pragma,
+                exp.Into,
+                exp.Lock,
+                exp.Command,
+                exp.NextValueFor,
+            ),
+        ):
+            return False
+        if isinstance(node, exp.Anonymous):
+            return False
+        if isinstance(node, exp.Column) and node.name.upper() == "NEXTVAL":
+            return False
+        if isinstance(node, exp.Func) and isinstance(node.parent, exp.Dot):
+            return False
+    return True


### PR DESCRIPTION
## What
Adds opt-in read-only Snowflake connections that validate SQL with SQLGlot before execution and disable ingestr URI export when validation cannot be enforced.

## Changes
- Add `read_only` Snowflake configuration, serialization, schema, and documentation.
- Validate SELECT, SHOW, DESCRIBE, and safe EXPLAIN statements across Snowflake query paths while rejecting writes, unsafe functions, flow-operator chains, and parser failures.
- Reuse the embedded SQL parser and add connection, parser, and Snowflake execution tests.

## How to test
1. Run `make format`, `make test`, and `make build-no-duckdb`.

## Risk & rollback
- **Risk:** Medium — conservative SQL classification can reject unsupported read-only Snowflake syntax, while unsafe or unclassified syntax fails closed.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, `make format`)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
