### PR TITLE
fix(academy-sql-intermediate): correct course acceptance guidance

### DIFF
--- a/templates/academy-sql-intermediate/AGENTS.md
+++ b/templates/academy-sql-intermediate/AGENTS.md
@@ -113,6 +113,12 @@ Out of scope. Answer in two sentences and say which course covers it properly:
 - Use `bruin query --connection duckdb-default --description "<what this proves>"
   --query "<SQL>"`. Always include `--description`.
 - Use `--limit` when exploring.
+- Use Bruin MCP and official Bruin documentation when Bruin behaviour or syntax is
+  uncertain.
+- Use the Bruin CLI for local queries, validation, and pipeline execution.
+- Retrieving documentation through MCP does not replace running the actual query or
+  pipeline locally.
+- Do not invent Bruin syntax when documentation is available.
 - Read the asset files in `pipeline/assets/generate/` before querying. Note that no
   column in this project has a description. That is deliberate - the student is going
   to write them.

--- a/templates/academy-sql-intermediate/README.md
+++ b/templates/academy-sql-intermediate/README.md
@@ -112,9 +112,9 @@ MotherDuck. No lesson requires it.
 | `dates` | 1,096 | one calendar day, 2023-01-01 to 2025-12-31 |
 | `stores` | 6 | one store |
 | `products` | 60 | one product |
-| `customers` | 510 | one customer account |
-| `orders` | 1,212 | one order, as delivered by the source system |
-| `order_items` | 2,895 | one line on an order |
+| `customers` | 510 | source-system rows representing 500 customer IDs, including 10 duplicated IDs |
+| `orders` | 1,212 | source-system rows representing 1,200 order IDs; 12 IDs have a changed-status resend |
+| `order_items` | 2,895 | source-system rows representing 2,880 distinct order lines, including 15 exact duplicate rows |
 | `fx_rates` | 5,480 | one date and currency pair |
 
 [`docs/schema.md`](docs/schema.md) lists the columns. It does not say what they mean.

--- a/templates/academy-sql-intermediate/README.md
+++ b/templates/academy-sql-intermediate/README.md
@@ -122,8 +122,10 @@ That is the point - lesson 3 has you find out, and lesson 11 has you write it do
 
 ## What is wrong with this data
 
-Something. Several things. Finding them is lesson 3, and nothing in this repository
-tells you what they are before you get there.
+The table above records source-system grain, including known duplicate populations, so those raw
+rows are not mistaken for unique business entities. Lesson 3 still has you profile the actual
+tables, verify the counts, and quantify the impact; the detailed defect effects and fixes are not
+provided here.
 
 Do not fix anything you find before lesson 8. Profile first, decide what a defensible
 number is second, clean third. In that order, every time.

--- a/templates/academy-sql-intermediate/course/answer-key.md
+++ b/templates/academy-sql-intermediate/course/answer-key.md
@@ -21,7 +21,7 @@ when the student says it is.
 | Join and grain safety | 1 |
 | Governance | 2 |
 | Verification | 2 |
-| Defence | 1 |
+| Defence, including the currency basis | 1 |
 
 ## The nine objections, and the number each turns on
 
@@ -97,6 +97,10 @@ and check the number follows from it.
 - Three "independent" verifications that are the same query written three ways.
 - A mart asset that reads `orders` directly.
 - `docs/defence.md` that answers the four questions with confidence rather than with numbers.
+
+The currency-basis requirement belongs to the single Defence point. The student must state a basis
+that is true of the query and support it with the currency-composition query; this is not an
+additional point. The six rubric areas therefore total exactly 10 points.
 
 ## After the grade
 

--- a/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
+++ b/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
@@ -49,11 +49,12 @@ time component the column carries.
 ON CAST(o.ordered_at AS DATE) = f.rate_date
 ```
 
-That casted date-only join returns 6,060 rows and multiplies every order line by 5 - 2023 line
-revenue goes from the correct **264,926.21** unconverted to **1,324,631.05**, exactly 5 times too
-high, because the join fanned out before the sum ran. A literal raw timestamp-to-date join,
-`ON o.ordered_at = f.rate_date`, is a separate type-mismatch problem; in this data it returns only
-335 rows. It is not the explanation for the 5x fan-out.
+At the order-rate grain, across all generated orders, this casted date-only join returns 6,060 rows
+(1,212 orders times 5 rates). The 2023 line-revenue diagnostic is a different, cleaned line-level
+grain; its date-only join fans each line out by 5 before the sum. That is why 2023 line revenue goes
+from the correct **264,926.21** unconverted to **1,324,631.05**, exactly 5 times too high. A literal
+raw timestamp-to-date join, `ON o.ordered_at = f.rate_date`, is a separate type-mismatch problem; in
+this data it returns only 335 rows. It is not the explanation for the 5x fan-out.
 
 ```sql
 -- Correct: one matching rate for the order date, source currency, and USD target.

--- a/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
+++ b/templates/academy-sql-intermediate/course/lessons/06-patterns-agents-get-wrong.md
@@ -42,10 +42,27 @@ not the whole day. The half-open form has no such trap: the boundary is unambigu
 time component the column carries.
 
 **Aggregate before you join** is the general fix behind the FX case in this lesson. `fx_rates` has
-5 currency pairs for every date. Join it to orders on date alone and every order line is multiplied
-by 5 - 2023 line revenue goes from a correct 264,926.21 to 1,324,631.05, exactly 5 times too
-high, because the join fanned out before the sum ran. Convert properly, matching on both the date
-and the order's own `currency_code`, and 2023 line revenue in USD is 258,645.94. The rule that
+5 currency pairs for every date. There are two different mistakes to keep apart:
+
+```sql
+-- Incorrect: date-only join; every order matches all five pairs for that date.
+ON CAST(o.ordered_at AS DATE) = f.rate_date
+```
+
+That casted date-only join returns 6,060 rows and multiplies every order line by 5 - 2023 line
+revenue goes from the correct **264,926.21** unconverted to **1,324,631.05**, exactly 5 times too
+high, because the join fanned out before the sum ran. A literal raw timestamp-to-date join,
+`ON o.ordered_at = f.rate_date`, is a separate type-mismatch problem; in this data it returns only
+335 rows. It is not the explanation for the 5x fan-out.
+
+```sql
+-- Correct: one matching rate for the order date, source currency, and USD target.
+ON CAST(o.ordered_at AS DATE) = f.rate_date
+AND o.currency_code = f.from_currency
+AND f.to_currency = 'USD'
+```
+
+Converting properly with all three predicates gives **258,645.94** in USD for 2023. The rule that
 generalises past FX: if a join is one-to-many and you need to sum something from the "one" side,
 aggregate first, then join the already-aggregated result - never sum after a fan-out join and hope
 the multiplication cancels out.
@@ -55,8 +72,8 @@ the multiplication cancels out.
    A: `order_items`'s 15 duplicates are byte-identical, so `SELECT DISTINCT *` removes them correctly. `orders`'s 12 duplicates share an `order_id` but differ in `order_status` and `_loaded_at`, so `DISTINCT` would keep both non-identical rows; only `QUALIFY ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY _loaded_at DESC) = 1` picks the one to keep.
 2. Q: A weekly revenue chart has a gap in the middle. Is the gap more likely a missing-data problem or a missing-row problem, and what fixes it?
    A: Almost always a missing-row problem - the week had genuinely zero orders for that category, so it never appeared in the `GROUP BY` output. Building a spine from `dates` and `LEFT JOIN`ing the sales onto it turns the gap into an explicit zero.
-3. Q: Why does joining `fx_rates` to `orders` on date alone multiply revenue by exactly 5 rather than giving a wrong-but-plausible number?
-   A: Because `fx_rates` carries 5 currency pairs for every date, so each order line joins to 5 rows instead of 1, and summing after that join sums each line 5 times over - the fan-out factor is exactly the row multiplier, 5.
+3. Q: Why does the casted date-only join to `fx_rates` multiply revenue by exactly 5 rather than giving a wrong-but-plausible number, and what is a separate timestamp/date mistake?
+   A: Because `fx_rates` carries 5 currency pairs for every date, so each order line joins to 5 rows instead of 1, and summing after that join sums each line 5 times over. Comparing the raw `ordered_at` timestamp directly to `rate_date` is a separate type-mismatch problem; it returns only 335 rows here rather than the 6,060-row casted date-only join.
 
 ## Task
 Fix `queries/weekly-category.sql` from lesson 5 so that a category-week with no sales appears as

--- a/templates/academy-sql-intermediate/course/lessons/12-glossary-and-readme.md
+++ b/templates/academy-sql-intermediate/course/lessons/12-glossary-and-readme.md
@@ -29,6 +29,13 @@ and not `unit_price`. Anyone who later needs a different revenue definition for 
 should be adding a new, separately named term, not editing this one out from under the assets that
 depend on it.
 
+State grain with the source-row qualifier this project requires. Raw `customers` contains 510
+source rows for 500 customer IDs, raw `orders` contains 1,212 source rows for 1,200 order IDs, and
+raw `order_items` contains 2,895 source rows for 2,880 distinct order lines. After lesson 8, the
+deduplicated staging assets can describe `stg_customers`, `stg_orders`, and `stg_order_items` as one
+row per customer, order, and order line respectively. Do not use those staging grains to describe
+the raw tables.
+
 The maintenance rule is the part that gets skipped: these files decay. An `AGENTS.md` line stops
 being true the day the schema changes under it, and a glossary term stops being true the day someone
 redefines the metric without updating the entry. Update these files when the agent gets something
@@ -56,7 +63,7 @@ metric is actually computed.
 ## Rubric (for `review my work`)
 - [ ] `docs/glossary.md` has a `Revenue` entry naming one exact expression (`quantity * net_price`) and the column it runs on (`order_items.net_price`).
 - [ ] Entries exist for all six stub-TODO terms: AOV, active customer, churn, category, net vs gross, fiscal period.
-- [ ] A grain statement appears for `orders` and for `order_items`, and it is true of the table it names. Raw `orders` holds 1,212 rows for 1,200 orders and raw `order_items` holds 2,895 for 2,880, so "one row per order" is only correct about `stg_orders`. Accept either the deduplicated staging asset named explicitly, or the raw table described as one row per order as delivered by the source system.
+- [ ] A grain statement appears for `orders` and for `order_items`, and it is true of the table it names. Raw `orders` holds 1,212 source rows for 1,200 order IDs and raw `order_items` holds 2,895 source rows for 2,880 distinct lines. A one-row-per-order or one-row-per-line statement must name the deduplicated staging asset, not the raw table.
 - [ ] At least one entry cites the specific asset file where that metric is defined.
 - [ ] The file no longer contains the word `TODO`.
 

--- a/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
+++ b/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
@@ -12,8 +12,10 @@ the honest answer is that it depends on what you wrote.
 
 Before you add or edit course context, preserve an untouched copy for the before run. If the working
 copy has already changed, initialize `academy-sql-intermediate` again in a separate empty directory
-and use that pristine copy for the baseline session. This makes the comparison reproducible rather
-than asking the modified course copy to recreate its original state.
+outside the existing Git repository (for example, under `/tmp`) and use that pristine copy for the
+baseline session. Do not put it under the course repository: Bruin would reuse its repository-root
+`.bruin.yml` and relative `academy.duckdb` path. This makes the comparison reproducible rather than
+asking the modified course copy to recreate its original state.
 
 The method has four steps. **One**, `docs/eval/questions.md` ships eight questions with one
 defensible answer each, and the verified answers are in `docs/eval/answers.md`. Add two of your

--- a/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
+++ b/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
@@ -10,6 +10,11 @@ This is the lesson that makes the course honest. You have spent three lessons wr
 tags and a glossary on the argument that they make an agent more accurate. Now measure it, because
 the honest answer is that it depends on what you wrote.
 
+Before you add or edit course context, preserve an untouched copy for the before run. If the working
+copy has already changed, initialize `academy-sql-intermediate` again in a separate empty directory
+and use that pristine copy for the baseline session. This makes the comparison reproducible rather
+than asking the modified course copy to recreate its original state.
+
 The method has four steps. **One**, `docs/eval/questions.md` ships eight questions with one
 defensible answer each, and the verified answers are in `docs/eval/answers.md`. Add two of your
 own, drawn from a mistake you actually saw an agent make in this project, so the set is ten.

--- a/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
+++ b/templates/academy-sql-intermediate/course/lessons/13-measure-your-context.md
@@ -13,11 +13,14 @@ the honest answer is that it depends on what you wrote.
 The method has four steps. **One**, `docs/eval/questions.md` ships eight questions with one
 defensible answer each, and the verified answers are in `docs/eval/answers.md`. Add two of your
 own, drawn from a mistake you actually saw an agent make in this project, so the set is ten.
-**Two**, in a fresh agent session with no context beyond the raw repository, ask all ten and record
-the answers. **Three**, score them against `answers.md`: one point each, exact match, no partial
-credit. **Four**, in another fresh session with your descriptions, glossary and `AGENTS.md` in
-place, ask the same ten and score again. Report both numbers and roughly how much longer the second
-set of answers took.
+**Two**, in a fresh agent session, use the untouched template and its built-in instructor
+instructions, ask all ten questions, and record the answers. **Three**, score them against
+`answers.md`: one point each, exact match, no partial credit. **Four**, in another fresh agent
+session, use the same base template plus the student-authored descriptions, glossary, `AGENTS.md`,
+and any other context additions made during the course; ask the same ten questions and score again.
+Report both numbers and roughly how much longer the second set of answers took. Both runs must use
+fresh agent sessions. Do not let the agent read `docs/eval/answers.md` before both scores are
+recorded; otherwise the measurement is contaminated.
 
 Then the framing that keeps this from being a sales pitch. Published measurements go both ways. A
 well-modelled semantic layer moved accuracy up seventeen to twenty-three points on a

--- a/templates/academy-sql-intermediate/course/lessons/14-capstone-defend-the-answer.md
+++ b/templates/academy-sql-intermediate/course/lessons/14-capstone-defend-the-answer.md
@@ -59,9 +59,12 @@ it, or hint at what it lists until the student's defence is written.
 - [ ] Layering, 2 points: staging assets contain no `JOIN`; one core asset and one mart asset exist; the mart's `depends` names no asset from `pipeline/assets/generate/`.
 - [ ] Join and grain safety, 1 point: order rows are deduplicated with `QUALIFY ROW_NUMBER() ... ORDER BY _loaded_at DESC`, order lines with `DISTINCT`, and the customer join does not fan out.
 - [ ] Governance, 2 points: every mart column has a description, and `meta` carries both a metric definition and a known limitation.
-- [ ] The currency basis in `meta.currency` is true of the query. Orders are priced in five currencies and are not converted, so a headline figure that sums them untouched is not an amount in any currency. Either the figure is converted through `fx_rates` on both date and currency, or `meta.currency` says the number is a mixed-currency sum and the defence says why that is acceptable. Ask for the query that shows the currency composition behind the figure - do not accept the `meta` field on its own.
 - [ ] Verification, 2 points: three checks of the headline figure by three different routes, each with its number recorded.
-- [ ] Defence, 1 point: `docs/defence.md` answers all four questions and anticipates at least six of the nine objections in the key.
+- [ ] Defence, 1 point: `docs/defence.md` answers all four questions, anticipates at least six of the nine objections in the key, and states a currency basis that is true of the query. Orders are priced in five currencies and are not converted, so a headline figure that sums them untouched is not an amount in any currency. Either convert through `fx_rates` on both date and currency, or state that the figure is a mixed-currency sum and explain why it is acceptable. Ask for the query showing the currency composition; do not accept `meta.currency` alone.
+
+The rubric totals exactly 10 points: Contract quality (2) + Layering (2) + Join and grain safety
+(1) + Governance (2) + Verification (2) + Defence (1). The currency-basis requirement is part
+of the single Defence point, not an additional point.
 
 ## Done signal
 Confirm all five deliverables exist on disk, that the headline figure is stated with a currency

--- a/templates/academy-sql-intermediate/docs/schema.md
+++ b/templates/academy-sql-intermediate/docs/schema.md
@@ -65,7 +65,7 @@ list_price        DECIMAL
 
 ## customers
 
-One row per customer account.
+510 source-system rows representing 500 customer IDs, including 10 duplicated IDs.
 
 ```text
 customer_id   INTEGER
@@ -80,7 +80,8 @@ segment       VARCHAR
 
 ## orders
 
-One row per order, as delivered by the source system.
+1,212 source-system rows representing 1,200 order IDs. Twelve IDs have a later
+resend with a changed status, so the raw table is not one row per order.
 
 ```text
 order_id                INTEGER
@@ -96,7 +97,8 @@ order_total             DECIMAL
 
 ## order_items
 
-One row per line on an order.
+2,895 source-system rows representing 2,880 distinct order lines, including 15
+exact duplicate rows.
 
 ```text
 order_id     INTEGER


### PR DESCRIPTION
## Summary
- make lesson 6 FX joins and the timestamp/date mismatch explicit
- correct raw source-row grain descriptions and lesson 12 guidance
- clarify lesson 13 measurement protocol and make lesson 14 scoring unambiguously 10 points
- add Bruin MCP/official docs and CLI guidance to the instructor instructions

## Validation
- `make format`
- `make test`
- current CLI init in existing Git repo and with `--in-place`
- current CLI init in an empty Git repo
- local and cloud `bruin validate`
- local `bruin run` for all seven generators
- requested row counts, FX figures, defects, SQL execution, deterministic checksums, and packaging invariants