### PR TITLE
Add notification rule cloud commands

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -6234,8 +6234,6 @@ func CloudNotificationRules() *cli.Command {
 			cloudNotificationRulesList(),
 			cloudNotificationRulesCreate(),
 			cloudNotificationRulesUpdate(),
-			cloudNotificationRulesToggle("enable", true),
-			cloudNotificationRulesToggle("disable", false),
 			cloudNotificationRulesDelete(),
 		},
 	}
@@ -6440,41 +6438,6 @@ func cloudNotificationRulesUpdate() *cli.Command {
 				return cli.Exit("", 1)
 			}
 			if err := printNotificationRuleResult(rule, output, "Updated"); err != nil {
-				printError(err, output, "Failed to format notification rule")
-				return cli.Exit("", 1)
-			}
-			return nil
-		},
-	}
-}
-
-func cloudNotificationRulesToggle(name string, enabled bool) *cli.Command {
-	action := strings.ToUpper(name[:1]) + name[1:]
-	return &cli.Command{
-		Name:  name,
-		Usage: action + " a notification rule",
-		Flags: []cli.Flag{apiKeyFlag(), outputFlag(), notificationRuleIDFlag()},
-		Action: func(ctx context.Context, c *cli.Command) error {
-			defer RecoverFromPanic()
-			output := c.String("output")
-
-			id, err := notificationRuleID(c)
-			if err != nil {
-				printError(err, output, "Invalid notification rule ID")
-				return cli.Exit("", 1)
-			}
-			client, err := newCloudClient(c)
-			if err != nil {
-				printError(err, output, "Failed to create API client")
-				return cli.Exit("", 1)
-			}
-
-			rule, err := client.SetNotificationRuleEnabled(ctx, id, enabled)
-			if err != nil {
-				printError(err, output, "Failed to "+name+" notification rule")
-				return cli.Exit("", 1)
-			}
-			if err := printNotificationRuleResult(rule, output, action+"d"); err != nil {
 				printError(err, output, "Failed to format notification rule")
 				return cli.Exit("", 1)
 			}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -44,6 +44,7 @@ func Cloud(isDebug *bool) *cli.Command {
 			CloudConnectionSets(),
 			CloudDashboards(),
 			CloudScheduledAgents(),
+			CloudNotificationRules(),
 			CloudSkills(),
 			CloudAuditLogs(),
 			CloudCost(),
@@ -6222,6 +6223,299 @@ func derefString(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+func CloudNotificationRules() *cli.Command {
+	return &cli.Command{
+		Name:  "notification-rules",
+		Usage: "Manage Bruin Cloud notification rules",
+		Commands: []*cli.Command{
+			cloudNotificationRulesSchema(),
+			cloudNotificationRulesList(),
+			cloudNotificationRulesCreate(),
+			cloudNotificationRulesUpdate(),
+			cloudNotificationRulesToggle("enable", true),
+			cloudNotificationRulesToggle("disable", false),
+			cloudNotificationRulesDelete(),
+		},
+	}
+}
+
+func notificationRuleIDFlag() *cli.IntFlag {
+	return &cli.IntFlag{
+		Name:     "notification-rule-id",
+		Usage:    "notification rule ID",
+		Required: true,
+	}
+}
+
+func notificationRuleID(c *cli.Command) (int, error) {
+	id := c.Int("notification-rule-id")
+	if id <= 0 {
+		return 0, fmt.Errorf("--notification-rule-id must be a positive integer, got %d", id)
+	}
+	return id, nil
+}
+
+func notificationRuleInputFlags() []cli.Flag {
+	return []cli.Flag{
+		apiKeyFlag(),
+		outputFlag(),
+		&cli.StringFlag{Name: "rule", Usage: "notification rule as a JSON or YAML object"},
+		&cli.StringFlag{Name: "rule-file", Usage: "path to a JSON or YAML notification rule"},
+	}
+}
+
+func notificationRuleFields(c *cli.Command) (map[string]any, error) {
+	if c.IsSet("rule") && c.IsSet("rule-file") {
+		return nil, errors.New("pass only one of --rule or --rule-file")
+	}
+	if !c.IsSet("rule") && !c.IsSet("rule-file") {
+		return nil, errors.New("provide the notification rule with --rule or --rule-file")
+	}
+
+	raw := c.String("rule")
+	if c.IsSet("rule-file") {
+		data, err := os.ReadFile(c.String("rule-file"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read --rule-file: %w", err)
+		}
+		raw = string(data)
+	}
+
+	fields, err := parseJSONOrYAMLObject([]byte(raw))
+	if err != nil {
+		return nil, fmt.Errorf("invalid notification rule (expected a JSON or YAML object): %w", err)
+	}
+	if fields == nil {
+		return nil, errors.New("notification rule must be a JSON or YAML object")
+	}
+	return fields, nil
+}
+
+func cloudNotificationRulesSchema() *cli.Command {
+	return &cli.Command{
+		Name:  "schema",
+		Usage: "Show the notification rule schema and example",
+		Flags: []cli.Flag{apiKeyFlag(), outputFlag()},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			schema, err := client.GetNotificationRuleSchema(ctx)
+			if err != nil {
+				printError(err, output, "Failed to get notification rule schema")
+				return cli.Exit("", 1)
+			}
+
+			var decoded any
+			if err := json.Unmarshal(schema, &decoded); err != nil {
+				printError(err, output, "Failed to parse notification rule schema")
+				return cli.Exit("", 1)
+			}
+			data, _ := json.MarshalIndent(decoded, "", "  ")
+			fmt.Println(string(data))
+			return nil
+		},
+	}
+}
+
+func cloudNotificationRulesList() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List the team's notification rules",
+		Flags: []cli.Flag{apiKeyFlag(), outputFlag()},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			rules, err := client.ListNotificationRules(ctx)
+			if err != nil {
+				printError(err, output, "Failed to list notification rules")
+				return cli.Exit("", 1)
+			}
+			if rules == nil {
+				rules = []bruincloud.NotificationRule{}
+			}
+
+			if output == "json" {
+				data, _ := json.MarshalIndent(rules, "", "  ")
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(rules) == 0 {
+				infoPrinter.Println("No notification rules yet.")
+				return nil
+			}
+
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{"ID", "Name", "Enabled", "Updated"})
+			for _, rule := range rules {
+				t.AppendRow(table.Row{rule.ID, rule.Name, rule.Enabled, derefString(rule.UpdatedAt)})
+			}
+			t.Render()
+			return nil
+		},
+	}
+}
+
+func cloudNotificationRulesCreate() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a notification rule",
+		Flags: notificationRuleInputFlags(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			fields, err := notificationRuleFields(c)
+			if err != nil {
+				printError(err, output, "Invalid notification rule")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			rule, err := client.CreateNotificationRule(ctx, fields)
+			if err != nil {
+				printError(err, output, "Failed to create notification rule")
+				return cli.Exit("", 1)
+			}
+			printNotificationRuleResult(rule, output, "Created")
+			return nil
+		},
+	}
+}
+
+func cloudNotificationRulesUpdate() *cli.Command {
+	return &cli.Command{
+		Name:  "update",
+		Usage: "Replace a notification rule",
+		Flags: append(notificationRuleInputFlags(), notificationRuleIDFlag()),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			id, err := notificationRuleID(c)
+			if err != nil {
+				printError(err, output, "Invalid notification rule ID")
+				return cli.Exit("", 1)
+			}
+			fields, err := notificationRuleFields(c)
+			if err != nil {
+				printError(err, output, "Invalid notification rule")
+				return cli.Exit("", 1)
+			}
+
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			rule, err := client.UpdateNotificationRule(ctx, id, fields)
+			if err != nil {
+				printError(err, output, "Failed to update notification rule")
+				return cli.Exit("", 1)
+			}
+			printNotificationRuleResult(rule, output, "Updated")
+			return nil
+		},
+	}
+}
+
+func cloudNotificationRulesToggle(name string, enabled bool) *cli.Command {
+	action := strings.ToUpper(name[:1]) + name[1:]
+	return &cli.Command{
+		Name:  name,
+		Usage: action + " a notification rule",
+		Flags: []cli.Flag{apiKeyFlag(), outputFlag(), notificationRuleIDFlag()},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			id, err := notificationRuleID(c)
+			if err != nil {
+				printError(err, output, "Invalid notification rule ID")
+				return cli.Exit("", 1)
+			}
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+
+			rule, err := client.SetNotificationRuleEnabled(ctx, id, enabled)
+			if err != nil {
+				printError(err, output, "Failed to "+name+" notification rule")
+				return cli.Exit("", 1)
+			}
+			printNotificationRuleResult(rule, output, action+"d")
+			return nil
+		},
+	}
+}
+
+func cloudNotificationRulesDelete() *cli.Command {
+	return &cli.Command{
+		Name:  "delete",
+		Usage: "Delete a notification rule",
+		Flags: []cli.Flag{apiKeyFlag(), outputFlag(), notificationRuleIDFlag()},
+		Action: func(ctx context.Context, c *cli.Command) error {
+			defer RecoverFromPanic()
+			output := c.String("output")
+
+			id, err := notificationRuleID(c)
+			if err != nil {
+				printError(err, output, "Invalid notification rule ID")
+				return cli.Exit("", 1)
+			}
+			client, err := newCloudClient(c)
+			if err != nil {
+				printError(err, output, "Failed to create API client")
+				return cli.Exit("", 1)
+			}
+			if err := client.DeleteNotificationRule(ctx, id); err != nil {
+				printError(err, output, "Failed to delete notification rule")
+				return cli.Exit("", 1)
+			}
+
+			if output == "json" {
+				data, _ := json.Marshal(map[string]any{"success": true, "deleted_rule_id": id})
+				fmt.Println(string(data))
+				return nil
+			}
+			successPrinter.Printf("Deleted notification rule %d.\n", id)
+			return nil
+		},
+	}
+}
+
+func printNotificationRuleResult(rule *bruincloud.NotificationRule, output, action string) {
+	if output == "json" {
+		data, _ := json.MarshalIndent(rule, "", "  ")
+		fmt.Println(string(data))
+		return
+	}
+	successPrinter.Printf("%s notification rule %d (%s).\n", action, rule.ID, rule.Name)
 }
 
 func CloudAuditLogs() *cli.Command {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -6399,7 +6399,10 @@ func cloudNotificationRulesCreate() *cli.Command {
 				printError(err, output, "Failed to create notification rule")
 				return cli.Exit("", 1)
 			}
-			printNotificationRuleResult(rule, output, "Created")
+			if err := printNotificationRuleResult(rule, output, "Created"); err != nil {
+				printError(err, output, "Failed to format notification rule")
+				return cli.Exit("", 1)
+			}
 			return nil
 		},
 	}
@@ -6436,7 +6439,10 @@ func cloudNotificationRulesUpdate() *cli.Command {
 				printError(err, output, "Failed to update notification rule")
 				return cli.Exit("", 1)
 			}
-			printNotificationRuleResult(rule, output, "Updated")
+			if err := printNotificationRuleResult(rule, output, "Updated"); err != nil {
+				printError(err, output, "Failed to format notification rule")
+				return cli.Exit("", 1)
+			}
 			return nil
 		},
 	}
@@ -6468,7 +6474,10 @@ func cloudNotificationRulesToggle(name string, enabled bool) *cli.Command {
 				printError(err, output, "Failed to "+name+" notification rule")
 				return cli.Exit("", 1)
 			}
-			printNotificationRuleResult(rule, output, action+"d")
+			if err := printNotificationRuleResult(rule, output, action+"d"); err != nil {
+				printError(err, output, "Failed to format notification rule")
+				return cli.Exit("", 1)
+			}
 			return nil
 		},
 	}
@@ -6509,13 +6518,17 @@ func cloudNotificationRulesDelete() *cli.Command {
 	}
 }
 
-func printNotificationRuleResult(rule *bruincloud.NotificationRule, output, action string) {
+func printNotificationRuleResult(rule *bruincloud.NotificationRule, output, action string) error {
 	if output == "json" {
-		data, _ := json.MarshalIndent(rule, "", "  ")
+		data, err := json.MarshalIndent(rule, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(data))
-		return
+		return nil
 	}
 	successPrinter.Printf("%s notification rule %d (%s).\n", action, rule.ID, rule.Name)
+	return nil
 }
 
 func CloudAuditLogs() *cli.Command {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -812,13 +812,13 @@ func TestCloudNotificationRulesCommand_Help(t *testing.T) {
 	cmd := CloudNotificationRules()
 	require.NotNil(t, cmd)
 	assert.Equal(t, "notification-rules", cmd.Name)
-	require.Len(t, cmd.Commands, 7)
+	require.Len(t, cmd.Commands, 5)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
 		subNames[i] = sub.Name
 	}
-	assert.ElementsMatch(t, []string{"schema", "list", "create", "update", "enable", "disable", "delete"}, subNames)
+	assert.ElementsMatch(t, []string{"schema", "list", "create", "update", "delete"}, subNames)
 }
 
 func TestNotificationRuleFields(t *testing.T) {

--- a/cmd/cloud_test.go
+++ b/cmd/cloud_test.go
@@ -329,7 +329,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	cmd := Cloud(&isDebug)
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cloud", cmd.Name)
-	assert.Len(t, cmd.Commands, 17)
+	assert.Len(t, cmd.Commands, 18)
 
 	subNames := make([]string, len(cmd.Commands))
 	for i, sub := range cmd.Commands {
@@ -348,6 +348,7 @@ func TestCloudCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "connections")
 	assert.Contains(t, subNames, "connection-sets")
 	assert.Contains(t, subNames, "dashboards")
+	assert.Contains(t, subNames, "notification-rules")
 	assert.Contains(t, subNames, "scheduled-agents")
 	assert.Contains(t, subNames, "skills")
 	assert.Contains(t, subNames, "audit-logs")
@@ -804,6 +805,62 @@ func TestCloudScheduledAgentsCommand_Help(t *testing.T) {
 	assert.Contains(t, subNames, "trigger")
 	assert.Contains(t, subNames, "delete")
 	assert.Contains(t, subNames, "run-states")
+}
+
+func TestCloudNotificationRulesCommand_Help(t *testing.T) {
+	t.Parallel()
+	cmd := CloudNotificationRules()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "notification-rules", cmd.Name)
+	require.Len(t, cmd.Commands, 7)
+
+	subNames := make([]string, len(cmd.Commands))
+	for i, sub := range cmd.Commands {
+		subNames[i] = sub.Name
+	}
+	assert.ElementsMatch(t, []string{"schema", "list", "create", "update", "enable", "disable", "delete"}, subNames)
+}
+
+func TestNotificationRuleFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses inline JSON", func(t *testing.T) {
+		t.Parallel()
+		var fields map[string]any
+		cmd := &cli.Command{
+			Name:  "test",
+			Flags: notificationRuleInputFlags(),
+			Action: func(_ context.Context, c *cli.Command) error {
+				var err error
+				fields, err = notificationRuleFields(c)
+				return err
+			},
+		}
+		err := runCLI(t.Context(), cmd, []string{"test", "--rule", `{"name":"Failures","enabled":false}`})
+		require.NoError(t, err)
+		assert.Equal(t, "Failures", fields["name"])
+		assert.Equal(t, false, fields["enabled"])
+	})
+
+	t.Run("parses YAML file", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "rule.yml")
+		require.NoError(t, os.WriteFile(path, []byte("name: Failures\nenabled: true\n"), 0o600))
+		var fields map[string]any
+		cmd := &cli.Command{
+			Name:  "test",
+			Flags: notificationRuleInputFlags(),
+			Action: func(_ context.Context, c *cli.Command) error {
+				var err error
+				fields, err = notificationRuleFields(c)
+				return err
+			},
+		}
+		err := runCLI(t.Context(), cmd, []string{"test", "--rule-file", path})
+		require.NoError(t, err)
+		assert.Equal(t, "Failures", fields["name"])
+		assert.Equal(t, true, fields["enabled"])
+	})
 }
 
 func TestCloudScheduledAgentsRunStatesCommand_Help(t *testing.T) {

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -1168,15 +1168,14 @@ deliveries:
     channels: ["#alerts"]
 ```
 
-Enable, disable, or delete a rule by ID:
+Set `enabled: true` or `enabled: false` in the full rule document and use `update` to enable or disable it. Delete a rule by ID:
 
 ```bash
-bruin cloud notification-rules disable --notification-rule-id 42
-bruin cloud notification-rules enable --notification-rule-id 42
+bruin cloud notification-rules update --notification-rule-id 42 --rule-file ./notification-rule.yml
 bruin cloud notification-rules delete --notification-rule-id 42
 ```
 
-`create`, `update`, and `delete` require the `notification-rule:manage` token ability. `schema` and `list` require `notification-rule:list`. `enable` and `disable` read the current rule before replacing it, so they require both abilities.
+`create`, `update`, and `delete` require the `notification-rule:manage` token ability. `schema` and `list` require `notification-rule:list`.
 
 ---
 

--- a/docs/commands/cloud.md
+++ b/docs/commands/cloud.md
@@ -1134,6 +1134,52 @@ bruin cloud scheduled-agents run-states delete --scheduled-agent-id 42 --name me
 
 ---
 
+### `notification-rules`
+
+Manage the team's Cloud notification rules. Start with `schema` to see the supported events, selector fields, delivery types, limits, and a complete example.
+
+```bash
+bruin cloud notification-rules schema
+bruin cloud notification-rules list
+```
+
+Create or fully replace a rule from inline JSON/YAML or a file:
+
+```bash
+bruin cloud notification-rules create --rule-file ./notification-rule.yml
+bruin cloud notification-rules update --notification-rule-id 42 --rule-file ./notification-rule.yml
+```
+
+Example rule:
+
+```yaml
+name: Production failures
+enabled: true
+subscriptions:
+  - event_types: [run_failed, asset_failed]
+    selector:
+      operator: and
+      children:
+        - field: pipeline.tags
+          operator: contains
+          value: prod
+deliveries:
+  - type: slack
+    channels: ["#alerts"]
+```
+
+Enable, disable, or delete a rule by ID:
+
+```bash
+bruin cloud notification-rules disable --notification-rule-id 42
+bruin cloud notification-rules enable --notification-rule-id 42
+bruin cloud notification-rules delete --notification-rule-id 42
+```
+
+`create`, `update`, and `delete` require the `notification-rule:manage` token ability. `schema` and `list` require `notification-rule:list`. `enable` and `disable` read the current rule before replacing it, so they require both abilities.
+
+---
+
 ### `skills`
 
 Manage the team **skill library** — named instruction snippets you attach to agents. Team-scoped (you only see your own team's skills).

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -1081,6 +1081,67 @@ func (c *APIClient) TriggerScheduledAgent(ctx context.Context, scheduledAgentID 
 	return &result, nil
 }
 
+// --- Notification rules ---
+
+func (c *APIClient) GetNotificationRuleSchema(ctx context.Context) (json.RawMessage, error) {
+	var schema json.RawMessage
+	err := c.doRequest(ctx, http.MethodGet, "/notification-rules/schema", nil, &schema)
+	return schema, err
+}
+
+func (c *APIClient) ListNotificationRules(ctx context.Context) ([]NotificationRule, error) {
+	var resp struct {
+		Rules []NotificationRule `json:"rules"`
+	}
+	err := c.doRequest(ctx, http.MethodGet, "/notification-rules", nil, &resp)
+	return resp.Rules, err
+}
+
+func (c *APIClient) CreateNotificationRule(ctx context.Context, fields map[string]any) (*NotificationRule, error) {
+	var resp struct {
+		Rule NotificationRule `json:"rule"`
+	}
+	err := c.doRequest(ctx, http.MethodPost, "/notification-rules", fields, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Rule, nil
+}
+
+func (c *APIClient) UpdateNotificationRule(ctx context.Context, notificationRuleID int, fields map[string]any) (*NotificationRule, error) {
+	var resp struct {
+		Rule NotificationRule `json:"rule"`
+	}
+	err := c.doRequest(ctx, http.MethodPut, fmt.Sprintf("/notification-rules/%d", notificationRuleID), fields, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Rule, nil
+}
+
+func (c *APIClient) SetNotificationRuleEnabled(ctx context.Context, notificationRuleID int, enabled bool) (*NotificationRule, error) {
+	rules, err := c.ListNotificationRules(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, rule := range rules {
+		if rule.ID != notificationRuleID {
+			continue
+		}
+		return c.UpdateNotificationRule(ctx, notificationRuleID, map[string]any{
+			"name":          rule.Name,
+			"enabled":       enabled,
+			"subscriptions": rule.Subscriptions,
+			"deliveries":    rule.Deliveries,
+		})
+	}
+	return nil, fmt.Errorf("notification rule %d not found", notificationRuleID)
+}
+
+func (c *APIClient) DeleteNotificationRule(ctx context.Context, notificationRuleID int) error {
+	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/notification-rules/%d", notificationRuleID), nil, nil)
+}
+
 // --- Scheduled agent run state ---
 
 // ListRunStates returns the run-state ("memory") files persisted on a scheduled

--- a/pkg/bruincloud/api.go
+++ b/pkg/bruincloud/api.go
@@ -1119,25 +1119,6 @@ func (c *APIClient) UpdateNotificationRule(ctx context.Context, notificationRule
 	return &resp.Rule, nil
 }
 
-func (c *APIClient) SetNotificationRuleEnabled(ctx context.Context, notificationRuleID int, enabled bool) (*NotificationRule, error) {
-	rules, err := c.ListNotificationRules(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, rule := range rules {
-		if rule.ID != notificationRuleID {
-			continue
-		}
-		return c.UpdateNotificationRule(ctx, notificationRuleID, map[string]any{
-			"name":          rule.Name,
-			"enabled":       enabled,
-			"subscriptions": rule.Subscriptions,
-			"deliveries":    rule.Deliveries,
-		})
-	}
-	return nil, fmt.Errorf("notification rule %d not found", notificationRuleID)
-}
-
 func (c *APIClient) DeleteNotificationRule(ctx context.Context, notificationRuleID int) error {
 	return c.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/notification-rules/%d", notificationRuleID), nil, nil)
 }

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1723,35 +1723,6 @@ func TestUpdateNotificationRule(t *testing.T) {
 	assert.False(t, rule.Enabled)
 }
 
-func TestSetNotificationRuleEnabled(t *testing.T) {
-	t.Parallel()
-	requests := 0
-	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		switch requests {
-		case 1:
-			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "/notification-rules", r.URL.Path)
-			_, _ = w.Write([]byte(`{"rules":[{"id":7,"name":"Failures","enabled":true,"subscriptions":[{"event_types":["run_failed"]}],"deliveries":[{"type":"slack","channels":["alerts"]}]}]}`))
-		case 2:
-			assert.Equal(t, http.MethodPut, r.Method)
-			assert.Equal(t, "/notification-rules/7", r.URL.Path)
-			body := readJSON(t, r)
-			assert.Equal(t, "Failures", body["name"])
-			assert.Equal(t, false, body["enabled"])
-			assert.Equal(t, []any{map[string]any{"event_types": []any{"run_failed"}}}, body["subscriptions"])
-			_, _ = w.Write([]byte(`{"rule":{"id":7,"name":"Failures","enabled":false,"subscriptions":[],"deliveries":[]}}`))
-		default:
-			t.Fatalf("unexpected request %d", requests)
-		}
-	})
-
-	rule, err := client.SetNotificationRuleEnabled(t.Context(), 7, false)
-	require.NoError(t, err)
-	assert.False(t, rule.Enabled)
-	assert.Equal(t, 2, requests)
-}
-
 func TestDeleteNotificationRule(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bruincloud/api_test.go
+++ b/pkg/bruincloud/api_test.go
@@ -1650,6 +1650,119 @@ func TestDeleteScheduledAgent(t *testing.T) {
 	require.NoError(t, client.DeleteScheduledAgent(t.Context(), 11))
 }
 
+func TestGetNotificationRuleSchema(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/notification-rules/schema", r.URL.Path)
+		writeJSON(t, w, map[string]any{"schema_version": 1})
+	})
+
+	schema, err := client.GetNotificationRuleSchema(t.Context())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"schema_version":1}`, string(schema))
+}
+
+func TestListNotificationRules(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/notification-rules", r.URL.Path)
+		writeJSON(t, w, map[string]any{
+			"rules": []map[string]any{{
+				"id": 4, "name": "Failures", "enabled": true,
+				"subscriptions": []any{}, "deliveries": []any{},
+			}},
+		})
+	})
+
+	rules, err := client.ListNotificationRules(t.Context())
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, 4, rules[0].ID)
+	assert.Equal(t, "Failures", rules[0].Name)
+	assert.True(t, rules[0].Enabled)
+}
+
+func TestCreateNotificationRule(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/notification-rules", r.URL.Path)
+		body := readJSON(t, r)
+		assert.Equal(t, "Failures", body["name"])
+		assert.Equal(t, true, body["enabled"])
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(t, w, map[string]any{"rule": map[string]any{
+			"id": 5, "name": "Failures", "enabled": true,
+			"subscriptions": []any{}, "deliveries": []any{},
+		}})
+	})
+
+	rule, err := client.CreateNotificationRule(t.Context(), map[string]any{"name": "Failures", "enabled": true})
+	require.NoError(t, err)
+	assert.Equal(t, 5, rule.ID)
+	assert.Equal(t, "Failures", rule.Name)
+}
+
+func TestUpdateNotificationRule(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/notification-rules/5", r.URL.Path)
+		body := readJSON(t, r)
+		assert.Equal(t, false, body["enabled"])
+		writeJSON(t, w, map[string]any{"rule": map[string]any{
+			"id": 5, "name": "Failures", "enabled": false,
+			"subscriptions": []any{}, "deliveries": []any{},
+		}})
+	})
+
+	rule, err := client.UpdateNotificationRule(t.Context(), 5, map[string]any{"enabled": false})
+	require.NoError(t, err)
+	assert.False(t, rule.Enabled)
+}
+
+func TestSetNotificationRuleEnabled(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch requests {
+		case 1:
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/notification-rules", r.URL.Path)
+			_, _ = w.Write([]byte(`{"rules":[{"id":7,"name":"Failures","enabled":true,"subscriptions":[{"event_types":["run_failed"]}],"deliveries":[{"type":"slack","channels":["alerts"]}]}]}`))
+		case 2:
+			assert.Equal(t, http.MethodPut, r.Method)
+			assert.Equal(t, "/notification-rules/7", r.URL.Path)
+			body := readJSON(t, r)
+			assert.Equal(t, "Failures", body["name"])
+			assert.Equal(t, false, body["enabled"])
+			assert.Equal(t, []any{map[string]any{"event_types": []any{"run_failed"}}}, body["subscriptions"])
+			_, _ = w.Write([]byte(`{"rule":{"id":7,"name":"Failures","enabled":false,"subscriptions":[],"deliveries":[]}}`))
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	})
+
+	rule, err := client.SetNotificationRuleEnabled(t.Context(), 7, false)
+	require.NoError(t, err)
+	assert.False(t, rule.Enabled)
+	assert.Equal(t, 2, requests)
+}
+
+func TestDeleteNotificationRule(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/notification-rules/8", r.URL.Path)
+		writeJSON(t, w, map[string]any{"success": true, "deleted_rule_id": 8})
+	})
+
+	require.NoError(t, client.DeleteNotificationRule(t.Context(), 8))
+}
+
 func TestGetCostExplorerSchema(t *testing.T) {
 	t.Parallel()
 	var gotPath string

--- a/pkg/bruincloud/types.go
+++ b/pkg/bruincloud/types.go
@@ -414,6 +414,17 @@ type ScheduledAgentExecution struct {
 	ThreadID    int `json:"thread_id"`
 }
 
+// NotificationRule routes matching Cloud events to one or more destinations.
+type NotificationRule struct {
+	ID            int             `json:"id"`
+	Name          string          `json:"name"`
+	Enabled       bool            `json:"enabled"`
+	Subscriptions json.RawMessage `json:"subscriptions"`
+	Deliveries    json.RawMessage `json:"deliveries"`
+	CreatedAt     *string         `json:"created_at"`
+	UpdatedAt     *string         `json:"updated_at"`
+}
+
 // AuditLog is one entry in a team's audit trail as returned by GET /audit-logs.
 // Metadata is event-specific and left raw.
 type AuditLog struct {


### PR DESCRIPTION
## Summary

- add Bruin Cloud API client support for notification rule schema and CRUD endpoints
- add `bruin cloud notification-rules` commands for schema, list, create, update, enable, disable, and delete
- document JSON/YAML rule input and token abilities