### PR TITLE
Validate semantic-layer queries in bruin validate

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -219,6 +219,7 @@ func Lint(isDebug *bool) *cli.Command {
 			rules = append(rules, queryValidatorRules(logger, cm, connectionManager, fullRefresh, hookHoister)...)
 			rules = append(rules, lint.GetCustomCheckQueryDryRunRule(connectionManager, renderer))
 			rules = append(rules, lint.GetHookQueryDryRunRule(connectionManager))
+			rules = append(rules, lint.GetSemanticQueryDryRunRule(fs, &git.RepoFinder{}, connectionManager))
 			rules = append(rules, SeedAssetsValidator)
 
 			if c.Bool("fast") {

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -37,6 +37,8 @@ One of the beneficial features of the `validate` command is the ability to perfo
 
 Dry-run is automatically enabled for BigQuery and Snowflake.
 
+Semantic models in the repository-level `semantic/` directory are also validated. Model structure is checked on every run, including `--fast`. Dedicated `source.query` values and parenthesized `source.table` subqueries are dry-run against a pipeline SQL connection when one is available.
+
 However, there are also scenarios where dry-run is not the best suited tool:
 
 - Dry-run requires all the tables/views to be there, which means if you are running validation on a table that you haven't created yet, it'll fail.

--- a/docs/core-concepts/semantic-layer.md
+++ b/docs/core-concepts/semantic-layer.md
@@ -123,12 +123,15 @@ Semantic query mode cannot be combined with `--query`.
 | `name` | Yes | Unique model name inside the repository. |
 | `label` | No | Human-readable display label. |
 | `description` | No | Longer model description. |
-| `source.table` | Yes | Table, view, or SQL subquery used as the model source. |
+| `source.table` | One of `table` or `query` | Table, view, or parenthesized SQL subquery used as the model source. |
+| `source.query` | One of `table` or `query` | SQL query compiled as `(query) AS <model_name>`. |
 | `primary_key` | No | Primary key used as the default target key for joins into this model. |
 | `joins` | No | Relationships from this model to other semantic models. |
 | `dimensions` | No | Groupable fields. |
 | `metrics` | No | Aggregations and derived metrics. |
 | `segments` | No | Reusable filters. |
+
+Exactly one of `source.table` or `source.query` is required.
 
 `source.table` can be a relation name or a parenthesized query:
 
@@ -140,6 +143,16 @@ source:
       from analytics.orders
       where deleted_at is null
     ) as orders
+```
+
+`source.query` is the dedicated form for the same idea. Bruin wraps it as `(query) AS <model_name>`:
+
+```yaml
+source:
+  query: |
+    select *
+    from analytics.orders
+    where deleted_at is null
 ```
 
 ## Dimensions
@@ -362,9 +375,12 @@ General `query` flags such as `--output`, `--limit`, `--timeout`, and `--export`
 
 ## Validation Rules
 
-Bruin validates semantic models when it loads the repository semantic catalog:
+`bruin validate` loads `semantic/` next to `.bruin.yml` and reports schema and engine errors. Query sources (`source.query` and parenthesized `source.table`) are also dry-run against the pipeline connection when a SQL validator is available. `--fast` still checks model structure.
 
-- `name` and `source.table` are required.
+Bruin also validates semantic models when it loads the repository semantic catalog for `bruin query`:
+
+- `name` is required.
+- Exactly one of `source.table` or `source.query` is required.
 - Metric names, dimension names, and segment names must be unique within a model.
 - Metrics require `expression`.
 - Segments require `filter`.

--- a/pkg/lint/list.go
+++ b/pkg/lint/list.go
@@ -352,6 +352,13 @@ func GetRules(fs afero.Fs, finder repoFinder, excludeWarnings bool, parser sqlpa
 			AssetValidator:   EnsureTimeIntervalIsValidForAsset,
 			ApplicableLevels: []Level{LevelAsset},
 		},
+		&SimpleRule{
+			Identifier:       "semantic-layer-valid",
+			Fast:             true,
+			Severity:         ValidatorSeverityCritical,
+			Validator:        (&semanticLayerChecker{fs: fs, finder: finder}).Validate,
+			ApplicableLevels: []Level{LevelPipeline},
+		},
 	}
 
 	if parser != nil {

--- a/pkg/lint/semantic.go
+++ b/pkg/lint/semantic.go
@@ -29,10 +29,7 @@ func (c *semanticLayerChecker) Validate(ctx context.Context, p *pipeline.Pipelin
 		return nil, nil
 	}
 
-	issues, models, err := loadSemanticCatalogIssues(c.fs, dir)
-	if err != nil {
-		return issues, nil
-	}
+	issues, models := loadSemanticCatalogIssues(c.fs, dir)
 
 	if names := semantic.Names(models); len(names) > 0 {
 		if _, err := semantic.NewEngineWithModels(models[names[0]], models); err != nil {
@@ -76,10 +73,7 @@ func (r *semanticQueryDryRunner) Validate(ctx context.Context, p *pipeline.Pipel
 		return nil, nil
 	}
 
-	_, models, err := loadSemanticCatalogIssues(r.fs, dir)
-	if err != nil {
-		return nil, nil
-	}
+	_, models := loadSemanticCatalogIssues(r.fs, dir)
 
 	queryable := queryableSemanticModels(models)
 	if len(queryable) == 0 {
@@ -114,12 +108,12 @@ func (r *semanticQueryDryRunner) Validate(ctx context.Context, p *pipeline.Pipel
 	return issues, nil
 }
 
-func loadSemanticCatalogIssues(fs afero.Fs, dir string) ([]*Issue, map[string]*semantic.Model, error) {
+func loadSemanticCatalogIssues(fs afero.Fs, dir string) ([]*Issue, map[string]*semantic.Model) {
 	models, invalid, err := semantic.LoadDirPartialFS(fs, dir)
 	if err != nil {
 		return []*Issue{{
 			Description: fmt.Sprintf("Failed to load semantic models from '%s': %s", dir, err),
-		}}, nil, err
+		}}, nil
 	}
 
 	names := make([]string, 0, len(invalid))
@@ -134,7 +128,7 @@ func loadSemanticCatalogIssues(fs afero.Fs, dir string) ([]*Issue, map[string]*s
 			Description: fmt.Sprintf("Semantic model %q is invalid: %s", name, invalid[name]),
 		})
 	}
-	return issues, models, nil
+	return issues, models
 }
 
 func queryableSemanticModels(models map[string]*semantic.Model) []*semantic.Model {

--- a/pkg/lint/semantic.go
+++ b/pkg/lint/semantic.go
@@ -1,0 +1,213 @@
+package lint
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	semantic "github.com/bruin-data/bruin/semantic-engine"
+	"github.com/spf13/afero"
+)
+
+type semanticLayerChecker struct {
+	fs     afero.Fs
+	finder repoFinder
+	seen   sync.Map
+}
+
+func (c *semanticLayerChecker) Validate(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
+	dir := semanticDirForPipeline(ctx, c.fs, p, c.finder)
+	if dir == "" || !semanticDirExists(c.fs, dir) {
+		return nil, nil
+	}
+	if _, loaded := c.seen.LoadOrStore(dir, true); loaded {
+		return nil, nil
+	}
+
+	issues, models, err := loadSemanticCatalogIssues(c.fs, dir)
+	if err != nil {
+		return issues, nil
+	}
+
+	if names := semantic.Names(models); len(names) > 0 {
+		if _, err := semantic.NewEngineWithModels(models[names[0]], models); err != nil {
+			issues = append(issues, &Issue{
+				Description: fmt.Sprintf("Semantic catalog is invalid: %s", err),
+			})
+		}
+	}
+
+	return issues, nil
+}
+
+type semanticQueryDryRunner struct {
+	fs          afero.Fs
+	finder      repoFinder
+	connections connectionManager
+	seen        sync.Map
+}
+
+func GetSemanticQueryDryRunRule(fs afero.Fs, finder repoFinder, connections connectionManager) *SimpleRule {
+	runner := &semanticQueryDryRunner{
+		fs:          fs,
+		finder:      finder,
+		connections: connections,
+	}
+	return &SimpleRule{
+		Identifier:       "semantic-query-dry-run",
+		Fast:             false,
+		Severity:         ValidatorSeverityCritical,
+		Validator:        runner.Validate,
+		ApplicableLevels: []Level{LevelPipeline},
+	}
+}
+
+func (r *semanticQueryDryRunner) Validate(ctx context.Context, p *pipeline.Pipeline) ([]*Issue, error) {
+	dir := semanticDirForPipeline(ctx, r.fs, p, r.finder)
+	if dir == "" || !semanticDirExists(r.fs, dir) {
+		return nil, nil
+	}
+	if _, loaded := r.seen.Load(dir); loaded {
+		return nil, nil
+	}
+
+	_, models, err := loadSemanticCatalogIssues(r.fs, dir)
+	if err != nil {
+		return nil, nil
+	}
+
+	queryable := queryableSemanticModels(models)
+	if len(queryable) == 0 {
+		r.seen.Store(dir, true)
+		return nil, nil
+	}
+
+	validator := queryValidatorForPipeline(p, r.connections)
+	if validator == nil {
+		return nil, nil
+	}
+	r.seen.Store(dir, true)
+
+	var issues []*Issue
+	for _, model := range queryable {
+		q := &query.Query{Query: model.Source.DryRunSQL(model.Name)}
+		valid, err := validator.IsValid(query.WithQueryType(ctx, query.QueryTypeDryRun), q)
+		switch {
+		case err != nil:
+			issues = append(issues, &Issue{
+				Description: fmt.Sprintf("Failed to validate semantic model %q query: %s", model.Name, err),
+				Context:     []string{q.Query},
+			})
+		case !valid:
+			issues = append(issues, &Issue{
+				Description: fmt.Sprintf("Semantic model %q query is invalid: %s", model.Name, q.Query),
+				Context:     []string{q.Query},
+			})
+		}
+	}
+
+	return issues, nil
+}
+
+func loadSemanticCatalogIssues(fs afero.Fs, dir string) ([]*Issue, map[string]*semantic.Model, error) {
+	models, invalid, err := semantic.LoadDirPartialFS(fs, dir)
+	if err != nil {
+		return []*Issue{{
+			Description: fmt.Sprintf("Failed to load semantic models from '%s': %s", dir, err),
+		}}, nil, err
+	}
+
+	names := make([]string, 0, len(invalid))
+	for name := range invalid {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	issues := make([]*Issue, 0, len(names))
+	for _, name := range names {
+		issues = append(issues, &Issue{
+			Description: fmt.Sprintf("Semantic model %q is invalid: %s", name, invalid[name]),
+		})
+	}
+	return issues, models, nil
+}
+
+func queryableSemanticModels(models map[string]*semantic.Model) []*semantic.Model {
+	names := semantic.Names(models)
+	out := make([]*semantic.Model, 0)
+	for _, name := range names {
+		model := models[name]
+		if model != nil && model.Source.IsQueryable() {
+			out = append(out, model)
+		}
+	}
+	return out
+}
+
+func queryValidatorForPipeline(p *pipeline.Pipeline, connections connectionManager) queryValidator {
+	if p == nil || connections == nil {
+		return nil
+	}
+	for _, asset := range p.Assets {
+		if asset == nil || !asset.IsSQLAsset() {
+			continue
+		}
+		name, err := p.GetConnectionNameForAsset(asset)
+		if err != nil || name == "" {
+			continue
+		}
+		conn := connections.GetConnection(name)
+		validator, ok := conn.(queryValidator)
+		if ok {
+			return validator
+		}
+	}
+	return nil
+}
+
+func semanticDirForPipeline(ctx context.Context, fs afero.Fs, p *pipeline.Pipeline, finder repoFinder) string {
+	if configPath, ok := ctx.Value(config.ConfigFilePathContextKey).(string); ok && configPath != "" {
+		return filepath.Join(filepath.Dir(configPath), "semantic")
+	}
+	if p == nil || p.DefinitionFile.Path == "" {
+		return ""
+	}
+
+	dir := filepath.Dir(p.DefinitionFile.Path)
+	for {
+		if hasBruinConfig(fs, dir) {
+			return filepath.Join(dir, "semantic")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	if finder != nil {
+		repo, err := finder.Repo(p.DefinitionFile.Path)
+		if err == nil && repo != nil && repo.Path != "" {
+			return filepath.Join(repo.Path, "semantic")
+		}
+	}
+	return ""
+}
+
+func hasBruinConfig(fs afero.Fs, dir string) bool {
+	info, err := fs.Stat(filepath.Join(dir, ".bruin.yml"))
+	return err == nil && !info.IsDir()
+}
+
+func semanticDirExists(fs afero.Fs, dir string) bool {
+	info, err := fs.Stat(dir)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/pkg/lint/semantic_test.go
+++ b/pkg/lint/semantic_test.go
@@ -81,7 +81,7 @@ source: {}
 		name        string
 		files       map[string][]byte
 		pipeline    *pipeline.Pipeline
-		ctx         context.Context
+		configPath  string
 		wantCount   int
 		wantContain []string
 	}{
@@ -143,7 +143,7 @@ source: {}
 			pipeline: &pipeline.Pipeline{
 				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
 			},
-			ctx:         context.WithValue(context.Background(), config.ConfigFilePathContextKey, "/other/.bruin.yml"),
+			configPath:  "/other/.bruin.yml",
 			wantCount:   1,
 			wantContain: []string{"empty", "source.table or source.query is required"},
 		},
@@ -170,9 +170,9 @@ source: {}
 			}
 
 			checker := &semanticLayerChecker{fs: fs}
-			ctx := tt.ctx
-			if ctx == nil {
-				ctx = t.Context()
+			ctx := t.Context()
+			if tt.configPath != "" {
+				ctx = context.WithValue(ctx, config.ConfigFilePathContextKey, tt.configPath)
 			}
 
 			got, err := checker.Validate(ctx, tt.pipeline)

--- a/pkg/lint/semantic_test.go
+++ b/pkg/lint/semantic_test.go
@@ -145,7 +145,7 @@ source: {}
 			},
 			ctx:         context.WithValue(context.Background(), config.ConfigFilePathContextKey, "/other/.bruin.yml"),
 			wantCount:   1,
-			wantContain: []string{"empty"},
+			wantContain: []string{"broken.yml"},
 		},
 		{
 			name: "reports only once for the same catalog",

--- a/pkg/lint/semantic_test.go
+++ b/pkg/lint/semantic_test.go
@@ -1,0 +1,352 @@
+package lint
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/bruin/pkg/config"
+	"github.com/bruin-data/bruin/pkg/pipeline"
+	"github.com/bruin-data/bruin/pkg/query"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRulesIncludesSemanticLayerValid(t *testing.T) {
+	t.Parallel()
+
+	rules, err := GetRules(afero.NewMemMapFs(), nil, false, nil, false)
+	require.NoError(t, err)
+
+	var found Rule
+	for _, rule := range rules {
+		if rule.Name() == "semantic-layer-valid" {
+			found = rule
+			break
+		}
+	}
+	require.NotNil(t, found)
+	assert.True(t, found.IsFast())
+	assert.Equal(t, ValidatorSeverityCritical, found.GetSeverity())
+	assert.Contains(t, found.GetApplicableLevels(), LevelPipeline)
+}
+
+func TestSemanticLayerValid(t *testing.T) {
+	t.Parallel()
+
+	validTableModel := []byte(`schema: v1
+name: sales
+source:
+  table: analytics.orders
+metrics:
+  - name: revenue
+    expression: sum(amount)
+`)
+	validQueryModel := []byte(`schema: v1
+name: filtered_orders
+source:
+  query: |
+    select * from analytics.orders
+    where deleted_at is null
+metrics:
+  - name: revenue
+    expression: sum(amount)
+`)
+	validParenModel := []byte(`schema: v1
+name: paren_orders
+source:
+  table: |
+    (
+      select * from analytics.orders
+      where deleted_at is null
+    ) as paren_orders
+metrics:
+  - name: revenue
+    expression: sum(amount)
+`)
+	invalidBothModel := []byte(`schema: v1
+name: both
+source:
+  table: analytics.orders
+  query: select 1
+`)
+	invalidEmptyModel := []byte(`schema: v1
+name: empty
+source: {}
+`)
+
+	tests := []struct {
+		name        string
+		files       map[string][]byte
+		pipeline    *pipeline.Pipeline
+		ctx         context.Context
+		wantCount   int
+		wantContain []string
+	}{
+		{
+			name: "no semantic directory",
+			files: map[string][]byte{
+				"/project/.bruin.yml": []byte("environments:\n  default:\n    connections: {}\n"),
+			},
+			pipeline: &pipeline.Pipeline{
+				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "valid table, query, and parenthesized sources",
+			files: map[string][]byte{
+				"/project/.bruin.yml":                         []byte("environments:\n  default:\n    connections: {}\n"),
+				"/project/semantic/sales.yml":                 validTableModel,
+				"/project/semantic/filtered.yml":              validQueryModel,
+				"/project/semantic/commerce/paren_orders.yml": validParenModel,
+			},
+			pipeline: &pipeline.Pipeline{
+				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "rejects table and query together",
+			files: map[string][]byte{
+				"/project/.bruin.yml":        []byte("environments:\n  default:\n    connections: {}\n"),
+				"/project/semantic/both.yml": invalidBothModel,
+			},
+			pipeline: &pipeline.Pipeline{
+				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+			},
+			wantCount:   1,
+			wantContain: []string{"both", "invalid"},
+		},
+		{
+			name: "rejects empty source",
+			files: map[string][]byte{
+				"/project/.bruin.yml":         []byte("environments:\n  default:\n    connections: {}\n"),
+				"/project/semantic/empty.yml": invalidEmptyModel,
+			},
+			pipeline: &pipeline.Pipeline{
+				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+			},
+			wantCount:   1,
+			wantContain: []string{"empty", "invalid"},
+		},
+		{
+			name: "uses config file path from context",
+			files: map[string][]byte{
+				"/other/.bruin.yml":           []byte("environments:\n  default:\n    connections: {}\n"),
+				"/other/semantic/broken.yml":  invalidEmptyModel,
+				"/project/.bruin.yml":         []byte("environments:\n  default:\n    connections: {}\n"),
+				"/project/semantic/sales.yml": validTableModel,
+			},
+			pipeline: &pipeline.Pipeline{
+				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+			},
+			ctx:         context.WithValue(context.Background(), config.ConfigFilePathContextKey, "/other/.bruin.yml"),
+			wantCount:   1,
+			wantContain: []string{"empty"},
+		},
+		{
+			name: "reports only once for the same catalog",
+			files: map[string][]byte{
+				"/project/.bruin.yml":         []byte("environments:\n  default:\n    connections: {}\n"),
+				"/project/semantic/empty.yml": invalidEmptyModel,
+			},
+			pipeline: &pipeline.Pipeline{
+				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := afero.NewMemMapFs()
+			for path, body := range tt.files {
+				require.NoError(t, afero.WriteFile(fs, path, body, 0o644))
+			}
+
+			checker := &semanticLayerChecker{fs: fs}
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = t.Context()
+			}
+
+			got, err := checker.Validate(ctx, tt.pipeline)
+			require.NoError(t, err)
+			assert.Len(t, got, tt.wantCount)
+			for _, want := range tt.wantContain {
+				require.NotEmpty(t, got)
+				assert.Contains(t, got[0].Description, want)
+			}
+
+			if tt.name == "reports only once for the same catalog" {
+				second, err := checker.Validate(ctx, tt.pipeline)
+				require.NoError(t, err)
+				assert.Empty(t, second)
+			}
+		})
+	}
+}
+
+func TestSemanticQueryDryRun(t *testing.T) {
+	t.Parallel()
+
+	queryModel := []byte(`schema: v1
+name: filtered_orders
+source:
+  query: select * from analytics.orders where deleted_at is null
+metrics:
+  - name: revenue
+    expression: sum(amount)
+`)
+	parenModel := []byte(`schema: v1
+name: paren_orders
+source:
+  table: |
+    (
+      select * from analytics.orders
+    ) as paren_orders
+metrics:
+  - name: revenue
+    expression: sum(amount)
+`)
+	tableModel := []byte(`schema: v1
+name: sales
+source:
+  table: analytics.orders
+metrics:
+  - name: revenue
+    expression: sum(amount)
+`)
+
+	sqlAsset := &pipeline.Asset{
+		Name: "orders",
+		Type: pipeline.AssetTypeDuckDBQuery,
+	}
+	p := &pipeline.Pipeline{
+		DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
+		Assets:         []*pipeline.Asset{sqlAsset},
+	}
+
+	writeCatalog := func(t *testing.T, fs afero.Fs, models map[string][]byte) {
+		t.Helper()
+		require.NoError(t, afero.WriteFile(fs, "/project/.bruin.yml", []byte("environments:\n  default:\n    connections: {}\n"), 0o644))
+		for name, body := range models {
+			require.NoError(t, afero.WriteFile(fs, filepath.Join("/project/semantic", name), body, 0o644))
+		}
+	}
+
+	t.Run("skips plain table sources", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		writeCatalog(t, fs, map[string][]byte{"sales.yml": tableModel})
+		validator := &recordingQueryValidator{valid: true}
+		runner := &semanticQueryDryRunner{
+			fs:          fs,
+			connections: &fakeConnectionManager{validator: validator},
+		}
+
+		issues, err := runner.Validate(t.Context(), p)
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+		assert.Empty(t, validator.queries)
+	})
+
+	t.Run("dry-runs query and parenthesized table sources", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		writeCatalog(t, fs, map[string][]byte{
+			"filtered.yml": queryModel,
+			"paren.yml":    parenModel,
+			"sales.yml":    tableModel,
+		})
+		validator := &recordingQueryValidator{valid: true}
+		runner := &semanticQueryDryRunner{
+			fs:          fs,
+			connections: &fakeConnectionManager{validator: validator},
+		}
+
+		issues, err := runner.Validate(t.Context(), p)
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+		require.Len(t, validator.queries, 2)
+		assert.Contains(t, validator.queries, "SELECT * FROM (select * from analytics.orders where deleted_at is null) AS filtered_orders")
+		assert.Contains(t, validator.queries[0]+validator.queries[1], "SELECT * FROM (")
+		assert.Contains(t, validator.queries[0]+validator.queries[1], ") as paren_orders")
+	})
+
+	t.Run("reports invalid query", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		writeCatalog(t, fs, map[string][]byte{"filtered.yml": queryModel})
+		runner := &semanticQueryDryRunner{
+			fs:          fs,
+			connections: &fakeConnectionManager{validator: &fakeQueryValidator{isValid: false}},
+		}
+
+		issues, err := runner.Validate(t.Context(), p)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].Description, `Semantic model "filtered_orders" query is invalid`)
+	})
+
+	t.Run("reports dry-run error", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		writeCatalog(t, fs, map[string][]byte{"filtered.yml": queryModel})
+		runner := &semanticQueryDryRunner{
+			fs:          fs,
+			connections: &fakeConnectionManager{validator: &fakeQueryValidator{err: errors.New("syntax error")}},
+		}
+
+		issues, err := runner.Validate(t.Context(), p)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].Description, `Failed to validate semantic model "filtered_orders" query`)
+		assert.Contains(t, issues[0].Description, "syntax error")
+	})
+
+	t.Run("skips when pipeline has no query validator", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		writeCatalog(t, fs, map[string][]byte{"filtered.yml": queryModel})
+		runner := &semanticQueryDryRunner{
+			fs:          fs,
+			connections: &fakeConnectionManager{validator: struct{}{}},
+		}
+
+		issues, err := runner.Validate(t.Context(), p)
+		require.NoError(t, err)
+		assert.Empty(t, issues)
+	})
+
+	t.Run("GetSemanticQueryDryRunRule is a slow pipeline rule", func(t *testing.T) {
+		t.Parallel()
+
+		rule := GetSemanticQueryDryRunRule(afero.NewMemMapFs(), nil, &fakeConnectionManager{})
+		assert.Equal(t, "semantic-query-dry-run", rule.Name())
+		assert.False(t, rule.IsFast())
+		assert.Contains(t, rule.GetApplicableLevels(), LevelPipeline)
+		assert.Equal(t, ValidatorSeverityCritical, rule.GetSeverity())
+	})
+}
+
+type recordingQueryValidator struct {
+	valid   bool
+	err     error
+	queries []string
+}
+
+func (r *recordingQueryValidator) IsValid(ctx context.Context, q *query.Query) (bool, error) {
+	r.queries = append(r.queries, q.Query)
+	return r.valid, r.err
+}

--- a/pkg/lint/semantic_test.go
+++ b/pkg/lint/semantic_test.go
@@ -118,7 +118,7 @@ source: {}
 				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
 			},
 			wantCount:   1,
-			wantContain: []string{"both", "invalid"},
+			wantContain: []string{"both", "source.table and source.query cannot both be set"},
 		},
 		{
 			name: "rejects empty source",
@@ -130,7 +130,7 @@ source: {}
 				DefinitionFile: pipeline.DefinitionFile{Path: "/project/pipelines/daily/pipeline.yml"},
 			},
 			wantCount:   1,
-			wantContain: []string{"empty", "invalid"},
+			wantContain: []string{"empty", "source.table or source.query is required"},
 		},
 		{
 			name: "uses config file path from context",
@@ -145,7 +145,7 @@ source: {}
 			},
 			ctx:         context.WithValue(context.Background(), config.ConfigFilePathContextKey, "/other/.bruin.yml"),
 			wantCount:   1,
-			wantContain: []string{"broken.yml"},
+			wantContain: []string{"empty", "source.table or source.query is required"},
 		},
 		{
 			name: "reports only once for the same catalog",

--- a/semantic-engine/engine.go
+++ b/semantic-engine/engine.go
@@ -90,8 +90,8 @@ func (e *Engine) validate() error {
 	if e.model.Name == "" {
 		return errors.New("model name is required")
 	}
-	if strings.TrimSpace(e.model.Source.Table) == "" {
-		return errors.New("source.table is required")
+	if err := e.model.Source.validate(); err != nil {
+		return err
 	}
 	if err := validateJoins(e.model); err != nil {
 		return err

--- a/semantic-engine/engine_test.go
+++ b/semantic-engine/engine_test.go
@@ -216,6 +216,126 @@ func TestLoadFile_AcceptsLegacyDacSchemaID(t *testing.T) {
 	}
 }
 
+func TestLoadFile_AcceptsQuerySource(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "orders.yml")
+	body := "name: orders\nsource:\n  query: |\n    select * from analytics.orders\n    where deleted_at is null\nmetrics:\n  - name: revenue\n    expression: sum(amount)\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	model, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("load model with source.query: %v", err)
+	}
+	if !model.Source.HasQuery() {
+		t.Fatal("expected source.query to be set")
+	}
+	if model.Source.Table != "" {
+		t.Fatalf("expected empty source.table, got %q", model.Source.Table)
+	}
+	want := "(select * from analytics.orders\nwhere deleted_at is null) AS orders"
+	if got := model.SourceRelation(); got != want {
+		t.Fatalf("SourceRelation() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadFile_AcceptsParenthesizedTableSource(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "orders.yml")
+	body := "name: orders\nsource:\n  table: |\n    (\n      select * from analytics.orders\n      where deleted_at is null\n    ) as orders\nmetrics:\n  - name: revenue\n    expression: sum(amount)\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	model, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("load model with parenthesized source.table: %v", err)
+	}
+	if !model.Source.IsQueryable() {
+		t.Fatal("expected parenthesized source.table to be queryable")
+	}
+	if model.Source.HasQuery() {
+		t.Fatal("parenthesized source.table should not set source.query")
+	}
+}
+
+func TestLoadFile_RejectsTableAndQueryTogether(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "orders.yml")
+	body := "name: orders\nsource:\n  table: analytics.orders\n  query: select 1\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := LoadFile(path); err == nil {
+		t.Fatal("expected error when both source.table and source.query are set")
+	}
+}
+
+func TestLoadFile_RejectsEmptySource(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "orders.yml")
+	if err := os.WriteFile(path, []byte("name: orders\nsource: {}\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := LoadFile(path); err == nil {
+		t.Fatal("expected error when source has neither table nor query")
+	}
+}
+
+func TestGenerateSQL_QuerySource(t *testing.T) {
+	t.Parallel()
+
+	engine := minimalEngine(t, &Model{
+		Name:    "orders",
+		Source:  Source{Query: "select * from analytics.orders where deleted_at is null"},
+		Metrics: []Metric{{Name: "revenue", Expression: "sum(amount)"}},
+	})
+
+	sql, err := engine.GenerateSQL(&Query{Metrics: []string{"revenue"}})
+	if err != nil {
+		t.Fatalf("GenerateSQL: %v", err)
+	}
+	expectContains(t, sql, "FROM (select * from analytics.orders where deleted_at is null) AS orders")
+}
+
+func TestGenerateSQL_ParenthesizedTableSource(t *testing.T) {
+	t.Parallel()
+
+	table := "(\n      select * from analytics.orders\n      where deleted_at is null\n    ) as orders"
+	engine := minimalEngine(t, &Model{
+		Name:    "orders",
+		Source:  Source{Table: table},
+		Metrics: []Metric{{Name: "revenue", Expression: "sum(amount)"}},
+	})
+
+	sql, err := engine.GenerateSQL(&Query{Metrics: []string{"revenue"}})
+	if err != nil {
+		t.Fatalf("GenerateSQL: %v", err)
+	}
+	expectContains(t, sql, "FROM "+table)
+}
+
+func TestSourceDryRunSQL(t *testing.T) {
+	t.Parallel()
+
+	querySource := Source{Query: "select 1 as id;"}
+	if got := querySource.DryRunSQL("orders"); got != "SELECT * FROM (select 1 as id) AS orders" {
+		t.Fatalf("query DryRunSQL = %q", got)
+	}
+
+	tableSource := Source{Table: "(select 1 as id) as orders"}
+	if got := tableSource.DryRunSQL("orders"); got != "SELECT * FROM (select 1 as id) as orders" {
+		t.Fatalf("table DryRunSQL = %q", got)
+	}
+}
+
 func TestLoadDir_EmptyDirIsOk(t *testing.T) {
 	t.Parallel()
 
@@ -801,9 +921,17 @@ func TestNewEngine_ValidationErrors(t *testing.T) {
 			want:  "model name is required",
 		},
 		{
-			name:  "missing source table",
+			name:  "missing source table and query",
 			model: Model{Name: "m"},
-			want:  "source.table is required",
+			want:  "source.table or source.query is required",
+		},
+		{
+			name: "table and query cannot both be set",
+			model: Model{
+				Name:   "m",
+				Source: Source{Table: "analytics.orders", Query: "select 1"},
+			},
+			want: "source.table and source.query cannot both be set",
 		},
 		{
 			name: "duplicate name across dim and metric",

--- a/semantic-engine/engine_test.go
+++ b/semantic-engine/engine_test.go
@@ -271,8 +271,12 @@ func TestLoadFile_RejectsTableAndQueryTogether(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	if _, err := LoadFile(path); err == nil {
+	_, err := LoadFile(path)
+	if err == nil {
 		t.Fatal("expected error when both source.table and source.query are set")
+	}
+	if !strings.Contains(err.Error(), "source.table and source.query cannot both be set") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -284,8 +288,12 @@ func TestLoadFile_RejectsEmptySource(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	if _, err := LoadFile(path); err == nil {
+	_, err := LoadFile(path)
+	if err == nil {
 		t.Fatal("expected error when source has neither table nor query")
+	}
+	if !strings.Contains(err.Error(), "source.table or source.query is required") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/semantic-engine/graph.go
+++ b/semantic-engine/graph.go
@@ -196,16 +196,16 @@ func (p *queryPlan) dimensionSQL(binding *dimensionBinding) string {
 
 func (p *queryPlan) fromSQL() string {
 	if len(p.joinOrder) == 0 {
-		return " FROM " + p.engine.model.Source.Table
+		return " FROM " + p.engine.model.SourceRelation()
 	}
 
 	var sql strings.Builder
 	sql.WriteString(" FROM (SELECT * FROM ")
-	sql.WriteString(p.engine.model.Source.Table)
+	sql.WriteString(p.engine.model.SourceRelation())
 	sql.WriteString(") base")
 	for _, spec := range p.joinOrder {
 		sql.WriteString(" LEFT JOIN (SELECT * FROM ")
-		sql.WriteString(spec.model.Source.Table)
+		sql.WriteString(spec.model.SourceRelation())
 		sql.WriteString(") ")
 		sql.WriteString(spec.alias)
 		sql.WriteString(" ON ")

--- a/semantic-engine/model.go
+++ b/semantic-engine/model.go
@@ -1,5 +1,10 @@
 package semantic
 
+import (
+	"errors"
+	"strings"
+)
+
 // Model describes a single semantic model with dimensions, metrics, and segments.
 type Model struct {
 	Schema      string      `yaml:"schema,omitempty" json:"schema,omitempty"`
@@ -15,7 +20,64 @@ type Model struct {
 }
 
 type Source struct {
-	Table string `yaml:"table" json:"table"`
+	Table string `yaml:"table,omitempty" json:"table,omitempty"`
+	Query string `yaml:"query,omitempty" json:"query,omitempty"`
+}
+
+// Relation is the SQL fragment used in FROM. A dedicated query is compiled as
+// `(<query>) AS <alias>`. A table value is used as-is, including the accepted
+// parenthesized subquery form: `(select ...) as alias`.
+func (s Source) Relation(alias string) string {
+	query := strings.TrimRight(strings.TrimSpace(s.Query), ";")
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return s.Table
+	}
+	if alias == "" {
+		return "(" + query + ")"
+	}
+	return "(" + query + ") AS " + alias
+}
+
+// HasQuery reports whether the source is a dedicated SQL query.
+func (s Source) HasQuery() bool {
+	return strings.TrimSpace(s.Query) != ""
+}
+
+// IsQueryable reports whether the source is a SQL query rather than a relation
+// name. That includes source.query and a parenthesized source.table.
+func (s Source) IsQueryable() bool {
+	if s.HasQuery() {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(s.Table), "(")
+}
+
+// DryRunSQL wraps the source so a validator can dry-run it as a complete query.
+func (s Source) DryRunSQL(alias string) string {
+	return "SELECT * FROM " + s.Relation(alias)
+}
+
+func (s Source) validate() error {
+	table := strings.TrimSpace(s.Table)
+	query := strings.TrimSpace(s.Query)
+	switch {
+	case table == "" && query == "":
+		return errors.New("source.table or source.query is required")
+	case table != "" && query != "":
+		return errors.New("source.table and source.query cannot both be set")
+	default:
+		return nil
+	}
+}
+
+// SourceRelation is the model's FROM relation, including the model name alias
+// when the source is a dedicated query.
+func (m *Model) SourceRelation() string {
+	if m == nil {
+		return ""
+	}
+	return m.Source.Relation(m.Name)
 }
 
 type Join struct {

--- a/semantic-engine/schemas/semantic-model/v1/schema.json
+++ b/semantic-engine/schemas/semantic-model/v1/schema.json
@@ -60,13 +60,24 @@
   "$defs": {
     "source": {
       "type": "object",
-      "required": ["table"],
       "properties": {
         "table": {
           "type": "string",
           "minLength": 1
+        },
+        "query": {
+          "type": "string",
+          "minLength": 1
         }
       },
+      "oneOf": [
+        {
+          "required": ["table"]
+        },
+        {
+          "required": ["query"]
+        }
+      ],
       "patternProperties": {
         "^x-": true
       },

--- a/semantic-engine/schemas/semantic-model/v1/schema.json
+++ b/semantic-engine/schemas/semantic-model/v1/schema.json
@@ -70,14 +70,6 @@
           "minLength": 1
         }
       },
-      "oneOf": [
-        {
-          "required": ["table"]
-        },
-        {
-          "required": ["query"]
-        }
-      ],
       "patternProperties": {
         "^x-": true
       },

--- a/skills/bruin-semantic-layer/SKILL.md
+++ b/skills/bruin-semantic-layer/SKILL.md
@@ -8,7 +8,7 @@ description: Use when creating, editing, reviewing, or troubleshooting Bruin sem
 ## Workflow
 
 1. Find the repository root and inspect `semantic/` before editing. Bruin loads every `.yml` and `.yaml` model under the repository-level `semantic/` directory next to `.bruin.yml`.
-2. Use local source of truth before guessing: `docs/core-concepts/semantic-layer.md`, `docs/commands/query.md`, `pkg/semantic/model.go`, `pkg/semantic/engine.go`, and `pkg/semantic/graph.go`.
+2. Use local source of truth before guessing: `docs/core-concepts/semantic-layer.md`, `docs/commands/query.md`, `semantic-engine/model.go`, `semantic-engine/engine.go`, and `semantic-engine/graph.go`.
 3. Keep model names unique across the semantic catalog. New models should set `schema: v1`, although omitted schema defaults to `v1`.
 4. Prefer reusable, business-named metrics, dimensions, and segments. Avoid putting dashboard-specific logic into one large SQL query.
 5. Validate with a narrow semantic query first, then run the repository-required final checks before finishing.
@@ -75,7 +75,9 @@ segments:
 
 ## Default Model Behavior
 
-- `source.table` is required and can be a relation name or a parenthesized SQL subquery with an alias.
+- Exactly one of `source.table` or `source.query` is required.
+- `source.table` can be a relation name or a parenthesized SQL subquery with an alias.
+- `source.query` is compiled as `(query) AS <model_name>`.
 - `label`, `description`, `group`, `hidden`, and `format` metadata help consumers but do not change SQL generation.
 - Dimension `expression` defaults to the dimension `name`.
 - Dimension `type` can be `string`, `number`, `boolean`, or `time`; only `time` dimensions can use granularities.
@@ -156,11 +158,12 @@ Semantic query mode requires at least one dimension or metric and cannot be comb
 
 ## Validation Notes
 
-- Required model fields: `name` and `source.table`.
+- Required model fields: `name` and exactly one of `source.table` or `source.query`.
+- `bruin validate` loads `semantic/` next to `.bruin.yml` (`semantic-layer-valid`, fast) and dry-runs query sources (`semantic-query-dry-run`).
 - Required item fields: dimension `name`, metric `name` and `expression`, segment `name` and `filter`.
 - Window metrics must reference exactly one metric, for example `expression: "{revenue}"`.
 - Window `order_by` and `partition_by` values must reference dimensions on the model.
 - Joined dimensions must resolve through a safe join path.
 - Unknown metrics, dimensions, segments, filter operators, sort fields, and granularities fail semantic query compilation.
 
-For behavior changes, update the implementation, tests, and user-facing docs together: `pkg/semantic/`, `docs/core-concepts/semantic-layer.md`, and `docs/commands/query.md`.
+For behavior changes, update the implementation, tests, and user-facing docs together: `semantic-engine/`, `docs/core-concepts/semantic-layer.md`, and `docs/commands/query.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Adds a dedicated `source.query` field for semantic-layer models and validates the repository semantic catalog with `bruin validate`. The existing parenthesized `source.table` form stays supported.

Fixes [BRU-6479](https://linear.app/bruin/issue/BRU-6479/validate-queries-in-the-semantic-layer).

## Changes
- `semantic-engine`: `source.query` compiles as `(query) AS <model_name>`; exactly one of `table` or `query` is required.
- Schema: `source` accepts `table` and/or `query`; the engine rejects missing or combined sources with a clear error.
- `bruin validate` loads `semantic/` next to `.bruin.yml` (`semantic-layer-valid`, fast).
- Query sources (`source.query` and parenthesized `source.table`) are dry-run against a pipeline SQL connection (`semantic-query-dry-run`). Plain table names are not dry-run. `--fast` still checks model structure.
- Docs and the semantic-layer skill updated.

## How to test
1. Define a model with `source.query` or the existing parenthesized `source.table` form.
2. Run `bruin validate` (and `bruin validate --fast`) on a repo that has `semantic/` next to `.bruin.yml`.
3. Confirm schema/engine errors are reported, and query sources are dry-run when a SQL validator is available.
4. Confirm `source.table: analytics.orders` still works and is not dry-run.

Example valid query source:

```yaml
source:
  query: |
    select *
    from analytics.orders
    where deleted_at is null
```

Example still-supported parenthesized table:

```yaml
source:
  table: |
    (
      select * from analytics.orders
      where deleted_at is null
    ) as orders
```

## Risk & rollback
- **Risk:** low — existing table sources keep working; query dry-run is skipped when no SQL validator is available.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Builds and lint pass (`make build-no-duckdb`, Go format + `make lint`; Python format skipped, no Python changes)
- [ ] Integration tests pass if affected (`make integration-test`)
- [x] No unrelated changes included
- [x] Tested locally with `bruin validate --fast` on query, parenthesized table, and conflicting source fixtures

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
Fixes BRU-6479

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BRU-6479](https://linear.app/bruin/issue/BRU-6479/validate-queries-in-the-semantic-layer)

<div><a href="https://cursor.com/agents/bc-ec4ad967-6244-4b1a-97ac-970235f82673?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec4ad967-6244-4b1a-97ac-970235f82673&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

