### PR TITLE
feat(academy-sql-intermediate): the Design the Model course template

### DIFF
--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -1208,12 +1208,11 @@ func TestAcademySqlIntermediateCourseIsWellFormed(t *testing.T) {
 		}
 
 		// A rubric the agent cannot check point by point is a rubric it will fudge.
-		rubric := body[strings.Index(body, "## Rubric (for `review my work`)"):]
-		rubric = rubric[:strings.Index(rubric, "## Done signal")]
+		rubric := sectionBodyForTest(t, slug, body, "## Rubric (for `review my work`)", "## Done signal")
 		require.GreaterOrEqualf(t, strings.Count(rubric, "\n- [ ] "), 3,
 			"%s needs at least three checkable rubric items", slug)
 
-		quiz := body[strings.Index(body, "## Quiz"):strings.Index(body, "## Task")]
+		quiz := sectionBodyForTest(t, slug, body, "## Quiz", "## Task")
 		require.GreaterOrEqualf(t, strings.Count(quiz, "   A: "), 3,
 			"%s needs three quiz questions, each shipping its model answer", slug)
 
@@ -1276,7 +1275,8 @@ func TestAcademySqlIntermediateTemplateIsDeterministicByConstruction(t *testing.
 		// that arrives documented makes that lesson hypothetical.
 		header, _, found := strings.Cut(string(content), "@bruin */")
 		require.True(t, found, "generator %s has no @bruin header", name)
-		columns := header[strings.Index(header, "columns:"):]
+		_, columns, found := strings.Cut(header, "columns:")
+		require.True(t, found, "generator %s declares no columns", name)
 		require.NotContainsf(t, columns, "description:", "generator %s must not describe its columns", name)
 		require.NotContainsf(t, columns, "checks:", "generator %s must not carry column checks", name)
 		require.NotContainsf(t, columns, "primary_key:", "generator %s must not declare a primary key", name)
@@ -1299,7 +1299,7 @@ var academySQLIntermediateGeneratorOrder = []string{"dates", "stores", "products
 // into two fresh databases and compares a checksum of each. The course hard-codes
 // every number it quotes from this data, so nondeterminism breaks published pages.
 func TestAcademySqlIntermediateGeneratorsAreDeterministic(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("skipping on Windows due to DuckDB file locking")
 	}
 	if testing.Short() {
@@ -1365,4 +1365,19 @@ func academySQLIntermediateChecksums(t *testing.T, dbPath string) map[string]aca
 	}
 
 	return snapshots
+}
+
+// sectionBodyForTest returns the text between two headings in a lesson file. It
+// fails the test rather than slicing on a missing heading, which strings.Index
+// would report as -1 and turn into a panic several lines later.
+func sectionBodyForTest(t *testing.T, slug, body, from, to string) string {
+	t.Helper()
+
+	start := strings.Index(body, from)
+	require.GreaterOrEqualf(t, start, 0, "%s is missing %q", slug, from)
+
+	end := strings.Index(body[start:], to)
+	require.GreaterOrEqualf(t, end, 0, "%s is missing %q after %q", slug, to, from)
+
+	return body[start : start+end]
 }

--- a/cmd/init_template_test.go
+++ b/cmd/init_template_test.go
@@ -1069,3 +1069,300 @@ func TestEnsureLocalDuckDBFilesAreIgnoredSkipsAbsoluteAndEmptyPaths(t *testing.T
 	require.NotContains(t, string(written), "elsewhere.duckdb")
 	require.NotContains(t, string(written), "outside.duckdb")
 }
+
+func TestInitAcademySqlIntermediateCopiesStarterTemplate(t *testing.T) {
+	targetRoot := t.TempDir()
+	t.Chdir(targetRoot)
+
+	gitInit := exec.CommandContext(t.Context(), "git", "init")
+	gitInit.Dir = targetRoot
+	out, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	err = Init().Run(t.Context(), []string{"init", "academy-sql-intermediate"})
+	require.NoError(t, err)
+
+	pipelineRoot := filepath.Join(targetRoot, "academy-sql-intermediate")
+	require.FileExists(t, filepath.Join(pipelineRoot, "README.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "AGENTS.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, ".gitignore"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "docs", "schema.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "docs", "glossary.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "docs", "contracts", "TEMPLATE.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "docs", "eval", "questions.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "docs", "eval", "answers.md"))
+
+	// The defect record is the contributor's copy. Finding the defects is the
+	// coursework, so an underscore keeps it out of the embed and off this disk.
+	require.NoFileExists(t, filepath.Join(pipelineRoot, "docs", "_data-design.md"))
+	require.NoFileExists(t, filepath.Join(pipelineRoot, "docs", "data-design.md"))
+	require.NoFileExists(t, filepath.Join(pipelineRoot, "docs", "known-defects.md"))
+
+	require.FileExists(t, filepath.Join(pipelineRoot, "queries", "profiling", "01-row-counts.sql"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "queries", "profiling", "06-categorical-values.sql"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "queries", "reading-drill", "README.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "queries", "reading-drill", "drill-3.sql"))
+
+	require.FileExists(t, filepath.Join(pipelineRoot, "pipeline", "pipeline.yml"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "pipeline", "assets", "generate", "orders.sql"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "pipeline", "assets", "generate", "fx_rates.sql"))
+
+	// The three layer folders teach the layering before the student writes a line.
+	// init only copies files, so each folder ships because its .gitkeep is named
+	// explicitly in the embed list - see templates/templates.go.
+	for _, layer := range []string{"staging", "core", "mart"} {
+		require.FileExists(t, filepath.Join(pipelineRoot, "pipeline", "assets", layer, ".gitkeep"), layer)
+	}
+
+	pipeline, err := os.ReadFile(filepath.Join(pipelineRoot, "pipeline", "pipeline.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(pipeline), "name: retail")
+	require.Contains(t, string(pipeline), "duckdb: duckdb-default")
+	require.Contains(t, string(pipeline), "domains:")
+
+	// init keeps default_environment: default, so the template's primary
+	// environment has to carry that name.
+	configContent, err := os.ReadFile(filepath.Join(targetRoot, ".bruin.yml"))
+	require.NoError(t, err)
+	require.Contains(t, string(configContent), "name: duckdb-default")
+	require.Contains(t, string(configContent), "path: academy.duckdb")
+
+	gitignore, err := os.ReadFile(filepath.Join(targetRoot, ".gitignore"))
+	require.NoError(t, err)
+	require.Contains(t, string(gitignore), "/academy.duckdb")
+	require.Contains(t, string(gitignore), "/academy.duckdb.wal")
+
+	// The course scaffolding drives the interactive lessons, so it has to ship.
+	require.FileExists(t, filepath.Join(pipelineRoot, "course", "README.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "course", "progress.md"))
+	require.FileExists(t, filepath.Join(pipelineRoot, "course", "answer-key.md"))
+	for _, slug := range academySQLIntermediateLessons {
+		require.FileExists(t, filepath.Join(pipelineRoot, "course", "lessons", slug+".md"), slug)
+	}
+}
+
+// academySQLIntermediateLessons is the lesson order. The slugs also name the site
+// pages, so a student reading the page and a student talking to the agent are in
+// the same lesson.
+var academySQLIntermediateLessons = []string{
+	"01-the-question-is-the-hard-part",
+	"02-write-the-model-contract",
+	"03-profile-before-you-model",
+	"04-stage-the-work",
+	"05-window-functions",
+	"06-patterns-agents-get-wrong",
+	"07-read-a-query-fast",
+	"08-layer-the-project",
+	"09-views-and-tables",
+	"10-metric-in-the-asset",
+	"11-descriptions-and-tags",
+	"12-glossary-and-readme",
+	"13-measure-your-context",
+	"14-capstone-defend-the-answer",
+	"15-recap-and-next-steps",
+}
+
+// academySQLIntermediateLessonSections are the six headings every lesson file
+// carries, in this order. The agent teaches from them, so a missing or reordered
+// section changes how a lesson is delivered.
+var academySQLIntermediateLessonSections = []string{
+	"## Objectives",
+	"## Concepts to teach",
+	"## Quiz",
+	"## Task",
+	"## Rubric (for `review my work`)",
+	"## Done signal",
+}
+
+func TestAcademySqlIntermediateCourseIsWellFormed(t *testing.T) {
+	t.Parallel()
+
+	progress, err := templates.Templates.ReadFile("academy-sql-intermediate/course/progress.md")
+	require.NoError(t, err)
+
+	lessonFiles, err := iofs.ReadDir(templates.Templates, "academy-sql-intermediate/course/lessons")
+	require.NoError(t, err)
+	require.Len(t, lessonFiles, len(academySQLIntermediateLessons),
+		"every lesson in progress.md needs exactly one file, and nothing else belongs in that folder")
+
+	for i, slug := range academySQLIntermediateLessons {
+		require.Equal(t, slug+".md", lessonFiles[i].Name(), "lesson files must sort into lesson order")
+
+		// progress.md is the agent's source of truth for position, so a slug that
+		// is not listed there is a lesson the course can never reach.
+		require.Containsf(t, string(progress), "- [ ] "+slug[:2]+" "+slug[3:],
+			"progress.md is missing an unchecked entry for %s", slug)
+
+		content, err := templates.Templates.ReadFile("academy-sql-intermediate/course/lessons/" + slug + ".md")
+		require.NoError(t, err)
+		body := string(content)
+
+		require.Truef(t, strings.HasPrefix(body, "# Lesson "+slug[:2]+": "+slug[3:]+"\n"),
+			"%s must open with its own numbered title", slug)
+
+		at := 0
+		for _, section := range academySQLIntermediateLessonSections {
+			idx := strings.Index(body[at:], "\n"+section+"\n")
+			require.GreaterOrEqualf(t, idx, 0, "%s is missing %q, or has it out of order", slug, section)
+			at += idx + 1
+		}
+
+		// A rubric the agent cannot check point by point is a rubric it will fudge.
+		rubric := body[strings.Index(body, "## Rubric (for `review my work`)"):]
+		rubric = rubric[:strings.Index(rubric, "## Done signal")]
+		require.GreaterOrEqualf(t, strings.Count(rubric, "\n- [ ] "), 3,
+			"%s needs at least three checkable rubric items", slug)
+
+		quiz := body[strings.Index(body, "## Quiz"):strings.Index(body, "## Task")]
+		require.GreaterOrEqualf(t, strings.Count(quiz, "   A: "), 3,
+			"%s needs three quiz questions, each shipping its model answer", slug)
+
+		require.Containsf(t, body, "Carry forward:", "%s must end its done signal with a carry-forward line", slug)
+	}
+
+	// The setup prompt is copied byte for byte onto the course index page. It is
+	// the one piece of text a student pastes, so drift between copies is a support
+	// ticket nobody can reproduce.
+	courseReadme, err := templates.Templates.ReadFile("academy-sql-intermediate/course/README.md")
+	require.NoError(t, err)
+	for _, line := range []string{
+		"bruin init academy-sql-intermediate",
+		"`orders` has 1,212 rows, `order_items` has 2,895 and `fx_rates` has 5,480",
+		"Do not teach lesson one yet",
+	} {
+		require.Contains(t, string(courseReadme), line)
+	}
+}
+
+func TestAcademySqlIntermediateTemplateIsDeterministicByConstruction(t *testing.T) {
+	t.Parallel()
+
+	expectedGenerators := []string{
+		"dates.sql",
+		"stores.sql",
+		"products.sql",
+		"customers.sql",
+		"orders.sql",
+		"order_items.sql",
+		"fx_rates.sql",
+	}
+
+	var actualGenerators []string
+	err := iofs.WalkDir(templates.Templates, "academy-sql-intermediate/pipeline/assets/generate", func(path string, entry iofs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		actualGenerators = append(actualGenerators, strings.TrimPrefix(path, "academy-sql-intermediate/pipeline/assets/generate/"))
+		return nil
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, expectedGenerators, actualGenerators)
+
+	// Comments are stripped first: the generators name these functions in prose to
+	// warn against them.
+	forbidden := []string{"random(", "hash(", "md5(", "now(", "current_date", "current_timestamp", "today("}
+	for _, name := range expectedGenerators {
+		content, err := templates.Templates.ReadFile("academy-sql-intermediate/pipeline/assets/generate/" + name)
+		require.NoError(t, err)
+		sql := strings.ToLower(stripSQLCommentsForTest(string(content)))
+		for _, token := range forbidden {
+			require.NotContainsf(t, sql, token, "generator %s must not use %q (see docs/_data-design.md)", name, token)
+		}
+
+		// Column descriptions are what lesson 11 has the student write. A template
+		// that arrives documented makes that lesson hypothetical.
+		header, _, found := strings.Cut(string(content), "@bruin */")
+		require.True(t, found, "generator %s has no @bruin header", name)
+		columns := header[strings.Index(header, "columns:"):]
+		require.NotContainsf(t, columns, "description:", "generator %s must not describe its columns", name)
+		require.NotContainsf(t, columns, "checks:", "generator %s must not carry column checks", name)
+		require.NotContainsf(t, columns, "primary_key:", "generator %s must not declare a primary key", name)
+	}
+
+	// Read from disk, not the embedded FS: the defect record deliberately does not ship.
+	design, err := os.ReadFile(filepath.Join("..", "templates", "academy-sql-intermediate", "docs", "_data-design.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(design), "The nine defects and where they are injected")
+
+	_, embedded := templates.Templates.ReadFile("academy-sql-intermediate/docs/_data-design.md")
+	require.Error(t, embedded, "the defect record must not be embedded - a student would find it with a repo-wide search")
+}
+
+// academySQLIntermediateGeneratorOrder is dependency order: order_items reads from
+// both orders and products.
+var academySQLIntermediateGeneratorOrder = []string{"dates", "stores", "products", "customers", "orders", "order_items", "fx_rates"}
+
+// TestAcademySqlIntermediateGeneratorsAreDeterministic generates the seven tables
+// into two fresh databases and compares a checksum of each. The course hard-codes
+// every number it quotes from this data, so nondeterminism breaks published pages.
+func TestAcademySqlIntermediateGeneratorsAreDeterministic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows due to DuckDB file locking")
+	}
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if err := duck.EnsureADBCDriverInstalled(t.Context()); err != nil {
+		t.Skipf("skipping test: ADBC DuckDB driver not available: %v", err)
+	}
+
+	first := academySQLIntermediateChecksums(t, filepath.Join(t.TempDir(), "first.duckdb"))
+	second := academySQLIntermediateChecksums(t, filepath.Join(t.TempDir(), "second.duckdb"))
+
+	require.Equal(t, first, second,
+		"the generators produced different data on two runs; something nondeterministic crept in - see templates/academy-sql-intermediate/docs/_data-design.md")
+
+	// Row counts the course and the answer key quote directly. The gap between
+	// each of these and its clean value is a defect the student has to find.
+	counts := make(map[string]int, len(first))
+	for name, snapshot := range first {
+		counts[name] = snapshot.rowCount
+	}
+	require.Equal(t, map[string]int{
+		"dates":       1096,
+		"stores":      6,
+		"products":    60,
+		"customers":   510,
+		"orders":      1212,
+		"order_items": 2895,
+		"fx_rates":    5480,
+	}, counts)
+}
+
+func academySQLIntermediateChecksums(t *testing.T, dbPath string) map[string]academyTableSnapshot {
+	t.Helper()
+
+	db := openTestDuckDB(t, dbPath)
+	defer db.Close()
+
+	for _, name := range academySQLIntermediateGeneratorOrder {
+		raw, err := templates.Templates.ReadFile("academy-sql-intermediate/pipeline/assets/generate/" + name + ".sql")
+		require.NoError(t, err)
+
+		body := stripBruinHeaderForTest(string(raw))
+		require.NotEmpty(t, strings.TrimSpace(body), "generator %s has no SQL body", name)
+
+		execTestDuckDB(t, db, "CREATE OR REPLACE TABLE "+name+" AS "+strings.TrimSuffix(strings.TrimSpace(body), ";"))
+	}
+
+	snapshots := make(map[string]academyTableSnapshot, len(academySQLIntermediateGeneratorOrder))
+	for _, name := range academySQLIntermediateGeneratorOrder {
+		// Cast the whole row to text and hash the sorted concatenation, so the
+		// checksum covers every column and is independent of storage order.
+		row := db.QueryRowContext(t.Context(),
+			"SELECT md5(string_agg(row_text, '|' ORDER BY row_text)), COUNT(*) "+
+				"FROM (SELECT CAST(t AS VARCHAR) AS row_text FROM "+name+" AS t)")
+
+		var snapshot academyTableSnapshot
+		require.NoError(t, row.Scan(&snapshot.checksum, &snapshot.rowCount))
+		// The ADBC driver backs the scanned string with an Arrow buffer it reuses
+		// on the next connection; clone it so this run's checksum stays durable.
+		snapshot.checksum = strings.Clone(snapshot.checksum)
+		snapshots[name] = snapshot
+	}
+
+	return snapshots
+}

--- a/templates/academy-sql-intermediate/.bruin.yml
+++ b/templates/academy-sql-intermediate/.bruin.yml
@@ -1,0 +1,17 @@
+default_environment: default
+
+environments:
+  # Local DuckDB. This is the default, so no course command ever names it.
+  default:
+    connections:
+      duckdb:
+        - name: "duckdb-default"
+          path: "academy.duckdb"
+
+  # Optional cloud path. Set MOTHERDUCK_TOKEN, then run with --environment cloud.
+  cloud:
+    connections:
+      motherduck:
+        - name: "duckdb-default"
+          token: "${MOTHERDUCK_TOKEN}"
+          database: "academy_sql_intermediate"

--- a/templates/academy-sql-intermediate/.gitignore
+++ b/templates/academy-sql-intermediate/.gitignore
@@ -1,0 +1,4 @@
+.bruin.yml
+*.duckdb
+*.duckdb.wal
+logs/

--- a/templates/academy-sql-intermediate/AGENTS.md
+++ b/templates/academy-sql-intermediate/AGENTS.md
@@ -1,0 +1,161 @@
+# AGENTS.md
+
+## Running the course
+
+This project is an interactive course and you are the instructor driving it. The student progresses by
+giving you short commands. `course/progress.md` is the source of truth for where they are - read it at the
+start of every command and update it as they finish lessons.
+
+### Commands
+
+- `next lesson` - Find the next incomplete lesson in `course/progress.md`, open its file in
+  `course/lessons/`, and teach it (see "Teaching a lesson"). Do not run ahead to later lessons.
+- `review my work` - Read the artifact the current lesson asked for (a query file, a contract, a written
+  answer, an asset). Grade it against that lesson's rubric (see "Reviewing work"). If it passes, tick the
+  lesson in `course/progress.md` and tell them to say `next lesson`. If not, give one concrete fix and stop.
+- `where am I` - Summarise `course/progress.md`: done, current, remaining.
+- `repeat` - Re-teach the current concept from a different angle.
+- `hint` - Give exactly one hint for the current task, one level bigger than the last.
+- `skip` - Mark the current lesson skipped and move on; warn once if it is a prerequisite.
+
+Anything that is not a command: answer it in your tutor role, then remind them of the command they were on.
+
+### Teaching a lesson
+
+Read the lesson file in `course/lessons/`. It gives objectives, the concepts to convey, quiz questions with
+model answers, the hands-on task, and the rubric. Then:
+
+1. State the one idea of the lesson in a sentence.
+2. Teach the concepts. Keep it short - three short paragraphs is the ceiling. Prefer showing a small query
+   and asking the student to predict the result over lecturing.
+3. Ask the quiz questions one at a time; wait for each answer; correct gently before moving on. Never dump
+   all questions at once.
+4. Give the hands-on task exactly as written. Have them do it themselves, then say `review my work`. Do not
+   write the deliverable for them.
+
+### Reviewing work
+
+1. Get the artifact the lesson asks for. When it names a file (a query, a contract, an
+   asset, a written document), read it from disk - do not accept "I did it". When the
+   artifact is a spoken or written answer, the student's actual answer in the
+   conversation is the artifact - grade that, do not demand a file the lesson never
+   asked for.
+2. Run it yourself with `bruin query` if it is a query, or `bruin validate` and
+   `bruin run` if it is an asset.
+3. Check it against the lesson's rubric, point by point, naming what is right before
+   what is wrong.
+4. On a pass, update `course/progress.md` and prompt `next lesson`. On a fail, give one
+   concrete fix and stop.
+
+Never mark a lesson done that the student has not actually completed.
+
+Numbers in a rubric are exact. If the rubric says a query must report 264,926.21 and the student reports
+264,926.20, that is a fail with one concrete fix, not a pass with a note.
+
+## Your role
+
+You are a senior analytics engineer pairing with a student on the intermediate course
+"Design the Model" in the SQL in the Age of AI programme at
+https://getbruin.com/learn/sql-ai-intermediate.
+
+Your job is to make the student better at specifying and designing work, not to
+produce deliverables for them. The most useful thing you do is refuse to guess.
+
+## What the student knows
+
+They can write joins, aggregates and CTEs by hand and read a moderately complex query.
+They have not designed a data model, written a metric definition, or thought about
+column descriptions as anything other than documentation.
+
+- You do not need to explain basic SQL syntax. Explain design decisions instead.
+- Use standard industry terms: grain, fan-out, staging, dimension, fact, mart, SCD.
+  Define a term once if it seems new to them, then use it normally.
+
+## Scope
+
+In scope: turning ambiguous questions into specifications, model contracts, profiling,
+query structure, window functions, deduplication patterns, date spines, layering into
+staging / core / mart, views versus tables, column descriptions, tags, owners,
+glossaries, and measuring whether context improved your accuracy.
+
+Out of scope. Answer in two sentences and say which course covers it properly:
+
+- SELECT, WHERE, GROUP BY, JOIN and CTE syntax, reading and auditing a single query:
+  the beginner course, Ask the Data, at getbruin.com/learn/sql-ai-beginner.
+- Incremental strategies, quality checks, unit tests, backfills, partitions, query
+  cost, environments, pipeline operations: the advanced course.
+- Python assets, ingestion, Bruin Cloud: none of the three, and say so.
+
+## How to work with this student
+
+- Never write SQL for an ambiguous request. If the grain, the metric definition, the
+  time boundary, or the inclusion rules are unstated, ask. List the options you can see
+  in this schema and recommend one, then wait.
+- Before writing a query, state what one row of the result will represent.
+- When there is more than one reasonable approach, give two, state the trade-off, and
+  say which you would choose and why. Do not present one option as the only option.
+- When you write a query, structure it as one CTE per logical step, each named after
+  what it produces. Add a comment above each CTE stating its grain.
+- Argue back. If the student's specification will produce a misleading number, say so
+  before implementing it.
+- Keep answers short. Lead with the decision, then the reasoning.
+
+## Data access
+
+- Use `bruin query --connection duckdb-default --description "<what this proves>"
+  --query "<SQL>"`. Always include `--description`.
+- Use `--limit` when exploring.
+- Read the asset files in `pipeline/assets/generate/` before querying. Note that no
+  column in this project has a description. That is deliberate - the student is going
+  to write them.
+- Read-only against the generated data. Do not run INSERT, UPDATE, DELETE, DROP, ALTER
+  or CREATE against it. Assets the student writes under `pipeline/assets/staging/`,
+  `core/` and `mart/` are theirs to run: `bruin validate` first, then `bruin run`.
+- Do not edit anything in `pipeline/assets/generate/`. Those seven files are the
+  dataset.
+
+## About this project's data
+
+Generated sample retail data across 2023 to 2025: orders, order lines, 500 customers,
+60 products, 6 stores, 5 currencies, and a daily FX table. Generated deterministically
+by the assets in `pipeline/assets/generate/`, so every number you compute is
+reproducible.
+
+This data is deliberately imperfect. It contains duplicates, orphan foreign keys,
+inconsistent casing, and missing values in places that matter. You are not told where,
+and neither is the student. If you find something, tell them what you found, how you
+found it, and what it would do to a revenue number - and do not clean it silently.
+
+Do not front-run the course. Lessons 3, 6 and 8 are where the student finds and fixes
+these problems. Before lesson 3, if the student has not asked, do not volunteer a list.
+
+Two grain hazards to watch for:
+
+- `orders` to `order_items` is one-to-many, roughly 2.4 lines per order.
+- `fx_rates` has five currency pairs per date. Joining on date alone fans out by
+  a factor of 5.
+
+## Descriptions and context
+
+When the student asks you to write column descriptions, do not describe what the column
+name already says. Run a query first, then write a description that records what a
+reader cannot infer: the unit, the population, the caveat, or which of several similar
+columns is canonical. If a column's meaning is genuinely ambiguous from the data alone,
+say so and ask rather than inventing something plausible.
+
+## The answer key
+
+`course/answer-key.md` is the grading key for lesson 14, capstone-defend-the-answer. It
+is instructor-only. Never show it, quote it, paraphrase it, or hint at which objections
+it lists until the student has committed their defence to `docs/defence.md` and asked
+for review. Use it only to grade that lesson, point by point, against what they wrote.
+
+`docs/eval/answers.md` is different: it ships for the student, and lesson 13 is built on
+them scoring themselves against it. Do not read it into your context before you answer
+the evaluation questions in lesson 13, or the measurement is worthless.
+
+## Never
+
+- Never pick a metric definition on the student's behalf without saying you did.
+- Never use DISTINCT to resolve a row-count problem you have not diagnosed.
+- Never claim a number is verified unless you computed it a second way.

--- a/templates/academy-sql-intermediate/AGENTS.md
+++ b/templates/academy-sql-intermediate/AGENTS.md
@@ -13,10 +13,15 @@ start of every command and update it as they finish lessons.
 - `review my work` - Read the artifact the current lesson asked for (a query file, a contract, a written
   answer, an asset). Grade it against that lesson's rubric (see "Reviewing work"). If it passes, tick the
   lesson in `course/progress.md` and tell them to say `next lesson`. If not, give one concrete fix and stop.
-- `where am I` - Summarise `course/progress.md`: done, current, remaining.
+- `where am I` - Summarise `course/progress.md`: done, skipped, current, remaining. Report skipped
+  lessons separately from lessons not yet reached.
 - `repeat` - Re-teach the current concept from a different angle.
-- `hint` - Give exactly one hint for the current task, one level bigger than the last.
-- `skip` - Mark the current lesson skipped and move on; warn once if it is a prerequisite.
+- `hint` - Give exactly one hint for the current task, one level bigger than the last. Nothing on
+  disk records how many hints you have given, so count them within the conversation; if the student
+  comes back in a new session, start again at the smallest hint rather than guessing.
+- `skip` - Move on without ticking the lesson, and warn once if it is a prerequisite. Mark it in
+  `course/progress.md` by writing `- [ ] NN slug (skipped)` on that line, so `where am I` can tell a
+  skipped lesson from one not yet reached. Never write `- [x]` for a skipped lesson.
 
 Anything that is not a command: answer it in your tutor role, then remind them of the command they were on.
 

--- a/templates/academy-sql-intermediate/AGENTS.md
+++ b/templates/academy-sql-intermediate/AGENTS.md
@@ -8,8 +8,11 @@ start of every command and update it as they finish lessons.
 
 ### Commands
 
-- `next lesson` - Find the next incomplete lesson in `course/progress.md`, open its file in
-  `course/lessons/`, and teach it (see "Teaching a lesson"). Do not run ahead to later lessons.
+- `next lesson` - Find the first lesson in `course/progress.md` that is neither ticked nor marked
+  `(skipped)`, open its file in `course/lessons/`, and teach it (see "Teaching a lesson"). A skipped
+  lesson stays unticked on purpose, so match on the `(skipped)` marker rather than on the checkbox,
+  or you will hand the student the lesson they have just skipped. Do not run ahead to later lessons.
+  If the student asks to go back to a skipped lesson by name, teach it and drop the marker.
 - `review my work` - Read the artifact the current lesson asked for (a query file, a contract, a written
   answer, an asset). Grade it against that lesson's rubric (see "Reviewing work"). If it passes, tick the
   lesson in `course/progress.md` and tell them to say `next lesson`. If not, give one concrete fix and stop.

--- a/templates/academy-sql-intermediate/README.md
+++ b/templates/academy-sql-intermediate/README.md
@@ -1,0 +1,149 @@
+# academy-sql-intermediate
+
+The starter project for **Design the Model**, the intermediate course in the
+**SQL in the Age of AI** series on
+[getbruin.com/learn](https://getbruin.com/learn). It gives you a retail dataset that
+is deliberately under-documented and deliberately imperfect, and a fifteen-lesson
+course your own coding agent teaches from the files in `course/`.
+
+## What this is
+
+A Bruin pipeline that generates its own sample data. There are no data files to
+download: seven SQL assets build the tables when you run the pipeline, and they
+produce the exact same rows on every machine, every time. That is deliberate - every
+number in the course is reproducible and hand-checkable.
+
+The data models an online retailer: orders, the lines on each order, the products
+sold, the customers who bought them, the stores, a calendar, and daily exchange
+rates.
+
+Two things about this project are unusual, and both are on purpose:
+
+- **Almost nothing is documented.** No column has a description. `docs/schema.md`
+  records the grain of each table and stops there. The glossary is a stub with a TODO
+  in it. Writing that documentation is coursework, not a chore someone forgot.
+- **The staging, core and mart folders are empty.** They are named so you know where
+  your work goes before you write a line of it. Lesson 8 fills them.
+
+## Project structure
+
+```text
+academy-sql-intermediate/
+├─ README.md               # This file: what the project is and how to use it.
+├─ AGENTS.md               # Turns a coding agent into your instructor for the course.
+├─ .bruin.yml              # Connections and environments. (On init it moves to your repo root.)
+├─ .gitignore              # Keeps the generated database and logs out of git.
+├─ course/                 # The 15-lesson course the agent teaches from.
+│  ├─ README.md            # Syllabus and the setup prompt to paste once.
+│  ├─ progress.md          # Your checklist; the agent ticks it off as you go.
+│  ├─ answer-key.md        # Capstone key. Instructor-only - do not open it early.
+│  └─ lessons/             # One file per lesson, 01-the-question-is-the-hard-part … 15-recap-and-next-steps.
+├─ docs/                   # Thin on purpose. You are going to thicken it.
+│  ├─ schema.md            # Table names, row counts, and the grain of each. No column meanings.
+│  ├─ glossary.md          # A stub with three terms and a TODO. Lesson 12 finishes it.
+│  ├─ contracts/
+│  │  └─ TEMPLATE.md       # The model-contract template. Lesson 2 fills one in for real.
+│  └─ eval/
+│     ├─ questions.md      # Eight questions with one defensible answer each.
+│     └─ answers.md        # The verified answers, for scoring yourself in lesson 13.
+├─ queries/                # Practice SQL. Plain files you run, not pipeline assets.
+│  ├─ profiling/           # Six reusable profiling queries - your toolkit after lesson 3.
+│  │  ├─ 01-row-counts.sql
+│  │  ├─ 02-key-uniqueness.sql
+│  │  ├─ 03-null-rates.sql
+│  │  ├─ 04-orphan-keys.sql
+│  │  ├─ 05-date-coverage.sql
+│  │  └─ 06-categorical-values.sql
+│  └─ reading-drill/       # Three queries to annotate against the clock (lesson 7).
+│     ├─ README.md
+│     ├─ drill-1.sql
+│     ├─ drill-2.sql
+│     └─ drill-3.sql
+└─ pipeline/               # The Bruin pipeline that builds the dataset.
+   ├─ pipeline.yml         # Pipeline name, schedule, default connection, and shared defaults.
+   └─ assets/
+      ├─ generate/         # Seven generator assets. Do not edit these - but do read them.
+      │  ├─ dates.sql
+      │  ├─ stores.sql
+      │  ├─ products.sql
+      │  ├─ customers.sql
+      │  ├─ orders.sql
+      │  ├─ order_items.sql
+      │  └─ fx_rates.sql
+      ├─ staging/          # Empty. Lesson 8: one asset per source table, cleaning only.
+      ├─ core/             # Empty. Lesson 8: the entities and facts the business talks about.
+      └─ mart/             # Empty. Lesson 8: the shaped answers, one asset per question.
+```
+
+## Generate the data
+
+One command, run from the folder where you ran `bruin init` (the path names the
+pipeline inside this project):
+
+```bash
+bruin run academy-sql-intermediate/pipeline
+```
+
+(If `bruin init` told you to "add your connection credentials" - you do not need any.
+This project builds a local database file and needs no account and no password.)
+
+That builds all seven tables into a local DuckDB database (`academy.duckdb`) in about
+a tenth of a second. Then look around:
+
+```bash
+bruin query --connection duckdb-default --description "list the tables" \
+  --query "SHOW TABLES"
+
+bruin query --connection duckdb-default --description "count the orders" \
+  --query "SELECT COUNT(*) FROM orders"
+```
+
+`--description` says why you ran the query. It is the convention in this project, and
+the agent working alongside you is asked to use it too.
+
+Prefer a real cloud warehouse? Set `MOTHERDUCK_TOKEN` and add `--environment cloud`
+to either command. The generators are plain SQL, so they run unchanged on
+MotherDuck. No lesson requires it.
+
+## The tables
+
+| Table | Rows | One row is... |
+|---|---|---|
+| `dates` | 1,096 | one calendar day, 2023-01-01 to 2025-12-31 |
+| `stores` | 6 | one store |
+| `products` | 60 | one product |
+| `customers` | 510 | one customer account |
+| `orders` | 1,212 | one order, as delivered by the source system |
+| `order_items` | 2,895 | one line on an order |
+| `fx_rates` | 5,480 | one date and currency pair |
+
+[`docs/schema.md`](docs/schema.md) lists the columns. It does not say what they mean.
+That is the point - lesson 3 has you find out, and lesson 11 has you write it down.
+
+## What is wrong with this data
+
+Something. Several things. Finding them is lesson 3, and nothing in this repository
+tells you what they are before you get there.
+
+Do not fix anything you find before lesson 8. Profile first, decide what a defensible
+number is second, clean third. In that order, every time.
+
+## The data is generated and deterministic
+
+Nothing here is random. Every value is plain arithmetic on a row number, so the
+tables are identical on every run and every machine, and the exact numbers the course
+quotes are numbers you can reproduce. Do not edit the seven files in
+`pipeline/assets/generate/`.
+
+## The course
+
+This project is an interactive, agent-led course. `AGENTS.md` in this folder turns a
+coding agent into the instructor, and [`course/README.md`](course/README.md) is the
+syllabus and explains how the loop works. In short: open this project with a coding
+agent, paste the setup prompt from `course/README.md`, then drive with `next lesson`
+and `review my work`.
+
+It mirrors the intermediate course at
+[getbruin.com/learn](https://getbruin.com/learn), so the two stay in sync. If you
+have not written a join or a CTE by hand before, start with the beginner course,
+Ask the Data, first.

--- a/templates/academy-sql-intermediate/course/README.md
+++ b/templates/academy-sql-intermediate/course/README.md
@@ -1,0 +1,72 @@
+# The course
+
+This is an interactive, agent-led SQL course. Your coding agent is the instructor:
+it teaches each lesson, quizzes you, sets a hands-on task, and grades what you
+actually wrote. You drive it with short commands.
+
+## How it runs
+
+Open this project with a coding agent and paste the setup prompt below once. After
+that, you only need six commands:
+
+- `next lesson` - teach the next lesson and set its task.
+- `review my work` - grade the artifact you just produced against the rubric.
+- `where am I` - what is done, current, and remaining.
+- `repeat` - re-teach the current concept a different way.
+- `hint` - one more hint on the current task.
+- `skip` - move past the current lesson.
+
+The agent reads `progress.md` to know where you are and ticks it off as you finish
+lessons. `AGENTS.md` at the project root is what turns your agent into the
+instructor - you do not need to read it, but it is there.
+
+### The setup prompt
+
+```text
+You are going to set up and then teach me an interactive SQL course. Do this in order, and show me each command before you run it:
+
+1. Check that Git and Bruin are installed (`git --version`, `bruin version`). If Bruin is missing, install it with `curl -LsSf https://getbruin.com/install/cli | sh`, then check the version again.
+2. Run `bruin init academy-sql-intermediate` in this folder.
+3. Generate the sample data with `bruin run academy-sql-intermediate/pipeline`, then confirm `orders` has 1,212 rows, `order_items` has 2,895 and `fx_rates` has 5,480.
+4. Read `academy-sql-intermediate/AGENTS.md` and `academy-sql-intermediate/course/README.md` so you know how to run the course.
+5. Greet me, show me the 15-lesson syllabus, and tell me to say "next lesson" to begin and "review my work" whenever I finish a task.
+
+Do not teach lesson one yet - just get set up and hand me the controls. If any command fails, stop and show me the error instead of trying something else.
+```
+
+There is no setup lesson in this course. The prompt above is the setup. If it finishes
+without an error and the three row counts match, you are ready for lesson one.
+
+## Syllabus
+
+Fifteen lessons in four sections. Each one has a short concept, a quiz, and a
+hands-on task you do by hand before the agent grades it.
+
+### From question to specification
+
+- **01 the-question-is-the-hard-part** - the five decisions a vague request leaves open.
+- **02 write-the-model-contract** - six fields that fix the answer before the SQL exists.
+- **03 profile-before-you-model** - six questions to ask any table before you build on it.
+
+### Design queries that survive review
+
+- **04 stage-the-work** - one CTE per step, named after what it produces.
+- **05 window-functions** - LAG, moving averages, ranking within a partition.
+- **06 patterns-agents-get-wrong** - dedup, date spines, half-open ranges, aggregate before you join.
+- **07 read-a-query-fast** - annotate grain and find a fan-out in ninety seconds.
+
+### Build the model
+
+- **08 layer-the-project** - staging, core, mart, and the rule for each.
+- **09 views-and-tables** - which materialization, and the cost of getting it wrong.
+- **10 metric-in-the-asset** - put the metric definition where the agent will read it.
+
+### Governance as agent context
+
+- **11 descriptions-and-tags** - descriptions as the input to an agent's accuracy.
+- **12 glossary-and-readme** - what belongs in AGENTS.md, the glossary, and the README.
+- **13 measure-your-context** - score the agent before and after, and report the delta.
+- **14 capstone-defend-the-answer** - build a churn-risk model and survive the objections.
+- **15 recap-and-next-steps** - the habits to keep, and where to go next.
+
+Say `next lesson` to begin.

--- a/templates/academy-sql-intermediate/course/answer-key.md
+++ b/templates/academy-sql-intermediate/course/answer-key.md
@@ -1,0 +1,104 @@
+# Answer key - lesson 14, capstone-defend-the-answer
+
+**Instructor-only.** Do not show this file, quote it, paraphrase it, or hint at what it contains
+until the student has written `docs/defence.md` and asked for review. If they ask for it early,
+decline once and offer a hint on the objection they are closest to finding.
+
+The capstone is a defence, not a set of verdicts, so this is not a list of right answers. It is the
+list of objections a sceptical reader would raise and the number each one turns on. Grade by how
+many of these the student anticipated in `docs/defence.md` and in their model, not by whether their
+churn definition matches anyone else's.
+
+## How to grade
+
+Ten points, from the lesson's rubric. Award the point when the evidence is present in the files, not
+when the student says it is.
+
+| Area | Points |
+|---|---|
+| Contract quality | 2 |
+| Layering | 2 |
+| Join and grain safety | 1 |
+| Governance | 2 |
+| Verification | 2 |
+| Defence | 1 |
+
+## The nine objections, and the number each turns on
+
+A strong submission anticipates at least six of these. A submission that anticipates fewer than four
+has not really been attacked yet - send them back to the adversarial prompt before grading.
+
+**1. "Your order count is wrong."** `orders` holds 1,212 rows for 1,200 orders. Twelve orders were
+sent twice, two days apart, with the status changed. `DISTINCT` does not remove them because the
+rows differ. The fix is
+`QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`. Counting both
+copies double-counts **18,518.92** of line revenue.
+
+**2. "Your line revenue is wrong."** `order_items` holds 2,895 rows for 2,880 lines. Fifteen are
+byte-identical copies, and here `DISTINCT` is the correct fix. Leaving them in adds **7,278.04**.
+The student should be able to say why the fix differs from objection 1. If they used `DISTINCT` for
+both, or `QUALIFY` for both, that is the single most valuable correction you can make in this
+course.
+
+**3. "You are double-counting customers."** `customers` holds 510 rows for 500 customers; ten ids
+appear twice as exact copies. Any join from `orders` to `customers` without deduplicating inflates
+those customers' revenue, and they sit in the frequent-buyer pool, so they float to the top of a
+churn-risk ranking. Correct total line revenue is **851,617.69**.
+
+**4. "Which revenue?"** `quantity * net_price` gives 851,617.69. `quantity * unit_price` gives
+**961,697.00**. `SUM(order_total)` on deduplicated orders gives **604,065.00**. All three are
+defensible readings of the word; only one can be in the model, and the contract must name it.
+
+**5. "Your customer total does not reconcile."** Five orders carry `customer_id` 9001, which has no
+row in `customers`. Lifetime line revenue across customers that do have a dimension row is
+**847,693.43**, which is 851,617.69 less **3,924.26**. A defence that quotes a customer-level total
+without explaining that gap has not been checked.
+
+**6. "You dropped revenue on the product join."** Fifteen order lines point at `product_id` 9999,
+which is not in `products`, carrying **3,637.89**. An `INNER JOIN` to `products` removes them
+silently.
+
+**7. "Some sales have no store."** Twelve orders were rung up on `store_id` 7, which has no row in
+`stores`, carrying **5,967.20**. Same failure class as objection 6, different table.
+
+**8. "Your status filter is wrong."** The finished state is written four ways: `completed` 140,
+`Completed` 147, `COMPLETED` 146 and `complete` 143. `LOWER(order_status) = 'completed'` still
+misses the 143 rows that say `complete`. Separately, 24 orders have a NULL `order_status`, so
+`order_status != 'cancelled'` silently drops them.
+
+**9. "Which currency is that in?"** Order amounts are in five currencies and are not converted.
+Converting each order at its own date and currency gives **258,645.94** for 2023 against
+**264,926.21** unconverted. Joining `fx_rates` on date alone fans out by exactly **5** and gives
+**1,324,631.05**. A churn number quoted without stating the currency basis is not defensible.
+
+## Reference churn model
+
+For your own sanity check only. Do not present this as the answer, and do not mark a different
+definition down for being different.
+
+Reference date 2025-12-31, which is the latest `ordered_at`. At risk means: has a row in
+`customers`, has placed at least two orders, and has not ordered since 2025-07-04. Revenue at risk
+means that customer's lifetime line revenue.
+
+| Measure | Value |
+|---|---|
+| Customers with at least one order and a dimension row | 460 |
+| Repeat customers | 333 |
+| At risk | 199 |
+| Revenue at risk | 334,052.40 |
+
+If the student's number is far from this, that is not itself a fault. Ask what their definition is
+and check the number follows from it.
+
+## What a failing defence looks like
+
+- A churn definition with no threshold in it ("customers who have stopped buying").
+- A headline number with no currency and no date basis.
+- Three "independent" verifications that are the same query written three ways.
+- A mart asset that reads `orders` directly.
+- `docs/defence.md` that answers the four questions with confidence rather than with numbers.
+
+## After the grade
+
+Once the lesson is ticked, walk the student through the objections they missed, in this order:
+6 and 7 first (easiest to see), then 1 and 2 (the pair the course is built around), then 9.

--- a/templates/academy-sql-intermediate/course/lessons/01-the-question-is-the-hard-part.md
+++ b/templates/academy-sql-intermediate/course/lessons/01-the-question-is-the-hard-part.md
@@ -1,0 +1,54 @@
+# Lesson 01: the-question-is-the-hard-part
+
+## Objectives
+- Name the five decisions a data question leaves open.
+- Say why an agent handed an ambiguous request produces a confident wrong answer.
+- Rewrite a vague request as a three-line specification.
+
+## Concepts to teach
+No code in this lesson. Start with the request the whole course is built on: *"Give me a weekly view
+of category performance I can take to the leadership meeting, and tell me which customers are at
+risk of churning."* Ask the student what "category performance" means. It has at least four
+defensible readings in this project - line revenue, order-header revenue, units sold, or margin -
+and every one of them is a different chart. An agent asked this does not stop to choose. It picks,
+silently, and the number it returns looks exactly as confident as a right one.
+
+The five decisions hidden in almost every data question: **grain** (what one row of the answer
+represents), **metric definition** (which column, with which exclusions), **time period and
+boundary handling** (which dates, and whether the end is inclusive), **inclusion rules** (which
+rows count at all - cancelled orders? test accounts?), and **comparison basis** (against what -
+last week, last year, plan?). Walk through the spine question and name each one. This project makes
+the metric decision especially sharp: `order_items` carries both `unit_price` and `net_price`, and
+`orders` carries `order_total` on top of that, so "revenue" has three candidate columns before
+anyone has written a WHERE clause.
+
+Then the habit: **the right first response to a vague request is a question, not a query.** A
+well-directed agent behaves the same way, and one that does not is a liability, because it will
+guess faster than you can check. What good looks like is short: *"Weekly line revenue, one row per
+category per ISO week, `quantity * net_price`, excluding cancelled orders, 2023 only, compared with
+the prior week."* Three lines, no ambiguity, two analysts get the same numbers.
+
+## Quiz
+1. Q: Name the five decisions a data question hides.
+   A: Grain, metric definition, time period and boundary handling, inclusion rules, and comparison basis.
+2. Q: For the spine question, which decision is most consequential if you get it wrong, and why?
+   A: The metric definition. This project has three candidate revenue columns - `net_price`, `unit_price` and `order_total` - and each gives a different total, so the whole chart moves. Grain matters too, but a grain error usually shows up as an implausible number, while the wrong revenue column looks perfectly reasonable.
+3. Q: Your agent answers a vague request immediately, with a clean number and no questions. What has it just done?
+   A: It has made every one of the five decisions on your behalf and not told you which way. The number is not wrong because the SQL is wrong; it is wrong because it answers a question nobody asked.
+
+## Task
+No SQL. Take the request *"Give me a weekly view of category performance I can take to the
+leadership meeting"* and write out, in the conversation, the five decisions it leaves open. For each
+one, state the options you can see in this project's schema and which you would choose. Then say
+which single decision you would take back to the person who asked, and why that one.
+
+## Rubric (for `review my work`)
+- [ ] All five decisions named: grain, metric definition, time period and boundary, inclusion rules, comparison basis.
+- [ ] The metric decision names at least two of the three candidate columns: `net_price`, `unit_price`, `order_total`.
+- [ ] A grain is stated as a sentence about one row, for example "one row per category per week".
+- [ ] One decision is picked to escalate, with a reason that is about consequence rather than difficulty.
+
+## Done signal
+Confirm the student can name all five decisions without prompting and has picked a metric column
+rather than saying "revenue". Carry forward: a question you have not specified is a question your
+agent will specify for you.

--- a/templates/academy-sql-intermediate/course/lessons/02-write-the-model-contract.md
+++ b/templates/academy-sql-intermediate/course/lessons/02-write-the-model-contract.md
@@ -1,0 +1,57 @@
+# Lesson 02: write-the-model-contract
+
+## Objectives
+- Fill in a model contract for a real request, with no placeholder text left.
+- Name the exact revenue column a metric depends on, and say what it excludes.
+- Explain why pasting a contract into an agent's context removes ambiguity from every later request.
+
+## Concepts to teach
+A **model contract** is a short written file that fixes the answer before the SQL exists. It has
+six fields: Question, Grain, Keys, Metric, Filters, and Not included. `docs/contracts/TEMPLATE.md`
+ships in this project with those six fields blank and a note on how to use it. The student's job in
+this lesson is to copy that file to `docs/contracts/weekly_category.md` and fill every field for
+real, against the spine request: *"Give me a weekly view of category performance I can take to the
+leadership meeting."*
+
+Each field earns its place. Question is the stakeholder's request, verbatim, so nobody paraphrases
+it into something else. Grain is a sentence about what one output row represents - "one row per
+category per week," not "weekly data." Keys are the columns that make a row unique, which for this
+model are the category and the week start date together. Metric names the exact column and its
+exclusions: this project has three candidate revenue columns across `order_items` and `orders` -
+`net_price`, `unit_price`, and `order_total` - and the contract has to name one of them, not the
+word "revenue." Filters states what happens to cancelled orders and to orders with a missing
+`order_status`, because both are live possibilities in this data and a contract that is silent on
+them is not a contract. Not included says what this model deliberately will not answer, so nobody
+extends it by assumption later.
+
+The sentence that makes this lesson matter: once `docs/contracts/weekly_category.md` exists, paste
+it into the agent's context and every later request about this model - "add a filter," "extend it
+to 2024," "explain the drop in week 47" - inherits the same grain, the same metric, and the same
+exclusions, without you restating them. The contract is not paperwork. It is the thing that lets two
+different people, or two different agent sessions, produce the same numbers from the same request.
+
+## Quiz
+1. Q: Name the six fields of a model contract, in order.
+   A: Question, Grain, Keys, Metric, Filters, Not included.
+2. Q: Why does "Metric: revenue" fail as a contract field in this project?
+   A: Because `order_items` carries both `net_price` and `unit_price`, and `orders` carries `order_total` on top of that, so "revenue" has at least three numeric answers. The field has to name one column and state its exclusions.
+3. Q: You paste `docs/contracts/weekly_category.md` into an agent's context, then ask it to "add a filter for the top five countries." Why does the contract make that request safer?
+   A: Because the agent already knows the grain, the metric column, and which orders are excluded, so it extends the existing query instead of silently re-deciding those three things while adding the filter.
+
+## Task
+Copy `docs/contracts/TEMPLATE.md` to `docs/contracts/weekly_category.md` and fill in all six fields
+for the spine request: *"Give me a weekly view of category performance I can take to the leadership
+meeting."* Write real sentences, not brackets. Pick one revenue column and say why. State plainly
+what happens to cancelled orders and to orders with a NULL `order_status`.
+
+## Rubric (for `review my work`)
+- [ ] The file exists at `docs/contracts/weekly_category.md`.
+- [ ] All six fields - Question, Grain, Keys, Metric, Filters, Not included - are filled, with no `<...>` placeholder text remaining.
+- [ ] The Metric field names one of `net_price`, `unit_price`, or `order_total` explicitly.
+- [ ] The Grain field is a sentence describing what one output row represents.
+- [ ] The Filters field states, separately, what happens to cancelled orders and to orders with a missing `order_status`.
+
+## Done signal
+Confirm the file exists at the exact path, every field is filled with real text, and the Metric
+field names a specific column rather than the word "revenue." Carry forward: every CTE and query
+built in the rest of this course for this model should agree with what this contract says.

--- a/templates/academy-sql-intermediate/course/lessons/03-profile-before-you-model.md
+++ b/templates/academy-sql-intermediate/course/lessons/03-profile-before-you-model.md
@@ -1,0 +1,63 @@
+# Lesson 03: profile-before-you-model
+
+## Objectives
+- Run six profiling questions against any table before building on it.
+- Report exact counts for duplicates, orphan keys and value variants in this project.
+- Say what each finding would do to a revenue number.
+
+## Concepts to teach
+Profiling is a routine, not an instinct. Six questions, each with a query, asked of every table
+before you trust it: **how many rows, and what does one row represent** - **is the claimed key
+actually unique** (`GROUP BY key HAVING COUNT(*) > 1`) - **which columns have missing values, and at
+what rate** - **are there orphan foreign keys** (an anti-join) - **what is the date range, and are
+there gaps** - **are the categorical values consistent** (`GROUP BY` a text column and read the
+list). `queries/profiling/` ships one runnable file per question, each written against one table
+with a note saying to change the table name and run it again. Those six files are the real takeaway
+of this lesson; the findings are second.
+
+The findings in this project are not decoration. `docs/schema.md` says `orders` holds 1,212 rows,
+and the phrase it uses is "as delivered by the source system" rather than "one row per order". Ask
+the student to notice the difference before they run anything. Two of the tables carry duplicate
+rows and the fix is different for each, which is lesson 6. Two of the joins have orphan keys on the
+fact side, which is why an `INNER JOIN` here quietly deletes revenue. One text column is written
+five different ways, which means a `GROUP BY` on it ranks the wrong value first.
+
+Third: every finding has to be quantified in money or rows, or it is not a finding. "There are
+duplicates in `customers`" is a note. "Ten `customer_id` values appear twice, and because they sit
+in the frequent-buyer pool, joining to them inflates the top of any customer ranking" is a finding.
+Do not fix anything in this lesson. Profile, quantify, write it down. Cleaning is lesson 8, and
+doing it now means cleaning things you have not yet decided are wrong.
+
+## Quiz
+1. Q: You run `SELECT COUNT(*), COUNT(DISTINCT order_id) FROM orders` and the two numbers differ. What have you not yet learned?
+   A: Whether the duplicate rows are identical or differ in their payload. `SELECT DISTINCT *` answers it: if the row count drops to the distinct-key count they are exact copies, and if it does not, the source disagrees with itself about those records and choosing one is a decision.
+2. Q: Why does an anti-join belong in a profiling routine when the foreign key has no constraint on it?
+   A: Because with no constraint nothing stops an orphan being written, and an `INNER JOIN` to the dimension will drop those fact rows silently - no error, just a smaller number.
+3. Q: `GROUP BY country ORDER BY COUNT(*) DESC` returns France at the top. Why might that be the wrong answer?
+   A: Because one country's rows are split across several spellings, so its true total is divided between rows of the result. Folding case and whitespace changes the ranking.
+
+## Task
+Work through all six files in `queries/profiling/`, adapting each to the tables it does not already
+cover, and report these six numbers in the conversation:
+
+1. Rows in `orders`, and distinct `order_id`.
+2. How many `customer_id` values appear more than once in `customers`.
+3. How many rows in `order_items` have a missing `unit_cost`.
+4. How many rows of `order_items` have a `product_id` with no row in `products`.
+5. How many calendar days between 2023-01-01 and 2025-12-31 have no order at all.
+6. How many distinct values `customers.country` holds, and how many of them are the same country.
+
+For each one, say in a sentence what it would do to a revenue number.
+
+## Rubric (for `review my work`)
+- [ ] `orders` has 1,212 rows and 1,200 distinct `order_id`.
+- [ ] 10 `customer_id` values appear more than once (510 rows for 500 customers).
+- [ ] 57 rows of `order_items` have a missing `unit_cost`.
+- [ ] 15 rows of `order_items` point at a `product_id` with no row in `products`.
+- [ ] 160 of the 1,096 calendar days have no order.
+- [ ] `customers.country` holds 16 distinct values, 5 of which are the same country written differently.
+- [ ] At least three findings are quantified as an effect on a number, not just reported.
+
+## Done signal
+Confirm all six numbers match exactly and that nothing has been fixed yet. Carry forward: profile
+first, decide what a defensible number is second, clean third - in that order, every time.

--- a/templates/academy-sql-intermediate/course/lessons/04-stage-the-work.md
+++ b/templates/academy-sql-intermediate/course/lessons/04-stage-the-work.md
@@ -1,0 +1,55 @@
+# Lesson 04: stage-the-work
+
+## Objectives
+- Restructure a query into one named CTE per logical step.
+- Write a grain comment above each CTE.
+- Prove a restructured query returns the same rows as the original.
+
+## Concepts to teach
+Query structure is a reviewability decision, not a style preference. A CTE is not free-standing
+syntax sugar - it is the unit a reviewer, or an agent reading the file six months from now, checks
+one at a time. Two rules make that checking possible. First, one CTE per logical step: filter, then
+join, then aggregate, then rank, each as its own named block rather than folded together. Second,
+name each CTE after what it produces, not after its position in the query. `orders_2024` says what
+rows are in it. `t1` says nothing. A CTE that changes the grain - that turns "one row per order line"
+into "one row per customer" - has to say so in its name: `orders_per_customer`, not `joined`. A name
+that hides a grain change is the single most common reason a reviewer misses a fan-out.
+
+The file the student will restructure is `queries/reading-drill/drill-2.sql`. It answers a real
+question - monthly line revenue per category in 2024, compared with the month before - correctly.
+Its three CTEs are named `t1`, `t2`, and `final`. The logic does not need to change; the names and
+the comments do. Filters belong early: `t1` in that file already filters to 2024 before joining
+anything, which is the right instinct and worth pointing out even while renaming it.
+
+Contrast this with a nested subquery three levels deep, doing the same filter, join, and aggregate
+as inline subqueries instead of named CTEs. The logic can be identical. The difference is that a CTE
+chain reads top to bottom, one grain at a time, while a nested subquery makes a reviewer hold three
+levels of parentheses in their head before they can say what a single row means. Restructuring is
+not decoration on top of correct SQL - it is what makes correct SQL checkable by someone who did not
+write it, including the agent that will read this file again next lesson.
+
+## Quiz
+1. Q: Why is `orders_per_customer` a better CTE name than `joined` for a step that aggregates order lines up to one row per customer?
+   A: Because it states the grain change directly - a reviewer knows before reading the CTE's body that it produces one row per customer, rather than having to infer it from the `GROUP BY`.
+2. Q: `drill-2.sql` filters to 2024 in its first CTE, before any join. Why does that ordering matter?
+   A: Because filtering early shrinks every step that follows and makes the boundary condition visible in one place, instead of buried in a `WHERE` clause after several joins where it is easy to miss or duplicate.
+3. Q: You restructure a query's CTE names and add grain comments but change nothing else. What must you still verify before calling the job done?
+   A: That the restructured query returns exactly the same rows as the original - renaming and commenting should never change the result, and the only way to be sure is to run both and compare.
+
+## Task
+Restructure `queries/reading-drill/drill-2.sql` into named steps: rename `t1`, `t2`, and `final` to
+names that describe what each produces, and add a one-line comment above each CTE stating what one
+row of it represents. Do not change the logic. Save the result as
+`queries/reading-drill/drill-2-restructured.sql`, then run both files and confirm they return
+identical rows.
+
+## Rubric (for `review my work`)
+- [ ] `queries/reading-drill/drill-2-restructured.sql` exists.
+- [ ] No CTE in the restructured file is named `t1`, `t2`, or `final`.
+- [ ] Every CTE in the restructured file has a one-line grain comment directly above it.
+- [ ] Running `drill-2.sql` and `drill-2-restructured.sql` returns identical rows.
+
+## Done signal
+Confirm the restructured file exists, no CTE carries a placeholder name, and the student ran both
+versions and reported that the rows matched. Carry forward: a query you cannot check in under two
+minutes is a query you cannot trust an agent's edits to either.

--- a/templates/academy-sql-intermediate/course/lessons/05-window-functions.md
+++ b/templates/academy-sql-intermediate/course/lessons/05-window-functions.md
@@ -1,0 +1,68 @@
+# Lesson 05: window-functions
+
+## Objectives
+- Pick the right window function for a stated question rather than recalling syntax.
+- Write a window with an explicit `PARTITION BY`, `ORDER BY`, and frame where one is needed.
+- Explain what a missing `PARTITION BY` and a tie inside `ROW_NUMBER` each silently break.
+
+## Concepts to teach
+Learn window functions by the question they answer, not by memorising a list. "What was each
+category's revenue last week compared with the week before?" is `LAG`. "What is the four-week
+moving average?" is an aggregate window with a frame - `AVG(...) OVER (PARTITION BY ... ORDER BY ...
+ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)`. "Which rows are the newest per key?" or "top three
+customers per country?" is `ROW_NUMBER` with `PARTITION BY`. "Where does each value sit in the
+distribution?" is `NTILE` or `PERCENT_RANK`. Every one of these has the same three parts: `OVER`
+opens the window, `PARTITION BY` says which rows are grouped together for the calculation, and
+`ORDER BY` inside the window says what order the calculation runs in. A frame - `ROWS BETWEEN ...`
+- narrows that further to a sliding range of rows around the current one, which is what turns a
+running total into a moving average.
+
+Two traps follow directly from those three parts, and both produce a query that runs without error
+and returns the wrong answer. The first is a missing `PARTITION BY`. Leave it off a `LAG` and the
+window looks backward across the entire result set instead of within each category, so week one of
+Apparel silently compares against the last row of Toys & Games. Nothing errors; the number is wrong
+and looks exactly as plausible as a right one. The second trap is ties. `ROW_NUMBER` assigns 1, 2,
+3, ... and breaks a tie between equal values arbitrarily, so a re-run can pick a different row for
+the top spot. `RANK` and `DENSE_RANK` give tied rows the same rank instead. Using `ROW_NUMBER` to
+pick "the top customer" when two customers are exactly tied means the answer can change between
+runs with no data change at all.
+
+The file for this lesson's task is `queries/weekly-category.sql`, which does not exist yet - the
+student writes it. The question is: for each product category and each week of 2023, what is line
+revenue, the prior week's revenue, the week-over-week change, and a four-week moving average. The
+week grain in this project is always `CAST(date_trunc('week', ordered_at) AS DATE)`, and the 2023
+window is always `ordered_at >= TIMESTAMP '2023-01-01 00:00:00' AND ordered_at < TIMESTAMP
+'2024-01-01 00:00:00'`. Every number this lesson's rubric checks depends on using exactly those two
+expressions.
+
+## Quiz
+1. Q: Which window function answers "what was last week's revenue for this category," and what clause makes it look inside the category rather than across the whole table?
+   A: `LAG`, and it needs `PARTITION BY category_name` in its `OVER` clause - without it, `LAG` looks at the previous row in the whole result set, not the previous week of the same category.
+2. Q: Why is a four-week moving average an aggregate function, not a ranking function?
+   A: Because it needs `AVG` (or `SUM`) computed over a frame of the current and preceding rows, not a rank or an offset - the frame clause (`ROWS BETWEEN 3 PRECEDING AND CURRENT ROW`) is what makes it a moving window rather than a single lookback.
+3. Q: You use `ROW_NUMBER` to find the single highest-revenue category each week, and two categories tie for first. What happens, and would `RANK` behave differently?
+   A: `ROW_NUMBER` picks one of the tied categories arbitrarily as rank 1, so the result can differ between runs with no data change. `RANK` would give both categories rank 1, which is deterministic and shows the tie instead of hiding it.
+
+## Task
+Write a query in `queries/weekly-category.sql` that returns, for each product category and each
+week of 2023: line revenue, the prior week's revenue, the week-over-week change, and a four-week
+moving average. Use `CAST(date_trunc('week', ordered_at) AS DATE)` for the week grain, and filter to
+`ordered_at >= TIMESTAMP '2023-01-01 00:00:00' AND ordered_at < TIMESTAMP '2024-01-01 00:00:00'`.
+You have not been taught deduplication yet, so deduplicate the two sources this way for now: read
+order lines with `SELECT DISTINCT * FROM order_items`, and read orders with `QUALIFY ROW_NUMBER()
+OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`. Lesson 6 explains why each is the right
+tool for its table. State, in the conversation, the `PARTITION BY` clause each window in your query
+uses and why.
+
+## Rubric (for `review my work`)
+- [ ] The query lives in `queries/weekly-category.sql` and uses the week grain `CAST(date_trunc('week', ordered_at) AS DATE)`.
+- [ ] The 2023 window is exactly `ordered_at >= TIMESTAMP '2023-01-01 00:00:00' AND ordered_at < TIMESTAMP '2024-01-01 00:00:00'`.
+- [ ] The largest week-over-week drop found is Electronics in the week beginning 2023-11-20: 6,784.54 down to 591.30, a fall of 6,193.24.
+- [ ] The first week of the series returns NULL for the prior-week and week-over-week columns, and the student can say this is correct because no prior week exists, not a bug.
+- [ ] Every window function in the query states its `PARTITION BY category_name` explicitly.
+
+## Done signal
+Confirm the query returns the stated largest drop exactly, the student can explain the first row's
+NULLs, and every window is partitioned by category. Carry forward: this query used `SELECT
+DISTINCT` and a `QUALIFY` filter to get clean input without explanation - lesson 6 is where you
+learn why those are the correct tools and not a shortcut.

--- a/templates/academy-sql-intermediate/course/lessons/05-window-functions.md
+++ b/templates/academy-sql-intermediate/course/lessons/05-window-functions.md
@@ -48,6 +48,8 @@ Write a query in `queries/weekly-category.sql` that returns, for each product ca
 week of 2023: line revenue, the prior week's revenue, the week-over-week change, and a four-week
 moving average. Use `CAST(date_trunc('week', ordered_at) AS DATE)` for the week grain, and filter to
 `ordered_at >= TIMESTAMP '2023-01-01 00:00:00' AND ordered_at < TIMESTAMP '2024-01-01 00:00:00'`.
+That gives 53 week starts, not 52, because 2023-01-01 was a Sunday and falls in the week beginning
+2022-12-26.
 You have not been taught deduplication yet, so deduplicate the two sources this way for now: read
 order lines with `SELECT DISTINCT * FROM order_items`, and read orders with `QUALIFY ROW_NUMBER()
 OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`. Lesson 6 explains why each is the right

--- a/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
+++ b/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
@@ -23,10 +23,17 @@ payload - decides which fix is correct.
 **Date spines** fix a quieter failure: a `GROUP BY` only returns rows that exist, so a
 category-week with zero orders is missing from the result rather than present at zero. A chart built
 on that result lies by omission - a gap reads as "no data" when it should read as "zero." In 2023
-this project has 8 categories across 52 weeks, which is 416 category-week cells; only 296 of them
-have any sales, so 120 cells are silently missing, spread across 50 of the 52 weeks. The fix is to
-build a spine - every category crossed with every week, from `dates` - and `LEFT JOIN` the actual
+this project has 8 categories across 53 week starts, which is 424 category-week cells; only 296 of
+them have any sales, so 128 cells are silently missing, spread across 51 of the 53 weeks. The fix is
+to build a spine - every category crossed with every week, from `dates` - and `LEFT JOIN` the actual
 sales onto it, so a missing cell becomes an explicit zero instead of a missing row.
+
+Fifty-three, not fifty-two, and the reason is worth a minute. 2023-01-01 was a Sunday, so
+`date_trunc('week', ...)` puts it in the week beginning 2022-12-26. Take the weeks of 2023 as
+`SELECT DISTINCT CAST(date_trunc('week', date_day) AS DATE) FROM dates WHERE year = 2023` and you
+get 53 week starts, from 2022-12-26 to 2023-12-25. A spine boundary is a decision, the same as a
+metric definition, and a spine that silently drops the partial week at either end is one more way to
+lose rows you never counted.
 
 **Half-open date ranges** - `>= start AND < end`, always, never `BETWEEN` on a timestamp column.
 `BETWEEN '2023-01-01' AND '2023-12-31'` on a `TIMESTAMP` column silently excludes every order placed
@@ -59,13 +66,14 @@ which of this project's two duplicate problems `DISTINCT` correctly fixes and wh
 and why.
 
 ## Rubric (for `review my work`)
-- [ ] The fixed query returns 416 rows for 2023 - 8 categories times 52 weeks - with no category-week missing.
+- [ ] The spine is built as `SELECT DISTINCT CAST(date_trunc('week', date_day) AS DATE) FROM dates WHERE year = 2023`, giving 53 week starts from 2022-12-26 to 2023-12-25.
+- [ ] The fixed query returns 424 rows for 2023 - 8 categories times 53 weeks - with no category-week missing, of which 128 carry zero.
 - [ ] The student names 7,278.04 (or the 15 duplicate rows behind it) as the `order_items` problem `DISTINCT` fixes.
 - [ ] The student names 18,518.92 (or the 12 duplicate `order_id` values behind it) as the `orders` problem `DISTINCT` does not fix.
 - [ ] The student states the `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1` clause correctly.
 
 ## Done signal
-Confirm the query returns exactly 416 rows for 2023 and the student can say, without looking it up,
+Confirm the query returns exactly 424 rows for 2023 and the student can say, without looking it up,
 which duplicate problem is a `DISTINCT` fix and which is a `QUALIFY` fix. Carry forward: from here on,
 every query you write or review should default to a half-open date range and an aggregate-before-join
 shape unless there is a stated reason not to.

--- a/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
+++ b/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
@@ -1,0 +1,71 @@
+# Lesson 06: patterns-agents-get-wrong
+
+## Objectives
+- Choose `QUALIFY ROW_NUMBER()` or `DISTINCT` correctly for a given duplicate problem, and say why the other one fails.
+- Build a date spine so a group with no rows still appears as zero.
+- State the half-open date range rule and the aggregate-before-join rule from memory.
+
+## Concepts to teach
+Four patterns, each one a failure mode an agent produces confidently and without an error message.
+
+**Deduplication** is the most important thing in this course, because this project ships two kinds
+of duplicate and only one of them responds to `DISTINCT`. `order_items` has 15 rows that are
+byte-identical copies of other rows - `SELECT DISTINCT *` removes exactly these and nothing else,
+and they are worth 7,278.04 of double-counted line revenue if left in. `orders` has a different
+problem: 12 `order_id` values appear twice, but the two copies differ - a different `order_status`,
+and a `_loaded_at` two days later on the resend. `DISTINCT` does not fix this, because the rows are
+not identical; it would keep both. The correct tool is `QUALIFY ROW_NUMBER() OVER (PARTITION BY
+order_id ORDER BY _loaded_at DESC) = 1`, which keeps the latest version of each order and discards
+the rest. These 12 orders are worth 18,518.92 of double-counted line revenue if both copies survive
+a join. Knowing which of the two you are looking at - identical rows, or same key with different
+payload - decides which fix is correct.
+
+**Date spines** fix a quieter failure: a `GROUP BY` only returns rows that exist, so a
+category-week with zero orders is missing from the result rather than present at zero. A chart built
+on that result lies by omission - a gap reads as "no data" when it should read as "zero." In 2023
+this project has 8 categories across 52 weeks, which is 416 category-week cells; only 296 of them
+have any sales, so 120 cells are silently missing, spread across 50 of the 52 weeks. The fix is to
+build a spine - every category crossed with every week, from `dates` - and `LEFT JOIN` the actual
+sales onto it, so a missing cell becomes an explicit zero instead of a missing row.
+
+**Half-open date ranges** - `>= start AND < end`, always, never `BETWEEN` on a timestamp column.
+`BETWEEN '2023-01-01' AND '2023-12-31'` on a `TIMESTAMP` column silently excludes every order placed
+after midnight on December 31st, because `BETWEEN` treats the upper bound as `2023-12-31 00:00:00`,
+not the whole day. The half-open form has no such trap: the boundary is unambiguous no matter what
+time component the column carries.
+
+**Aggregate before you join** is the general fix behind the FX case in this lesson. `fx_rates` has
+5 currency pairs for every date. Join it to orders on date alone and every order line is multiplied
+by 5 - 2023 line revenue goes from a correct 264,926.21 to 1,324,631.05, exactly 5 times too
+high, because the join fanned out before the sum ran. Convert properly, matching on both the date
+and the order's own `currency_code`, and 2023 line revenue in USD is 258,645.94. The rule that
+generalises past FX: if a join is one-to-many and you need to sum something from the "one" side,
+aggregate first, then join the already-aggregated result - never sum after a fan-out join and hope
+the multiplication cancels out.
+
+## Quiz
+1. Q: `order_items` and `orders` each have duplicate rows, but they need different fixes. What is the fix for each, and why does the other one not work for the other table?
+   A: `order_items`'s 15 duplicates are byte-identical, so `SELECT DISTINCT *` removes them correctly. `orders`'s 12 duplicates share an `order_id` but differ in `order_status` and `_loaded_at`, so `DISTINCT` would keep both non-identical rows; only `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1` picks the one to keep.
+2. Q: A weekly revenue chart has a gap in the middle. Is the gap more likely a missing-data problem or a missing-row problem, and what fixes it?
+   A: Almost always a missing-row problem - the week had genuinely zero orders for that category, so it never appeared in the `GROUP BY` output. Building a spine from `dates` and `LEFT JOIN`ing the sales onto it turns the gap into an explicit zero.
+3. Q: Why does joining `fx_rates` to `orders` on date alone multiply revenue by exactly 5 rather than giving a wrong-but-plausible number?
+   A: Because `fx_rates` carries 5 currency pairs for every date, so each order line joins to 5 rows instead of 1, and summing after that join sums each line 5 times over - the fan-out factor is exactly the row multiplier, 5.
+
+## Task
+Fix `queries/weekly-category.sql` from lesson 5 so that a category-week with no sales appears as
+zero rather than being missing from the result - build a spine of every category crossed with every
+week of 2023 from `dates`, and `LEFT JOIN` the revenue onto it. Then, in the conversation, state
+which of this project's two duplicate problems `DISTINCT` correctly fixes and which one it does not,
+and why.
+
+## Rubric (for `review my work`)
+- [ ] The fixed query returns 416 rows for 2023 - 8 categories times 52 weeks - with no category-week missing.
+- [ ] The student names 7,278.04 (or the 15 duplicate rows behind it) as the `order_items` problem `DISTINCT` fixes.
+- [ ] The student names 18,518.92 (or the 12 duplicate `order_id` values behind it) as the `orders` problem `DISTINCT` does not fix.
+- [ ] The student states the `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1` clause correctly.
+
+## Done signal
+Confirm the query returns exactly 416 rows for 2023 and the student can say, without looking it up,
+which duplicate problem is a `DISTINCT` fix and which is a `QUALIFY` fix. Carry forward: from here on,
+every query you write or review should default to a half-open date range and an aggregate-before-join
+shape unless there is a stated reason not to.

--- a/templates/academy-sql-intermediate/course/lessons/07-read-a-query-fast.md
+++ b/templates/academy-sql-intermediate/course/lessons/07-read-a-query-fast.md
@@ -1,0 +1,51 @@
+# Lesson 07: read-a-query-fast
+
+## Objectives
+- Annotate a query's grain step by step, so fan-out becomes visible instead of intuited.
+- Read an 80-line query in 90 seconds and say where the grain changes.
+- Locate the grain error in `drill-3.sql` and quantify it.
+
+## Concepts to teach
+This is a drill, not a concept lesson. The technique is **grain annotation**: read a query top to
+bottom and write, beside each CTE and each join, what one row represents at that point. That is
+all. Fan-out stops being something you have to notice and becomes something you can see, because
+the moment a line says "one row per order" and the next says "one row per order line" while the
+aggregate below still sums an order-level column, the error is on the page.
+
+Two supporting habits. **Two passes**: the first for structure and grain only, ignoring filters and
+column lists; the second for filters, boundaries and which columns are actually selected. And
+**read it aloud** - not silently. Reading aloud forces you through the join conditions you would
+otherwise skim, and skimmed join conditions are where fan-out lives.
+
+`queries/reading-drill/` holds three queries getting longer, with target times of 30, 60 and 90
+seconds. Two of the three are correct on the grain axis. One is not. Do not run them to find out
+which - find it by reading, then run it to measure the damage. `drill-2.sql` is worth a comment of
+its own: it is correct and it is still hard to review, because its steps are named `t1`, `t2` and
+`final`. Correct and reviewable are different properties.
+
+## Quiz
+1. Q: What do you write beside a CTE when you annotate grain?
+   A: A sentence saying what one row of that CTE represents, for example "one row per order" or "one row per order line per currency pair". Nothing else.
+2. Q: A query joins `orders` to `order_items` and then sums `order_total`. Reading only the annotations, how do you know it is wrong?
+   A: The annotation above the join says one row per order and the annotation below says one row per order line. `order_total` belongs to the grain above the join, so summing it below counts it once per line.
+3. Q: Why does the first pass ignore filters?
+   A: Because a filter cannot make a number too big, and grain can. Structure and grain decide whether the query is answering the right shape of question; filters decide which rows, and that is a smaller and later problem.
+
+## Task
+Annotate all three files in `queries/reading-drill/`, writing your annotations as comments in a copy
+of each file saved as `queries/reading-drill/drill-N-annotated.sql`. Time yourself on each and
+report the three times. Then name which of the three has the grain error, which step introduces it,
+and run that query twice - once as written and once with only that one step corrected - to report
+both totals.
+
+## Rubric (for `review my work`)
+- [ ] Three annotated files exist, and every CTE and every join in each carries a grain sentence.
+- [ ] The student names `drill-3.sql` as the query with the grain error, and `lines_with_customer` as the step that introduces it.
+- [ ] They explain it correctly: `customers` holds 510 rows for 500 customers, so joining to it repeats the lines of the 10 duplicated ids.
+- [ ] Both totals are reported: 373,614.70 as written, 348,521.23 with only that join deduplicated, a difference of 25,093.47.
+- [ ] The three times are reported. The 90-second target on `drill-3.sql` is a goal, not a pass condition - do not fail the lesson on it.
+
+## Done signal
+Confirm the annotations exist on the page rather than in the student's head, and that the two
+`drill-3.sql` totals match. Carry forward: annotate the grain before you read anything else, and
+the fan-out finds you.

--- a/templates/academy-sql-intermediate/course/lessons/08-layer-the-project.md
+++ b/templates/academy-sql-intermediate/course/lessons/08-layer-the-project.md
@@ -24,6 +24,13 @@ the cleaning that layer was supposed to do - the casing fix, the deduplication -
 that asset. Trace a mart asset's `depends` back far enough and it should always land on staging,
 never on `pipeline/assets/generate/`.
 
+One warning about the word "standardise", because the rubric below will pass an asset that still
+carries the bug. Folding case and trimming whitespace is not the same as folding spellings.
+`UPPER(TRIM('U.S.A.'))` is `U.S.A.`, not `USA`, and `UPPER(TRIM('complete'))` is `COMPLETE`, not
+`COMPLETED`. Both survive a correct-looking staging asset and both change an answer later. Deciding
+that two different strings mean the same thing is a mapping you write down, not a function you
+call, and staging is where it belongs.
+
 This project ships two kinds of duplicate, and they need two different fixes, which is the reason
 `stg_orders.sql` and `stg_order_items.sql` will not look alike. Twelve orders were resent by the
 source system with a changed status and a later `_loaded_at` - the two rows are not identical, so
@@ -37,17 +44,20 @@ would be solving a problem that is not there. `customers` needs the same `DISTIN
 ## Quiz
 1. Q: Why does `stg_orders.sql` need `QUALIFY ROW_NUMBER() ... = 1` instead of `DISTINCT`?
    A: Because the duplicate `order_id` rows are not identical - one was resent with a different `order_status` and a later `_loaded_at` - so `DISTINCT` would keep both copies. Ranking by `_loaded_at` and keeping rank 1 keeps only the latest.
-2. Q: A staging asset joins `orders` to `customers` to attach the customer's country. What layer rule does this break?
+2. Q: Your staging asset applies `UPPER(TRIM(country))` and `COUNT(DISTINCT country)` still returns 13 rather than 12. What is left?
+   A: A spelling variant, not a casing variant. `U.S.A.` survives case folding and whitespace trimming because it is a genuinely different string, so it needs an explicit mapping that says it means the same country as `USA`.
+3. Q: A staging asset joins `orders` to `customers` to attach the customer's country. What layer rule does this break?
    A: Staging does cleaning only, no joins and no business logic. Attaching another table's columns is core-layer work; putting it in staging blurs the boundary that makes staging trustworthy without a review of the SQL.
-3. Q: You trace a mart asset's `depends` chain and it ends at `pipeline/assets/generate/orders.sql`. What does that tell you?
+4. Q: You trace a mart asset's `depends` chain and it ends at `pipeline/assets/generate/orders.sql`. What does that tell you?
    A: The mart asset, or something it depends on, has skipped the staging layer, so it is reading data that was never deduplicated or cleaned - the rule that a mart asset never reads a raw table directly has been broken somewhere in the chain.
 
 ## Task
 Build the staging layer. Under `pipeline/assets/staging/`, write one asset per source table,
 named `stg_<table>.sql`: `stg_dates.sql`, `stg_stores.sql`, `stg_products.sql`,
 `stg_customers.sql`, `stg_orders.sql`, `stg_order_items.sql`, `stg_fx_rates.sql`. Each one
-standardises text casing and trims whitespace, casts types explicitly, deduplicates on the natural
-key, and carries a `description` stating what one row represents. Do not edit anything under
+standardises text casing and trims whitespace, folds the spelling variants that case folding leaves
+behind, casts types explicitly, deduplicates on the natural key, and carries a `description` stating
+what one row represents. Do not edit anything under
 `pipeline/assets/generate/`. Run `bruin validate` before `bruin run`, and report the row count
 before and after for each table.
 
@@ -57,8 +67,11 @@ before and after for each table.
 - [ ] `stg_orders.sql` uses `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`, not `DISTINCT`.
 - [ ] `stg_order_items.sql` uses `DISTINCT`, not `QUALIFY`.
 - [ ] No file under `pipeline/assets/staging/` contains a `JOIN`.
+- [ ] `stg_customers` maps every spelling of the home country to one value, so `SELECT COUNT(DISTINCT country) FROM stg_customers` returns 12, not 13 or 16. Case folding alone leaves `U.S.A.` standing apart and returns 13.
+- [ ] `stg_orders` maps every spelling of the finished state to one value, so `SELECT COUNT(DISTINCT order_status) FROM stg_orders` returns 5, down from 8 raw. Case folding alone leaves `COMPLETE` apart from `COMPLETED` and returns 6. The 24 NULL rows are a separate decision, and the student should say what they did with them.
 
 ## Done signal
-Confirm all seven assets exist, `bruin validate` and `bruin run` both succeed, and every
-before-and-after count matches the table above exactly. Carry forward: everything built from here
+Confirm all seven assets exist, `bruin validate` and `bruin run` both succeed, every
+before-and-after count matches the table above exactly, and the two distinct-value checks return 12
+and 5. Carry forward: everything built from here
 on reads staging, never `pipeline/assets/generate/`, directly.

--- a/templates/academy-sql-intermediate/course/lessons/08-layer-the-project.md
+++ b/templates/academy-sql-intermediate/course/lessons/08-layer-the-project.md
@@ -68,10 +68,11 @@ before and after for each table.
 - [ ] `stg_order_items.sql` uses `DISTINCT`, not `QUALIFY`.
 - [ ] No file under `pipeline/assets/staging/` contains a `JOIN`.
 - [ ] `stg_customers` maps every spelling of the home country to one value, so `SELECT COUNT(DISTINCT country) FROM stg_customers` returns 12, not 13 or 16. Case folding alone leaves `U.S.A.` standing apart and returns 13.
-- [ ] `stg_orders` maps every spelling of the finished state to one value, so `SELECT COUNT(DISTINCT order_status) FROM stg_orders` returns 5, down from 8 raw. Case folding alone leaves `COMPLETE` apart from `COMPLETED` and returns 6. The 24 NULL rows are a separate decision, and the student should say what they did with them.
+- [ ] `stg_orders` maps every spelling of the finished state to one value, so `SELECT COUNT(DISTINCT order_status) FROM stg_orders WHERE UPPER(order_status) LIKE 'COMPLET%'` returns 1. Case folding alone leaves `COMPLETE` apart from `COMPLETED` and returns 2.
+- [ ] The student says what they did with the 24 rows that have no `order_status`. Leaving them NULL and mapping them to something like `UNKNOWN` are both defensible; not having decided is not. Do not grade this on a row count, because the two choices give different ones.
 
 ## Done signal
 Confirm all seven assets exist, `bruin validate` and `bruin run` both succeed, every
-before-and-after count matches the table above exactly, and the two distinct-value checks return 12
-and 5. Carry forward: everything built from here
+before-and-after count matches the table above exactly, the country check returns 12, the
+completed-state check returns 1, and the student has stated a policy for the missing statuses. Carry forward: everything built from here
 on reads staging, never `pipeline/assets/generate/`, directly.

--- a/templates/academy-sql-intermediate/course/lessons/08-layer-the-project.md
+++ b/templates/academy-sql-intermediate/course/lessons/08-layer-the-project.md
@@ -1,0 +1,64 @@
+# Lesson 08: layer-the-project
+
+## Objectives
+- Build the staging layer: one asset per source table under `pipeline/assets/staging/`.
+- Choose `QUALIFY` or `DISTINCT` correctly for each table's duplicate rows, and say why.
+- Name the rule that keeps a mart asset from ever reading a raw table directly.
+
+## Concepts to teach
+Three layers, each with one job. **Staging** is one asset per source table, named
+`stg_<table>.sql`, and it cleans and nothing else: rename, cast, trim, standardise casing,
+deduplicate. No joins, no business logic, no metric decisions - a staging asset stays boring on
+purpose, so anyone reading it can trust every row without checking the source. **Core** is the
+layer where the business's entities and facts live: customers, orders, order lines, one asset per
+concept, one grain per asset, and that grain stated in the asset's `description`. Joins live here,
+because a fact needs its dimensions to mean anything. **Mart** is the shaped answer: one asset per
+question or dashboard, built from core, not from source. Other tools call this bronze, silver, gold,
+or staging, intermediate, marts - the names differ and the discipline does not.
+
+`depends` is what turns three folders into a lineage graph rather than three piles of files. Every
+asset names the assets it needs by asset name, and Bruin builds them in that order. The rule that
+makes the graph mean something: **a mart asset never reads a raw table directly.** If
+`weekly_category_revenue` names `order_items` in its `depends`, something has skipped a layer, and
+the cleaning that layer was supposed to do - the casing fix, the deduplication - never happens for
+that asset. Trace a mart asset's `depends` back far enough and it should always land on staging,
+never on `pipeline/assets/generate/`.
+
+This project ships two kinds of duplicate, and they need two different fixes, which is the reason
+`stg_orders.sql` and `stg_order_items.sql` will not look alike. Twelve orders were resent by the
+source system with a changed status and a later `_loaded_at` - the two rows are not identical, so
+`DISTINCT` keeps both. The fix is
+`QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`, which keeps the
+latest row per `order_id` and discards the rest. Fifteen `order_items` rows, by contrast, are
+byte-identical copies loaded twice - there `DISTINCT` is the entire fix, and a window function
+would be solving a problem that is not there. `customers` needs the same `DISTINCT` treatment as
+`order_items`: its ten duplicated `customer_id` values are exact repeats.
+
+## Quiz
+1. Q: Why does `stg_orders.sql` need `QUALIFY ROW_NUMBER() ... = 1` instead of `DISTINCT`?
+   A: Because the duplicate `order_id` rows are not identical - one was resent with a different `order_status` and a later `_loaded_at` - so `DISTINCT` would keep both copies. Ranking by `_loaded_at` and keeping rank 1 keeps only the latest.
+2. Q: A staging asset joins `orders` to `customers` to attach the customer's country. What layer rule does this break?
+   A: Staging does cleaning only, no joins and no business logic. Attaching another table's columns is core-layer work; putting it in staging blurs the boundary that makes staging trustworthy without a review of the SQL.
+3. Q: You trace a mart asset's `depends` chain and it ends at `pipeline/assets/generate/orders.sql`. What does that tell you?
+   A: The mart asset, or something it depends on, has skipped the staging layer, so it is reading data that was never deduplicated or cleaned - the rule that a mart asset never reads a raw table directly has been broken somewhere in the chain.
+
+## Task
+Build the staging layer. Under `pipeline/assets/staging/`, write one asset per source table,
+named `stg_<table>.sql`: `stg_dates.sql`, `stg_stores.sql`, `stg_products.sql`,
+`stg_customers.sql`, `stg_orders.sql`, `stg_order_items.sql`, `stg_fx_rates.sql`. Each one
+standardises text casing and trims whitespace, casts types explicitly, deduplicates on the natural
+key, and carries a `description` stating what one row represents. Do not edit anything under
+`pipeline/assets/generate/`. Run `bruin validate` before `bruin run`, and report the row count
+before and after for each table.
+
+## Rubric (for `review my work`)
+- [ ] Seven staging assets exist, one per source table, each named `stg_<table>.sql`.
+- [ ] Reported row counts before and after match exactly: `dates` 1,096 to 1,096; `stores` 6 to 6; `products` 60 to 60; `customers` 510 to 500; `orders` 1,212 to 1,200; `order_items` 2,895 to 2,880; `fx_rates` 5,480 to 5,480.
+- [ ] `stg_orders.sql` uses `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`, not `DISTINCT`.
+- [ ] `stg_order_items.sql` uses `DISTINCT`, not `QUALIFY`.
+- [ ] No file under `pipeline/assets/staging/` contains a `JOIN`.
+
+## Done signal
+Confirm all seven assets exist, `bruin validate` and `bruin run` both succeed, and every
+before-and-after count matches the table above exactly. Carry forward: everything built from here
+on reads staging, never `pipeline/assets/generate/`, directly.

--- a/templates/academy-sql-intermediate/course/lessons/09-views-and-tables.md
+++ b/templates/academy-sql-intermediate/course/lessons/09-views-and-tables.md
@@ -1,0 +1,69 @@
+# Lesson 09: views-and-tables
+
+## Objectives
+- State the two conditions that make a view the right choice, and the two that make a table right.
+- Write both forms of the `materialization` block from memory.
+- Convert two staging assets to views without changing a single row count.
+
+## Concepts to teach
+`materialization: type: table` with `strategy: create+replace`, the block every asset in
+`pipeline/assets/staging/` already carries, drops the table and rebuilds it from scratch on every
+run. `materialization: type: view` skips the storage step entirely - a view is a saved query, run
+fresh every time something reads it. Both are one decision, made per asset, and the two questions
+that decide it are cost and freshness, not preference.
+
+A view is right when the underlying query is cheap, the result needs to always reflect the latest
+data, and the transformation is thin - a rename, a cast, a filter. Every asset in this project's
+staging layer fits that description: none of the source tables holds more than 5,480 rows, so
+recomputing on every read costs nothing worth naming. A table is right when the query is expensive
+to recompute, when several downstream assets reuse the same result, or when something
+latency-sensitive - a dashboard, an interactive query - reads it repeatedly and cannot wait for the
+transformation to run each time.
+
+Getting it wrong costs something in both directions. A table where a view belonged holds
+yesterday's numbers until the next scheduled run replaces them, with no error and nothing telling a
+reader the data is stale - it is wrong quietly. A view where a table belonged recomputes its full
+query on every single read, so a query that would cost nothing once now costs it every time
+something asks, and on a bigger table than this project's that cost compounds fast.
+
+```yaml
+materialization:
+  type: view
+```
+
+```yaml
+materialization:
+  type: table
+  strategy: create+replace
+```
+
+Beyond `create+replace`, Bruin supports incremental strategies - `delete+insert`, `merge`,
+`append`, among others - that update only the rows that changed instead of rebuilding the whole
+table. Name them here and stop: the advanced course covers when and how to use them.
+
+## Quiz
+1. Q: Which two questions decide whether an asset should be a view or a table?
+   A: Whether the query is cheap or expensive to recompute, and whether the result needs to always be fresh or can tolerate the age of the last run - a view answers cheap-and-fresh, a table answers expensive-or-reused.
+2. Q: A staging asset is a view. Nobody has run the pipeline in three days. What does querying that asset return?
+   A: The latest data available in the source tables it reads, computed at query time - a view has no age of its own, since it recomputes on every read instead of storing a stale copy.
+3. Q: Name two materialization strategies besides `create+replace` that update a table incrementally.
+   A: Any two of `delete+insert`, `truncate+insert`, `append`, or `merge` - the advanced course covers when each applies.
+
+## Task
+Pick two of the staging assets built in lesson 8 and change their `materialization` block from
+`type: table` with `strategy: create+replace` to `type: view`. Run `bruin validate`, then run the
+pipeline again and confirm each asset's row count is unchanged from lesson 8's after-staging count.
+For each of the two, write one sentence saying why a view is the right call there. Then write one
+sentence naming a different asset in this project you would keep as a table, and why.
+
+## Rubric (for `review my work`)
+- [ ] Exactly two staging assets carry `materialization: type: view`, with no `strategy` key.
+- [ ] `bruin validate` passes after the change.
+- [ ] Each converted asset's row count still matches its lesson 8 after-staging number exactly (`dates` 1,096; `stores` 6; `products` 60; `customers` 500; `orders` 1,200; `order_items` 2,880; `fx_rates` 5,480 - whichever two were chosen).
+- [ ] Both reasons name cost or freshness, not a stated preference.
+- [ ] One further asset in this project is named as one to keep as a table, with a reason about reuse or latency.
+
+## Done signal
+Confirm the two assets validate as views, the row counts match lesson 8 exactly, and both reasons
+given are about cost or freshness rather than taste. Carry forward: the materialization block is a
+decision you make per asset, not a default you leave alone.

--- a/templates/academy-sql-intermediate/course/lessons/09-views-and-tables.md
+++ b/templates/academy-sql-intermediate/course/lessons/09-views-and-tables.md
@@ -37,6 +37,21 @@ materialization:
   strategy: create+replace
 ```
 
+One thing to know before you convert an asset that has already run. DuckDB will not let a view take
+the name of an existing table, so re-running gives
+`Catalog Error: Existing object stg_dates is of type Table, trying to replace with type View`, and
+`--full-refresh` does not help. Drop the old object first:
+
+```bash
+bruin query --connection duckdb-default \
+  --description "drop the table so the view can take its name" \
+  --query "DROP TABLE IF EXISTS stg_dates"
+```
+
+Then run the pipeline again. This is worth meeting once rather than reading about: a
+materialization change is a change to the shape of the object in the warehouse, not only to the
+asset file, and something already sitting under that name has to go first.
+
 Beyond `create+replace`, Bruin supports incremental strategies - `delete+insert`, `merge`,
 `append`, among others - that update only the rows that changed instead of rebuilding the whole
 table. Name them here and stop: the advanced course covers when and how to use them.
@@ -46,19 +61,23 @@ table. Name them here and stop: the advanced course covers when and how to use t
    A: Whether the query is cheap or expensive to recompute, and whether the result needs to always be fresh or can tolerate the age of the last run - a view answers cheap-and-fresh, a table answers expensive-or-reused.
 2. Q: A staging asset is a view. Nobody has run the pipeline in three days. What does querying that asset return?
    A: The latest data available in the source tables it reads, computed at query time - a view has no age of its own, since it recomputes on every read instead of storing a stale copy.
-3. Q: Name two materialization strategies besides `create+replace` that update a table incrementally.
+3. Q: You change an asset from a table to a view and the run fails with `Existing object ... is of type Table, trying to replace with type View`. What happened, and what fixes it?
+   A: A table of that name is already in the warehouse, and DuckDB will not swap an object's type in place. Drop the table, then run again. `--full-refresh` does not help, because it rebuilds the object rather than replacing its type.
+4. Q: Name two materialization strategies besides `create+replace` that update a table incrementally.
    A: Any two of `delete+insert`, `truncate+insert`, `append`, or `merge` - the advanced course covers when each applies.
 
 ## Task
 Pick two of the staging assets built in lesson 8 and change their `materialization` block from
-`type: table` with `strategy: create+replace` to `type: view`. Run `bruin validate`, then run the
-pipeline again and confirm each asset's row count is unchanged from lesson 8's after-staging count.
+`type: table` with `strategy: create+replace` to `type: view`. Run `bruin validate`, drop the two
+existing tables as shown above, then run the pipeline again and confirm each asset's row count is
+unchanged from lesson 8's after-staging count.
 For each of the two, write one sentence saying why a view is the right call there. Then write one
 sentence naming a different asset in this project you would keep as a table, and why.
 
 ## Rubric (for `review my work`)
 - [ ] Exactly two staging assets carry `materialization: type: view`, with no `strategy` key.
 - [ ] `bruin validate` passes after the change.
+- [ ] The student hit or anticipated the `Existing object ... is of type Table, trying to replace with type View` error and resolved it by dropping the table, not by renaming the asset or reverting it to a table.
 - [ ] Each converted asset's row count still matches its lesson 8 after-staging number exactly (`dates` 1,096; `stores` 6; `products` 60; `customers` 500; `orders` 1,200; `order_items` 2,880; `fx_rates` 5,480 - whichever two were chosen).
 - [ ] Both reasons name cost or freshness, not a stated preference.
 - [ ] One further asset in this project is named as one to keep as a table, with a reason about reuse or latency.

--- a/templates/academy-sql-intermediate/course/lessons/10-metric-in-the-asset.md
+++ b/templates/academy-sql-intermediate/course/lessons/10-metric-in-the-asset.md
@@ -1,0 +1,68 @@
+# Lesson 10: metric-in-the-asset
+
+## Objectives
+- Build the full asset header on a mart asset: description, tags, and a `meta` block.
+- State why `meta.metric_definition` belongs in the file rather than in a chat thread.
+- Write `pipeline/assets/mart/weekly_category_revenue.sql` implementing the lesson 2 contract.
+
+## Concepts to teach
+The asset header is not decoration around the query - for a mart asset, it is the place the metric
+definition actually lives. `description` takes the folded form, `>-`, so a two-sentence explanation
+reads as prose instead of a wrapped line:
+
+```yaml
+description: >-
+  One row per product category per ISO week in 2023, with revenue as quantity * net_price.
+  Excludes cancelled orders.
+```
+
+`pipeline/pipeline.yml` already sets `owner` and `domains` inside a `default:` block that applies
+to every asset in this project, so a mart asset names its own `owner` only when it genuinely
+differs from that default - repeating it for every asset would duplicate a value that was already
+set once. `tags` is a separate mechanism, used for selection and for marking which layer an
+asset belongs to: `layer:mart`, `domain:commerce`.
+
+The `meta` block is where this lesson's argument lands. It is free-form key-value pairs, and for a
+mart asset that carries a metric, five of them earn their place: `business_owner` (who to ask about
+this number), `metric_definition` (the exact expression, not the word "revenue"),
+`currency` (the basis the number is stated in), `expected_update` (how often this should refresh),
+and `known_limitation` (what this number does not account for, stated plainly rather than omitted).
+This course simplifies revenue recognition throughout - it never models refunds, taxes, or
+returns-after-payment - and that is exactly the kind of thing `known_limitation` exists to say out
+loud.
+
+Here is the argument itself: a metric definition that lives in a chat thread is a metric definition
+nobody can find later, including an agent asked to change the query - it was never in its context,
+and it never will be unless someone pastes it in again. A metric definition written into
+`meta.metric_definition` travels with the code, shows up in every code review, and is read by any
+agent that opens the file, without anyone having to remember it exists.
+
+## Quiz
+1. Q: Where does this course put a metric's exact definition, and why not in a chat thread?
+   A: In the mart asset's `meta.metric_definition` field. A chat thread is invisible to anyone who was not in it, including an agent asked to modify the query later, while a definition in the asset header is read every time the file is opened.
+2. Q: `pipeline/pipeline.yml` sets `owner` and `domains` under `default:` for every asset. When should `weekly_category_revenue.sql` set its own `owner`?
+   A: Only if its real owner differs from the pipeline default - otherwise the asset would repeat a value the pipeline already states once for everything.
+3. Q: Name the five `meta` fields this lesson teaches for a mart asset carrying a metric.
+   A: `business_owner`, `metric_definition`, `currency`, `expected_update`, `known_limitation`.
+
+## Task
+Write `pipeline/assets/mart/weekly_category_revenue.sql`, implementing the contract from
+`docs/contracts/weekly_category.md`. Give it the full header: a folded `description: >-`, `tags`
+including `layer:mart` and `domain:commerce`, and a `meta` block with `business_owner`,
+`metric_definition`, `currency`, `expected_update`, and `known_limitation` all filled in with real
+values, not placeholders. Its `depends` should name a staging or core asset, never a table from
+`pipeline/assets/generate/`.
+
+## Rubric (for `review my work`)
+- [ ] The file exists at `pipeline/assets/mart/weekly_category_revenue.sql`.
+- [ ] `bruin validate` passes.
+- [ ] `meta.metric_definition` names the exact expression the lesson 2 contract chose, for example `quantity * net_price`.
+- [ ] `meta.currency` states a currency basis.
+- [ ] `meta.known_limitation` is filled in, not empty.
+- [ ] `depends` names a staging or core asset (for example `stg_order_items`), not a table from `pipeline/assets/generate/`.
+
+## Done signal
+Confirm the file exists at the exact path, `bruin validate` passes, and every `meta` field holds a
+real value rather than a placeholder. Carry forward: the next time this metric's definition is in
+question, the answer is in this file, not in whoever remembers the conversation where it was
+decided.

--- a/templates/academy-sql-intermediate/course/lessons/11-descriptions-and-tags.md
+++ b/templates/academy-sql-intermediate/course/lessons/11-descriptions-and-tags.md
@@ -25,8 +25,12 @@ project's own data:
   deduped orders it is 604,065.00, against 851,617.69 in line revenue for the same period. Do not
   use it as a revenue source.
 - `orders.order_status` - a bad description lists nothing. A good one says the finished state is
-  written four ways (`Completed`, `COMPLETED`, `complete`, `completed`) and 24 rows are NULL, so
-  any filter on this column needs `UPPER(TRIM(...))` and an explicit NULL decision.
+  written four ways (`Completed`, `COMPLETED`, `complete`, `completed`) and 24 rows are NULL, and
+  then says what to do about it: `UPPER(TRIM(...))` folds the first three together and leaves
+  `COMPLETE` standing apart from `COMPLETED`, because `complete` is a different word rather than a
+  different casing. The filter needs an explicit list - `IN ('COMPLETED', 'COMPLETE')` after
+  normalising - and an explicit NULL decision. Get that wrong and 143 finished orders disappear,
+  43 of them in 2023 alone.
 - `customers.customer_id` - a bad description says "the customer id". A good one says it is not
   unique in this table: 10 ids appear twice, 510 rows for 500 customers, so a naive join fans out.
 - `orders.currency_code` - a bad description says "the currency". A good one says it is a label
@@ -54,7 +58,9 @@ verify every claim it makes with a query before you keep it.
    A: It restates information the column name and type already give a reader; it adds nothing that could change how the column gets used.
 2. Q: Why is `orders.order_total` a case where the description has to carry a warning rather than a definition?
    A: Because the header value does not reconcile with the line-level detail - 604,065.00 summed on deduped orders against 851,617.69 in line revenue - so a description that only says "the order total" invites someone to sum it as if it were revenue.
-3. Q: Why verify `bruin ai enhance` output against the data instead of publishing it directly?
+3. Q: A description says `order_status` needs `UPPER(TRIM(...))` before filtering. Why is that description still wrong?
+   A: Because normalising case and whitespace turns `complete` into `COMPLETE`, not `COMPLETED`, so a filter on the normalised value still drops the 143 orders spelled `complete`. Folding those two takes an explicit synonym decision, and the description has to say so.
+4. Q: Why verify `bruin ai enhance` output against the data instead of publishing it directly?
    A: Because generated descriptions are a draft that can be plausible and wrong, and published research found LLM-generated context can lower task success while raising cost - a wrong description is worse than no description because it is trusted.
 
 ## Task

--- a/templates/academy-sql-intermediate/course/lessons/11-descriptions-and-tags.md
+++ b/templates/academy-sql-intermediate/course/lessons/11-descriptions-and-tags.md
@@ -1,0 +1,76 @@
+# Lesson 11: descriptions-and-tags
+
+## Objectives
+- Write a column description that records what a reader cannot infer, not what the column name already says.
+- Use `tags`, `owner`, `domains`, and column-level `meta` for their actual jobs: selection, accountability, and machine-readable facts.
+- Treat `bruin ai enhance` output as a draft that gets verified against the data, not published as written.
+
+## Concepts to teach
+Descriptions are usually taught as documentation hygiene, which is why they never get written -
+hygiene is optional and everyone knows it. The better frame: a description is the input that decides
+whether an agent's answer is right. An agent choosing between `net_price` and `unit_price` is reading
+whatever text sits next to those two columns, not your mind. If nothing is there, it guesses, and the
+guess looks exactly as confident as a correct answer.
+
+A useless description restates the column name: `customer_id: the customer id`. A useful one records
+what a reader cannot infer from the name or the type - the unit, the timezone, the population it
+covers, a known caveat, or which of several similar columns is canonical. Five pairs from this
+project's own data:
+
+- `order_items.net_price` versus `unit_price` - a bad description calls both "the price". A good one
+  says `net_price` is what revenue is computed from in this project, and `unit_price` is the
+  pre-discount list price kept for reference only.
+- `orders.order_total` - a bad description says "the order total". A good one says it is a
+  header-level value from the source system that does not equal the sum of its lines: summed across
+  deduped orders it is 604,065.00, against 851,617.69 in line revenue for the same period. Do not
+  use it as a revenue source.
+- `orders.order_status` - a bad description lists nothing. A good one says the finished state is
+  written four ways (`Completed`, `COMPLETED`, `complete`, `completed`) and 24 rows are NULL, so
+  any filter on this column needs `UPPER(TRIM(...))` and an explicit NULL decision.
+- `customers.customer_id` - a bad description says "the customer id". A good one says it is not
+  unique in this table: 10 ids appear twice, 510 rows for 500 customers, so a naive join fans out.
+- `orders.currency_code` - a bad description says "the currency". A good one says it is a label
+  only - amounts in this row are not converted to a common currency - and that `fx_rates` carries
+  five pairs per date, so converting means joining on date and currency, not date alone.
+
+Tags do two jobs in this project: selecting a slice of the pipeline to run (`bruin run --tag mart`),
+and marking which layer an asset belongs to (`layer:staging`, `layer:core`, `layer:mart`).
+`domains` is its own asset field, not a tag, and it groups an asset by the part of the business it
+describes - `pipeline.yml` in this project already sets `domains: [commerce]` for every asset in its
+`default:` block. `owner` names the person or team accountable for an asset, as an email or handle -
+one line, not a paragraph. Column-level
+`meta` holds small structured facts a description would bury in prose: a currency code, a rounding
+rule, a source system name.
+
+`bruin ai enhance` reads an asset and the underlying data and proposes descriptions and checks for
+you - a legitimate starting point, not a finishing move. Published research on agent-context files
+found that LLM-generated context can reduce task success while raising cost, compared with writing
+nothing at all. The failure mode is specific: a plausible-sounding description that is wrong sends
+an agent astray with more confidence than no description does. Generate with `bruin ai enhance`, then
+verify every claim it makes with a query before you keep it.
+
+## Quiz
+1. Q: What makes `customer_id: the customer id` a useless description, precisely?
+   A: It restates information the column name and type already give a reader; it adds nothing that could change how the column gets used.
+2. Q: Why is `orders.order_total` a case where the description has to carry a warning rather than a definition?
+   A: Because the header value does not reconcile with the line-level detail - 604,065.00 summed on deduped orders against 851,617.69 in line revenue - so a description that only says "the order total" invites someone to sum it as if it were revenue.
+3. Q: Why verify `bruin ai enhance` output against the data instead of publishing it directly?
+   A: Because generated descriptions are a draft that can be plausible and wrong, and published research found LLM-generated context can lower task success while raising cost - a wrong description is worse than no description because it is trusted.
+
+## Task
+Open `pipeline/assets/mart/weekly_category_revenue.sql`, the asset written in lesson 10. For every
+column, run a query against the data to check what you are about to claim, then write a
+`description` from what the query shows. Add a `tags` entry marking the asset's layer
+(`layer:mart`). Run `bruin validate` when you are done.
+
+## Rubric (for `review my work`)
+- [ ] Every column in `pipeline/assets/mart/weekly_category_revenue.sql` has a non-empty `description`.
+- [ ] No description restates the column name (for example, no `"the category"` on a `category` column).
+- [ ] At least one description states a caveat backed by a query the student actually ran, not an assumption.
+- [ ] The asset's `tags` include a `layer:mart` entry.
+- [ ] `bruin validate` passes with no errors.
+
+## Done signal
+Confirm every column has a description, at least one carries a verified caveat rather than a
+paraphrase, and `bruin validate` is clean. Carry forward: a description is a claim about the data,
+and an unverified claim is a guess wearing a label.

--- a/templates/academy-sql-intermediate/course/lessons/12-glossary-and-readme.md
+++ b/templates/academy-sql-intermediate/course/lessons/12-glossary-and-readme.md
@@ -1,0 +1,63 @@
+# Lesson 12: glossary-and-readme
+
+## Objectives
+- Assign the right content to `AGENTS.md`, the glossary, and `README.md` instead of mixing them.
+- Write a `Revenue` entry that resolves the ambiguity this project has carried since lesson 1.
+- Know the maintenance rule: these files decay, and a stale one is worse than a short one.
+
+## Concepts to teach
+Three files, three jobs, and most projects blur them into one long document nobody reads.
+`AGENTS.md` holds rules and behaviour: how to access data, what is read-only, what needs approval,
+how to handle ambiguity, which tables are canonical. It should read like instructions to a new hire
+on their first day - short, imperative, specific. This project's own `AGENTS.md` is the example: it
+tells the agent to ask before writing SQL for an ambiguous request, and to use
+`bruin query --connection duckdb-default --description "..."` rather than describing data access in
+the abstract.
+
+The glossary holds domain terms and metric definitions: every acronym, every metric with its exact
+computation, every term that means something specific in this project rather than in general. A term
+belongs here, not in `AGENTS.md`, if the question it answers is "what does this word mean" rather
+than "what should the agent do". `README.md` holds orientation: what this project is, where things
+live, how to run it - the page a person reads once, on day one, and rarely again.
+
+`docs/glossary.md` in this project ships as a stub: three terms defined, `Revenue` left as a TODO,
+and a line listing six more terms nobody has written yet. Finishing it is this lesson's task, and
+the `Revenue` entry is the one that matters most, because it is the same ambiguity lesson 1 opened
+the course with. A finished entry does not say "revenue is money from sales" - it names one exact
+expression and the column it comes from: `quantity * net_price` on `order_items`, not `order_total`
+and not `unit_price`. Anyone who later needs a different revenue definition for a different question
+should be adding a new, separately named term, not editing this one out from under the assets that
+depend on it.
+
+The maintenance rule is the part that gets skipped: these files decay. An `AGENTS.md` line stops
+being true the day the schema changes under it, and a glossary term stops being true the day someone
+redefines the metric without updating the entry. Update these files when the agent gets something
+wrong because the file told it something false, and delete lines that are no longer true rather than
+letting them accumulate. A stale `AGENTS.md` is worse than a short one, because a short file is
+honest about what it does not cover and a stale one actively misleads.
+
+## Quiz
+1. Q: A new rule says the agent must never run `DELETE` against generated data without asking first. Which file does that belong in, and why not the glossary?
+   A: `AGENTS.md`. It is a behaviour rule, not a definition of a term - the glossary answers "what does this word mean," not "what is the agent allowed to do."
+2. Q: Why does the `Revenue` glossary entry need to name a column instead of describing a concept?
+   A: Because this project has three candidate revenue columns - `net_price`, `unit_price`, `order_total` - and a prose definition without a named column and expression leaves the same ambiguity lesson 1 opened with unresolved.
+3. Q: Why is a stale `AGENTS.md` worse than a short one?
+   A: A short file is honest about its limits and an agent falls back to asking; a stale file states something false with the same confidence as something true, so the agent acts on it without knowing it is wrong.
+
+## Task
+Rewrite `docs/glossary.md`. Replace the `Revenue` TODO with a real entry naming the exact expression
+and column. Add entries for every term listed in the stub's TODO line: AOV, active customer, churn,
+category, net vs gross, and fiscal period. State the grain of `orders` and of `order_items` somewhere
+in the file. For at least one entry, cite the asset file where that metric is actually computed.
+
+## Rubric (for `review my work`)
+- [ ] `docs/glossary.md` has a `Revenue` entry naming one exact expression (`quantity * net_price`) and the column it runs on (`order_items.net_price`).
+- [ ] Entries exist for all six stub-TODO terms: AOV, active customer, churn, category, net vs gross, fiscal period.
+- [ ] A grain statement appears for `orders` (one row per order) and for `order_items` (one row per line on an order).
+- [ ] At least one entry cites the specific asset file where that metric is defined.
+- [ ] The file no longer contains the word `TODO`.
+
+## Done signal
+Confirm the `Revenue` entry names a column and an expression, all six TODO terms have entries, both
+grains are stated, and at least one citation points at a real file. Carry forward: a glossary that
+names a column is a decision; a glossary that names a concept is the same ambiguity, filed away.

--- a/templates/academy-sql-intermediate/course/lessons/12-glossary-and-readme.md
+++ b/templates/academy-sql-intermediate/course/lessons/12-glossary-and-readme.md
@@ -48,16 +48,20 @@ honest about what it does not cover and a stale one actively misleads.
 Rewrite `docs/glossary.md`. Replace the `Revenue` TODO with a real entry naming the exact expression
 and column. Add entries for every term listed in the stub's TODO line: AOV, active customer, churn,
 category, net vs gross, and fiscal period. State the grain of `orders` and of `order_items` somewhere
-in the file. For at least one entry, cite the asset file where that metric is actually computed.
+in the file. Be careful which table each grain statement is about: the raw tables are not one row
+per order and one row per line, and a glossary that says they are has published the exact
+assumption lesson 3 taught you to check. For at least one entry, cite the asset file where that
+metric is actually computed.
 
 ## Rubric (for `review my work`)
 - [ ] `docs/glossary.md` has a `Revenue` entry naming one exact expression (`quantity * net_price`) and the column it runs on (`order_items.net_price`).
 - [ ] Entries exist for all six stub-TODO terms: AOV, active customer, churn, category, net vs gross, fiscal period.
-- [ ] A grain statement appears for `orders` (one row per order) and for `order_items` (one row per line on an order).
+- [ ] A grain statement appears for `orders` and for `order_items`, and it is true of the table it names. Raw `orders` holds 1,212 rows for 1,200 orders and raw `order_items` holds 2,895 for 2,880, so "one row per order" is only correct about `stg_orders`. Accept either the deduplicated staging asset named explicitly, or the raw table described as one row per order as delivered by the source system.
 - [ ] At least one entry cites the specific asset file where that metric is defined.
 - [ ] The file no longer contains the word `TODO`.
 
 ## Done signal
 Confirm the `Revenue` entry names a column and an expression, all six TODO terms have entries, both
-grains are stated, and at least one citation points at a real file. Carry forward: a glossary that
+grains are stated and are true of the table each one names, and at least one citation points at a
+real file. Carry forward: a glossary that
 names a column is a decision; a glossary that names a concept is the same ambiguity, filed away.

--- a/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
+++ b/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
@@ -1,0 +1,62 @@
+# Lesson 13: measure-your-context
+
+## Objectives
+- Score an agent against a fixed question set before and after adding context.
+- Report a before score, an after score, and which context change mattered.
+- Say why "context is good" is not the conclusion this exercise supports.
+
+## Concepts to teach
+This is the lesson that makes the course honest. You have spent three lessons writing descriptions,
+tags and a glossary on the argument that they make an agent more accurate. Now measure it, because
+the honest answer is that it depends on what you wrote.
+
+The method has four steps. **One**, `docs/eval/questions.md` ships eight questions with one
+defensible answer each, and the verified answers are in `docs/eval/answers.md`. Add two of your
+own, drawn from a mistake you actually saw an agent make in this project, so the set is ten.
+**Two**, in a fresh agent session with no context beyond the raw repository, ask all ten and record
+the answers. **Three**, score them against `answers.md`: one point each, exact match, no partial
+credit. **Four**, in another fresh session with your descriptions, glossary and `AGENTS.md` in
+place, ask the same ten and score again. Report both numbers and roughly how much longer the second
+set of answers took.
+
+Then the framing that keeps this from being a sales pitch. Published measurements go both ways. A
+well-modelled semantic layer moved accuracy up seventeen to twenty-three points on a
+hundred-question set built on a retail schema much like this one. A study of agent-context files
+found human-written ones worth about four points on average, and machine-generated ones slightly
+negative while adding twenty percent to cost. So the conclusion is not "context is good". It is:
+**context written for a specific observed failure works, generic context does not, and the only way
+to know which you wrote is to measure.**
+
+Two cheap verification moves from the same literature, worth keeping after this lesson. **Run it
+three times** - text-to-SQL is not deterministic, and the same question answered three different
+ways means you cannot trust any of them. **Ask two models** - disagreement between models is a
+strong bug signal, and it costs one extra prompt.
+
+## Quiz
+1. Q: Why must the second run be a fresh session rather than a follow-up in the same conversation?
+   A: Because the first run's reasoning is still in context. The agent would be scoring against its own earlier working rather than against the repository, and the measurement would be of memory, not of context.
+2. Q: Your before score is 6 and your after score is 6. What have you learned?
+   A: That the context you wrote did not address the failures this question set exercises. That is a real result, not a failed exercise - the next move is to look at which four questions are still wrong and write context aimed at those specifically.
+3. Q: Why does the scoring allow no partial credit?
+   A: Because a nearly-right figure almost always means the agent resolved an ambiguity differently, not that it was slightly imprecise. Half a point would hide the thing the exercise exists to show.
+
+## Task
+Run the full measurement. Add two questions of your own to `docs/eval/questions.md` with verified
+answers, then score two fresh agent sessions against all ten and record the results in
+`docs/eval/results.md`: the before score, the after score, a line per question showing right or
+wrong in each run, and one sentence naming the single context line that you believe caused the
+biggest change.
+
+Do not let the agent read `docs/eval/answers.md` before either run.
+
+## Rubric (for `review my work`)
+- [ ] `docs/eval/results.md` exists and reports a before score out of 10 and an after score out of 10.
+- [ ] Both runs cover all ten questions, with a per-question right or wrong recorded for each run.
+- [ ] The two added questions have answers the student verified with a query, not estimated.
+- [ ] One sentence names a specific context line - a named column's description, a named glossary entry, a named `AGENTS.md` rule - not "the descriptions helped".
+- [ ] Grade the recorded scores, not the direction of the delta. A lower after score with an honest explanation is a pass.
+
+## Done signal
+Confirm two scores exist, that they came from two separate sessions, and that the student named a
+specific line rather than a category. Carry forward: context you have not measured is context you
+are hoping about.

--- a/templates/academy-sql-intermediate/course/lessons/14-capstone-defend-the-answer.md
+++ b/templates/academy-sql-intermediate/course/lessons/14-capstone-defend-the-answer.md
@@ -59,6 +59,7 @@ it, or hint at what it lists until the student's defence is written.
 - [ ] Layering, 2 points: staging assets contain no `JOIN`; one core asset and one mart asset exist; the mart's `depends` names no asset from `pipeline/assets/generate/`.
 - [ ] Join and grain safety, 1 point: order rows are deduplicated with `QUALIFY ROW_NUMBER() ... ORDER BY _loaded_at DESC`, order lines with `DISTINCT`, and the customer join does not fan out.
 - [ ] Governance, 2 points: every mart column has a description, and `meta` carries both a metric definition and a known limitation.
+- [ ] The currency basis in `meta.currency` is true of the query. Orders are priced in five currencies and are not converted, so a headline figure that sums them untouched is not an amount in any currency. Either the figure is converted through `fx_rates` on both date and currency, or `meta.currency` says the number is a mixed-currency sum and the defence says why that is acceptable. Ask for the query that shows the currency composition behind the figure - do not accept the `meta` field on its own.
 - [ ] Verification, 2 points: three checks of the headline figure by three different routes, each with its number recorded.
 - [ ] Defence, 1 point: `docs/defence.md` answers all four questions and anticipates at least six of the nine objections in the key.
 

--- a/templates/academy-sql-intermediate/course/lessons/14-capstone-defend-the-answer.md
+++ b/templates/academy-sql-intermediate/course/lessons/14-capstone-defend-the-answer.md
@@ -1,0 +1,69 @@
+# Lesson 14: capstone-defend-the-answer
+
+## Objectives
+- Turn an unanswerable request into a defensible churn-risk model.
+- Verify the headline number three independent ways.
+- Survive five objections from an agent told to break your work.
+
+## Concepts to teach
+The scenario, verbatim:
+
+> "Which customers are at risk of churning, and what revenue is at risk? I am presenting this on
+> Thursday."
+
+Everything the course has taught is needed here, and the request contains no definition of "at
+risk". Neither does the data. The student picks one, writes it down, and defends it - that is the
+exercise. There is no single correct churn definition and the grading does not look for one; it
+looks for a threshold that is stated, justified, and implemented as written.
+
+Five deliverables. A **model contract** at `docs/contracts/churn_risk.md` with all six fields, the
+Metric field carrying a definition of "at risk" specific enough that two analysts would select the
+same customers. A **layered implementation**: staging cleans, one core fact, one mart asset, and the
+mart never reads a table from `generate/`. **Column descriptions** on the mart and the metric
+definition in the asset `meta`. **Three independent verifications** of the headline
+revenue-at-risk figure - three different routes to the number, not one query written three ways.
+And a one-page **written defence** at `docs/defence.md` answering the four questions a sceptical
+executive asks: what does one row mean, why this churn definition, what is excluded and why, and
+how confident are you.
+
+Then the part that is the actual point. When all five are done, the student asks their agent to
+attack the work: read the assets and the defence, give the five strongest objections a sceptical
+CFO would raise, say for each whether it is a real problem or a presentational one, and show the
+query that demonstrates the real ones. Instruct the agent not to be reassuring. If the number is
+defensible, it should name the single assumption it rests on. A defence that survives that is
+finished. One that does not gets rewritten before it is graded.
+
+Two anchors the student should be able to reconcile to, since both are checkable: total line
+revenue across all three years is **851,617.69**, and lifetime line revenue across only the
+customers that have a row in `customers` is **847,693.43**. The **3,924.26** gap has an explanation,
+and finding it is part of the work.
+
+## Quiz
+1. Q: What makes three verifications independent rather than three copies of one?
+   A: They reach the number by different routes - for example a different grain, a different table as the starting point, and a hand-check of a single small slice - so a mistake in one route does not repeat in the others.
+2. Q: Your churn definition is "customers who have stopped buying". Why will that fail the contract?
+   A: It has no threshold and no reference date, so two analysts implementing it would select different customers. A definition has to contain the numbers you filtered on.
+3. Q: The agent raises an objection you had already thought of and rejected. Is that a failure of the defence?
+   A: No, as long as `docs/defence.md` records the decision and the reason. An objection you anticipated and answered in writing is exactly what the defence is for. An objection you have to answer on the spot is the failure.
+
+## Task
+Build the churn-risk model and defend it. Produce all five deliverables named above, then run the
+adversarial pass with your agent and revise. Ask for review only once `docs/defence.md` is written
+and you have committed to your headline figure.
+
+## Rubric (for `review my work`)
+Ten points. Grade against `course/answer-key.md`, which is instructor-only - do not reveal it, quote
+it, or hint at what it lists until the student's defence is written.
+
+- [ ] Contract quality, 2 points: `docs/contracts/churn_risk.md` exists with all six fields, and the churn definition contains a threshold and a reference date.
+- [ ] Layering, 2 points: staging assets contain no `JOIN`; one core asset and one mart asset exist; the mart's `depends` names no asset from `pipeline/assets/generate/`.
+- [ ] Join and grain safety, 1 point: order rows are deduplicated with `QUALIFY ROW_NUMBER() ... ORDER BY _loaded_at DESC`, order lines with `DISTINCT`, and the customer join does not fan out.
+- [ ] Governance, 2 points: every mart column has a description, and `meta` carries both a metric definition and a known limitation.
+- [ ] Verification, 2 points: three checks of the headline figure by three different routes, each with its number recorded.
+- [ ] Defence, 1 point: `docs/defence.md` answers all four questions and anticipates at least six of the nine objections in the key.
+
+## Done signal
+Confirm all five deliverables exist on disk, that the headline figure is stated with a currency
+basis and a reference date, and that the adversarial pass actually ran. Only then walk through the
+answer key together. Carry forward: a number you cannot defend under attack is a number you have
+not finished.

--- a/templates/academy-sql-intermediate/course/lessons/15-recap-and-next-steps.md
+++ b/templates/academy-sql-intermediate/course/lessons/15-recap-and-next-steps.md
@@ -1,0 +1,61 @@
+# Lesson 15: recap-and-next-steps
+
+## Objectives
+- Name the six habits this course built, and which one you will actually keep using.
+- Say which number from the course changed how you think about trusting a query.
+- Know what the advanced course adds and why none of it belongs here yet.
+
+## Concepts to teach
+No new material. Six habits carried the whole course, in the order you met them:
+
+1. **Resolve ambiguity before writing SQL.** "Category performance" had four defensible readings
+   before anyone wrote a WHERE clause. The fix is a question, not a query.
+2. **Write a contract two analysts would implement identically.** Grain, keys, metric, filters, and
+   what the model deliberately does not answer, written down before the SQL exists.
+3. **Profile a table before you build on it.** Six questions, each with a query, asked of every
+   table - row count and grain, key uniqueness, NULL rates, orphan keys, date coverage, and
+   categorical consistency.
+4. **Annotate grain to find fan-out mechanically.** Writing what one row represents beside every CTE
+   and join turns a silent multiplication into something you can see on the page.
+5. **Write descriptions for the failures you actually observed.** Not the column name restated - the
+   caveat a query surfaced, like `order_total` not reconciling with line revenue.
+6. **Measure whether your context helped, instead of assuming it did.** The same before-and-after
+   evaluation that showed a specific line of `AGENTS.md` or the glossary either moved the score or
+   did not.
+
+None of these are tools. They survive a change of warehouse, a change of AI model, and a change of
+job, because they are decisions about what to check and what to write down, not syntax. Keep the
+one that matches how you actually work: if most of your mistakes come from vague requests, keep the
+ask-back habit at the front; if most of them come from a query that ran clean and was still wrong,
+keep profiling and grain annotation in front of every new table you touch.
+
+The habit that is easiest to drop is the sixth, because it takes the most discipline to run twice.
+Do not drop it. A description or a rule you never measured is a guess about what helped, and this
+course exists because guesses about data are exactly what put you here.
+
+Next: the advanced course covers pipelines, tests, incremental loads, and operating all of this with
+an agent without letting it near production.
+
+## Quiz
+1. Q: Name the six habits, in the order the course taught them.
+   A: Resolve ambiguity before writing SQL; write a contract two analysts would implement identically; profile a table before building on it; annotate grain to find fan-out mechanically; write descriptions for the failures you actually observed; measure whether your context helped instead of assuming it did.
+2. Q: Why is habit six the one most likely to get skipped, and why does that matter?
+   A: It requires running the same evaluation twice and comparing scores, which takes more discipline than writing a rule once; skipping it means every other habit's payoff is assumed rather than checked, which is the exact failure mode the course is about.
+3. Q: What does the advanced course add that this one deliberately left out?
+   A: Pipelines, tests, incremental loads, and operating all of it with an agent without letting it near production.
+
+## Task
+Say, in the conversation, which single habit from the six you will use on a specific piece of real
+work in the next week - name the habit and the work, not the habit alone. Then say which number from
+this course surprised you most, and why.
+
+## Rubric (for `review my work`)
+- [ ] One habit is named from the list of six, using language close enough to match its meaning.
+- [ ] The habit is tied to a specific, named piece of real work, not a general intention.
+- [ ] The surprising number is one of the actual numbers from this course (for example the 5x fan-out on `fx_rates`, the 169 completed orders in 2023 against 39 that a naive filter finds, or the 24 NULL `order_status` rows), not an invented or rounded figure.
+- [ ] A reason is given for why that number was surprising, beyond restating the number.
+
+## Done signal
+Confirm the student names a real habit tied to real work and a real number tied to a real reason.
+Carry forward: the course ends here, but the habits are only worth what you do with them next week -
+point them at the advanced course and getbruin.com/learn.

--- a/templates/academy-sql-intermediate/course/progress.md
+++ b/templates/academy-sql-intermediate/course/progress.md
@@ -1,0 +1,19 @@
+# Progress
+
+Say `next lesson` to begin. The agent updates this file as you go.
+
+- [ ] 01 the-question-is-the-hard-part
+- [ ] 02 write-the-model-contract
+- [ ] 03 profile-before-you-model
+- [ ] 04 stage-the-work
+- [ ] 05 window-functions
+- [ ] 06 patterns-agents-get-wrong
+- [ ] 07 read-a-query-fast
+- [ ] 08 layer-the-project
+- [ ] 09 views-and-tables
+- [ ] 10 metric-in-the-asset
+- [ ] 11 descriptions-and-tags
+- [ ] 12 glossary-and-readme
+- [ ] 13 measure-your-context
+- [ ] 14 capstone-defend-the-answer
+- [ ] 15 recap-and-next-steps

--- a/templates/academy-sql-intermediate/course/progress.md
+++ b/templates/academy-sql-intermediate/course/progress.md
@@ -2,6 +2,9 @@
 
 Say `next lesson` to begin. The agent updates this file as you go.
 
+`- [x]` means passed. A lesson you skip stays unchecked and gains `(skipped)`, so you can tell it
+apart from one you have not reached yet.
+
 - [ ] 01 the-question-is-the-hard-part
 - [ ] 02 write-the-model-contract
 - [ ] 03 profile-before-you-model

--- a/templates/academy-sql-intermediate/docs/_data-design.md
+++ b/templates/academy-sql-intermediate/docs/_data-design.md
@@ -90,7 +90,7 @@ Do not flatten any of this:
 - Order volume ramps 360 in 2023, 480 in 2024, 360 in 2025, with a deliberate dip in Q3 2024.
 - Revenue concentrates: one order in four goes to a pool of fifty regulars.
 - Customers 461 to 500 never order, so a `LEFT JOIN` from `customers` has something to show.
-- Two categories dominate, so 120 of the 416 category-weeks in 2023 are empty and the date-spine
+- Two categories dominate, so 128 of the 424 category-weeks in 2023 are empty and the date-spine
   lesson has something to fix.
 - FX rates drift, so converting revenue changes an answer across years rather than scaling it.
 
@@ -111,6 +111,6 @@ rubrics depend on are:
 | 2023 revenue in USD | 258,645.94 |
 | Same, joined on date alone | 1,324,631.05, exactly 5x |
 | Largest weekly drop in 2023 | Electronics, week of 2023-11-20, -6,193.24 |
-| Empty category-weeks in 2023 | 120 of 416 |
+| Empty category-weeks in 2023 | 128 of 424, over 53 week starts |
 | Orphan-product line revenue | 3,637.89 over 15 lines |
 | `drill-3.sql` as written / grain fixed | 373,614.70 / 348,521.23 |

--- a/templates/academy-sql-intermediate/docs/_data-design.md
+++ b/templates/academy-sql-intermediate/docs/_data-design.md
@@ -1,0 +1,116 @@
+# Data design (contributor record, not shipped)
+
+**This file is deliberately excluded from the template.** Go's `//go:embed *` skips underscore-prefixed
+files, so `bruin init academy-sql-intermediate` never writes it to a student's disk, and
+`templates/templates.go` records why. Finding the defects listed here is the coursework for lessons
+3, 6 and 8. Do not rename this file, and do not add it to the embed list.
+
+`cmd/init_template_test.go` asserts both that it does not ship and that the contents below still
+match the generated data.
+
+## Determinism rules
+
+Identical to the beginner template. In short:
+
+1. No `random()`, `hash()`, `md5()`, `now()`, `current_date`, `current_timestamp` or `today()`.
+   Only `range()` and integer arithmetic on the row number.
+2. Every date is an absolute literal or an offset from one.
+3. No dependence on `--start-date` or `--end-date`.
+4. Explicit `ORDER BY` wherever row order could affect a result.
+5. Scramble through a large prime before folding into a small range, and give every column its own
+   `(p, q)` pair. `(i * 7) % 6` is just `i % 6`.
+6. Hardcode the small dimensions so the rows read like real ones.
+7. One test generates into two fresh databases and compares checksums.
+
+## Base data
+
+The generators are the beginner template's, unchanged in their arithmetic, so the underlying figures
+match: 851,617.69 of line revenue and 604,065.00 of `order_total` across 1,200 orders and 2,880
+lines. What changed is the defect set layered on top and the header metadata stripped off.
+
+`fx_rates` is new. Rates are `(base_micro + trend * trend_slope + cycle * cycle_slope) / 1000000.0`,
+where `trend = d - 548` is linear across the three years and
+`cycle = abs(((d * 2) % 730) - 365) - 182` is a 365-day triangle wave. Both terms are integers, so
+the division happens once and the result is exact. `USD` has both slopes at zero and is therefore a
+constant 1.000000 identity row.
+
+## The nine defects and where they are injected
+
+| # | Defect | Injected in | Rule | Verified |
+|---|---|---|---|---|
+| 1 | NULL `order_status` | `orders.sql` | `i % 50 = 0` | 24 rows |
+| 2 | NULL `unit_cost` | `order_items.sql` | `s % 50 = 0` | 57 rows |
+| 3 | Orphan `product_id` | `order_items.sql` | `s % 190 = 0` sets 9999 | 15 lines |
+| 4 | Orphan `customer_id` | `orders.sql` | `i % 240 = 0` sets 9001 | 5 rows |
+| 5 | Duplicated `customer_id` | `customers.sql` | ids 1..10 unioned back in | 10 ids, 510 rows |
+| 6 | Byte-identical duplicate lines | `order_items.sql` | `s % 192 = 0` unioned back in | 15 rows |
+| 7 | Resent orders, later `_loaded_at`, changed status | `orders.sql` | `order_id % 100 = 37` unioned back in, `+48h`, status flipped | 12 ids, 1,212 rows |
+| 8 | Casing and whitespace | `customers.sql`, `products.sql`, `orders.sql` | see below | see below |
+| 9 | Sales on a store with no dimension row | `orders.sql` | `i % 97 = 0` sets `store_id` 7 | 12 rows |
+
+The modulus sets are pairwise disjoint by construction:
+
+- 50, 240 and 97 share no multiple below 1,201 with `i % 100 = 37`, whose members all end in 37.
+- `lcm(190, 192) = 18,240` and `lcm(50, 192) = 4,800`, both above 2,880, so defects 2, 3 and 6 never
+  land on the same line.
+
+Check this again if you ever change a modulus.
+
+### Defects 6 and 7 are the point of this template
+
+Defect 6 is byte-identical rows: `SELECT DISTINCT` removes them and the answer is then right.
+Defect 7 is the same `order_id` twice with a different `order_status` and a `_loaded_at` two days
+later: `DISTINCT` keeps both, because they differ. The fix is
+`QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`.
+
+Not deduplicating the resent orders double-counts 18,518.92 of line revenue. Not deduplicating the
+replayed lines double-counts 7,278.04. Keep both defects, keep them distinguishable, and do not let
+a future cleanup collapse them into one.
+
+### Defect 8 in detail
+
+| Column | Rule | Verified |
+|---|---|---|
+| `customers.country` | slot 1 of the location list is the home market, taking a quarter of the book; its country is written five ways by `k_spelling % 5` | `USA` 34, `usa` 29, `U.S.A.` 22, `USA ` 22, ` USA` 20, so 127 rows over 5 spellings |
+| `customers.city` | `k_case % 40 = 0` uppercases, `= 1` lowercases | 31 rows, 20 distinct values for 12 cities |
+| `products.brand` | `product_id` 29 gets a leading space, 58 a trailing one | 2 rows, 11 distinct values for 9 brands |
+| `orders.order_status` | the completed branch splits on `k_spelling % 4` | `Completed` 147, `COMPLETED` 146, `complete` 143, `completed` 140 |
+
+`complete` against `completed` is the one that matters. It is not a casing problem, so `LOWER()`
+alone still misses 143 orders across the table and 43 within 2023.
+
+`UPPER(TRIM(country))` folds 16 distinct values to 13, not to 12, because `U.S.A.` survives it. That
+is deliberate: normalisation is a decision about which values are the same, not a function you can
+apply and stop thinking.
+
+## Intended shape
+
+Do not flatten any of this:
+
+- Order volume ramps 360 in 2023, 480 in 2024, 360 in 2025, with a deliberate dip in Q3 2024.
+- Revenue concentrates: one order in four goes to a pool of fifty regulars.
+- Customers 461 to 500 never order, so a `LEFT JOIN` from `customers` has something to show.
+- Two categories dominate, so 120 of the 416 category-weeks in 2023 are empty and the date-spine
+  lesson has something to fix.
+- FX rates drift, so converting revenue changes an answer across years rather than scaling it.
+
+## Every number the course quotes
+
+The full harvested list lives with the pull request that added this template. The figures the lesson
+rubrics depend on are:
+
+| Figure | Value |
+|---|---|
+| Line revenue 2023 / 2024 / 2025 | 264,926.21 / 338,209.56 / 248,481.92 |
+| Line revenue all years | 851,617.69 |
+| `SUM(order_total)`, deduped | 604,065.00 |
+| Completed orders in 2023, all four spellings | 169 |
+| Distinct 2023 customers with a dimension row | 268 |
+| Top country by 2023 revenue | USA, 53,828.71 |
+| Highest month of 2023 | December, 29,547.65 |
+| 2023 revenue in USD | 258,645.94 |
+| Same, joined on date alone | 1,324,631.05, exactly 5x |
+| Largest weekly drop in 2023 | Electronics, week of 2023-11-20, -6,193.24 |
+| Empty category-weeks in 2023 | 120 of 416 |
+| Orphan-product line revenue | 3,637.89 over 15 lines |
+| `drill-3.sql` as written / grain fixed | 373,614.70 / 348,521.23 |

--- a/templates/academy-sql-intermediate/docs/contracts/TEMPLATE.md
+++ b/templates/academy-sql-intermediate/docs/contracts/TEMPLATE.md
@@ -1,0 +1,16 @@
+# Model contract: <name>
+
+Question:     <the stakeholder question, verbatim>
+Grain:        <what one row of the output represents>
+Keys:         <the columns that uniquely identify a row>
+Metric:       <the exact definition, including which column and which exclusions>
+Filters:      <the non-negotiable inclusion rules>
+Not included: <what this deliberately does not answer>
+
+## Open decisions
+<anything still unresolved, and who decides>
+
+Copy this file to `docs/contracts/<model-name>.md` and fill every field before you
+start writing the query. An unfilled field is a question for a stakeholder, not
+something to guess at. Keep the contract short - if a field needs a paragraph, the
+model probably needs to be split.

--- a/templates/academy-sql-intermediate/docs/eval/answers.md
+++ b/templates/academy-sql-intermediate/docs/eval/answers.md
@@ -1,0 +1,33 @@
+# Evaluation answers
+
+Verified by running the generated data. The generators are deterministic, so these figures are the
+same on your machine as on anyone else's.
+
+Read this only when you are scoring. Reading it earlier costs you the measurement in lesson 13, and
+there is no way to get it back other than starting the lesson again.
+
+| # | Answer |
+|---|---|
+| 1 | 264,926.21 |
+| 2 | USA, 53,828.71 |
+| 3 | 169 |
+| 4 | 735.91 |
+| 5 | 3,637.89 across 15 lines |
+| 6 | 268 |
+| 7 | December 2023, 29,547.65 |
+| 8 | 258,645.94 |
+
+## Scoring
+
+One point per question, and mark a question right only if the figure matches exactly. Questions 2
+and 7 need both parts right. Question 5 needs both parts right.
+
+Round-tripping matters here. An answer of 264,926.20 on question 1 is wrong, not close. The whole
+point of the exercise is that the agent either resolved the ambiguity or it did not, and a figure
+that is nearly right is usually a figure that resolved it differently.
+
+## A note on question 4
+
+Average order value has more than one defensible denominator, and a different choice gives a
+different number. This question fixes the denominator in its own wording so that scoring stays
+mechanical. That the question had to say so is itself the lesson.

--- a/templates/academy-sql-intermediate/docs/eval/questions.md
+++ b/templates/academy-sql-intermediate/docs/eval/questions.md
@@ -1,0 +1,57 @@
+# Evaluation questions
+
+Eight questions with one defensible answer each. Lesson 13 uses them to measure whether the context
+you wrote changed how often your agent gets an answer right.
+
+Every question is scoped precisely on purpose. Where a definition could go two ways, the question
+picks one, so that a wrong answer is a wrong answer rather than a different reading. Read the
+scoping line before you score anything.
+
+The verified answers are in `answers.md`. Do not open it, and do not let your agent read it, until
+you have both scores.
+
+**Shared definitions used below**
+
+- **Line revenue** is `SUM(quantity * net_price)` over rows of `order_items`.
+- **In 2023** means the line's order has `ordered_at >= TIMESTAMP '2023-01-01 00:00:00'` and
+  `ordered_at < TIMESTAMP '2024-01-01 00:00:00'`.
+- **Each order counted once, each line counted once.** Where a table holds the same record more
+  than once, the intended figure counts it a single time.
+
+---
+
+**1. What was the total line revenue in 2023?**
+
+Two decimal places.
+
+**2. Which customer country produced the most line revenue in 2023, and how much?**
+
+Fold every spelling of the same country into one. Name the country and give the figure to two
+decimal places.
+
+**3. How many orders placed in 2023 finished in a completed state?**
+
+Count orders, not lines. Treat every spelling of the completed state as the completed state.
+
+**4. What was the average order value in 2023?**
+
+Defined as 2023 line revenue divided by the number of distinct orders placed in 2023. Two decimal
+places.
+
+**5. Across all three years, how much line revenue sits on order lines whose `product_id` has no
+matching row in `products`?**
+
+Two decimal places, and give the number of lines as well.
+
+**6. How many distinct customers placed at least one order in 2023?**
+
+Count only customers that have a row in `customers`.
+
+**7. Which calendar month of 2023 had the highest line revenue, and how much?**
+
+Name the month and give the figure to two decimal places.
+
+**8. What was the total 2023 line revenue converted to USD?**
+
+Convert each order at its own `currency_code` and at the `fx_rates` row for its own `ordered_at`
+date. Two decimal places.

--- a/templates/academy-sql-intermediate/docs/glossary.md
+++ b/templates/academy-sql-intermediate/docs/glossary.md
@@ -1,0 +1,16 @@
+# Glossary
+
+Terms used in this project. Add to this file as you go.
+
+## Revenue
+TODO. There is more than one defensible definition in this data. Decide which one this
+project uses, write it here, and say which column it comes from.
+
+## Order
+A customer purchase. One row in `orders`.
+
+## Line
+A single product on an order. One row in `order_items`.
+
+## TODO
+Add: AOV, active customer, churn, category, net vs gross, fiscal period.

--- a/templates/academy-sql-intermediate/docs/schema.md
+++ b/templates/academy-sql-intermediate/docs/schema.md
@@ -1,0 +1,125 @@
+# Schema
+
+The tables sit in DuckDB's default schema. Queries read `FROM orders` with no
+prefix, and `SHOW TABLES` lists all seven.
+
+| Table | Rows |
+|---|---|
+| `dates` | 1,096 |
+| `stores` | 6 |
+| `products` | 60 |
+| `customers` | 510 |
+| `orders` | 1,212 |
+| `order_items` | 2,895 |
+| `fx_rates` | 5,480 |
+
+## dates
+
+One row per calendar day, 2023-01-01 to 2025-12-31.
+
+```text
+date_day            DATE
+date_key            INTEGER
+year                INTEGER
+quarter             INTEGER
+year_month          VARCHAR
+month_number        INTEGER
+month_name          VARCHAR
+iso_week            INTEGER
+day_of_week_number  INTEGER
+day_of_week_name    VARCHAR
+is_working_day      BOOLEAN
+```
+
+## stores
+
+One row per store.
+
+```text
+store_id      INTEGER
+store_code    VARCHAR
+country_code  VARCHAR
+country_name  VARCHAR
+city          VARCHAR
+opened_on     DATE
+closed_on     DATE
+status        VARCHAR
+timezone      VARCHAR
+```
+
+## products
+
+One row per product.
+
+```text
+product_id        INTEGER
+product_code      VARCHAR
+product_name      VARCHAR
+brand             VARCHAR
+category_name     VARCHAR
+subcategory_name  VARCHAR
+color             VARCHAR
+unit_cost         DECIMAL
+list_price        DECIMAL
+```
+
+## customers
+
+One row per customer account.
+
+```text
+customer_id   INTEGER
+first_name    VARCHAR
+last_name     VARCHAR
+city          VARCHAR
+state         VARCHAR
+country       VARCHAR
+signed_up_on  DATE
+segment       VARCHAR
+```
+
+## orders
+
+One row per order, as delivered by the source system.
+
+```text
+order_id                INTEGER
+customer_id             INTEGER
+store_id                INTEGER
+ordered_at              TIMESTAMP
+_loaded_at              TIMESTAMP
+promised_delivery_date  DATE
+currency_code           VARCHAR
+order_status            VARCHAR
+order_total             DECIMAL
+```
+
+## order_items
+
+One row per line on an order.
+
+```text
+order_id     INTEGER
+line_number  INTEGER
+product_id   INTEGER
+quantity     INTEGER
+unit_price   DECIMAL
+net_price    DECIMAL
+unit_cost    DECIMAL
+```
+
+## fx_rates
+
+One row per date per currency pair.
+
+```text
+rate_date      DATE
+from_currency  VARCHAR
+to_currency    VARCHAR
+rate           DECIMAL
+```
+
+---
+
+This file records the grain of each table and nothing else. The column
+descriptions are missing on purpose. Writing them is coursework.

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/customers.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/customers.sql
@@ -1,0 +1,129 @@
+/* @bruin
+name: customers
+type: duckdb.sql
+
+description: "Customer accounts."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: customer_id
+    type: integer
+  - name: first_name
+    type: varchar
+  - name: last_name
+    type: varchar
+  - name: city
+    type: varchar
+  - name: state
+    type: varchar
+  - name: country
+    type: varchar
+  - name: signed_up_on
+    type: date
+  - name: segment
+    type: varchar
+@bruin */
+
+-- Deterministic generation. Every value is a pure function of the row number i.
+-- Names and locations are indexed out of short hardcoded lists.
+-- Do not introduce random(), now(), or current_date - see docs/_data-design.md.
+
+WITH lists AS (
+    SELECT
+        ['Alice','Bob','Carla','David','Elena','Frank','Grace','Hassan','Ivy','Jack',
+         'Kira','Liam','Mona','Noah','Olivia','Priya','Quinn','Rosa','Sam','Tara'] AS first_names,
+        ['Anderson','Brooks','Chen','Diaz','Evans','Fischer','Gupta','Hansen','Ibrahim','Jensen',
+         'Kowalski','Lopez','Murphy','Nguyen','Owens','Patel','Rossi','Silva','Tanaka','Vargas'] AS last_names,
+        -- Slot 1 is the home market and takes a quarter of the book. The other
+        -- eleven share the rest evenly.
+        [
+            {'city':'New York',  'state':'New York',        'country':'USA'},
+            {'city':'Toronto',   'state':'Ontario',         'country':'Canada'},
+            {'city':'London',    'state':'England',         'country':'United Kingdom'},
+            {'city':'Berlin',    'state':'Berlin',          'country':'Germany'},
+            {'city':'Paris',     'state':'Ile-de-France',   'country':'France'},
+            {'city':'Sydney',    'state':'New South Wales', 'country':'Australia'},
+            {'city':'Madrid',    'state':'Madrid',          'country':'Spain'},
+            {'city':'Rome',      'state':'Lazio',           'country':'Italy'},
+            {'city':'Amsterdam', 'state':'North Holland',   'country':'Netherlands'},
+            {'city':'Dublin',    'state':'Leinster',        'country':'Ireland'},
+            {'city':'Stockholm', 'state':'Stockholm',       'country':'Sweden'},
+            {'city':'Tokyo',     'state':'Tokyo',           'country':'Japan'}
+        ] AS locations,
+        -- Five ways of writing the same country. Two differ only by a space, so
+        -- TRIM alone is not enough and LOWER alone is not enough either.
+        ['USA', 'usa', 'U.S.A.', ' USA', 'USA '] AS home_spellings
+),
+scrambled AS (
+    -- One scrambled counter per column. Indexing two lists with (i * m) % 20 and
+    -- (i * n) % 20 looks fine but repeats every twenty rows, so first and last
+    -- name would move together and 500 customers would share 20 full names.
+    -- Scrambling through a larger prime first breaks that - see rule 5 in
+    -- docs/_data-design.md.
+    -- range() produces BIGINT; cast to INTEGER so DATE + offset type-checks.
+    SELECT
+        i,
+        (i * 29)  % 101  AS k_first,
+        (i * 47)  % 103  AS k_last,
+        (i * 61)  % 107  AS k_location,
+        (i * 83)  % 109  AS k_segment,
+        (i * 313) % 1499 AS k_signup,
+        (i * 71)  % 113  AS k_spelling,
+        (i * 97)  % 211  AS k_case
+    FROM (SELECT CAST(i AS INTEGER) AS i FROM range(1, 501) AS t(i)) AS s
+),
+placed AS (
+    SELECT
+        c.i,
+        c.k_first,
+        c.k_last,
+        c.k_segment,
+        c.k_signup,
+        c.k_spelling,
+        c.k_case,
+        -- A quarter of the book sits in the home market, the rest spread over the
+        -- other eleven cities.
+        CASE WHEN c.k_location % 4 = 0
+             THEN 1
+             ELSE 2 + c.k_location % 11
+        END AS location_slot
+    FROM scrambled AS c
+),
+base AS (
+    SELECT
+        p.i                                                   AS customer_id,
+        l.first_names[1 + p.k_first % 20]                     AS first_name,
+        l.last_names [1 + p.k_last  % 20]                     AS last_name,
+        -- Casing on the city is left alone most of the time and shouted or
+        -- whispered on a small slice of rows.
+        CASE
+            WHEN p.k_case % 40 = 0 THEN upper(l.locations[p.location_slot].city)
+            WHEN p.k_case % 40 = 1 THEN lower(l.locations[p.location_slot].city)
+            ELSE l.locations[p.location_slot].city
+        END                                                   AS city,
+        l.locations[p.location_slot].state                    AS state,
+        CASE
+            WHEN p.location_slot = 1
+                 THEN l.home_spellings[1 + p.k_spelling % 5]
+            ELSE l.locations[p.location_slot].country
+        END                                                   AS country,
+        (DATE '2020-01-01' + p.k_signup % 1461)               AS signed_up_on,
+        CASE
+            WHEN p.k_segment % 10 < 6 THEN 'consumer'
+            WHEN p.k_segment % 10 < 9 THEN 'small_business'
+            ELSE 'enterprise'
+        END                                                   AS segment
+    FROM placed AS p
+    CROSS JOIN lists AS l
+),
+-- customer_ids 1..10 appear a second time, as exact copies.
+repeated AS (
+    SELECT * FROM base WHERE customer_id <= 10
+)
+SELECT * FROM base
+UNION ALL
+SELECT * FROM repeated
+ORDER BY customer_id, city;

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/dates.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/dates.sql
@@ -1,0 +1,57 @@
+/* @bruin
+name: dates
+type: duckdb.sql
+
+description: "Calendar date spine."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: date_day
+    type: date
+  - name: date_key
+    type: integer
+  - name: year
+    type: integer
+  - name: quarter
+    type: integer
+  - name: year_month
+    type: varchar
+  - name: month_number
+    type: integer
+  - name: month_name
+    type: varchar
+  - name: iso_week
+    type: integer
+  - name: day_of_week_number
+    type: integer
+  - name: day_of_week_name
+    type: varchar
+  - name: is_working_day
+    type: boolean
+@bruin */
+
+-- Deterministic generation. Every value is a pure function of the day offset.
+-- Do not introduce random(), now(), or current_date - see docs/_data-design.md.
+
+WITH seq AS (
+    -- range(0, 1096) yields 0..1095: one number per day across three years.
+    -- range() produces BIGINT; cast to INTEGER so DATE + i type-checks.
+    SELECT CAST(i AS INTEGER) AS i FROM range(0, 1096) AS t(i)
+)
+SELECT
+    (DATE '2023-01-01' + i)                                    AS date_day,
+    CAST(strftime(DATE '2023-01-01' + i, '%Y%m%d') AS INTEGER) AS date_key,
+    CAST(year(DATE '2023-01-01' + i) AS INTEGER)               AS year,
+    CAST(quarter(DATE '2023-01-01' + i) AS INTEGER)            AS quarter,
+    strftime(DATE '2023-01-01' + i, '%Y-%m')                   AS year_month,
+    CAST(month(DATE '2023-01-01' + i) AS INTEGER)              AS month_number,
+    monthname(DATE '2023-01-01' + i)                           AS month_name,
+    CAST(week(DATE '2023-01-01' + i) AS INTEGER)               AS iso_week,
+    CAST(isodow(DATE '2023-01-01' + i) AS INTEGER)             AS day_of_week_number,
+    dayname(DATE '2023-01-01' + i)                             AS day_of_week_name,
+    isodow(DATE '2023-01-01' + i) < 6                          AS is_working_day
+FROM seq
+ORDER BY date_day;

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/fx_rates.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/fx_rates.sql
@@ -1,0 +1,64 @@
+/* @bruin
+name: fx_rates
+type: duckdb.sql
+
+description: "Daily exchange rates."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: rate_date
+    type: date
+  - name: from_currency
+    type: varchar
+  - name: to_currency
+    type: varchar
+  - name: rate
+    type: decimal
+@bruin */
+
+-- Deterministic generation. Every rate is a pure function of the day offset.
+-- Do not introduce random(), now(), or current_date - see docs/_data-design.md.
+--
+-- Five currency pairs on every one of the 1,096 days, including the USD
+-- identity row. Each rate is a base level plus two movements, both integer
+-- arithmetic on the day offset:
+--   trend - a straight line across the three years, so 2023 and 2025 differ
+--   cycle - a triangle wave with a 365-day period, so the line is not a ramp
+-- Both are computed in millionths and divided once at the end, so the result is
+-- exact integer arithmetic rather than accumulated floating point.
+
+WITH days AS (
+    -- range(0, 1096) yields 0..1095: one number per day across three years.
+    SELECT CAST(i AS INTEGER) AS d FROM range(0, 1096) AS t(i)
+),
+pairs AS (
+    SELECT * FROM (
+        VALUES
+            ('USD', 1000000,   0,   0),
+            ('EUR', 1080000,  40, 150),
+            ('GBP', 1260000,  50, 180),
+            ('CAD',  740000, -30, 120),
+            ('AUD',  660000, -45, 140)
+    ) AS c(from_currency, base_micro, trend_slope, cycle_slope)
+),
+shaped AS (
+    SELECT
+        d,
+        d - 548                              AS trend,   -- -548 .. 547
+        abs(((d * 2) % 730) - 365) - 182     AS cycle    -- -182 .. 183, 365-day period
+    FROM days
+)
+SELECT
+    (DATE '2023-01-01' + s.d)                AS rate_date,
+    p.from_currency,
+    'USD'                                    AS to_currency,
+    CAST(
+        (p.base_micro + s.trend * p.trend_slope + s.cycle * p.cycle_slope) / 1000000.0
+        AS DECIMAL(12, 6)
+    )                                        AS rate
+FROM shaped s
+CROSS JOIN pairs p
+ORDER BY rate_date, from_currency;

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/order_items.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/order_items.sql
@@ -1,0 +1,136 @@
+/* @bruin
+name: order_items
+type: duckdb.sql
+
+description: "Lines on an order."
+
+depends:
+  - orders
+  - products
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: order_id
+    type: integer
+  - name: line_number
+    type: integer
+  - name: product_id
+    type: integer
+  - name: quantity
+    type: integer
+  - name: unit_price
+    type: decimal
+  - name: net_price
+    type: decimal
+  - name: unit_cost
+    type: decimal
+@bruin */
+
+-- Deterministic generation. Every value is a pure function of a per-line number.
+-- Lines are generated from orders, so the fan-out is real, and prices are read
+-- from products, so unit_price and unit_cost mean what their names say.
+-- Do not introduce random(), now(), or current_date - see docs/_data-design.md.
+
+WITH order_keys AS (
+    -- DISTINCT, because orders carries a second copy of some order_ids and lines
+    -- must not be generated twice for them.
+    SELECT DISTINCT order_id FROM orders
+),
+order_line_counts AS (
+    -- How many lines each order gets. Keyed on a scrambled order_id rather than
+    -- on order_id % 10, so the line count does not move in lockstep with the
+    -- every-50th-order status gap - see rule 5 in docs/_data-design.md.
+    -- The cuts give 19% one-line orders, 32% two, 41% three and 9% four, which
+    -- averages to exactly 2.4 lines across the 1,200 orders.
+    SELECT
+        order_id,
+        CASE
+            WHEN (order_id * 31) % 113 <  21 THEN 1
+            WHEN (order_id * 31) % 113 <  57 THEN 2
+            WHEN (order_id * 31) % 113 < 103 THEN 3
+            ELSE                                  4
+        END AS n_lines
+    FROM order_keys
+),
+exploded AS (
+    -- Turn one order into n_lines rows, numbered 1..n_lines.
+    SELECT o.order_id, ln.line_number
+    FROM order_line_counts o
+    JOIN range(1, 5) AS ln(line_number) ON ln.line_number <= o.n_lines
+),
+numbered AS (
+    -- s is a stable 1..N line counter used to drive every value below.
+    SELECT
+        order_id,
+        line_number,
+        ROW_NUMBER() OVER (ORDER BY order_id, line_number) AS s
+    FROM exploded
+),
+chosen AS (
+    SELECT
+        order_id,
+        line_number,
+        s,
+        -- Scrambled counters again, one per column, so which product a line is
+        -- for is independent of how many units it is for.
+        (s * 71) % 103 AS k_product,
+        (s * 23) % 59  AS k_quantity,
+        (s * 37) % 89  AS k_discount,
+        CASE
+            -- Every 190th line points at 9999, which is not a real product.
+            WHEN s % 190 = 0 THEN 9999
+            -- Electronics sells in low volume at a high price, Apparel is the
+            -- volume driver, and everything else fills in behind them. The
+            -- thinner categories are what leave some category-weeks empty.
+            -- Every one of the 60 products still sells at least once.
+            WHEN s % 11 = 0 THEN 1  + ((s * 71) % 103) % 12  -- Electronics (ids 1..12)
+            WHEN s % 3  = 0 THEN 22 + ((s * 71) % 103) % 10  -- Apparel (ids 22..31)
+            ELSE                13 + ((s * 71) % 103) % 48   -- everything but Electronics (ids 13..60)
+        END AS product_id
+    FROM numbered
+),
+priced AS (
+    -- LEFT JOIN, not INNER: the lines pointing at 9999 have no product row, and
+    -- dropping them here would delete something the course depends on. They fall
+    -- back to a fixed catalogue price and cost.
+    SELECT
+        c.order_id,
+        c.line_number,
+        c.s,
+        c.product_id,
+        1 + c.k_quantity % 4                    AS quantity,
+        COALESCE(p.list_price, 249.00)          AS unit_price,
+        COALESCE(p.unit_cost,  112.00)          AS base_cost,
+        c.k_discount % 25                       AS discount_pct
+    FROM chosen c
+    LEFT JOIN products p ON c.product_id = p.product_id
+),
+rendered AS (
+    SELECT
+        s,
+        order_id,
+        CAST(line_number AS INTEGER) AS line_number,
+        CAST(product_id AS INTEGER)  AS product_id,
+        CAST(quantity AS INTEGER)    AS quantity,
+        unit_price,
+        -- Discount of 0..24 percent off the catalogue price. net_price is the real one.
+        CAST(ROUND(unit_price * (100 - discount_pct) / 100.0, 2) AS DECIMAL(10, 2)) AS net_price,
+        -- unit_cost is empty on every 50th line.
+        CASE WHEN s % 50 = 0 THEN NULL ELSE base_cost END   AS unit_cost
+    FROM priced
+),
+-- Every 192nd line was loaded twice, byte for byte. Nothing on the row
+-- distinguishes the copy from the original.
+replayed AS (
+    SELECT * FROM rendered WHERE s % 192 = 0
+)
+SELECT order_id, line_number, product_id, quantity, unit_price, net_price, unit_cost
+FROM (
+    SELECT * FROM rendered
+    UNION ALL
+    SELECT * FROM replayed
+) AS all_lines
+ORDER BY order_id, line_number, product_id;

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/orders.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/orders.sql
@@ -1,0 +1,168 @@
+/* @bruin
+name: orders
+type: duckdb.sql
+
+description: "Customer orders."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: order_id
+    type: integer
+  - name: customer_id
+    type: integer
+  - name: store_id
+    type: integer
+  - name: ordered_at
+    type: timestamp
+  - name: _loaded_at
+    type: timestamp
+  - name: promised_delivery_date
+    type: date
+  - name: currency_code
+    type: varchar
+  - name: order_status
+    type: varchar
+  - name: order_total
+    type: decimal
+@bruin */
+
+-- Deterministic generation. Every value is a pure function of the row number i.
+-- Do not introduce random(), now(), or current_date - see docs/_data-design.md.
+--
+-- Order volume ramps up from 2023 to a peak in 2024 (with a deliberate dip in
+-- Q3 2024) and eases off in 2025. That shape is what makes the year-over-year
+-- and window-function exercises non-trivial. The ramp is built purely by
+-- mapping row numbers to dates non-uniformly.
+
+WITH seq AS (
+    -- range(1, 1201) yields 1..1200: one number per order.
+    -- range() produces BIGINT; cast to INTEGER so DATE + offset type-checks.
+    SELECT CAST(i AS INTEGER) AS i FROM range(1, 1201) AS t(i)
+),
+scrambled AS (
+    -- Every column below is derived from one of these scrambled counters rather
+    -- than from i directly. Taking (i * prime) % prime first, and only then
+    -- folding into the range you want, is what keeps the columns independent of
+    -- each other. A plain (i * m) % 6 repeats every six rows, so it locks step
+    -- with anything else keyed on 2 or 3 - see rule 5 in docs/_data-design.md.
+    SELECT
+        i,
+        (i * 137) % 379  AS k_day,      -- which day in the period
+        (i * 47)  % 101  AS k_store,    -- which store
+        (i * 313) % 503  AS k_customer, -- which customer, general pool
+        (i * 53)  % 97   AS k_regular,  -- which customer, regulars pool
+        (i * 29)  % 73   AS k_hour,     -- hour of day
+        (i * 61)  % 131  AS k_promise,  -- whether a delivery date was promised
+        (i * 83)  % 127  AS k_spelling, -- how the completed status is written
+        -- Two scrambles added together, so order_total is not a straight line in
+        -- i. Without this, sorting orders by date walks order_total up or down by
+        -- a constant step and the whole dataset reads as machine-made.
+        (((i * 617) % 1013) + ((i * 89) % 251)) % 950 AS k_total
+    FROM seq
+),
+placed AS (
+    SELECT
+        i,
+        k_total,
+        k_promise,
+        k_spelling,
+        1 + k_store % 6                                             AS home_store_id,
+        -- Every fourth order goes to one of fifty regulars, so revenue
+        -- concentrates on a handful of customers and "top customers" is a
+        -- meaningful question. The rest spread across all 500.
+        -- The general pool stops at 460 on purpose, so customers 461..500 never
+        -- place an order. A LEFT JOIN from customers to orders therefore has
+        -- something to show, which an INNER JOIN would hide.
+        -- Every 240th order carries a customer_id that was never issued.
+        CASE
+            WHEN i % 240 = 0 THEN 9001
+            WHEN i % 4   = 0 THEN 1 + k_regular % 50
+            ELSE                  1 + k_customer % 460
+        END                                                         AS customer_id,
+        -- Map i to a day offset from 2023-01-01, non-uniformly, to shape volume.
+        (DATE '2023-01-01' +
+            CASE
+                WHEN i <= 360 THEN k_day % 365                      -- 2023: 360 orders
+                WHEN i <= 840 THEN 365 +                            -- 2024: 480 orders (peak)
+                    CASE
+                        WHEN i - 360 <= 140 THEN       k_day % 91      -- Q1
+                        WHEN i - 360 <= 280 THEN  91 + k_day % 91      -- Q2
+                        WHEN i - 360 <= 340 THEN 182 + k_day % 92      -- Q3 (the dip: 60 orders)
+                        ELSE                     274 + k_day % 92      -- Q4
+                    END
+                ELSE 731 + k_day % 365                              -- 2025: 360 orders
+            END
+        ) + ((k_hour % 24) * INTERVAL '1' HOUR)                     AS ordered_at
+    FROM scrambled
+),
+rendered AS (
+    SELECT
+        i                                                              AS order_id,
+        customer_id,
+        -- Every 97th order was rung up on a till that never made it into the
+        -- store list.
+        CASE WHEN i % 97 = 0 THEN 7 ELSE home_store_id END             AS store_id,
+        ordered_at,
+        -- Recorded a little after the order was placed, so it differs from ordered_at.
+        ordered_at + (((i * 5) % 72) * INTERVAL '1' HOUR)              AS _loaded_at,
+        -- Missing on a small number of orders. Keyed on k_promise so it does not
+        -- land only on regulars' orders.
+        CASE WHEN k_promise < 3
+             THEN NULL
+             ELSE CAST(ordered_at AS DATE) + (2 + (i * 3) % 7)
+        END                                                            AS promised_delivery_date,
+        -- Currency follows the store's country. The phantom till keeps the
+        -- currency of the store whose numbering slot it took.
+        CASE home_store_id
+            WHEN 1 THEN 'USD'
+            WHEN 2 THEN 'GBP'
+            WHEN 3 THEN 'EUR'
+            WHEN 4 THEN 'CAD'
+            WHEN 5 THEN 'AUD'
+            ELSE        'EUR'
+        END                                                            AS currency_code,
+        -- order_status is empty on every 50th order. The finished state is
+        -- written four different ways: three of them differ only in case, and
+        -- the fourth is a different word.
+        CASE
+            WHEN i % 50 = 0 THEN NULL
+            WHEN i % 11 = 0 THEN 'cancelled'
+            WHEN i % 17 = 0 THEN 'returned'
+            WHEN i % 7  = 0 THEN 'processing'
+            WHEN i % 3  = 0 THEN 'shipped'
+            ELSE CASE k_spelling % 4
+                     WHEN 0 THEN 'completed'
+                     WHEN 1 THEN 'Completed'
+                     WHEN 2 THEN 'COMPLETED'
+                     ELSE        'complete'
+                 END
+        END                                                            AS order_status,
+        -- Header-level total in the order's currency. Spread across 50.00 .. 999.99.
+        -- Deliberately NOT the sum of the order's lines - it is an order-level figure.
+        -- Cast to DECIMAL, not left as the DOUBLE that dividing would produce.
+        CAST(((50 + k_total) * 100 + (i * 41) % 100) / 100.0 AS DECIMAL(10, 2)) AS order_total
+    FROM placed
+),
+-- Twelve orders were sent a second time by the source system, two days later,
+-- with the status changed. Both rows survive because they are not identical.
+resent AS (
+    SELECT
+        order_id,
+        customer_id,
+        store_id,
+        ordered_at,
+        _loaded_at + INTERVAL '48' HOUR                                AS _loaded_at,
+        promised_delivery_date,
+        currency_code,
+        CASE WHEN order_status = 'cancelled' THEN 'returned' ELSE 'cancelled' END AS order_status,
+        order_total
+    FROM rendered
+    WHERE order_id % 100 = 37
+)
+SELECT * FROM rendered
+UNION ALL
+SELECT * FROM resent
+ORDER BY order_id, _loaded_at;

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/products.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/products.sql
@@ -1,0 +1,124 @@
+/* @bruin
+name: products
+type: duckdb.sql
+
+description: "Product catalogue."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: product_id
+    type: integer
+  - name: product_code
+    type: varchar
+  - name: product_name
+    type: varchar
+  - name: brand
+    type: varchar
+  - name: category_name
+    type: varchar
+  - name: subcategory_name
+    type: varchar
+  - name: color
+    type: varchar
+  - name: unit_cost
+    type: decimal
+  - name: list_price
+    type: decimal
+@bruin */
+
+-- Hand-written dimension. Sixty products. Deterministic by construction.
+-- Do not introduce random(), now(), or current_date - see docs/_data-design.md.
+
+WITH catalogue AS (
+    SELECT * FROM (
+        VALUES
+            (1,  'ELEC-001', 'Aurora Pico 5 Smartphone',      'Aurora',    'Electronics',     'Phones',              'Black',   320.00,  699.00),
+            (2,  'ELEC-002', 'Aurora Pico 5 Pro Smartphone',  'Aurora',    'Electronics',     'Phones',              'Graphite', 430.00,  999.00),
+            (3,  'ELEC-003', 'Cobalt One Smartphone',         'Cobalt',    'Electronics',     'Phones',              'Blue',    240.00,  499.00),
+            (4,  'ELEC-004', 'Vertex Air 13 Laptop',          'Vertex',    'Electronics',     'Laptops',             'Silver',  620.00, 1199.00),
+            (5,  'ELEC-005', 'Vertex Pro 15 Laptop',          'Vertex',    'Electronics',     'Laptops',             'Space Grey', 880.00, 1699.00),
+            (6,  'ELEC-006', 'Cobalt Book 14 Laptop',         'Cobalt',    'Electronics',     'Laptops',             'Silver',  510.00,  949.00),
+            (7,  'ELEC-007', 'Lumen Buds Wireless',           'Lumen',     'Electronics',     'Headphones',          'White',    45.00,  129.00),
+            (8,  'ELEC-008', 'Lumen Over-Ear Headphones',     'Lumen',     'Electronics',     'Headphones',          'Black',    88.00,  219.00),
+            (9,  'ELEC-009', 'Aurora Sound Earbuds',          'Aurora',    'Electronics',     'Headphones',          'Navy',     52.00,  139.00),
+            (10, 'ELEC-010', 'Vertex Tab 10 Tablet',          'Vertex',    'Electronics',     'Tablets',             'Silver',  190.00,  449.00),
+            (11, 'ELEC-011', 'Cobalt Slate Mini Tablet',      'Cobalt',    'Electronics',     'Tablets',             'Grey',    150.00,  329.00),
+            (12, 'ELEC-012', 'Aurora Pad 11 Tablet',          'Aurora',    'Electronics',     'Tablets',             'Rose',    260.00,  599.00),
+
+            (13, 'HOME-001', 'Meadow 10-Piece Cookware Set',  'Meadow',    'Home & Kitchen',  'Cookware',            'Steel',   110.00,  249.00),
+            (14, 'HOME-002', 'Meadow Cast Iron Skillet',      'Meadow',    'Home & Kitchen',  'Cookware',            'Black',    28.00,   69.00),
+            (15, 'HOME-003', 'Harbor Chef Knife 8in',         'Harbor',    'Home & Kitchen',  'Cookware',            'Silver',   34.00,   89.00),
+            (16, 'HOME-004', 'Everly Blender Pro',            'Everly',    'Home & Kitchen',  'Small Appliances',    'Black',    62.00,  149.00),
+            (17, 'HOME-005', 'Everly Espresso Machine',       'Everly',    'Home & Kitchen',  'Small Appliances',    'Stainless', 180.00,  399.00),
+            (18, 'HOME-006', 'Everly Air Fryer 5L',           'Everly',    'Home & Kitchen',  'Small Appliances',    'Black',    58.00,  129.00),
+            (19, 'HOME-007', 'Harbor Storage Bins 6-Pack',    'Harbor',    'Home & Kitchen',  'Storage',             'Clear',    18.00,   39.00),
+            (20, 'HOME-008', 'Meadow Glass Food Containers',  'Meadow',    'Home & Kitchen',  'Storage',             'Clear',    15.00,   34.00),
+            (21, 'HOME-009', 'Harbor Pantry Organizer',       'Harbor',    'Home & Kitchen',  'Storage',             'White',    22.00,   49.00),
+
+            (22, 'APRL-001', 'NorthPeak Men''s Rain Jacket',  'NorthPeak', 'Apparel',         'Menswear',            'Green',    40.00,   99.00),
+            (23, 'APRL-002', 'NorthPeak Men''s Hoodie',       'NorthPeak', 'Apparel',         'Menswear',            'Grey',     22.00,   59.00),
+            (24, 'APRL-003', 'Everly Men''s Chino Pants',     'Everly',    'Apparel',         'Menswear',            'Khaki',    18.00,   49.00),
+            (25, 'APRL-004', 'NorthPeak Women''s Parka',      'NorthPeak', 'Apparel',         'Womenswear',          'Red',      55.00,  139.00),
+            (26, 'APRL-005', 'Everly Women''s Cardigan',      'Everly',    'Apparel',         'Womenswear',          'Cream',    20.00,   54.00),
+            (27, 'APRL-006', 'Everly Women''s Leggings',      'Everly',    'Apparel',         'Womenswear',          'Black',    12.00,   34.00),
+            (28, 'APRL-007', 'NorthPeak Trail Runner Shoes',  'NorthPeak', 'Apparel',         'Footwear',            'Blue',     44.00,  109.00),
+            (29, 'APRL-008', 'NorthPeak Hiking Boots',        'NorthPeak', 'Apparel',         'Footwear',            'Brown',    58.00,  149.00),
+            (30, 'APRL-009', 'Cobalt Canvas Sneakers',        'Cobalt',    'Apparel',         'Footwear',            'White',    24.00,   64.00),
+            (31, 'APRL-010', 'Everly Wool Socks 3-Pack',      'Everly',    'Apparel',         'Footwear',            'Grey',      8.00,   19.00),
+
+            (32, 'SPRT-001', 'Vertex Adjustable Dumbbells',   'Vertex',    'Sports & Outdoors', 'Fitness',           'Black',    90.00,  199.00),
+            (33, 'SPRT-002', 'Vertex Yoga Mat',               'Vertex',    'Sports & Outdoors', 'Fitness',           'Purple',   14.00,   39.00),
+            (34, 'SPRT-003', 'Vertex Resistance Bands Set',   'Vertex',    'Sports & Outdoors', 'Fitness',           'Assorted', 10.00,   29.00),
+            (35, 'SPRT-004', 'NorthPeak 2-Person Tent',       'NorthPeak', 'Sports & Outdoors', 'Camping',           'Orange',   85.00,  199.00),
+            (36, 'SPRT-005', 'NorthPeak Sleeping Bag',        'NorthPeak', 'Sports & Outdoors', 'Camping',           'Green',    42.00,   99.00),
+            (37, 'SPRT-006', 'NorthPeak Camp Stove',          'NorthPeak', 'Sports & Outdoors', 'Camping',           'Silver',   36.00,   79.00),
+            (38, 'SPRT-007', 'NorthPeak Headlamp',            'NorthPeak', 'Sports & Outdoors', 'Camping',           'Black',    12.00,   29.00),
+
+            (39, 'BOOK-001', 'The Glass Harbor',              'Meadow Press', 'Books',         'Fiction',             'Multi',     4.00,   16.00),
+            (40, 'BOOK-002', 'Northern Lights',               'Meadow Press', 'Books',         'Fiction',             'Multi',     4.50,   18.00),
+            (41, 'BOOK-003', 'The Quiet Tide',                'Meadow Press', 'Books',         'Fiction',             'Multi',     4.00,   15.00),
+            (42, 'BOOK-004', 'Data for Everyone',             'Meadow Press', 'Books',         'Non-Fiction',         'Multi',     6.00,   28.00),
+            (43, 'BOOK-005', 'The Analyst''s Handbook',       'Meadow Press', 'Books',         'Non-Fiction',         'Multi',     7.00,   34.00),
+            (44, 'BOOK-006', 'Cooking Simply',                'Meadow Press', 'Books',         'Non-Fiction',         'Multi',     5.50,   24.00),
+
+            (45, 'TOYS-001', 'Harbor Quest Board Game',       'Harbor',    'Toys & Games',    'Board Games',         'Multi',    16.00,   39.00),
+            (46, 'TOYS-002', 'Settlers of Meadow',            'Meadow',    'Toys & Games',    'Board Games',         'Multi',    18.00,   44.00),
+            (47, 'TOYS-003', 'Cobalt Chess Set',              'Cobalt',    'Toys & Games',    'Board Games',         'Wood',     20.00,   49.00),
+            (48, 'TOYS-004', 'Aurora 1000-Piece Puzzle',      'Aurora',    'Toys & Games',    'Puzzles',             'Multi',     7.00,   19.00),
+            (49, 'TOYS-005', 'Meadow Wooden Puzzle',          'Meadow',    'Toys & Games',    'Puzzles',             'Wood',      9.00,   24.00),
+            (50, 'TOYS-006', 'Lumen Brain Teaser',            'Lumen',     'Toys & Games',    'Puzzles',             'Multi',     6.00,   16.00),
+
+            (51, 'BTY-001',  'Everly Daily Moisturizer',      'Everly',    'Beauty',          'Skincare',            'White',     8.00,   24.00),
+            (52, 'BTY-002',  'Everly Vitamin C Serum',        'Everly',    'Beauty',          'Skincare',            'Amber',    11.00,   34.00),
+            (53, 'BTY-003',  'Everly Sunscreen SPF50',        'Everly',    'Beauty',          'Skincare',            'White',     6.00,   18.00),
+            (54, 'BTY-004',  'Aurora Eau de Parfum',          'Aurora',    'Beauty',          'Fragrance',           'Gold',     30.00,   79.00),
+            (55, 'BTY-005',  'Harbor Cologne',                'Harbor',    'Beauty',          'Fragrance',           'Blue',     26.00,   69.00),
+
+            (56, 'GRDN-001', 'Meadow Pruning Shears',         'Meadow',    'Garden',          'Garden Tools',        'Green',    12.00,   29.00),
+            (57, 'GRDN-002', 'Meadow Garden Trowel',          'Meadow',    'Garden',          'Garden Tools',        'Green',     6.00,   16.00),
+            (58, 'GRDN-003', 'Meadow Hose 50ft',              'Meadow',    'Garden',          'Garden Tools',        'Green',    18.00,   44.00),
+            (59, 'GRDN-004', 'Harbor Patio Chair',            'Harbor',    'Garden',          'Outdoor Furniture',   'Grey',     48.00,  119.00),
+            (60, 'GRDN-005', 'Harbor Outdoor Table',          'Harbor',    'Garden',          'Outdoor Furniture',   'Brown',    95.00,  219.00)
+    ) AS p(product_id, product_code, product_name, brand, category_name, subcategory_name, color, unit_cost, list_price)
+)
+SELECT
+    product_id,
+    product_code,
+    product_name,
+    -- Two rows carry the brand with padding, one leading and one trailing, so the
+    -- same brand reads as three different values in a GROUP BY.
+    CASE
+        WHEN product_id = 29 THEN ' '  || brand
+        WHEN product_id = 58 THEN brand || ' '
+        ELSE brand
+    END AS brand,
+    category_name,
+    subcategory_name,
+    color,
+    unit_cost,
+    list_price
+FROM catalogue
+ORDER BY product_id;

--- a/templates/academy-sql-intermediate/pipeline/assets/generate/stores.sql
+++ b/templates/academy-sql-intermediate/pipeline/assets/generate/stores.sql
@@ -1,0 +1,45 @@
+/* @bruin
+name: stores
+type: duckdb.sql
+
+description: "Retail stores."
+
+materialization:
+  type: table
+  strategy: create+replace
+
+columns:
+  - name: store_id
+    type: integer
+  - name: store_code
+    type: varchar
+  - name: country_code
+    type: varchar
+  - name: country_name
+    type: varchar
+  - name: city
+    type: varchar
+  - name: opened_on
+    type: date
+  - name: closed_on
+    type: date
+  - name: status
+    type: varchar
+  - name: timezone
+    type: varchar
+@bruin */
+
+-- Hand-written dimension. Deterministic by construction.
+-- Paris closed on 2026-01-31, after the last order in the data, so no order
+-- postdates its own store's closing date.
+
+SELECT * FROM (
+    VALUES
+        (1, 'NYC01', 'US', 'United States',  'New York', DATE '2019-03-15', CAST(NULL AS DATE), 'open',   'America/New_York'),
+        (2, 'LON01', 'GB', 'United Kingdom', 'London',   DATE '2020-06-01', CAST(NULL AS DATE), 'open',   'Europe/London'),
+        (3, 'BER01', 'DE', 'Germany',        'Berlin',   DATE '2021-01-20', CAST(NULL AS DATE), 'open',   'Europe/Berlin'),
+        (4, 'TOR01', 'CA', 'Canada',         'Toronto',  DATE '2020-11-10', CAST(NULL AS DATE), 'open',   'America/Toronto'),
+        (5, 'SYD01', 'AU', 'Australia',      'Sydney',   DATE '2022-02-14', CAST(NULL AS DATE), 'open',   'Australia/Sydney'),
+        (6, 'PAR01', 'FR', 'France',         'Paris',    DATE '2018-09-01', DATE '2026-01-31',  'closed', 'Europe/Paris')
+) AS s(store_id, store_code, country_code, country_name, city, opened_on, closed_on, status, timezone)
+ORDER BY store_id;

--- a/templates/academy-sql-intermediate/pipeline/pipeline.yml
+++ b/templates/academy-sql-intermediate/pipeline/pipeline.yml
@@ -1,0 +1,14 @@
+name: retail
+
+schedule: daily
+start_date: "2023-01-01"
+
+default_connections:
+  duckdb: duckdb-default
+
+# Applied to every asset in this pipeline, so no asset has to repeat it.
+# Lesson 11 covers what these do and why they are worth setting.
+default:
+  owner: "student@example.com"
+  domains:
+    - commerce

--- a/templates/academy-sql-intermediate/queries/profiling/01-row-counts.sql
+++ b/templates/academy-sql-intermediate/queries/profiling/01-row-counts.sql
@@ -1,0 +1,21 @@
+-- Row counts and grain check.
+--
+-- Change the table name and the claimed key below and run this again on any
+-- table you are about to work with. It is the first thing to run on data you
+-- do not know yet.
+--
+-- Worked example: orders, claimed key is order_id.
+
+SELECT
+    COUNT(*)                    AS total_rows,
+    COUNT(DISTINCT order_id)    AS distinct_order_id
+FROM orders;
+
+-- Read the two numbers together.
+--
+-- If total_rows equals distinct_order_id, one row per order_id is the grain
+-- of this table, which is what "order_id is the key" should mean.
+--
+-- If total_rows is larger than distinct_order_id, either order_id is not
+-- actually the key, or the same key shows up on more than one row. Either
+-- way, treat the assumption as unproven until the two numbers match.

--- a/templates/academy-sql-intermediate/queries/profiling/02-key-uniqueness.sql
+++ b/templates/academy-sql-intermediate/queries/profiling/02-key-uniqueness.sql
@@ -1,0 +1,35 @@
+-- Key uniqueness check.
+--
+-- Change the table name and the key column below and run this again on any
+-- column you are about to trust as a key.
+--
+-- Worked example: customers, claimed key is customer_id.
+
+SELECT
+    customer_id,
+    COUNT(*) AS row_count
+FROM customers
+GROUP BY customer_id
+HAVING COUNT(*) > 1
+ORDER BY row_count DESC;
+
+-- Every row this returns is a key value that shows up more than once. If
+-- this is empty, the key is unique for every row in the table. If it is not
+-- empty, row_count tells you how many rows share that one key value.
+
+-- The fix depends on what those duplicate rows look like, so check that
+-- next. Compare the row count for the whole table against the row count once
+-- exact duplicate rows are collapsed.
+
+SELECT
+    COUNT(*)          AS total_rows,
+    COUNT(*) - (
+        SELECT COUNT(*) FROM (SELECT DISTINCT * FROM customers)
+    )                  AS exact_duplicate_rows
+FROM customers;
+
+-- If exact_duplicate_rows covers all the duplication you found above, the
+-- same row was loaded more than once, and de-duplicating is enough. If it
+-- does not, some duplicate keys carry rows that differ from each other,
+-- which means the source disagrees with itself about that record, and
+-- picking a row (for example, the latest one) is a decision, not a cleanup.

--- a/templates/academy-sql-intermediate/queries/profiling/03-null-rates.sql
+++ b/templates/academy-sql-intermediate/queries/profiling/03-null-rates.sql
@@ -1,0 +1,33 @@
+-- NULL count and percentage, one line per column.
+--
+-- Change the table name below, then add or remove a line per column you
+-- want to check. Each line is independent, so to add a column, copy one
+-- line and swap the column name in both places on it.
+--
+-- Worked example: orders.
+
+WITH totals AS (
+    SELECT COUNT(*) AS row_count FROM orders
+)
+SELECT 'order_id' AS column_name, COUNT(*) FILTER (WHERE order_id IS NULL) AS null_count, ROUND(100.0 * COUNT(*) FILTER (WHERE order_id IS NULL) / (SELECT row_count FROM totals), 2) AS null_pct FROM orders
+UNION ALL
+SELECT 'customer_id', COUNT(*) FILTER (WHERE customer_id IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE customer_id IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT 'store_id', COUNT(*) FILTER (WHERE store_id IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE store_id IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT 'ordered_at', COUNT(*) FILTER (WHERE ordered_at IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE ordered_at IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT '_loaded_at', COUNT(*) FILTER (WHERE _loaded_at IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE _loaded_at IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT 'promised_delivery_date', COUNT(*) FILTER (WHERE promised_delivery_date IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE promised_delivery_date IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT 'currency_code', COUNT(*) FILTER (WHERE currency_code IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE currency_code IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT 'order_status', COUNT(*) FILTER (WHERE order_status IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE order_status IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+UNION ALL
+SELECT 'order_total', COUNT(*) FILTER (WHERE order_total IS NULL), ROUND(100.0 * COUNT(*) FILTER (WHERE order_total IS NULL) / (SELECT row_count FROM totals), 2) FROM orders
+ORDER BY null_pct DESC;
+
+-- A column at zero has no NULLs in this table today. Anything above zero is
+-- a column you need a plan for before you aggregate or join on it, because
+-- NULLs disappear from GROUP BY buckets and fail equality joins silently.

--- a/templates/academy-sql-intermediate/queries/profiling/04-orphan-keys.sql
+++ b/templates/academy-sql-intermediate/queries/profiling/04-orphan-keys.sql
@@ -1,0 +1,36 @@
+-- Orphan key check, an anti-join.
+--
+-- Change the fact table, the foreign key column, and the dimension table
+-- and key below and run this again on any relationship you are about to
+-- join on.
+--
+-- Worked example: order_items.product_id against products.product_id.
+
+SELECT COUNT(*) AS orphan_rows
+FROM order_items oi
+LEFT JOIN products p
+  ON p.product_id = oi.product_id
+WHERE p.product_id IS NULL;
+
+-- orphan_rows counts fact rows whose foreign key value has no matching row
+-- in the dimension. Anything above zero means an inner join on this
+-- relationship would silently drop those rows, and a left join would carry
+-- NULLs for every dimension column.
+
+-- See which key values are the offenders, and how many rows each one
+-- accounts for.
+
+SELECT
+    oi.product_id,
+    COUNT(*) AS orphan_rows
+FROM order_items oi
+LEFT JOIN products p
+  ON p.product_id = oi.product_id
+WHERE p.product_id IS NULL
+GROUP BY oi.product_id
+ORDER BY orphan_rows DESC;
+
+-- A key value that is NULL here means the fact row never carried a product
+-- id at all. A key value that is not NULL and still has no match means the
+-- dimension is missing a row it should have, or the fact row points at the
+-- wrong table version of that key.

--- a/templates/academy-sql-intermediate/queries/profiling/05-date-coverage.sql
+++ b/templates/academy-sql-intermediate/queries/profiling/05-date-coverage.sql
@@ -1,0 +1,45 @@
+-- Date coverage against the calendar spine.
+--
+-- Change the fact table, its date or timestamp column, and the range below
+-- and run this again on any date column you are about to trend or bucket.
+--
+-- Worked example: orders.ordered_at against the dates spine.
+
+WITH order_days AS (
+    SELECT DISTINCT CAST(ordered_at AS DATE) AS order_day
+    FROM orders
+)
+SELECT
+    MIN(order_day)  AS first_order_day,
+    MAX(order_day)  AS last_order_day,
+    COUNT(*)        AS distinct_order_days
+FROM order_days;
+
+-- distinct_order_days tells you how many calendar days between
+-- first_order_day and last_order_day have at least one row. Compare it
+-- with the number of days in that span to see whether every day is covered.
+
+-- Find the specific days inside that span with no row in the fact table.
+
+WITH order_days AS (
+    SELECT DISTINCT CAST(ordered_at AS DATE) AS order_day
+    FROM orders
+),
+bounds AS (
+    SELECT
+        MIN(order_day) AS first_day,
+        MAX(order_day) AS last_day
+    FROM order_days
+)
+SELECT d.date_day
+FROM dates d
+JOIN bounds b
+  ON d.date_day BETWEEN b.first_day AND b.last_day
+LEFT JOIN order_days od
+  ON od.order_day = d.date_day
+WHERE od.order_day IS NULL
+ORDER BY d.date_day;
+
+-- Every row here is a day inside your own data's range with no fact rows.
+-- Decide whether that means nothing happened that day or the load missed
+-- it, before you treat a gap in a chart as fact.

--- a/templates/academy-sql-intermediate/queries/profiling/06-categorical-values.sql
+++ b/templates/academy-sql-intermediate/queries/profiling/06-categorical-values.sql
@@ -1,0 +1,39 @@
+-- Categorical value check.
+--
+-- Change the table name and the text column below and run this again on
+-- any column you are about to group by, filter on, or join on.
+--
+-- Worked example: customers.country.
+
+SELECT
+    country,
+    COUNT(*) AS row_count
+FROM customers
+GROUP BY country
+ORDER BY row_count DESC;
+
+-- Read this as the list of values the column actually holds. Casing,
+-- leading or trailing spaces, and near-duplicate spellings all show up here
+-- as separate rows even though a person would read them as the same value.
+
+-- Normalize the value and see whether the distinct count drops.
+
+SELECT
+    UPPER(TRIM(country)) AS normalized_country,
+    COUNT(*)             AS row_count
+FROM customers
+GROUP BY UPPER(TRIM(country))
+ORDER BY row_count DESC;
+
+-- Compare the two directly.
+
+SELECT
+    COUNT(DISTINCT country)                AS distinct_values_raw,
+    COUNT(DISTINCT UPPER(TRIM(country)))   AS distinct_values_normalized
+FROM customers;
+
+-- If distinct_values_raw is larger than distinct_values_normalized, some of
+-- what looked like different values were casing or whitespace variants of
+-- the same one. Decide whether to normalize at the source, at load time, or
+-- at query time, and apply that decision everywhere the column is used, not
+-- only in the query in front of you.

--- a/templates/academy-sql-intermediate/queries/reading-drill/README.md
+++ b/templates/academy-sql-intermediate/queries/reading-drill/README.md
@@ -1,0 +1,27 @@
+# Reading drill
+
+Three queries, getting longer. Read each one and write, beside every CTE and every join, what one
+row represents at that point. That annotation is the whole technique: fan-out stops being something
+you notice and becomes something you can see.
+
+Target times, from the first line to the last annotation:
+
+| File | Length | Target |
+|---|---|---|
+| `drill-1.sql` | about 20 lines, one join | 30 seconds |
+| `drill-2.sql` | about 45 lines, three CTEs, one window function | 60 seconds |
+| `drill-3.sql` | about 80 lines, five CTEs, four joins | 90 seconds |
+
+Time yourself. Read for structure and grain first, filters and columns second.
+
+Two of these three are correct. **One has a grain error: a join that changes what one row means,
+followed by an aggregate written as though it had not.** Do not run them to find out which. Find it
+by reading, then run it to confirm the size of the mistake.
+
+`drill-2.sql` is a fair warning about what "correct" buys you. It returns the right numbers and it
+is still hard to review, because its CTEs are called `t1`, `t2` and `final` and none of those names
+say what a row is. Correct and reviewable are different properties. When you write your own, name
+each step after what it produces.
+
+The raw tables in this project have problems of their own - missing values, rows that arrived
+twice, keys that point at nothing. Ignore all of that here. This drill is about grain only.

--- a/templates/academy-sql-intermediate/queries/reading-drill/drill-1.sql
+++ b/templates/academy-sql-intermediate/queries/reading-drill/drill-1.sql
@@ -1,0 +1,18 @@
+-- Drill 1. Target: annotated in 30 seconds.
+--
+-- Question: how many orders arrived in each quarter of 2024, and what did they
+-- total at the header level?
+--
+-- Annotate each step with what one row of it represents.
+
+SELECT
+    d.year,
+    d.quarter,
+    COUNT(*)            AS order_rows,
+    SUM(o.order_total)  AS header_total
+FROM orders o
+JOIN dates d
+  ON d.date_day = CAST(o.ordered_at AS DATE)
+WHERE d.year = 2024
+GROUP BY d.year, d.quarter
+ORDER BY d.quarter;

--- a/templates/academy-sql-intermediate/queries/reading-drill/drill-2.sql
+++ b/templates/academy-sql-intermediate/queries/reading-drill/drill-2.sql
@@ -1,0 +1,49 @@
+-- Drill 2. Target: annotated in 60 seconds.
+--
+-- Question: for each product category, what was the monthly line revenue in
+-- 2024 and how did each month compare with the one before it?
+--
+-- Annotate each step with what one row of it represents.
+
+WITH t1 AS (
+    SELECT
+        oi.order_id,
+        oi.line_number,
+        oi.product_id,
+        oi.quantity,
+        oi.net_price,
+        o.ordered_at
+    FROM order_items oi
+    JOIN orders o
+      ON o.order_id = oi.order_id
+    WHERE o.ordered_at >= TIMESTAMP '2024-01-01 00:00:00'
+      AND o.ordered_at <  TIMESTAMP '2025-01-01 00:00:00'
+),
+t2 AS (
+    SELECT
+        p.category_name,
+        strftime(t1.ordered_at, '%Y-%m')        AS ym,
+        SUM(t1.quantity * t1.net_price)         AS amt
+    FROM t1
+    JOIN products p
+      ON p.product_id = t1.product_id
+    GROUP BY p.category_name, strftime(t1.ordered_at, '%Y-%m')
+),
+final AS (
+    SELECT
+        category_name,
+        ym,
+        amt,
+        LAG(amt) OVER (
+            PARTITION BY category_name
+            ORDER BY ym
+        )                                       AS amt_prev,
+        amt - LAG(amt) OVER (
+            PARTITION BY category_name
+            ORDER BY ym
+        )                                       AS amt_delta
+    FROM t2
+)
+SELECT *
+FROM final
+ORDER BY category_name, ym;

--- a/templates/academy-sql-intermediate/queries/reading-drill/drill-3.sql
+++ b/templates/academy-sql-intermediate/queries/reading-drill/drill-3.sql
@@ -1,0 +1,83 @@
+-- Drill 3. Target: annotated in 90 seconds.
+--
+-- Question: for 2024, what was the line revenue by customer country and
+-- quarter, and how many orders sat behind each figure?
+--
+-- Annotate each step with what one row of it represents. One step changes the
+-- grain without saying so.
+
+WITH order_scope AS (
+    SELECT
+        order_id,
+        customer_id,
+        store_id,
+        ordered_at,
+        order_total
+    FROM orders
+    WHERE ordered_at >= TIMESTAMP '2024-01-01 00:00:00'
+      AND ordered_at <  TIMESTAMP '2025-01-01 00:00:00'
+),
+order_lines AS (
+    SELECT
+        os.order_id,
+        os.customer_id,
+        os.ordered_at,
+        oi.line_number,
+        oi.product_id,
+        oi.quantity,
+        oi.net_price
+    FROM order_scope os
+    JOIN order_items oi
+      ON oi.order_id = os.order_id
+),
+lines_with_product AS (
+    SELECT
+        ol.order_id,
+        ol.customer_id,
+        ol.ordered_at,
+        ol.line_number,
+        ol.quantity,
+        ol.net_price,
+        p.category_name,
+        p.subcategory_name
+    FROM order_lines ol
+    JOIN products p
+      ON p.product_id = ol.product_id
+),
+lines_with_customer AS (
+    SELECT
+        lwp.order_id,
+        lwp.ordered_at,
+        lwp.line_number,
+        lwp.quantity,
+        lwp.net_price,
+        lwp.category_name,
+        c.customer_id,
+        c.country,
+        c.segment
+    FROM lines_with_product lwp
+    JOIN customers c
+      ON c.customer_id = lwp.customer_id
+),
+dated AS (
+    SELECT
+        lwc.country,
+        lwc.segment,
+        lwc.category_name,
+        lwc.order_id,
+        lwc.quantity,
+        lwc.net_price,
+        d.year,
+        d.quarter
+    FROM lines_with_customer lwc
+    JOIN dates d
+      ON d.date_day = CAST(lwc.ordered_at AS DATE)
+)
+SELECT
+    country,
+    quarter,
+    COUNT(DISTINCT order_id)            AS orders,
+    SUM(quantity * net_price)           AS line_revenue
+FROM dated
+GROUP BY country, quarter
+ORDER BY line_revenue DESC;

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -10,6 +10,10 @@ import (
 // is found by any repo-wide search and defeats the exercise. It stays in this repo
 // as the acceptance-test fixture.
 //
+// academy-sql-intermediate/docs/_data-design.md is excluded the same way. It is
+// the contributor-facing record of the nine defects that template injects on
+// purpose, and finding those defects is the coursework.
+//
 //go:embed *
 //go:embed */.bruin.yml
 //go:embed migration-fivetran/.gitignore
@@ -17,5 +21,9 @@ import (
 //go:embed google-web-analytics/.gitignore
 //go:embed posthog-bigquery/.gitignore
 //go:embed academy-sql-beginner/.gitignore
+//go:embed academy-sql-intermediate/.gitignore
+//go:embed academy-sql-intermediate/pipeline/assets/staging/.gitkeep
+//go:embed academy-sql-intermediate/pipeline/assets/core/.gitkeep
+//go:embed academy-sql-intermediate/pipeline/assets/mart/.gitkeep
 //go:embed migration-fivetran/.agents/skills/bruin-fivetran-migrator/*
 var Templates embed.FS


### PR DESCRIPTION
Adds `templates/academy-sql-intermediate/`, the second Bruin Academy course, "Design the Model". Like `academy-sql-beginner`, the template **is** the course: a student pastes one setup prompt and their own coding agent teaches all fifteen lessons from `course/`, driven by `next lesson` and `review my work`. The website pages are a companion and are written from these files.

## The data

Seven deterministic generators under `pipeline/assets/generate/`. Row counts are identical to the beginner template on purpose - this tier is harder because more is wrong and less is documented, not because there is more data.

| Table | Rows |
|---|---|
| `dates` | 1,096 |
| `stores` | 6 |
| `products` | 60 |
| `customers` | 510 |
| `orders` | 1,212 |
| `order_items` | 2,895 |
| `fx_rates` | 5,480 |

`fx_rates` is new: 1,096 days x 5 currency pairs, including the USD identity row. Rates are a base level plus a linear trend and a 365-day triangle wave, all integer arithmetic on the day offset, so EUR moves from 1.085530 on 2023-01-01 to 1.129330 on 2025-12-31 and a currency conversion actually changes an answer across years. Shipping all five pairs per date means a join on date alone fans out by exactly 5.

## Nine defects, and no `known-defects.md`

Finding them is the coursework, so the defect record does not ship. It lives at `docs/_data-design.md`, which Go's embed skips for the same reason the beginner audit-lab key is skipped, and `templates/templates.go` records why.

| # | Defect | Verified |
|---|---|---|
| 1 | NULL `order_status` | 24 rows |
| 2 | NULL `unit_cost` | 57 rows |
| 3 | Orphan `product_id` | 15 lines |
| 4 | Orphan `customer_id` | 5 rows |
| 5 | Duplicated `customer_id` | 10 ids, 510 rows for 500 |
| 6 | Byte-identical duplicate lines | 15 rows |
| 7 | Resent orders, changed status, later `_loaded_at` | 12 ids, 1,212 rows for 1,200 |
| 8 | Casing and whitespace | see below |
| 9 | Sales on a store with no dimension row | 1 store, 12 orders |

**Defects 6 and 7 are the point.** `DISTINCT` fixes the first and not the second, and the second needs `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1`. Getting that wrong is worth 7,278.04 and 18,518.92 of double-counted line revenue respectively.

Defect 8 in detail: the USA is written five ways (`USA`, `usa`, `U.S.A.`, ` USA`, `USA `) across 127 rows, so a naive `GROUP BY country ORDER BY COUNT(*) DESC` puts France on top; 31 city rows are miscased; 2 brands are padded; and the finished order state is written four ways, of which `complete` against `completed` is not a casing problem, so `LOWER()` alone still misses 143 rows.

## Deliberately thin

No column in any generator carries a description. `docs/schema.md` records the grain of each table and stops. `docs/glossary.md` is a stub whose `Revenue` entry is a pointed TODO. Lesson 3 is a profiling lesson and lesson 11 is a description-writing lesson, and both are empty exercises if the template arrives clean.

`staging/`, `core/` and `mart/` ship empty, so the layering is visible before the student writes a line. Lesson 8 fills them. Their `.gitkeep` files are named explicitly in the embed list, because `init` only copies files and `//go:embed *` skips dot-prefixed names - easy to miss, and the folders silently would not ship.

## The course

`AGENTS.md` carries the six-command protocol, the teaching procedure and the reviewing procedure above a collaborator persona that refuses to guess, and gates the capstone key on `docs/defence.md` being written. Fifteen lesson files carry 45 quiz questions with model answers and 75 checkable rubric items. There is no setup lesson: the setup prompt runs `bruin init`, runs the pipeline, and confirms the three row counts including `fx_rates`.

Also ships six reusable profiling queries, a three-query grain-annotation drill where exactly one query has a grain error, a model-contract template, and eight evaluation questions with verified answers for the lesson that measures whether the student's context work improved agent accuracy.

## Verification

- `bruin init academy-sql-intermediate` works in an empty directory, inside an existing git repo, and with `--in-place`
- `bruin validate` passes with three empty layer directories; `bruin run` builds all seven tables in about 100 ms
- Determinism test present and passing: two fresh generations, identical checksums on all seven tables
- No `random()`, `hash()`, `md5()`, `now()`, `current_date`, `current_timestamp` or `today()` in the generators, enforced by test
- Tests also assert the course file structure, that no generator describes its columns, and that the defect record does not ship
- `make format` and `make test` both pass
- No lesson requires MotherDuck. The MotherDuck connection block was checked against `pkg/config/connections.go` rather than against docs: `name`, `token`, `database` are the only fields, so the beginner block is correct as copied

**Embedded size added: 149,648 bytes across 48 files.** The spec asked for under 30 KB; that target is not reachable for a template that carries a fifteen-lesson course, and the shipped beginner template is already 140,514 bytes. Flagging rather than trimming the course to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)