### PR TITLE
Fix ORDER BY query failure with row limit on T-SQL sources

### DIFF
--- a/pkg/query/tsql_limit.go
+++ b/pkg/query/tsql_limit.go
@@ -10,11 +10,64 @@ import (
 // since a derived-table wrapper is invalid T-SQL after a WITH clause.
 func TSQLLimit(sql string, limit int64) string {
 	sql = strings.TrimRight(sql, "; \n\t")
+	// A query ending in a bare ORDER BY (no TOP/OFFSET/FETCH/FOR) cannot be put
+	// inside a derived table or CTE — T-SQL rejects it. Limit it in place by
+	// appending OFFSET/FETCH to the existing ORDER BY instead of wrapping.
+	if endsWithBareOrderBy(sql) {
+		return fmt.Sprintf("%s\nOFFSET 0 ROWS FETCH NEXT %d ROWS ONLY", sql, limit)
+	}
 	if prefix, body, ok := splitLeadingWith(sql); ok {
 		name := uniqueCTEName(sql)
 		return fmt.Sprintf("%s,\n%s AS (\n%s\n)\nSELECT TOP %d * FROM %s", prefix, name, body, limit, name)
 	}
 	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, sql)
+}
+
+// endsWithBareOrderBy reports whether the outermost query ends with an ORDER BY
+// clause that has no accompanying TOP, OFFSET/FETCH, or FOR — the exact shape
+// T-SQL forbids inside a derived table, subquery, or CTE. Only depth-0 (outer
+// query) keywords count; ORDER BY / OFFSET inside a nested subquery is ignored.
+func endsWithBareOrderBy(sql string) bool {
+	depth := 0
+	lastOrderBy := -1
+	hasTop := false
+	offsetOrForAfter := false
+	for i := 0; i < len(sql); {
+		if ni, ok := skipLiteral(sql, i); ok {
+			i = ni
+			continue
+		}
+		switch sql[i] {
+		case '(':
+			depth++
+			i++
+			continue
+		case ')':
+			depth--
+			i++
+			continue
+		}
+		if depth == 0 {
+			if matchKeyword(sql, i, "TOP") {
+				hasTop = true
+			}
+			if matchKeyword(sql, i, "ORDER") {
+				j := skipSpaceAndComments(sql, i+len("ORDER"))
+				if matchKeyword(sql, j, "BY") {
+					lastOrderBy = i
+					offsetOrForAfter = false
+					i = j + len("BY")
+					continue
+				}
+			}
+			if lastOrderBy >= 0 &&
+				(matchKeyword(sql, i, "OFFSET") || matchKeyword(sql, i, "FETCH") || matchKeyword(sql, i, "FOR")) {
+				offsetOrForAfter = true
+			}
+		}
+		i++
+	}
+	return lastOrderBy >= 0 && !hasTop && !offsetOrForAfter
 }
 
 // uniqueCTEName returns a limit CTE name that does not already occur in sql.

--- a/pkg/query/tsql_limit.go
+++ b/pkg/query/tsql_limit.go
@@ -10,11 +10,8 @@ import (
 // since a derived-table wrapper is invalid T-SQL after a WITH clause.
 func TSQLLimit(sql string, limit int64) string {
 	sql = strings.TrimRight(sql, "; \n\t")
-	// A query ending in a bare ORDER BY (no TOP/OFFSET/FETCH/FOR) cannot be put
-	// inside a derived table or CTE — T-SQL rejects it. Limit it in place by
-	// appending OFFSET/FETCH to the existing ORDER BY instead of wrapping.
-	// FETCH requires a positive count, so limit < 1 keeps the TOP wrapper (TOP 0
-	// is valid and preserves the historical "no rows" behavior).
+	// A bare trailing ORDER BY is invalid inside a wrapper, so limit it in place.
+	// limit < 1 keeps the TOP wrapper since FETCH requires a positive count.
 	if limit >= 1 && endsWithBareOrderBy(sql) {
 		return fmt.Sprintf("%s\nOFFSET 0 ROWS FETCH NEXT %d ROWS ONLY", sql, limit)
 	}
@@ -25,15 +22,10 @@ func TSQLLimit(sql string, limit int64) string {
 	return fmt.Sprintf("SELECT TOP %d * FROM (\n%s\n) as t", limit, sql)
 }
 
-// endsWithBareOrderBy reports whether the outermost query ends with an ORDER BY
-// clause that has no accompanying TOP, OFFSET/FETCH, or FOR — the exact shape
-// T-SQL forbids inside a derived table, subquery, or CTE. Only depth-0 (outer
-// query) keywords count; ORDER BY / OFFSET inside a nested subquery is ignored.
-//
-// A depth-0 TOP only legalizes the ORDER BY when it governs the same query, so
-// it is ignored for compound queries (UNION/EXCEPT/INTERSECT): a TOP in one
-// branch does not legalize the trailing ORDER BY of the whole compound, which
-// still needs the in-place OFFSET/FETCH treatment.
+// endsWithBareOrderBy reports whether the outer query (depth-0 keywords only)
+// ends with an ORDER BY lacking TOP/OFFSET/FETCH/FOR — the shape T-SQL forbids
+// inside a derived table or CTE. A branch TOP does not count for compound
+// queries (UNION/EXCEPT/INTERSECT), whose ORDER BY still needs OFFSET/FETCH.
 func endsWithBareOrderBy(sql string) bool {
 	depth := 0
 	lastOrderBy := -1
@@ -78,9 +70,7 @@ func endsWithBareOrderBy(sql string) bool {
 		}
 		i++
 	}
-	// A governing TOP (outer query's own TOP, absent any set operator) makes the
-	// derived-table wrapper valid and would conflict with OFFSET/FETCH, so such
-	// queries keep the wrapper rather than being limited in place.
+	// A governing TOP makes the wrapper valid and conflicts with OFFSET/FETCH.
 	if hasTop && !hasSetOp {
 		return false
 	}

--- a/pkg/query/tsql_limit.go
+++ b/pkg/query/tsql_limit.go
@@ -13,7 +13,9 @@ func TSQLLimit(sql string, limit int64) string {
 	// A query ending in a bare ORDER BY (no TOP/OFFSET/FETCH/FOR) cannot be put
 	// inside a derived table or CTE — T-SQL rejects it. Limit it in place by
 	// appending OFFSET/FETCH to the existing ORDER BY instead of wrapping.
-	if endsWithBareOrderBy(sql) {
+	// FETCH requires a positive count, so limit < 1 keeps the TOP wrapper (TOP 0
+	// is valid and preserves the historical "no rows" behavior).
+	if limit >= 1 && endsWithBareOrderBy(sql) {
 		return fmt.Sprintf("%s\nOFFSET 0 ROWS FETCH NEXT %d ROWS ONLY", sql, limit)
 	}
 	if prefix, body, ok := splitLeadingWith(sql); ok {
@@ -27,10 +29,16 @@ func TSQLLimit(sql string, limit int64) string {
 // clause that has no accompanying TOP, OFFSET/FETCH, or FOR — the exact shape
 // T-SQL forbids inside a derived table, subquery, or CTE. Only depth-0 (outer
 // query) keywords count; ORDER BY / OFFSET inside a nested subquery is ignored.
+//
+// A depth-0 TOP only legalizes the ORDER BY when it governs the same query, so
+// it is ignored for compound queries (UNION/EXCEPT/INTERSECT): a TOP in one
+// branch does not legalize the trailing ORDER BY of the whole compound, which
+// still needs the in-place OFFSET/FETCH treatment.
 func endsWithBareOrderBy(sql string) bool {
 	depth := 0
 	lastOrderBy := -1
 	hasTop := false
+	hasSetOp := false
 	offsetOrForAfter := false
 	for i := 0; i < len(sql); {
 		if ni, ok := skipLiteral(sql, i); ok {
@@ -51,6 +59,9 @@ func endsWithBareOrderBy(sql string) bool {
 			if matchKeyword(sql, i, "TOP") {
 				hasTop = true
 			}
+			if matchKeyword(sql, i, "UNION") || matchKeyword(sql, i, "EXCEPT") || matchKeyword(sql, i, "INTERSECT") {
+				hasSetOp = true
+			}
 			if matchKeyword(sql, i, "ORDER") {
 				j := skipSpaceAndComments(sql, i+len("ORDER"))
 				if matchKeyword(sql, j, "BY") {
@@ -67,7 +78,13 @@ func endsWithBareOrderBy(sql string) bool {
 		}
 		i++
 	}
-	return lastOrderBy >= 0 && !hasTop && !offsetOrForAfter
+	// A governing TOP (outer query's own TOP, absent any set operator) makes the
+	// derived-table wrapper valid and would conflict with OFFSET/FETCH, so such
+	// queries keep the wrapper rather than being limited in place.
+	if hasTop && !hasSetOp {
+		return false
+	}
+	return lastOrderBy >= 0 && !offsetOrForAfter
 }
 
 // uniqueCTEName returns a limit CTE name that does not already occur in sql.

--- a/pkg/query/tsql_limit_test.go
+++ b/pkg/query/tsql_limit_test.go
@@ -147,6 +147,24 @@ func TestTSQLLimit(t *testing.T) {
 			limit:    100,
 			expected: "SELECT TOP 100 * FROM (\nSELECT id FROM t ORDER BY id FOR XML PATH\n) as t",
 		},
+		{
+			name:     "compound query with trailing ORDER BY is limited in place despite branch TOP",
+			query:    "SELECT TOP 10 id FROM t1 UNION SELECT id FROM t2 ORDER BY id",
+			limit:    50,
+			expected: "SELECT TOP 10 id FROM t1 UNION SELECT id FROM t2 ORDER BY id\nOFFSET 0 ROWS FETCH NEXT 50 ROWS ONLY",
+		},
+		{
+			name:     "compound query with trailing ORDER BY and no TOP is limited in place",
+			query:    "SELECT id FROM t1 UNION ALL SELECT id FROM t2 ORDER BY id",
+			limit:    50,
+			expected: "SELECT id FROM t1 UNION ALL SELECT id FROM t2 ORDER BY id\nOFFSET 0 ROWS FETCH NEXT 50 ROWS ONLY",
+		},
+		{
+			name:     "limit 0 with trailing ORDER BY keeps the TOP wrapper",
+			query:    "SELECT id FROM t ORDER BY id",
+			limit:    0,
+			expected: "SELECT TOP 0 * FROM (\nSELECT id FROM t ORDER BY id\n) as t",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/query/tsql_limit_test.go
+++ b/pkg/query/tsql_limit_test.go
@@ -105,6 +105,48 @@ func TestTSQLLimit(t *testing.T) {
 			limit:    10,
 			expected: "WITH __bruin_limited AS (SELECT 1 AS id),\n__bruin_limited_x AS (\nSELECT * FROM __bruin_limited\n)\nSELECT TOP 10 * FROM __bruin_limited_x",
 		},
+		{
+			name:     "trailing bare ORDER BY is limited in place",
+			query:    "SELECT id, name FROM users ORDER BY name DESC",
+			limit:    1000,
+			expected: "SELECT id, name FROM users ORDER BY name DESC\nOFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY",
+		},
+		{
+			name:     "trailing bare ORDER BY with trailing semicolon",
+			query:    "SELECT * FROM users ORDER BY id;",
+			limit:    10,
+			expected: "SELECT * FROM users ORDER BY id\nOFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY",
+		},
+		{
+			name:     "CTE query with trailing bare ORDER BY is limited in place",
+			query:    "WITH a AS (SELECT 1 AS id) SELECT * FROM a ORDER BY id",
+			limit:    5,
+			expected: "WITH a AS (SELECT 1 AS id) SELECT * FROM a ORDER BY id\nOFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY",
+		},
+		{
+			name:     "ORDER BY inside a subquery does not count as trailing",
+			query:    "SELECT * FROM (SELECT TOP 5 id FROM t ORDER BY id) x",
+			limit:    10,
+			expected: "SELECT TOP 10 * FROM (\nSELECT * FROM (SELECT TOP 5 id FROM t ORDER BY id) x\n) as t",
+		},
+		{
+			name:     "outer query with TOP keeps the derived-table wrapper",
+			query:    "SELECT TOP 10 id FROM t ORDER BY id",
+			limit:    100,
+			expected: "SELECT TOP 100 * FROM (\nSELECT TOP 10 id FROM t ORDER BY id\n) as t",
+		},
+		{
+			name:     "ORDER BY already using OFFSET/FETCH keeps the wrapper",
+			query:    "SELECT id FROM t ORDER BY id OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY",
+			limit:    100,
+			expected: "SELECT TOP 100 * FROM (\nSELECT id FROM t ORDER BY id OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY\n) as t",
+		},
+		{
+			name:     "ORDER BY with FOR XML keeps the wrapper",
+			query:    "SELECT id FROM t ORDER BY id FOR XML PATH",
+			limit:    100,
+			expected: "SELECT TOP 100 * FROM (\nSELECT id FROM t ORDER BY id FOR XML PATH\n) as t",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Running a query that ends in a bare `ORDER BY` against a T-SQL source (Fabric DW / MSSQL / Synapse) with a row limit failed with:

```
mssql: The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.
```

`TSQLLimit` applies the limit by wrapping the query in a derived table (`SELECT TOP N * FROM (<sql>) as t`) or, for CTE-leading queries, an appended CTE. T-SQL forbids an `ORDER BY` in either position unless `TOP`/`OFFSET`/`FETCH`/`FOR` is present, so any user query ending in a plain `ORDER BY` broke.

## Fix

Detect a trailing bare `ORDER BY` on the outer query (depth-0, comment/string/bracket-aware, reusing the existing scanner) and apply the limit in place with `OFFSET 0 ROWS FETCH NEXT N ROWS ONLY` instead of wrapping. Queries that don't end in a bare `ORDER BY` — including those already using `TOP`, `OFFSET`/`FETCH`, or `FOR XML` — keep the existing wrapper unchanged.

## Testing

- New unit tests in `tsql_limit_test.go` covering trailing ORDER BY (plain, CTE), nested/subquery ORDER BY, TOP, OFFSET/FETCH, and FOR XML.
- Verified end-to-end against a live Azure SQL Edge (T-SQL) instance: the reported query now returns correctly ordered, limited rows; plain queries still use the TOP wrapper.

Fixes the query-execution half of the Fabric DW sorting issue reported from the VS Code extension.