### PR TITLE
Show a folder tree in cloud dashboards folders

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4926,8 +4926,65 @@ func cloudDashboardsFolders() *cli.Command {
 				t.AppendRow(table.Row{f.ID, f.Name, f.DashboardCount})
 			}
 			t.Render()
+
+			printFolderTree(folders)
 			return nil
 		},
+	}
+}
+
+// printFolderTree renders the folders as an indented tree below the flat table,
+// so nesting (which the table's Name column can't show) is visible.
+func printFolderTree(folders []bruincloud.DashboardFolder) {
+	if len(folders) == 0 {
+		return
+	}
+
+	exists := make(map[int]bool, len(folders))
+	for _, f := range folders {
+		exists[f.ID] = true
+	}
+
+	children := make(map[int][]bruincloud.DashboardFolder)
+	var roots []bruincloud.DashboardFolder
+	for _, f := range folders {
+		// Treat a folder as top-level when it has no parent, or its parent isn't in
+		// the list (orphaned by pagination/permissions) — so every folder is shown.
+		if f.ParentID == nil || !exists[*f.ParentID] {
+			roots = append(roots, f)
+		} else {
+			children[*f.ParentID] = append(children[*f.ParentID], f)
+		}
+	}
+
+	// Guard against a cycle in the data (self/mutual parent) that would otherwise
+	// recurse until the process crashes.
+	visited := make(map[int]bool, len(folders))
+
+	// Draw subtrees with ├──/└── connectors and │ continuation lines.
+	var walk func(id int, prefix string)
+	walk = func(id int, prefix string) {
+		kids := children[id]
+		for i, c := range kids {
+			last := i == len(kids)-1
+			branch, next := "├── ", "│   "
+			if last {
+				branch, next = "└── ", "    "
+			}
+			fmt.Printf("%s%s%s\n", prefix, branch, c.Name)
+			if visited[c.ID] {
+				continue
+			}
+			visited[c.ID] = true
+			walk(c.ID, prefix+next)
+		}
+	}
+
+	fmt.Println("\nTree:")
+	for _, r := range roots {
+		visited[r.ID] = true
+		fmt.Println(r.Name) // top-level folders sit flush-left
+		walk(r.ID, "")
 	}
 }
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -4962,21 +4962,23 @@ func printFolderTree(w io.Writer, folders []bruincloud.DashboardFolder) {
 	// recurse until the process crashes.
 	visited := make(map[int]bool, len(folders))
 
-	// Draw subtrees with ├──/└── connectors and │ continuation lines.
+	// Draw subtrees with ├──/└── connectors and │ continuation lines. Skip already
+	// visited children up front so a cycle can't print the same folder twice.
 	var walk func(id int, prefix string)
 	walk = func(id int, prefix string) {
-		kids := children[id]
-		for i, c := range kids {
-			last := i == len(kids)-1
+		var pending []bruincloud.DashboardFolder
+		for _, c := range children[id] {
+			if !visited[c.ID] {
+				visited[c.ID] = true
+				pending = append(pending, c)
+			}
+		}
+		for i, c := range pending {
 			branch, next := "├── ", "│   "
-			if last {
+			if i == len(pending)-1 {
 				branch, next = "└── ", "    "
 			}
 			fmt.Fprintf(w, "%s%s%s\n", prefix, branch, c.Name)
-			if visited[c.ID] {
-				continue
-			}
-			visited[c.ID] = true
 			walk(c.ID, prefix+next)
 		}
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	path2 "path"
 	"path/filepath"
@@ -4927,7 +4928,7 @@ func cloudDashboardsFolders() *cli.Command {
 			}
 			t.Render()
 
-			printFolderTree(folders)
+			printFolderTree(os.Stdout, folders)
 			return nil
 		},
 	}
@@ -4935,7 +4936,7 @@ func cloudDashboardsFolders() *cli.Command {
 
 // printFolderTree renders the folders as an indented tree below the flat table,
 // so nesting (which the table's Name column can't show) is visible.
-func printFolderTree(folders []bruincloud.DashboardFolder) {
+func printFolderTree(w io.Writer, folders []bruincloud.DashboardFolder) {
 	if len(folders) == 0 {
 		return
 	}
@@ -4971,7 +4972,7 @@ func printFolderTree(folders []bruincloud.DashboardFolder) {
 			if last {
 				branch, next = "└── ", "    "
 			}
-			fmt.Printf("%s%s%s\n", prefix, branch, c.Name)
+			fmt.Fprintf(w, "%s%s%s\n", prefix, branch, c.Name)
 			if visited[c.ID] {
 				continue
 			}
@@ -4980,11 +4981,22 @@ func printFolderTree(folders []bruincloud.DashboardFolder) {
 		}
 	}
 
-	fmt.Println("\nTree:")
+	renderRoot := func(f bruincloud.DashboardFolder) {
+		visited[f.ID] = true
+		fmt.Fprintln(w, f.Name) // top-level folders sit flush-left
+		walk(f.ID, "")
+	}
+
+	fmt.Fprintln(w, "\nTree:")
 	for _, r := range roots {
-		visited[r.ID] = true
-		fmt.Println(r.Name) // top-level folders sit flush-left
-		walk(r.ID, "")
+		renderRoot(r)
+	}
+	// Any folder still unvisited belongs to a pure cycle (self/mutual parent) with no
+	// acyclic root — surface it flush-left instead of silently dropping it.
+	for _, f := range folders {
+		if !visited[f.ID] {
+			renderRoot(f)
+		}
 	}
 }
 

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -1174,7 +1174,7 @@ func TestPrintFolderTree(t *testing.T) {
 		{ID: 2, Name: "Reports", ParentID: pid(1)},
 		{ID: 3, Name: "Weekly", ParentID: pid(2)},
 		{ID: 4, Name: "Orphan", ParentID: pid(999)}, // parent absent from the list
-		{ID: 5, Name: "CycleA", ParentID: pid(6)},    // mutual cycle with CycleB
+		{ID: 5, Name: "CycleA", ParentID: pid(6)},   // mutual cycle with CycleB
 		{ID: 6, Name: "CycleB", ParentID: pid(5)},
 	}
 
@@ -1184,10 +1184,10 @@ func TestPrintFolderTree(t *testing.T) {
 
 	assert.Contains(t, out, "Tree:")
 	assert.Contains(t, out, "Marketing\n")
-	assert.Contains(t, out, "└── Reports")     // sole child of Marketing
-	assert.Contains(t, out, "    └── Weekly")  // nested under Reports
-	assert.Contains(t, out, "Orphan")          // orphan surfaced as a root
-	assert.Contains(t, out, "CycleA")          // cyclic component surfaced, not dropped
+	assert.Contains(t, out, "└── Reports")    // sole child of Marketing
+	assert.Contains(t, out, "    └── Weekly") // nested under Reports
+	assert.Contains(t, out, "Orphan")         // orphan surfaced as a root
+	assert.Contains(t, out, "CycleA")         // cyclic component surfaced, not dropped
 	assert.Contains(t, out, "CycleB")
 
 	// Empty input renders nothing.

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1162,4 +1163,35 @@ func TestRemoveMcpServer(t *testing.T) {
 		assert.False(t, removed)
 		require.Len(t, out, 1)
 	})
+}
+
+func TestPrintFolderTree(t *testing.T) {
+	t.Parallel()
+
+	pid := func(i int) *int { return &i }
+	folders := []bruincloud.DashboardFolder{
+		{ID: 1, Name: "Marketing"},
+		{ID: 2, Name: "Reports", ParentID: pid(1)},
+		{ID: 3, Name: "Weekly", ParentID: pid(2)},
+		{ID: 4, Name: "Orphan", ParentID: pid(999)}, // parent absent from the list
+		{ID: 5, Name: "CycleA", ParentID: pid(6)},    // mutual cycle with CycleB
+		{ID: 6, Name: "CycleB", ParentID: pid(5)},
+	}
+
+	var buf bytes.Buffer
+	printFolderTree(&buf, folders) // must terminate despite the cycle
+	out := buf.String()
+
+	assert.Contains(t, out, "Tree:")
+	assert.Contains(t, out, "Marketing\n")
+	assert.Contains(t, out, "└── Reports")     // sole child of Marketing
+	assert.Contains(t, out, "    └── Weekly")  // nested under Reports
+	assert.Contains(t, out, "Orphan")          // orphan surfaced as a root
+	assert.Contains(t, out, "CycleA")          // cyclic component surfaced, not dropped
+	assert.Contains(t, out, "CycleB")
+
+	// Empty input renders nothing.
+	var empty bytes.Buffer
+	printFolderTree(&empty, nil)
+	assert.Empty(t, empty.String())
 }

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -850,12 +850,24 @@ bruin cloud dashboards list --output json
 
 #### `folders`
 
-Lists the team's dashboard folders with their id, name, and dashboard count.
+Lists the team's dashboard folders with their id, name, and dashboard count. Folders
+can be nested, so below the flat table the command also prints an indented tree that
+shows the parent/child structure:
 
 ```bash
 bruin cloud dashboards folders
 bruin cloud dashboards folders --output json
 ```
+
+```
+Tree:
+Marketing
+└── Reports
+    └── Weekly
+Sales
+```
+
+With `--output json`, each folder also includes its `parent_id` and full `path`.
 
 #### `get`
 
@@ -906,7 +918,7 @@ Create a dashboard from a definition. The definition is written to the dashboard
 
 Pass `--agent-id` to bind the dashboard to an agent so its canvas chat and refresh work. If omitted, the server falls back to the agent encoded in a Cloud-CLI token; a generic team token has none, so the dashboard opens without a chat panel.
 
-Pass `--folder` to file the dashboard in a folder (by name; created if it doesn't exist). Folder names are unique per team. `dashboards list`/`get` return each dashboard's `folder_name`, and [`dashboards folders`](#folders) lists all folders.
+Pass `--folder` to file the dashboard in a folder, given as a path where `/` nests (e.g. `Marketing/Reports`); missing segments are created, and `--folder none` unfiles it. Names are unique per parent. `dashboards list`/`get` return each dashboard's `folder_name` as its full path, and [`dashboards folders`](#folders) lists all folders as a tree.
 
 ```bash
 # Title only (empty draft)

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -350,10 +350,13 @@ type Dashboard struct {
 	IsPublished *bool           `json:"is_published,omitempty"`
 }
 
-// DashboardFolder groups dashboards within a team.
+// DashboardFolder groups dashboards within a team. Folders can nest: ParentID is
+// the enclosing folder (nil at the top level) and Path is the full "A / B" path.
 type DashboardFolder struct {
 	ID             int    `json:"id"`
 	Name           string `json:"name"`
+	ParentID       *int   `json:"parent_id,omitempty"`
+	Path           string `json:"path,omitempty"`
 	DashboardCount int    `json:"dashboard_count"`
 }
 


### PR DESCRIPTION
`bruin cloud dashboards folders` now prints an indented tree under the flat table, so nested dashboard folders are readable at a glance. Adds `parent_id`/`path` to the folder response type; orphaned/cyclic data is handled safely.