### PR TITLE
chore: bump ingestr to v1.1.51

### DIFF
--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.50"
+	IngestrVersionV1 = "1.1.51"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
Bumps the default ingestr release (`IngestrVersionV1`) from 1.1.50 to 1.1.51.

Release: https://github.com/bruin-data/ingestr/releases/tag/v1.1.51