### PR TITLE
Stream SQL Server Change Tracking sources

### DIFF
--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -157,7 +157,7 @@ parameters:
 | `cdc_grpc_host` | No | source URI query | Vitess VStream gRPC host override. |
 | `cdc_grpc_tls` | No | source URI query | Vitess VStream TLS setting. |
 | `cdc_capture_instance` | No | source URI query | SQL Server log-based CDC capture instance name. |
-| `cdc_poll_interval` | No | source URI query | SQL Server log-based CDC poll interval, such as `10s`. |
+| `cdc_poll_interval` | No | source URI query | SQL Server poll interval, such as `10s`. Applies to both captures; Change Tracking only reads it while streaming, where it defaults to `1s`. |
 | `cdc_max_await_time` | No | source URI query | MongoDB change-stream maximum await time, such as `5s`. |
 | `cdc_schema_sample_size` | No | source URI query | MongoDB number of documents sampled to infer the schema. |
 | `cdc_dest_schema` | No | source URI query | Destination schema used for multi-table CDC runs. |

--- a/docs/platforms/mssql.md
+++ b/docs/platforms/mssql.md
@@ -343,7 +343,7 @@ ALTER DATABASE MyDatabase SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, A
 ALTER TABLE dbo.users ENABLE CHANGE_TRACKING;
 ```
 
-Change Tracking requires each source table to have a primary key, and does not support streaming.
+Change Tracking requires each source table to have a primary key, and replicates one table per asset — the `"*"` wildcard source table is only available for log-based CDC.
 
 ### Parameters
 
@@ -353,9 +353,10 @@ CDC is enabled by setting `cdc: "true"` on an `ingestr` asset with a SQL Server 
 |-----------|----------|------------|-------------|
 | `cdc` | Yes | both | Set to `"true"` to enable CDC mode |
 | `cdc_sql_capture` | No | both | `"cdc"` (log-based, default) or `"change_tracking"` |
-| `cdc_mode` | No | log-based CDC | `"stream"` for continuous streaming or `"batch"` for batch replication |
+| `stream` | No | both | Set to `true` for continuous (real-time) streaming. Omit for batch replication (read up to the current change position and exit) |
+| `cdc_mode` | No | both | **Deprecated** — use `stream` instead. `cdc_mode: stream` is equivalent to `stream: true` |
 | `cdc_capture_instance` | No | log-based CDC | Capture instance name to read from |
-| `cdc_poll_interval` | No | log-based CDC | Poll interval for change tables, such as `10s` |
+| `cdc_poll_interval` | No | both | Delay between polls of the source, such as `10s`. Change Tracking only applies it while streaming, where it defaults to `1s` |
 | `cdc_dest_schema` | No | log-based CDC | Destination schema to use for multi-table CDC runs |
 | `source_table` | Yes | both | Source table in `schema.table` format |
 | `incremental_strategy` | No | both | Defaults to `"merge"` when CDC is enabled. CDC assets must use `"merge"`; Bruin rejects other strategies. |
@@ -391,3 +392,29 @@ parameters:
   cdc: "true"
   cdc_sql_capture: change_tracking
 ```
+
+#### Streaming Change Tracking
+```yaml
+name: dbo.orders
+type: ingestr
+connection: bigquery
+
+parameters:
+  source_connection: mssql_prod
+  source_table: dbo.orders
+  destination: bigquery
+  cdc: "true"
+  cdc_sql_capture: change_tracking
+  cdc_poll_interval: 2s
+  stream: true
+```
+
+A streaming CDC asset (`stream: true`) runs continuously, so it is excluded from a normal `bruin run` and is launched on its own:
+
+```bash
+bruin run --stream assets/dbo.orders.asset.yml
+```
+
+Change Tracking reports the net change to a row rather than every individual change, so a shorter `cdc_poll_interval` narrows the window in which several updates to the same row collapse into one. Use log-based CDC when you need the full change history. While a stream is idle, ingestr periodically restamps its resume cursor so the recorded version stays inside the database's `CHANGE_RETENTION` window and a restart can resume instead of taking a fresh snapshot.
+
+See [Streaming assets](../assets/ingestr.md#streaming-assets) for the full behaviour and restrictions.

--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -247,9 +247,9 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 
 		// SQL Server exposes two capture mechanisms. Log-based CDC (mssql+cdc) is the
 		// default; Change Tracking (mssql+ct) is selected per-asset because it can't be
-		// derived from the scheme alone. The +ct source takes no query parameters and is
-		// driven purely by --primary-key / --incremental-strategy merge, so its
-		// source-specific parameters below are skipped.
+		// derived from the scheme alone. Change Tracking is otherwise driven by
+		// --primary-key / --incremental-strategy merge, and the only query parameter it
+		// reads is poll_interval, so the +cdc-only parameters below skip it.
 		sqlCapture, _ := asset.Parameters.GetString("cdc_sql_capture")
 		changeTracking := isMSSQLScheme(baseScheme) && sqlCapture == "change_tracking"
 		if changeTracking {
@@ -282,15 +282,20 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		if tls, _ := asset.Parameters.GetString("cdc_tls"); tls != "" {
 			q.Set("tls", tls)
 		}
-		// SQL Server log-based CDC parameters, confined to the mssql source so they
-		// cannot leak into other CDC URIs. Change Tracking (+ct) ignores query
-		// parameters, so these are only forwarded for the mssql+cdc source.
-		if isMSSQLScheme(baseScheme) && !changeTracking {
-			if captureInstance, _ := asset.Parameters.GetString("cdc_capture_instance"); captureInstance != "" {
-				q.Set("capture_instance", captureInstance)
-			}
+		// SQL Server parameters, confined to the mssql source so they cannot leak into
+		// other CDC URIs. Both captures poll the source, so poll_interval applies to
+		// either; for Change Tracking it only takes effect while streaming, where it
+		// sets the delay between polls (ingestr defaults to 1s).
+		if isMSSQLScheme(baseScheme) {
 			if pollInterval, _ := asset.Parameters.GetString("cdc_poll_interval"); pollInterval != "" {
 				q.Set("poll_interval", pollInterval)
+			}
+			// A capture instance is a log-based change table, which Change Tracking has
+			// no equivalent of.
+			if !changeTracking {
+				if captureInstance, _ := asset.Parameters.GetString("cdc_capture_instance"); captureInstance != "" {
+					q.Set("capture_instance", captureInstance)
+				}
 			}
 		}
 		// MongoDB change-stream parameters, confined to the mongodb source.
@@ -306,7 +311,11 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		// deprecated ?mode= and rejects mode=stream unless --stream is also passed.
 		// Continuous ingestion is driven purely by the --stream flag, which we
 		// enable below for the deprecated cdc_mode: stream alias.
-		if destSchema, _ := asset.Parameters.GetString("cdc_dest_schema"); destSchema != "" {
+
+		// dest_schema routes a multi-table CDC run. Change Tracking replicates a single
+		// table per asset and passes any parameter it does not recognise on to the SQL
+		// Server driver, so it is left out there.
+		if destSchema, _ := asset.Parameters.GetString("cdc_dest_schema"); destSchema != "" && !changeTracking {
 			q.Set("dest_schema", destSchema)
 		}
 		if stateID, _ := asset.Parameters.GetString("cdc_state_id"); stateID != "" {

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1822,9 +1822,10 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 			},
 		},
 		{
-			// Change Tracking uses the +ct scheme and ignores query parameters, so
-			// capture_instance/poll_interval must not leak into the emitted URI.
-			name: "SQL Server Change Tracking uses +ct scheme without query params",
+			// Change Tracking uses the +ct scheme and reads poll_interval. It has no
+			// capture instance and replicates one table, so capture_instance and
+			// dest_schema must not leak into the emitted URI.
+			name: "SQL Server Change Tracking uses +ct scheme with poll interval only",
 			asset: &pipeline.Asset{
 				Name:       "ct-mssql-asset",
 				Connection: "bq",
@@ -1835,18 +1836,46 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 					"cdc":                  "true",
 					"cdc_sql_capture":      "change_tracking",
 					"cdc_capture_instance": "dbo_users",
+					"cdc_dest_schema":      "replica",
 					"cdc_poll_interval":    "10s",
 				},
 			},
 			want: []string{
 				"ingest",
-				"--source-uri", "mssql+ct://user:pass@localhost:1433/db",
+				"--source-uri", "mssql+ct://user:pass@localhost:1433/db?poll_interval=10s",
 				"--source-table", "dbo.users",
 				"--dest-uri", "bigquery://uri-here",
 				"--dest-table", "ct-mssql-asset",
 				"--yes",
 				"--progress", "log",
 				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			name: "SQL Server Change Tracking streams with a poll interval",
+			asset: &pipeline.Asset{
+				Name:       "ct-mssql-stream-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "ms",
+					"source_table":      "dbo.users",
+					"destination":       "bigquery",
+					"cdc":               "true",
+					"cdc_sql_capture":   "change_tracking",
+					"cdc_poll_interval": "2s",
+					"stream":            "true",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mssql+ct://user:pass@localhost:1433/db?poll_interval=2s",
+				"--source-table", "dbo.users",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "ct-mssql-stream-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+				"--stream",
 			},
 		},
 	}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -333,6 +333,16 @@ func EnsureIngestrAssetIsValidForASingleAsset(ctx context.Context, p *pipeline.P
 			Description: "Invalid 'cdc_sql_capture' value: must be 'cdc' or 'change_tracking'",
 		})
 	}
+	// Change Tracking has no multi-table mode, so the wildcard source table that
+	// log-based CDC accepts would leave ingestr without a table to replicate.
+	if capture, _ := asset.Parameters.GetString("cdc_sql_capture"); capture == "change_tracking" {
+		if table, _ := asset.Parameters.GetString("source_table"); table == "*" {
+			issues = append(issues, &Issue{
+				Task:        asset,
+				Description: "SQL Server Change Tracking replicates a single table: name one in 'source_table', or use 'cdc_sql_capture: cdc' to replicate every table",
+			})
+		}
+	}
 	if v, exists := asset.Parameters.GetString("version"); exists && v != "" && !ingestrVersionPattern.MatchString(v) {
 		issues = append(issues, &Issue{
 			Task:        asset,

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -2602,6 +2602,54 @@ func TestEnsureIngestrAssetIsValidForASingleAsset(t *testing.T) {
 			wantErr:        assert.NoError,
 		},
 		{
+			name: "Change Tracking asset with a wildcard source table should fail",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{
+					"source_connection":    "conn1",
+					"source_table":         "*",
+					"destination":          "dest1",
+					"cdc":                  "true",
+					"cdc_sql_capture":      "change_tracking",
+					"incremental_strategy": "merge",
+				},
+			},
+			wantErrMessage: "SQL Server Change Tracking replicates a single table: name one in 'source_table', or use 'cdc_sql_capture: cdc' to replicate every table",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "Change Tracking asset with a single source table should pass",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{
+					"source_connection":    "conn1",
+					"source_table":         "dbo.users",
+					"destination":          "dest1",
+					"cdc":                  "true",
+					"cdc_sql_capture":      "change_tracking",
+					"incremental_strategy": "merge",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
+			name: "log-based CDC asset with a wildcard source table should pass",
+			asset: &pipeline.Asset{
+				Type: pipeline.AssetTypeIngestr,
+				Parameters: pipeline.ParameterMap{
+					"source_connection":    "conn1",
+					"source_table":         "*",
+					"destination":          "dest1",
+					"cdc":                  "true",
+					"cdc_sql_capture":      "cdc",
+					"incremental_strategy": "merge",
+				},
+			},
+			wantErrMessage: "",
+			wantErr:        assert.NoError,
+		},
+		{
 			name: "CDC ingestr asset with publication and slot params should pass",
 			asset: &pipeline.Asset{
 				Type: pipeline.AssetTypeIngestr,

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.50"
+	IngestrVersionV1 = "1.1.52"
 	sqlfluffVersion  = "3.4.1"
 )
 


### PR DESCRIPTION
ingestr v1.1.51 gave the `mssql+ct` source the `StreamingSource` capability, so Change Tracking can now poll continuously under `--stream` instead of exiting once caught up. Bruin already emits `--stream` from the generic `stream` parameter and routes streaming assets out of the batch DAG, so the scheme itself needs nothing new — but the pinned release predates the capability, and the `+ct` URI dropped the one parameter that configures the poll loop.

## Changes

- **Bump `IngestrVersionV1` to 1.1.52**, the current release.
- **Forward `cdc_poll_interval` for both SQL Server captures.** It was confined to `mssql+cdc` on the assumption that `+ct` reads no query parameters; `+ct` now takes `poll_interval` as the delay between polls, defaulting to `1s` and ignored outside a stream. `cdc_capture_instance` stays log-based only, since Change Tracking has no capture instance to name.
- **Stop sending `dest_schema` for `+ct`.** It routes a multi-table CDC run, which Change Tracking has no equivalent of, and the `+ct` source strips only `poll_interval` before handing the rest of the query to the SQL Server driver.
- **Reject a wildcard source table for Change Tracking.** Only the log-based source implements ingestr's `MultiTableSource`, and Bruin's wildcard path omits `--source-table` altogether, so the run failed downstream with no indication of why. This is now a lint error.
- **Docs**: dropped the "does not support streaming" line from the SQL Server CDC page, added `stream` to its parameter table and marked `cdc_mode` deprecated (matching the Postgres and MySQL pages), and added a streaming Change Tracking example covering the `bruin run --stream` launch, the net-change/poll-interval tradeoff, and idle cursor restamping.