### PR TITLE
ingestr: translate ODBC booleans for the v1 SQL Server driver

### DIFF
--- a/pkg/ingestr/operator.go
+++ b/pkg/ingestr/operator.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/bruin-data/bruin/pkg/ansisql"
@@ -207,6 +208,13 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		return err
 	}
 
+	// The engine is resolved before the URIs are built because the two ingestr
+	// families do not read every URI the same way.
+	engine, err := resolveIngestrEngine(asset)
+	if err != nil {
+		return err
+	}
+
 	// Source connection
 	sourceConnectionName, ok := asset.Parameters.GetString("source_connection")
 	if !ok {
@@ -233,6 +241,8 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 	if sourceVal, _ := asset.Parameters.GetString("source"); sourceVal == "gsheets" {
 		sourceURI = strings.ReplaceAll(sourceURI, "bigquery://", "gsheets://")
 	}
+
+	sourceURI = adaptURIForEngine(sourceURI, engine)
 
 	// Handle CDC mode - transform the source URI into ingestr's CDC scheme and auto-set merge strategy.
 	if cdcVal, _ := asset.Parameters.GetString("cdc"); cdcVal == "true" {
@@ -363,6 +373,8 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		destURI = applyClickHouseEngineParams(destURI, asset.Parameters)
 	}
 
+	destURI = adaptURIForEngine(destURI, engine)
+
 	destTable := asset.Name
 	if dt, ok := asset.Parameters.GetString("destination_table"); ok && dt != "" {
 		destTable = dt
@@ -432,10 +444,6 @@ func (o *BasicOperator) Run(ctx context.Context, ti scheduler.TaskInstance) erro
 		defer duck.UnlockDatabase(sourceURI)
 	}
 
-	engine, err := resolveIngestrEngine(asset)
-	if err != nil {
-		return err
-	}
 	if err := ensureFabricEngineSupport(engine, sourceURI, destURI); err != nil {
 		return err
 	}
@@ -633,6 +641,71 @@ func isMSSQLScheme(scheme string) bool {
 	return strings.HasPrefix(scheme, "mssql") || strings.HasPrefix(scheme, "sqlserver")
 }
 
+// odbcBooleanParameters are the SQL Server connection parameters whose values are
+// spelled the ODBC way ("yes"/"no") rather than as Go booleans.
+var odbcBooleanParameters = []string{"trustservercertificate", "encrypt"}
+
+// adaptURIForEngine rewrites a connection URI into the dialect the resolved
+// ingestr engine speaks.
+//
+// Only SQL Server needs this today. Bruin builds its SQL Server URIs the way the
+// v0 engine wants them, because that engine connects through pyodbc, where
+// booleans are written "TrustServerCertificate=yes"; a connection's `options`
+// carries the same spelling. The v1 engine reaches SQL Server through
+// go-mssqldb, which runs those values through strconv.ParseBool and fails the
+// run before it connects: "invalid trust server certificate 'yes'". Only the
+// values differ between the two, so they are translated in place and the rest of
+// the URI is left for ingestr to interpret.
+func adaptURIForEngine(uri string, engine resolvedEngine) string {
+	if engine.family != versionFamilyV1 {
+		return uri
+	}
+
+	parsed, err := ingestruri.Parse(uri)
+	if err != nil || !isMSSQLScheme(strings.ToLower(parsed.Scheme)) {
+		return uri
+	}
+
+	query := parsed.Query()
+	rewritten := false
+	for key, values := range query {
+		if !slices.Contains(odbcBooleanParameters, strings.ToLower(key)) {
+			continue
+		}
+		for i, value := range values {
+			converted, ok := odbcBooleanToGo(value)
+			if !ok {
+				continue
+			}
+			values[i] = converted
+			rewritten = true
+		}
+	}
+
+	if !rewritten {
+		return uri
+	}
+
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String()
+}
+
+// odbcBooleanToGo converts an ODBC boolean literal into one strconv.ParseBool
+// accepts, and reports whether it converted anything. Every other value is left
+// alone: it is either already a Go boolean or one only the driver can judge
+// (encrypt also takes "disable" and "strict").
+func odbcBooleanToGo(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "yes":
+		return "true", true
+	case "no":
+		return "false", true
+	}
+
+	return "", false
+}
+
 // isMongoDBScheme reports whether scheme belongs to the MongoDB family (mongodb,
 // mongodb+srv), which understands the change-stream CDC parameters.
 func isMongoDBScheme(scheme string) bool {
@@ -759,6 +832,13 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		return err
 	}
 
+	engine, err := resolveIngestrEngine(asset)
+	if err != nil {
+		return err
+	}
+
+	destURI = adaptURIForEngine(destURI, engine)
+
 	destTable := o.resolveSeedDestinationTableName(destConnectionName, destURI, asset.Name)
 
 	extraPackages = python.AddExtraPackages(destURI, sourceURI, extraPackages)
@@ -799,10 +879,6 @@ func (o *SeedOperator) Run(ctx context.Context, ti scheduler.TaskInstance) error
 		return errors.Wrap(err, "failed to find repo to run Ingestr")
 	}
 
-	engine, err := resolveIngestrEngine(asset)
-	if err != nil {
-		return err
-	}
 	if err := ensureFabricEngineSupport(engine, destURI); err != nil {
 		return err
 	}

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1729,15 +1729,20 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 	mockAtlas.On("GetIngestrURI").Return("mongodb+srv://user:pass@cluster.mongodb.net/db", nil)
 	mockMS := new(mockConnection)
 	mockMS.On("GetIngestrURI").Return("mssql://user:pass@localhost:1433/db", nil)
+	// What the mssql connection emits by default: pyodbc spellings, which the v1
+	// engine's Go SQL Server driver rejects until they are translated.
+	mockMSODBC := new(mockConnection)
+	mockMSODBC.On("GetIngestrURI").Return("mssql://user:pass@localhost:1433/db?TrustServerCertificate=yes&driver=ODBC+Driver+18+for+SQL+Server", nil)
 	mockBq := new(mockConnection)
 	mockBq.On("GetIngestrURI").Return("bigquery://uri-here", nil)
 
 	fetcher := simpleConnectionFetcher{
 		connections: map[string]*mockConnection{
-			"mongo": mockMongo,
-			"atlas": mockAtlas,
-			"ms":    mockMS,
-			"bq":    mockBq,
+			"mongo":   mockMongo,
+			"atlas":   mockAtlas,
+			"ms":      mockMS,
+			"ms_odbc": mockMSODBC,
+			"bq":      mockBq,
 		},
 	}
 
@@ -1849,6 +1854,57 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 				"--yes",
 				"--progress", "log",
 				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			// go-mssqldb parses TrustServerCertificate with strconv.ParseBool, so the
+			// ODBC "yes" the connection emits has to arrive as "true"; the ODBC driver
+			// name is dropped by ingestr itself and left alone here.
+			name: "SQL Server Change Tracking translates ODBC booleans for the v1 engine",
+			asset: &pipeline.Asset{
+				Name:       "ct-mssql-odbc-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "ms_odbc",
+					"source_table":      "dbo.users",
+					"destination":       "bigquery",
+					"cdc":               "true",
+					"cdc_sql_capture":   "change_tracking",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mssql+ct://user:pass@localhost:1433/db?TrustServerCertificate=true&driver=ODBC+Driver+18+for+SQL+Server",
+				"--source-table", "dbo.users",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "ct-mssql-odbc-asset",
+				"--yes",
+				"--progress", "log",
+				"--incremental-strategy", "merge",
+			},
+		},
+		{
+			// The v0 engine connects through pyodbc, which is what the ODBC spellings
+			// are for, so its URI must survive untouched.
+			name: "SQL Server keeps ODBC booleans for the v0 engine",
+			asset: &pipeline.Asset{
+				Name:       "mssql-v0-asset",
+				Connection: "bq",
+				Parameters: pipeline.ParameterMap{
+					"source_connection": "ms_odbc",
+					"source_table":      "dbo.users",
+					"destination":       "bigquery",
+					"version":           "v0",
+				},
+			},
+			want: []string{
+				"ingest",
+				"--source-uri", "mssql://user:pass@localhost:1433/db?TrustServerCertificate=yes&driver=ODBC+Driver+18+for+SQL+Server",
+				"--source-table", "dbo.users",
+				"--dest-uri", "bigquery://uri-here",
+				"--dest-table", "mssql-v0-asset",
+				"--yes",
+				"--progress", "log",
 			},
 		},
 		{
@@ -2341,6 +2397,71 @@ func TestEnsureFabricEngineSupport(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestAdaptURIForEngine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		uri    string
+		engine resolvedEngine
+		want   string
+	}{
+		{
+			name:   "v1 translates the ODBC trust flag the mssql connection emits",
+			uri:    "mssql://user:pass@localhost:1433/db?TrustServerCertificate=yes&driver=ODBC+Driver+18+for+SQL+Server",
+			engine: resolvedEngine{family: versionFamilyV1},
+			want:   "mssql://user:pass@localhost:1433/db?TrustServerCertificate=true&driver=ODBC+Driver+18+for+SQL+Server",
+		},
+		{
+			name:   "v1 translates change tracking URIs",
+			uri:    "mssql+ct://user:pass@localhost:1433/db?TrustServerCertificate=yes&poll_interval=2s",
+			engine: resolvedEngine{family: versionFamilyV1},
+			want:   "mssql+ct://user:pass@localhost:1433/db?TrustServerCertificate=true&poll_interval=2s",
+		},
+		{
+			// Parameter names reach go-mssqldb case-insensitively, and a connection's
+			// options can spell them any way, so the match cannot be exact.
+			name:   "v1 matches parameters and values regardless of case",
+			uri:    "sqlserver://user:pass@localhost:1433/db?trustservercertificate=YES&encrypt=No",
+			engine: resolvedEngine{family: versionFamilyV1},
+			want:   "sqlserver://user:pass@localhost:1433/db?encrypt=false&trustservercertificate=true",
+		},
+		{
+			// "disable" and "strict" are encrypt values only the driver understands.
+			name:   "v1 leaves values it has no translation for untouched",
+			uri:    "mssql://user:pass@localhost:1433/db?TrustServerCertificate=true&encrypt=disable",
+			engine: resolvedEngine{family: versionFamilyV1},
+			want:   "mssql://user:pass@localhost:1433/db?TrustServerCertificate=true&encrypt=disable",
+		},
+		{
+			name:   "v0 keeps the ODBC spellings pyodbc needs",
+			uri:    "mssql://user:pass@localhost:1433/db?TrustServerCertificate=yes&driver=ODBC+Driver+18+for+SQL+Server",
+			engine: resolvedEngine{family: versionFamilyV0},
+			want:   "mssql://user:pass@localhost:1433/db?TrustServerCertificate=yes&driver=ODBC+Driver+18+for+SQL+Server",
+		},
+		{
+			name:   "other sources are left alone",
+			uri:    "postgresql://user:pass@localhost:5432/db?sslmode=require",
+			engine: resolvedEngine{family: versionFamilyV1},
+			want:   "postgresql://user:pass@localhost:5432/db?sslmode=require",
+		},
+		{
+			name:   "an unparseable uri is passed through",
+			uri:    "mssql-without-a-scheme-separator",
+			engine: resolvedEngine{family: versionFamilyV1},
+			want:   "mssql-without-a-scheme-separator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, adaptURIForEngine(tt.uri, tt.engine))
 		})
 	}
 }

--- a/pkg/ingestr/operator_test.go
+++ b/pkg/ingestr/operator_test.go
@@ -1749,9 +1749,10 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 	finder := new(mockFinder)
 
 	tests := []struct {
-		name  string
-		asset *pipeline.Asset
-		want  []string
+		name          string
+		asset         *pipeline.Asset
+		want          []string
+		extraPackages []string
 	}{
 		{
 			name: "MongoDB CDC transforms URI and auto-sets merge strategy",
@@ -1906,6 +1907,8 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 				"--yes",
 				"--progress", "log",
 			},
+			// A plain mssql:// source runs on pyodbc, which the v0 engine installs.
+			extraPackages: []string{"pyodbc==5.1.0"},
 		},
 		{
 			name: "SQL Server Change Tracking streams with a poll interval",
@@ -1941,7 +1944,7 @@ func TestBasicOperator_MongoMSSQLCDCMode(t *testing.T) {
 			t.Parallel()
 
 			runner := new(mockRunner)
-			runner.On("RunIngestr", mock.Anything, tt.want, []string(nil), repo).Return(nil)
+			runner.On("RunIngestr", mock.Anything, tt.want, tt.extraPackages, repo).Return(nil)
 
 			startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 			endDate := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What

Bruin builds its SQL Server ingestr URIs in the ODBC dialect, so the default query string carries `TrustServerCertificate=yes`. That is what the v0 engine wants, because it connects through pyodbc, but the v1 engine reaches SQL Server through go-mssqldb, which parses the value with `strconv.ParseBool` and aborts before connecting:

```
failed to connect to source: failed to open SQL Server connection: invalid trust server certificate 'yes': strconv.ParseBool: parsing "yes": invalid syntax
```

Change Tracking and CDC sources exist only in the Go engine, so a `mssql+ct` / `mssql+cdc` asset fails on every run; a plain `mssql://` source on v1 fails the same way. The same spelling reaches the driver from a connection's `options`.

## How

- The resolved ingestr engine is now determined before the URIs are built, in both the basic and the seed operator.
- `adaptURIForEngine` translates the ODBC boolean spellings of `TrustServerCertificate` and `encrypt` (`yes`/`no` → `true`/`false`) for the v1 family, on the source and the destination URI.
- Parameter names and values are matched case-insensitively, values only the driver understands (`disable`, `strict`) are left alone, non-SQL-Server URIs are untouched, and v0 URIs keep the ODBC spellings pyodbc needs. ingestr drops the `driver` parameter itself, so it stays for v0.

## Tests

- Table test for the adapter: translation, case handling, untranslatable values, v0 pass-through, other sources, unparseable URIs.
- Operator-level cases asserting the emitted `--source-uri` for a `mssql+ct` asset on v1 and for an mssql asset pinned to v0.