### PR TITLE
Embed authenticated ingestr installer and archive hashes at build time

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/main' && github.sha || github.ref) }}
   cancel-in-progress: true
 env:
+  GH_TOKEN: ${{ github.token }}
   DOCKER_BUILDKIT: 1
   REGISTRY: ghcr.io
   IMAGE_NAME: bruin-data/bruin

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -145,6 +145,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Authenticate pinned ingestr and generate embedded hashes
+        run: python3 scripts/generate_ingestr_hashes.py
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -180,6 +182,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Authenticate pinned ingestr and generate embedded hashes
+        run: python3 scripts/generate_ingestr_hashes.py
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Extract metadata (tags, labels) for Docker

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -46,6 +46,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Authenticate pinned ingestr and generate embedded hashes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/generate_ingestr_hashes.py
+
       - name: Determine release tag (workflow run)
         id: workflow_tag
         if: ${{ github.event_name == 'workflow_run' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,29 @@ permissions:
   contents: write
 
 env:
+  GH_TOKEN: ${{ github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: bruin-data/bruin
 
 jobs:
+  verify-ingestr:
+    # Use GitHub's maintained runner image for trusted gh provisioning.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Authenticate pinned ingestr and generate embedded hashes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/generate_ingestr_hashes.py
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ingestr-hashes
+          path: pkg/python/ingestr_hashes.json
+          if-no-files-found: error
+          retention-days: 1
+
   integration-tests:
     strategy:
       matrix:
@@ -145,11 +164,16 @@ jobs:
           go test -v -timeout 30m ./...
 
   prepare-darwin:
+    needs: [verify-ingestr]
     runs-on: depot-ubuntu-latest-8
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ingestr-hashes
+          path: pkg/python
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
@@ -168,11 +192,16 @@ jobs:
 
 
   prepare-linux:
+    needs: [verify-ingestr]
     runs-on: depot-ubuntu-latest-8
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ingestr-hashes
+          path: pkg/python
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
@@ -226,6 +255,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ingestr-hashes
+          path: pkg/python
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
@@ -275,6 +308,7 @@ jobs:
           prerelease: false
 
   dockerBuild:
+    needs: [verify-ingestr]
     runs-on: depot-ubuntu-latest
     name: Docker Build
     permissions:
@@ -285,6 +319,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ingestr-hashes
+          path: pkg/python
 
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/.github/workflows/update-ingestr.yml
+++ b/.github/workflows/update-ingestr.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   update:
-    runs-on: depot-ubuntu-latest
+    # GitHub's maintained image supplies the authenticated release verifier.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -28,6 +29,12 @@ jobs:
 
           latest=$(curl -fsSL "https://api.github.com/repos/bruin-data/ingestr/releases/latest" | jq -er '.tag_name')
           latest=${latest#v}
+          # Discovery is not trusted verification. Validate before passing the
+          # value to later steps; the generator authenticates this exact tag.
+          if [[ ! "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected a stable ingestr release tag" >&2
+            exit 1
+          fi
           current=$(sed -nE 's/^[[:space:]]*IngestrVersionV1[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' pkg/python/uv.go)
 
           if [[ -z "$current" ]]; then
@@ -67,6 +74,12 @@ jobs:
           fi
           
           echo "Changes staged successfully"
+
+      - name: Verify candidate ingestr release
+        if: steps.check.outputs.new == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/generate_ingestr_hashes.py
 
       - name: Create Pull Request
         id: create-pr

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ logs/queries
 .devcontainer
 .codex/
 .amp/portals/*
+
+# Authenticated build input; generated automatically, never maintained in Git.
+/pkg/python/ingestr_hashes.json
+/pkg/python/ingestr_hashes.json.tmp

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,13 @@ SPARK_INTEGRATION_TEST = cd integration-tests/cloud-integration-tests/spark && e
 .PHONY: all clean test test-full test-unit build build-no-duckdb docs-app format format-ci lint lint-fast lint-full lint-ci pre-commit refresh-integration-expectations integration-test integration-test-light integration-test-cloud integration-test-spark integration-test-mssql validate-links sync-template-docs setup tools-update
 all: clean deps test build
 
-deps: 
+deps: ingestr-hashes
 	@printf "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)\n"
 	@go mod tidy
+
+.PHONY: ingestr-hashes
+ingestr-hashes:
+	@python3 scripts/generate_ingestr_hashes.py
 
 build: deps
 	@echo "$(OK_COLOR)==> Building the application...$(NO_COLOR)"
@@ -120,15 +124,17 @@ clean:
 
 test: test-unit
 
-test-unit:
+test-unit: ingestr-hashes
 	@echo "$(OK_COLOR)==> Running the unit tests (fast)$(NO_COLOR)"
+	@python3 -m unittest discover -s scripts -p 'test_generate_ingestr_hashes.py'
 	@$(MAKE) rustsqlparser-lib
 	@env SF_DISABLE_MINICORE=true go test -tags="no_duckdb_arrow" -p "$(TEST_CONCURRENCY)" -vet=off -timeout 10m ./cmd/... ./pkg/... ./templates/...
 	@echo "$(OK_COLOR)==> Running the semantic-engine module tests$(NO_COLOR)"
 	@cd semantic-engine && env SF_DISABLE_MINICORE=true go test -p "$(TEST_CONCURRENCY)" -timeout 10m ./...
 
-test-full:
+test-full: ingestr-hashes
 	@echo "$(OK_COLOR)==> Running the unit tests (full)$(NO_COLOR)"
+	@python3 -m unittest discover -s scripts -p 'test_generate_ingestr_hashes.py'
 	@$(MAKE) rustsqlparser-lib
 	@env SF_DISABLE_MINICORE=true go test -tags="no_duckdb_arrow" -race -p "$(TEST_CONCURRENCY)" -vet=off -timeout 10m ./cmd/... ./pkg/... ./templates/...
 	@echo "$(OK_COLOR)==> Running the semantic-engine module tests with race detection$(NO_COLOR)"
@@ -151,7 +157,7 @@ format: lint-python
 
 # Fast edit-loop check on changed Go packages. `go vet` is deliberately absent
 # because govet is already enabled by golangci-lint.
-lint:
+lint: ingestr-hashes
 	@echo "$(OK_COLOR)==> Running fast linters on packages changed since $(LINT_MERGE_BASE)$(NO_COLOR)"
 	@set -e; \
 	for module in $(LINT_MODULES); do \
@@ -163,7 +169,7 @@ lint:
 lint-fast: lint
 
 # Full check for CI and pre-merge validation.
-lint-full:
+lint-full: ingestr-hashes
 	@echo "$(OK_COLOR)==> Running all linters across the repository$(NO_COLOR)"
 	@golangci-lint run --timeout "$(LINT_TIMEOUT)" --concurrency "$(LINT_CONCURRENCY)" $(LINT_PARALLEL_FLAGS) --build-tags="$(LINT_BUILD_TAGS)" ./...
 	@cd semantic-engine && golangci-lint run --timeout "$(LINT_TIMEOUT)" --concurrency "$(LINT_CONCURRENCY)" $(LINT_PARALLEL_FLAGS) ./...

--- a/docs/assets/ingestr.md
+++ b/docs/assets/ingestr.md
@@ -38,6 +38,63 @@ to your data warehouses:
 > [!INFO]
 > See the ingestr [platform catalog](https://getbruin.com/docs/ingestr/supported-sources/platforms.html), [ingest command reference](https://getbruin.com/docs/ingestr/commands/ingest.html), and [incremental loading guide](https://getbruin.com/docs/ingestr/getting-started/incremental-loading.html) for the upstream source, destination, and strategy behavior.
 
+## Installation and archive verification
+
+On first use, Bruin downloads the shared ingestr installer from a commit-pinned
+GitHub URL and checks its SHA-256 against the hash embedded in Bruin. Only after
+that check succeeds does Bruin execute those exact script bytes, passing the
+exact ingestr version and trusted archive hash via the installer's `-s` option.
+The script checks the archive before extraction or installation. A script hash
+mismatch or installer failure stops installation without an unchecked fallback.
+
+This applies to macOS and Linux on x86_64 and arm64, and Windows on x86_64 with
+a shell. On Windows without `sh`, Bruin downloads, hashes, and extracts the ZIP
+natively. The shared script uses existing system download, archive, and SHA-256
+tools; it does not bootstrap verification tooling. No GitHub CLI, signing tools,
+credentials, or checksum sidecars are needed on the user's machine. The
+distributed Bruin binary is the trust anchor.
+
+Builds automatically verify GitHub's immutable release attestation and each of
+the five archives using `gh release verify` and `gh release verify-asset`. The
+generator reads the source commit from the verified attestation, fetches the
+exact release tag using Git's object verification, and requires the fetched
+commit to match. It hashes `install.sh` from that authenticated Git tree without
+executing it. The commit and script hash are embedded alongside the archive
+hashes, with no separate script pin or manual hash maintenance.
+
+The generated manifest is a temporary build input ignored by Git, not a
+committed or manually maintained file. Release CI
+generates it in an authenticated verification job and passes it to the Unix,
+Windows, and Docker build jobs. The version-update workflow also verifies the
+candidate release before proposing a version bump. The pin is v1.1.54, which
+includes the installer's optional expected-archive-hash interface. Earlier
+releases such as v1.1.50 lack that interface; v1.1.48 also lacks the required
+immutable-release evidence.
+
+Fresh installs of explicit v1+ version overrides require a matching embedded
+hash. An unknown version fails with an error: use the pinned version (omit
+`parameters.version` or set it to `v1`), or upgrade Bruin. There is no unverified
+download fallback. Existing cached binaries are reused without revalidation.
+Legacy v0 Python packages and explicit local-source development still use uv;
+this archive-verification guarantee does not apply to those paths.
+
+`make build` and `make build-no-duckdb` regenerate the manifest automatically
+before compilation. Makefile test and Go lint targets also generate it so they
+work from a fresh checkout. Developers need Python 3.11+, Git, and a trusted GitHub CLI
+supporting release verification, authenticated using `gh auth login` or
+`GH_TOKEN`. Each invocation verifies the release again; missing credentials,
+unsupported tooling, or a verification/download failure stops the command
+before compilation. Existing generated output is never a fallback for a failed
+build verification.
+
+For direct `go build`, GoReleaser, or `docker build` commands, first run
+`make ingestr-hashes`. Go's `go:embed` requires the generated
+`pkg/python/ingestr_hashes.json`; a fresh checkout cannot compile without it.
+Docker builds use the generated file from the local build context, so no token
+needs to enter the image. Both Docker release workflows arrange this input
+automatically. CI's release verification job uses GitHub's maintained Ubuntu
+runner image rather than downloading an unverified verifier executable.
+
 ## Asset Structure
 
 ```yaml
@@ -114,7 +171,7 @@ parameters:
 | `source` | No | _n/a_ | Overrides the inferred source type. For example, set `gsheets` when reusing a BigQuery connection for Google Sheets. |
 | `source_table` | Yes | `--source-table` | Table, sheet, or resource identifier to pull from the source. |
 | `file_type` | No | `--source-table` suffix | Appended to the `source_table` as `table#type` for connectors that need a file format hint (`csv`, `jsonl`, `parquet`). |
-| `version` | No | _n/a_ | Selects the version of ingestr to install and use. Valid options are bare family markers such as `v1` or `v0`, or a full version pin such as `v1.0.71`. |
+| `version` | No | _n/a_ | Selects the version of ingestr to install and use: `v1`, `v0`, or an exact pin such as `v1.1.54`. Fresh v1+ downloads require a trusted embedded hash; see [archive verification](#installation-and-archive-verification). |
 | `materialization` | No | `--incremental-*`, `--partition-by`, `--cluster-by` | Preferred way to define destination write behavior. Supports `type: table` with `create+replace`, `append`, `merge`, `delete+insert`, and `truncate+insert`. |
 | `destination` | Unless `connection` or `destination_connection` is set | _n/a_ | Logical destination type used for default connection inference. When `connection` and `destination_connection` are omitted, Bruin uses this value to choose the pipeline default destination connection. |
 | `destination_connection` | No | _n/a_ | Named destination connection to use when `connection` is omitted. This overrides default connection inference from `destination`. |

--- a/pkg/python/ingestr_installer.go
+++ b/pkg/python/ingestr_installer.go
@@ -2,7 +2,11 @@ package python
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,10 +27,10 @@ import (
 )
 
 const (
-	ingestrInstallerURL          = "https://getbruin.com/install/ingestr"
-	ingestrInstallerShellCommand = `curl -LsSf "$1" | sh -s -- -b "$2" "$3"`
-	ingestrReleaseDownloadURL    = "https://github.com/bruin-data/ingestr/releases/download"
-	maxIngestrBinarySize         = 512 * 1024 * 1024
+	ingestrReleaseDownloadURL = "https://github.com/bruin-data/ingestr/releases/download"
+	ingestrScriptDownloadURL  = "https://raw.githubusercontent.com/bruin-data/ingestr"
+	maxIngestrBinarySize      = 512 * 1024 * 1024
+	maxIngestrScriptSize      = 1024 * 1024
 )
 
 // ingestrInstallMu prevents concurrent installations within the same Bruin
@@ -34,15 +38,26 @@ const (
 // directory and the completed binary is moved into place atomically.
 var ingestrInstallMu sync.Mutex
 
+//go:embed ingestr_hashes.json
+var ingestrHashesJSON []byte
+
 type ingestrInstallFunc func(ctx context.Context, output io.Writer, installDir, version string) error
+
+type ingestrReleaseHashes struct {
+	Archives        map[string]string `json:"archives"`
+	InstallerCommit string            `json:"installer_commit"`
+	InstallerSHA256 string            `json:"installer_sha256"`
+}
 
 type ingestrInstallerRuntime struct {
 	goos               string
 	goarch             string
-	findShell          func(string) (string, error)
-	runShell           func(context.Context, io.Writer, string, []string) error
+	hashes             map[string]ingestrReleaseHashes
 	httpClient         *http.Client
 	releaseDownloadURL string
+	scriptDownloadURL  string
+	findShell          func(string) (string, error)
+	runScript          func(context.Context, io.Writer, string, []byte, []string) error
 }
 
 // IngestrChecker installs and locates standalone ingestr releases.
@@ -51,7 +66,7 @@ type IngestrChecker struct {
 }
 
 // EnsureIngestrInstalled returns the path to an exact ingestr release, installing
-// it with the official curl-based installer when it is not already present.
+// it from an archive verified against embedded hashes when not already present.
 func (c *IngestrChecker) EnsureIngestrInstalled(ctx context.Context, version string) (string, error) {
 	if !semver.IsValid("v" + version) {
 		return "", fmt.Errorf("invalid ingestr version %q", version)
@@ -139,64 +154,94 @@ func ingestrBinaryName(goos string) string {
 }
 
 func runIngestrInstaller(ctx context.Context, output io.Writer, installDir, version string) error {
+	var hashes map[string]ingestrReleaseHashes
+	if err := json.Unmarshal(ingestrHashesJSON, &hashes); err != nil {
+		return errors.Wrap(err, "invalid embedded ingestr hashes")
+	}
 	installer := ingestrInstallerRuntime{
 		goos:               runtime.GOOS,
 		goarch:             runtime.GOARCH,
-		findShell:          exec.LookPath,
-		runShell:           runIngestrShellInstaller,
+		hashes:             hashes,
 		httpClient:         &http.Client{Timeout: 5 * time.Minute},
 		releaseDownloadURL: ingestrReleaseDownloadURL,
+		scriptDownloadURL:  ingestrScriptDownloadURL,
+		findShell:          exec.LookPath,
+		runScript:          runVerifiedIngestrScript,
 	}
 	return installer.install(ctx, output, installDir, version)
 }
 
 func (r ingestrInstallerRuntime) install(ctx context.Context, output io.Writer, installDir, version string) error {
+	archiveName, err := ingestrArchiveName(r.goos, r.goarch)
+	if err != nil {
+		return err
+	}
+	release := r.hashes[version]
+	expected := release.Archives[archiveName]
+	if len(expected) != sha256.Size*2 {
+		return fmt.Errorf("no trusted embedded ingestr hash for v%s %s/%s; upgrade Bruin or use its pinned ingestr version", version, r.goos, r.goarch)
+	}
+
 	shell, err := r.findShell("sh")
 	if err != nil {
 		if r.goos == "windows" {
-			return r.installWindowsRelease(ctx, output, installDir, version)
+			return r.installWindowsRelease(ctx, output, installDir, version, archiveName, expected)
 		}
 		return errors.Wrap(err, "the ingestr installer requires sh")
 	}
-
-	if err := r.runShell(ctx, output, shell, ingestrInstallerCommandArgs(installDir, version, r.goos)); err != nil {
-		if r.goos == "windows" && ctx.Err() == nil {
-			if fallbackErr := r.installWindowsRelease(ctx, output, installDir, version); fallbackErr != nil {
-				return fmt.Errorf(
-					"failed to install ingestr v%s with the shell installer: %w; native Windows fallback failed: %w",
-					version,
-					err,
-					fallbackErr,
-				)
-			}
-			return nil
-		}
-		return errors.Wrapf(err, "failed to install ingestr v%s", version)
+	if len(release.InstallerCommit) != 40 || len(release.InstallerSHA256) != sha256.Size*2 {
+		return fmt.Errorf("no trusted embedded ingestr installer hash for v%s", version)
+	}
+	scriptURL := strings.TrimRight(r.scriptDownloadURL, "/") + "/" + url.PathEscape(release.InstallerCommit) + "/install.sh"
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, scriptURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create ingestr installer request")
+	}
+	response, err := r.httpClient.Do(request)
+	if err != nil {
+		return errors.Wrap(err, "failed to download ingestr installer")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download ingestr installer: server returned %s", response.Status)
+	}
+	script, err := io.ReadAll(io.LimitReader(response.Body, maxIngestrScriptSize+1))
+	if err != nil {
+		return errors.Wrap(err, "failed to read ingestr installer")
+	}
+	if len(script) > maxIngestrScriptSize || fmt.Sprintf("%x", sha256.Sum256(script)) != release.InstallerSHA256 {
+		return fmt.Errorf("ingestr installer SHA-256 verification failed")
+	}
+	if r.goos == "windows" {
+		// Git Bash/MSYS accepts drive-letter paths in slash form.
+		installDir = strings.ReplaceAll(installDir, `\`, "/")
+	}
+	args := []string{"-s", "--", "-b", installDir, "-s", expected, "v" + version}
+	if err := r.runScript(ctx, output, shell, script, args); err != nil {
+		return errors.Wrapf(err, "verified ingestr v%s installer failed", version)
 	}
 	return nil
 }
 
-func runIngestrShellInstaller(ctx context.Context, output io.Writer, shell string, args []string) error {
+func runVerifiedIngestrScript(ctx context.Context, output io.Writer, shell string, script []byte, args []string) error {
 	cmd := exec.CommandContext(ctx, shell, args...) //nolint:gosec
-	cmd.Env = environmentWithOverride(os.Environ(), "SHELL", "bruin-installer")
+	if runtime.GOOS == "windows" {
+		configureCommandCancellation(cmd)
+	} else {
+		// Give the installer's TERM trap time to stop downloads and clean up.
+		configureManagedCmd(cmd)
+	}
+	// Execute exactly the bytes verified in memory, never re-fetch the script.
+	cmd.Stdin = bytes.NewReader(script)
 	cmd.Stdout = output
 	cmd.Stderr = output
+	cmd.Env = append(os.Environ(), "SHELL=bruin-installer")
 	return cmd.Run()
 }
 
-func (r ingestrInstallerRuntime) installWindowsRelease(
-	ctx context.Context,
-	output io.Writer,
-	installDir string,
-	version string,
-) error {
-	archiveName, err := windowsIngestrArchiveName(r.goarch)
-	if err != nil {
-		return err
-	}
-
+func (r ingestrInstallerRuntime) installWindowsRelease(ctx context.Context, output io.Writer, installDir, version, archiveName, expected string) error {
 	downloadURL := strings.TrimRight(r.releaseDownloadURL, "/") + "/" + url.PathEscape("v"+version) + "/" + archiveName
-	_, _ = fmt.Fprintf(output, "Downloading ingestr v%s for Windows...\n", version)
+	_, _ = fmt.Fprintf(output, "Downloading ingestr v%s for %s/%s...\n", version, r.goos, r.goarch)
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
@@ -212,14 +257,15 @@ func (r ingestrInstallerRuntime) installWindowsRelease(
 		return fmt.Errorf("failed to download ingestr v%s: server returned %s", version, response.Status)
 	}
 
-	archiveFile, err := os.CreateTemp(installDir, ".ingestr-*.zip")
+	archiveFile, err := os.CreateTemp(installDir, ".ingestr-*")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temporary ingestr archive")
 	}
 	archivePath := archiveFile.Name()
 	defer os.Remove(archivePath)
 
-	_, copyErr := io.Copy(archiveFile, response.Body)
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(archiveFile, hash), io.LimitReader(response.Body, maxIngestrBinarySize+1))
 	closeErr := archiveFile.Close()
 	if copyErr != nil {
 		return errors.Wrap(copyErr, "failed to save ingestr release archive")
@@ -227,15 +273,24 @@ func (r ingestrInstallerRuntime) installWindowsRelease(
 	if closeErr != nil {
 		return errors.Wrap(closeErr, "failed to close ingestr release archive")
 	}
+	if written > maxIngestrBinarySize || fmt.Sprintf("%x", hash.Sum(nil)) != expected {
+		return fmt.Errorf("ingestr v%s %s archive SHA-256 verification failed", version, archiveName)
+	}
 
 	return extractWindowsIngestrArchive(archivePath, installDir)
 }
 
-func windowsIngestrArchiveName(goarch string) (string, error) {
-	if goarch != "amd64" {
-		return "", fmt.Errorf("ingestr standalone releases do not support windows/%s", goarch)
+func ingestrArchiveName(goos, goarch string) (string, error) {
+	osName := map[string]string{"linux": "Linux", "darwin": "Darwin", "windows": "Windows"}[goos]
+	archName := map[string]string{"amd64": "x86_64", "arm64": "arm64"}[goarch]
+	if osName == "" || archName == "" || (goos == "windows" && goarch != "amd64") {
+		return "", fmt.Errorf("ingestr standalone releases do not support %s/%s", goos, goarch)
 	}
-	return "ingestr_Windows_x86_64.zip", nil
+	ext := ".tar.gz"
+	if goos == "windows" {
+		ext = ".zip"
+	}
+	return "ingestr_" + osName + "_" + archName + ext, nil
 }
 
 func extractWindowsIngestrArchive(archivePath, installDir string) error {
@@ -285,31 +340,4 @@ func extractFileFromZip(source *zip.File, destination string) error {
 		return errors.Wrap(fileCloseErr, "failed to close ingestr binary")
 	}
 	return nil
-}
-
-func ingestrInstallerCommandArgs(installDir, version, goos string) []string {
-	if goos == "windows" {
-		// Git Bash/MSYS understands drive-letter paths in slash form.
-		installDir = strings.ReplaceAll(installDir, `\`, "/")
-	}
-	return []string{
-		"-c",
-		ingestrInstallerShellCommand,
-		"ingestr-installer",
-		ingestrInstallerURL,
-		installDir,
-		"v" + version,
-	}
-}
-
-func environmentWithOverride(environment []string, key, value string) []string {
-	prefix := key + "="
-	result := make([]string, 0, len(environment)+1)
-	for _, entry := range environment {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		result = append(result, entry)
-	}
-	return append(result, prefix+value)
 }

--- a/pkg/python/ingestr_installer_test.go
+++ b/pkg/python/ingestr_installer_test.go
@@ -4,12 +4,17 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,290 +23,143 @@ import (
 
 func TestIngestrCheckerInstallsAndCachesExactRelease(t *testing.T) {
 	t.Parallel()
-
-	homeDir := t.TempDir()
-	installCalls := 0
-	checker := &IngestrChecker{
-		install: func(_ context.Context, _ io.Writer, installDir, version string) error {
-			installCalls++
-			assert.Equal(t, "1.2.3", version)
-			return os.WriteFile(
-				filepath.Join(installDir, ingestrBinaryName(runtime.GOOS)),
-				[]byte("installed "+version),
-				0o755,
-			)
-		},
-	}
-
-	binaryPath, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
+	home := t.TempDir()
+	calls := 0
+	checker := &IngestrChecker{install: func(_ context.Context, _ io.Writer, dir, version string) error {
+		calls++
+		assert.Equal(t, "1.2.3", version)
+		return os.WriteFile(filepath.Join(dir, ingestrBinaryName(runtime.GOOS)), []byte("binary"), 0o755)
+	}}
+	path, err := checker.ensureIngestrInstalled(t.Context(), home, "1.2.3", io.Discard)
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(homeDir, "ingestr", "1.2.3", ingestrBinaryName(runtime.GOOS)), binaryPath)
-	assert.Equal(t, 1, installCalls)
-
-	contents, err := os.ReadFile(binaryPath)
+	assert.Equal(t, filepath.Join(home, "ingestr", "1.2.3", ingestrBinaryName(runtime.GOOS)), path)
+	// Unknown cached versions remain usable even without an embedded hash.
+	checker.install = nil
+	cached, err := checker.ensureIngestrInstalled(t.Context(), home, "1.2.3", io.Discard)
 	require.NoError(t, err)
-	assert.Equal(t, "installed 1.2.3", string(contents))
-
-	// A cached release is returned without invoking the installer again.
-	cachedPath, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
-	require.NoError(t, err)
-	assert.Equal(t, binaryPath, cachedPath)
-	assert.Equal(t, 1, installCalls)
-	assert.Empty(t, installationTempDirs(t, homeDir))
+	assert.Equal(t, path, cached)
+	assert.Equal(t, 1, calls)
 }
 
-func TestIngestrCheckerCleansUpFailedInstallation(t *testing.T) {
+func TestIngestrCheckerFailedInstallation(t *testing.T) {
 	t.Parallel()
-
-	homeDir := t.TempDir()
-	installErr := assert.AnError
-	checker := &IngestrChecker{
-		install: func(context.Context, io.Writer, string, string) error {
-			return installErr
-		},
-	}
-
-	_, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
-
-	require.ErrorIs(t, err, installErr)
-	assert.NoFileExists(t, filepath.Join(homeDir, "ingestr", "1.2.3", ingestrBinaryName(runtime.GOOS)))
-	assert.Empty(t, installationTempDirs(t, homeDir))
-}
-
-func TestIngestrCheckerRejectsInstallerWithoutBinary(t *testing.T) {
-	t.Parallel()
-
-	homeDir := t.TempDir()
-	checker := &IngestrChecker{
-		install: func(context.Context, io.Writer, string, string) error {
-			return nil
-		},
-	}
-
-	_, err := checker.ensureIngestrInstalled(t.Context(), homeDir, "1.2.3", io.Discard)
-
-	require.ErrorContains(t, err, "installer did not produce "+ingestrBinaryName(runtime.GOOS))
-	assert.Empty(t, installationTempDirs(t, homeDir))
-}
-
-func TestIngestrCheckerRejectsInvalidVersion(t *testing.T) {
-	t.Parallel()
-
-	checker := &IngestrChecker{}
-
-	_, err := checker.EnsureIngestrInstalled(t.Context(), "../../unexpected")
-
-	require.ErrorContains(t, err, "invalid ingestr version")
-}
-
-func TestIngestrInstallerCommandArgs(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		goos       string
-		installDir string
-		wantDir    string
-	}{
-		{
-			name:       "linux path",
-			goos:       "linux",
-			installDir: "/tmp/bruin home/ingestr",
-			wantDir:    "/tmp/bruin home/ingestr",
-		},
-		{
-			name:       "windows path is converted for msys",
-			goos:       "windows",
-			installDir: `C:\Users\runner admin\.bruin\ingestr`,
-			wantDir:    "C:/Users/runner admin/.bruin/ingestr",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			args := ingestrInstallerCommandArgs(tt.installDir, "1.2.3", tt.goos)
-
-			assert.Equal(t, []string{
-				"-c",
-				ingestrInstallerShellCommand,
-				"ingestr-installer",
-				ingestrInstallerURL,
-				tt.wantDir,
-				"v1.2.3",
-			}, args)
+	for _, missing := range []bool{false, true} {
+		t.Run(fmt.Sprint(missing), func(t *testing.T) {
+			home := t.TempDir()
+			checker := &IngestrChecker{install: func(context.Context, io.Writer, string, string) error {
+				if missing {
+					return nil
+				}
+				return assert.AnError
+			}}
+			_, err := checker.ensureIngestrInstalled(t.Context(), home, "1.2.3", io.Discard)
+			require.Error(t, err)
+			assert.NoFileExists(t, filepath.Join(home, "ingestr", "1.2.3", ingestrBinaryName(runtime.GOOS)))
+			matches, err := filepath.Glob(filepath.Join(home, "ingestr", ".install-*"))
+			require.NoError(t, err)
+			assert.Empty(t, matches)
 		})
 	}
 }
 
-func TestIngestrBinaryName(t *testing.T) {
+func TestIngestrCheckerRejectsInvalidVersion(t *testing.T) {
 	t.Parallel()
-
-	assert.Equal(t, "ingestr", ingestrBinaryName("linux"))
-	assert.Equal(t, "ingestr", ingestrBinaryName("darwin"))
-	assert.Equal(t, "ingestr.exe", ingestrBinaryName("windows"))
+	_, err := (&IngestrChecker{}).EnsureIngestrInstalled(t.Context(), "../../unexpected")
+	require.ErrorContains(t, err, "invalid ingestr version")
 }
 
-func TestIngestrInstallerRequiresShellOnUnix(t *testing.T) {
+func TestIngestrFreshDownload(t *testing.T) {
 	t.Parallel()
-
-	installer := ingestrInstallerRuntime{
-		goos: "linux",
-		findShell: func(string) (string, error) {
-			return "", os.ErrNotExist
-		},
+	for _, platform := range []struct{ os, arch, archive string }{
+		{"windows", "amd64", "ingestr_Windows_x86_64.zip"},
+	} {
+		t.Run(platform.os+platform.arch, func(t *testing.T) {
+			t.Parallel()
+			for _, scenario := range []string{"valid", "tampered", "wrong-version", "unknown", "http-error", "missing-binary", "cancelled"} {
+				t.Run(scenario, func(t *testing.T) {
+					name := ingestrBinaryName(platform.os)
+					entry := "nested/" + name
+					if scenario == "missing-binary" {
+						entry = "README.md"
+					}
+					archive := ingestrTestArchive(t, platform.os, entry, "trusted binary")
+					digest := fmt.Sprintf("%x", sha256.Sum256(archive))
+					if scenario == "tampered" {
+						archive = append(archive, 'x')
+					}
+					if scenario == "wrong-version" {
+						archive = ingestrTestArchive(t, platform.os, entry, "other release")
+					}
+					requests := 0
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						requests++
+						assert.Equal(t, "/v1.2.3/"+platform.archive, r.URL.Path)
+						if scenario == "http-error" {
+							w.WriteHeader(404)
+							return
+						}
+						_, _ = w.Write(archive)
+					}))
+					defer server.Close()
+					dir := t.TempDir()
+					destination := filepath.Join(dir, name)
+					require.NoError(t, os.WriteFile(destination, []byte("original"), 0o755))
+					r := ingestrInstallerRuntime{
+						goos: platform.os, goarch: platform.arch, httpClient: server.Client(), releaseDownloadURL: server.URL,
+						hashes:    map[string]ingestrReleaseHashes{"1.2.3": {Archives: map[string]string{platform.archive: digest}}},
+						findShell: func(string) (string, error) { return "", os.ErrNotExist },
+					}
+					version := "1.2.3"
+					if scenario == "unknown" {
+						version = "1.2.4"
+					}
+					ctx, cancel := context.WithCancel(t.Context())
+					defer cancel()
+					if scenario == "cancelled" {
+						cancel()
+					}
+					err := r.install(ctx, io.Discard, dir, version)
+					contents, readErr := os.ReadFile(destination)
+					require.NoError(t, readErr)
+					if scenario == "valid" {
+						require.NoError(t, err)
+						assert.Equal(t, "trusted binary", string(contents))
+					} else {
+						require.Error(t, err)
+						assert.Equal(t, "original", string(contents))
+						if scenario == "tampered" || scenario == "wrong-version" {
+							require.ErrorContains(t, err, "SHA-256 verification failed")
+						}
+						if scenario == "unknown" {
+							require.ErrorContains(t, err, "no trusted embedded")
+							assert.Zero(t, requests)
+						}
+					}
+				})
+			}
+		})
 	}
-
-	err := installer.install(t.Context(), io.Discard, t.TempDir(), "1.2.3")
-
-	require.ErrorContains(t, err, "requires sh")
 }
 
-func TestIngestrInstallerFallsBackToNativeWindowsDownload(t *testing.T) {
+func TestEmbeddedIngestrHashes(t *testing.T) {
 	t.Parallel()
-
-	archive := windowsIngestrTestArchive(t, "ingestr.exe", "windows binary")
-	requestedPath := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		requestedPath <- request.URL.Path
-		writer.Header().Set("Content-Type", "application/zip")
-		_, _ = writer.Write(archive)
-	}))
-	t.Cleanup(server.Close)
-	installDir := t.TempDir()
-	installer := ingestrInstallerRuntime{
-		goos:   "windows",
-		goarch: "amd64",
-		findShell: func(string) (string, error) {
-			return "", os.ErrNotExist
-		},
-		httpClient:         server.Client(),
-		releaseDownloadURL: server.URL,
+	var hashes map[string]ingestrReleaseHashes
+	require.NoError(t, json.Unmarshal(ingestrHashesJSON, &hashes))
+	require.Len(t, hashes[IngestrVersionV1].Archives, 5)
+	for _, digest := range hashes[IngestrVersionV1].Archives {
+		assert.Regexp(t, "^[a-f0-9]{64}$", digest)
 	}
-
-	err := installer.install(t.Context(), io.Discard, installDir, "1.2.3")
-
-	require.NoError(t, err)
-	assert.Equal(t, "/v1.2.3/ingestr_Windows_x86_64.zip", <-requestedPath)
-	contents, err := os.ReadFile(filepath.Join(installDir, "ingestr.exe"))
-	require.NoError(t, err)
-	assert.Equal(t, "windows binary", string(contents))
+	assert.Regexp(t, "^[a-f0-9]{40}$", hashes[IngestrVersionV1].InstallerCommit)
+	assert.Regexp(t, "^[a-f0-9]{64}$", hashes[IngestrVersionV1].InstallerSHA256)
+	_, err := ingestrArchiveName("windows", "arm64")
+	require.Error(t, err)
+	// The real default installer must fail closed before any network request.
+	require.ErrorContains(t, runIngestrInstaller(t.Context(), io.Discard, t.TempDir(), "99.0.0"), "no trusted embedded")
 }
 
-func TestIngestrInstallerFallsBackAfterWindowsShellFailure(t *testing.T) {
-	t.Parallel()
-
-	archive := windowsIngestrTestArchive(t, "ingestr.exe", "fallback binary")
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
-		_, _ = writer.Write(archive)
-	}))
-	t.Cleanup(server.Close)
-	installDir := t.TempDir()
-	installer := ingestrInstallerRuntime{
-		goos:   "windows",
-		goarch: "amd64",
-		findShell: func(string) (string, error) {
-			return "sh", nil
-		},
-		runShell: func(context.Context, io.Writer, string, []string) error {
-			return assert.AnError
-		},
-		httpClient:         server.Client(),
-		releaseDownloadURL: server.URL,
-	}
-
-	err := installer.install(t.Context(), io.Discard, installDir, "1.2.3")
-
-	require.NoError(t, err)
-	contents, err := os.ReadFile(filepath.Join(installDir, "ingestr.exe"))
-	require.NoError(t, err)
-	assert.Equal(t, "fallback binary", string(contents))
-}
-
-func TestIngestrInstallerDoesNotFallbackAfterContextCancellation(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-	installer := ingestrInstallerRuntime{
-		goos: "windows",
-		findShell: func(string) (string, error) {
-			return "sh", nil
-		},
-		runShell: func(ctx context.Context, _ io.Writer, _ string, _ []string) error {
-			return ctx.Err()
-		},
-	}
-
-	err := installer.install(ctx, io.Discard, t.TempDir(), "1.2.3")
-
-	require.ErrorIs(t, err, context.Canceled)
-}
-
-func TestNativeWindowsIngestrInstallerRejectsFailedDownload(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
-		http.Error(writer, "not found", http.StatusNotFound)
-	}))
-	t.Cleanup(server.Close)
-	installer := ingestrInstallerRuntime{
-		goarch:             "amd64",
-		httpClient:         server.Client(),
-		releaseDownloadURL: server.URL,
-	}
-
-	err := installer.installWindowsRelease(t.Context(), io.Discard, t.TempDir(), "1.2.3")
-
-	require.ErrorContains(t, err, "server returned 404 Not Found")
-}
-
-func TestNativeWindowsIngestrInstallerRequiresBinaryInArchive(t *testing.T) {
-	t.Parallel()
-
-	archive := windowsIngestrTestArchive(t, "README.md", "missing binary")
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
-		_, _ = writer.Write(archive)
-	}))
-	t.Cleanup(server.Close)
-	installer := ingestrInstallerRuntime{
-		goarch:             "amd64",
-		httpClient:         server.Client(),
-		releaseDownloadURL: server.URL,
-	}
-
-	err := installer.installWindowsRelease(t.Context(), io.Discard, t.TempDir(), "1.2.3")
-
-	require.ErrorContains(t, err, "archive did not contain ingestr.exe")
-}
-
-func TestWindowsIngestrArchiveNameRejectsUnsupportedArchitecture(t *testing.T) {
-	t.Parallel()
-
-	_, err := windowsIngestrArchiveName("arm64")
-
-	require.ErrorContains(t, err, "do not support windows/arm64")
-}
-
-func TestEnvironmentWithOverride(t *testing.T) {
-	t.Parallel()
-
-	result := environmentWithOverride([]string{"PATH=/bin", "SHELL=/bin/zsh", "VALUE=a=b"}, "SHELL", "bruin-installer")
-
-	assert.ElementsMatch(t, []string{"PATH=/bin", "VALUE=a=b", "SHELL=bruin-installer"}, result)
-}
-
-func installationTempDirs(t *testing.T, homeDir string) []string {
+func ingestrTestArchive(t *testing.T, goos, name, contents string) []byte {
 	t.Helper()
-
-	matches, err := filepath.Glob(filepath.Join(homeDir, "ingestr", ".install-*"))
-	require.NoError(t, err)
-	return matches
-}
-
-func windowsIngestrTestArchive(t *testing.T, name, contents string) []byte {
-	t.Helper()
-
+	require.Equal(t, "windows", goos)
 	var buffer bytes.Buffer
 	archive := zip.NewWriter(&buffer)
 	file, err := archive.Create(name)
@@ -310,4 +168,105 @@ func windowsIngestrTestArchive(t *testing.T, name, contents string) []byte {
 	require.NoError(t, err)
 	require.NoError(t, archive.Close())
 	return buffer.Bytes()
+}
+
+func TestIngestrVerifiedScript(t *testing.T) {
+	t.Parallel()
+	for _, platform := range []struct{ os, arch, archive string }{
+		{"linux", "amd64", "ingestr_Linux_x86_64.tar.gz"},
+		{"linux", "arm64", "ingestr_Linux_arm64.tar.gz"},
+		{"darwin", "amd64", "ingestr_Darwin_x86_64.tar.gz"},
+		{"darwin", "arm64", "ingestr_Darwin_arm64.tar.gz"},
+		{"windows", "amd64", "ingestr_Windows_x86_64.zip"},
+	} {
+		t.Run(platform.os+platform.arch, func(t *testing.T) {
+			t.Parallel()
+			for _, scenario := range []string{"valid", "tampered", "http-error", "missing-script-hash", "unknown-version", "cancelled", "script-failure"} {
+				t.Run(scenario, func(t *testing.T) {
+					script := []byte("#!/bin/sh\nprintf trusted\n")
+					commit := strings.Repeat("a", 40)
+					archiveHash := strings.Repeat("b", 64)
+					scriptHash := fmt.Sprintf("%x", sha256.Sum256(script))
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+						assert.Equal(t, "/"+commit+"/install.sh", request.URL.Path)
+						if scenario == "http-error" {
+							w.WriteHeader(http.StatusNotFound)
+							return
+						}
+						if scenario == "tampered" {
+							_, _ = w.Write([]byte("untrusted"))
+							return
+						}
+						_, _ = w.Write(script)
+					}))
+					defer server.Close()
+					dir := t.TempDir()
+					ran := false
+					if scenario == "missing-script-hash" {
+						scriptHash = ""
+					}
+					r := ingestrInstallerRuntime{
+						goos: platform.os, goarch: platform.arch,
+						httpClient: server.Client(), scriptDownloadURL: server.URL,
+						hashes: map[string]ingestrReleaseHashes{"1.2.3": {
+							Archives:        map[string]string{platform.archive: archiveHash},
+							InstallerCommit: commit, InstallerSHA256: scriptHash,
+						}},
+						findShell: func(string) (string, error) { return "test-sh", nil },
+						runScript: func(_ context.Context, _ io.Writer, shell string, contents []byte, args []string) error {
+							ran = true
+							assert.Equal(t, "test-sh", shell)
+							assert.Equal(t, script, contents)
+							wantDir := dir
+							if platform.os == "windows" {
+								wantDir = strings.ReplaceAll(dir, `\`, "/")
+							}
+							assert.Equal(t, []string{"-s", "--", "-b", wantDir, "-s", archiveHash, "v1.2.3"}, args)
+							if scenario == "script-failure" {
+								return assert.AnError
+							}
+							return nil
+						},
+					}
+					version := "1.2.3"
+					if scenario == "unknown-version" {
+						version = "1.2.4"
+					}
+					ctx, cancel := context.WithCancel(t.Context())
+					defer cancel()
+					if scenario == "cancelled" {
+						cancel()
+					}
+					err := r.install(ctx, io.Discard, dir, version)
+					if scenario == "valid" {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+					assert.Equal(t, scenario == "valid" || scenario == "script-failure", ran)
+					if scenario == "tampered" {
+						require.ErrorContains(t, err, "installer SHA-256 verification failed")
+					}
+					if scenario == "script-failure" {
+						require.ErrorIs(t, err, assert.AnError)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestRunVerifiedIngestrScript(t *testing.T) {
+	t.Parallel()
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	var output bytes.Buffer
+	// Shell metacharacters in arguments must remain literal; stdin is the exact
+	// verified source, and SHELL must disable user profile modification.
+	script := []byte("printf '%s|%s|%s' \"$SHELL\" \"$1\" \"$2\"\n")
+	err = runVerifiedIngestrScript(t.Context(), &output, shell, script, []string{"-s", "--", "path with spaces", "$(echo injected)"})
+	require.NoError(t, err)
+	assert.Equal(t, "bruin-installer|path with spaces|$(echo injected)", output.String())
 }

--- a/pkg/python/uv.go
+++ b/pkg/python/uv.go
@@ -44,7 +44,7 @@ const (
 	// IngestrVersionV0 is the legacy ingestr release pinned for parameters.version=v0.
 	IngestrVersionV0 = "0.14.155"
 	// IngestrVersionV1 is the current ingestr release used by default and for parameters.version=v1.
-	IngestrVersionV1 = "1.1.48"
+	IngestrVersionV1 = "1.1.54"
 	sqlfluffVersion  = "3.4.1"
 )
 
@@ -575,7 +575,7 @@ func isLegacyIngestrVersion(version string) bool {
 }
 
 // ingestrCommand resolves released v1+ versions to standalone binaries installed
-// by the official curl installer. Legacy v0 and local source checkouts continue to
+// from archives checked against embedded hashes. Legacy v0 and local source checkouts continue to
 // use uv because they are Python packages and have no compatible binary release.
 func (u *UvPythonRunner) ingestrCommand(ctx context.Context, extraPackages, args []string) (*CommandInstance, error) {
 	_, isLocal := u.ingestrPackage(ctx)

--- a/scripts/generate_ingestr_hashes.py
+++ b/scripts/generate_ingestr_hashes.py
@@ -1,0 +1,152 @@
+"""Generate embedded hashes using GitHub's authenticated immutable-release verifier.
+
+Requires a trusted installation of gh with `release verify` / `verify-asset`.
+Never installs tools or falls back to unsigned metadata. Build commands and
+release CI generate the ignored manifest before compiling Bruin.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = "bruin-data/ingestr"
+ARCHIVES = (
+    "ingestr_Darwin_arm64.tar.gz",
+    "ingestr_Darwin_x86_64.tar.gz",
+    "ingestr_Linux_arm64.tar.gz",
+    "ingestr_Linux_x86_64.tar.gz",
+    "ingestr_Windows_x86_64.zip",
+)
+
+
+def gh(*args):
+    # Pin the host too: GH_HOST must not redirect verification to another forge.
+    env = dict(os.environ, GH_HOST="github.com", GH_PROMPT_DISABLED="1")
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True, env=env
+    ).stdout
+
+
+def installer_hash(tag, verification):
+    # Only consume the statement returned by successful official verification,
+    # never the unverified bundle payload or release API target_commitish.
+    statement = verification["verificationResult"]["statement"]
+    purl = f"pkg:github/{REPO}@{tag}"
+    predicate = statement["predicate"]
+    if (
+        statement["predicateType"] != "https://in-toto.io/attestation/release/v0.2"
+        or predicate["repository"] != REPO
+        or predicate["tag"] != tag
+        or predicate["purl"] != purl
+    ):
+        raise ValueError("verified installer source has wrong repository or tag")
+    subjects = [item for item in statement["subject"] if item.get("uri") == purl]
+    if len(subjects) != 1:
+        raise ValueError("expected one verified installer source commit")
+    commit = subjects[0]["digest"]["sha1"]
+    if not re.fullmatch(r"[a-f0-9]{40}", commit):
+        raise ValueError("invalid verified installer source commit")
+
+    # Git validates its content-addressed objects; tie the fetched tree to the
+    # signed commit before reading the script. Never execute fetched source.
+    with tempfile.TemporaryDirectory(prefix="bruin-ingestr-source-") as directory:
+
+        def git(*args):
+            return subprocess.run(
+                ["git", "-C", directory, "-c", "transfer.fsckObjects=true", *args],
+                check=True,
+                capture_output=True,
+                env=dict(os.environ, GIT_TERMINAL_PROMPT="0"),
+            ).stdout
+
+        git("init", "--bare", "--quiet")
+        git(
+            "fetch",
+            "--quiet",
+            "--depth=1",
+            f"https://github.com/{REPO}.git",
+            f"refs/tags/{tag}",
+        )
+        if git("rev-parse", "FETCH_HEAD^{commit}").decode().strip() != commit:
+            raise ValueError("installer source does not match verified release commit")
+        script = git("show", f"{commit}:install.sh")
+    return commit, hashlib.sha256(script).hexdigest()
+
+
+def generate(version):
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
+        raise ValueError("expected an exact stable ingestr version")
+    tag = "v" + version
+    release = json.loads(gh("api", f"repos/{REPO}/releases/tags/{tag}"))
+    if release.get("tag_name") != tag or release.get("immutable") is not True:
+        raise ValueError("expected the exact immutable ingestr release")
+    verification = json.loads(
+        gh("release", "verify", tag, "--repo", REPO, "--format", "json")
+    )
+    commit, script_hash = installer_hash(tag, verification)
+    hashes = {}
+    with tempfile.TemporaryDirectory(prefix="bruin-ingestr-verify-") as directory:
+        for name in ARCHIVES:
+            gh(
+                "release",
+                "download",
+                tag,
+                "--repo",
+                REPO,
+                "--pattern",
+                name,
+                "--dir",
+                directory,
+            )
+            archive = Path(directory) / name
+            gh("release", "verify-asset", tag, str(archive), "--repo", REPO)
+            with archive.open("rb") as source:
+                hashes[name] = hashlib.file_digest(source, "sha256").hexdigest()
+            archive.unlink()
+    return (
+        json.dumps(
+            {
+                version: {
+                    "archives": hashes,
+                    "installer_commit": commit,
+                    "installer_sha256": script_hash,
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    source = (ROOT / "pkg/python/uv.go").read_text()
+    version = re.search(r'IngestrVersionV1\s*=\s*"([^"]+)"', source).group(1)
+    generated = generate(version)
+    destination = ROOT / "pkg/python/ingestr_hashes.json"
+    if args.check:
+        if destination.read_text() != generated:
+            raise ValueError(
+                "generated ingestr hashes differ from verified release; run generator"
+            )
+    else:
+        # Do not leave partial trusted output after a failed verification.
+        temporary = destination.with_suffix(".json.tmp")
+        temporary.write_text(generated)
+        temporary.replace(destination)
+    print(
+        f"Verified ingestr v{version} installer source and all {len(ARCHIVES)} archives; generated embedded hashes"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_generate_ingestr_hashes.py
+++ b/scripts/test_generate_ingestr_hashes.py
@@ -1,0 +1,241 @@
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import generate_ingestr_hashes as generator
+
+
+class GeneratorTests(unittest.TestCase):
+    def fake_gh(self, *args):
+        self.calls.append(args)
+        if args[0] == "api":
+            self.assertEqual(
+                args, ("api", "repos/bruin-data/ingestr/releases/tags/v1.1.50")
+            )
+            return json.dumps(self.release)
+        self.assertEqual(args[2], "v1.1.50")
+        self.assertEqual(args[args.index("--repo") + 1], "bruin-data/ingestr")
+        if args[1] == "download":
+            name = args[args.index("--pattern") + 1]
+            self.assertIn(name, generator.ARCHIVES)
+            (Path(args[-1]) / name).write_bytes(name.encode())
+        if args[1] == "verify-asset":
+            self.assertTrue(Path(args[3]).is_file())
+        if args[1] == self.fail:
+            raise subprocess.CalledProcessError(1, args, stderr="invalid evidence")
+        if args[1] == "verify":
+            return json.dumps(self.verification)
+        return ""
+
+    def setUp(self):
+        self.calls = []
+        self.release = {"tag_name": "v1.1.50", "immutable": True}
+        self.fail = None
+        self.commit = "a" * 40
+        self.git_commit = self.commit
+        self.script = b"#!/bin/sh\nprintf fixture\n"
+        self.verification = {
+            "verificationResult": {
+                "statement": {
+                    "predicateType": "https://in-toto.io/attestation/release/v0.2",
+                    "predicate": {
+                        "repository": "bruin-data/ingestr",
+                        "tag": "v1.1.50",
+                        "purl": "pkg:github/bruin-data/ingestr@v1.1.50",
+                    },
+                    "subject": [
+                        {
+                            "uri": "pkg:github/bruin-data/ingestr@v1.1.50",
+                            "digest": {"sha1": self.commit},
+                        }
+                    ],
+                }
+            }
+        }
+        self.git_calls = []
+        git = patch.object(generator.subprocess, "run", side_effect=self.fake_git)
+        git.start()
+        self.addCleanup(git.stop)
+
+    def fake_git(self, args, **kwargs):
+        self.assertTrue(kwargs["check"])
+        self.assertEqual(args[0], "git")
+        self.assertEqual(args[3:5], ["-c", "transfer.fsckObjects=true"])
+        command = args[5:]
+        self.git_calls.append(command)
+        output = b""
+        if command[0] == "fetch":
+            self.assertEqual(
+                command,
+                [
+                    "fetch",
+                    "--quiet",
+                    "--depth=1",
+                    "https://github.com/bruin-data/ingestr.git",
+                    "refs/tags/v1.1.50",
+                ],
+            )
+        elif command[0] == "rev-parse":
+            self.assertEqual(command[1], "FETCH_HEAD^{commit}")
+            output = (self.git_commit + "\n").encode()
+        elif command[0] == "show":
+            self.assertEqual(command[1], self.commit + ":install.sh")
+            output = self.script
+        return subprocess.CompletedProcess(args, 0, stdout=output)
+
+    def test_exact_release_and_every_asset_verified(self):
+        with patch.object(generator, "gh", self.fake_gh):
+            result = json.loads(generator.generate("1.1.50"))
+        self.assertEqual(
+            result,
+            {
+                "1.1.50": {
+                    "archives": {
+                        name: hashlib.sha256(name.encode()).hexdigest()
+                        for name in generator.ARCHIVES
+                    },
+                    "installer_commit": self.commit,
+                    "installer_sha256": hashlib.sha256(self.script).hexdigest(),
+                }
+            },
+        )
+        self.assertEqual(
+            self.calls[1],
+            (
+                "release",
+                "verify",
+                "v1.1.50",
+                "--repo",
+                "bruin-data/ingestr",
+                "--format",
+                "json",
+            ),
+        )
+        self.assertEqual(sum(c[1] == "verify-asset" for c in self.calls), 5)
+
+    def test_wrong_verified_source_identity(self):
+        for key, wrong in (
+            ("repository", "other/ingestr"),
+            ("tag", "v1.1.49"),
+            ("purl", "pkg:github/other/ingestr@v1.1.50"),
+        ):
+            predicate = self.verification["verificationResult"]["statement"][
+                "predicate"
+            ]
+            with self.subTest(key=key), patch.dict(predicate, {key: wrong}):
+                with self.assertRaisesRegex(ValueError, "wrong repository or tag"):
+                    generator.installer_hash("v1.1.50", self.verification)
+                self.assertEqual(self.git_calls, [])
+
+    def test_missing_verified_commit(self):
+        statement = self.verification["verificationResult"]["statement"]
+        for subjects in (
+            [],
+            [
+                {
+                    "uri": "pkg:github/other/ingestr@v1.1.50",
+                    "digest": {"sha1": self.commit},
+                }
+            ],
+        ):
+            with (
+                self.subTest(subjects=subjects),
+                patch.dict(statement, {"subject": subjects}),
+            ):
+                with self.assertRaisesRegex(
+                    ValueError, "one verified installer source"
+                ):
+                    generator.installer_hash("v1.1.50", self.verification)
+                self.assertEqual(self.git_calls, [])
+
+    def test_fetched_commit_must_match_signed_commit(self):
+        self.git_commit = "b" * 40
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            generator.installer_hash("v1.1.50", self.verification)
+        self.assertFalse(any(command[0] == "show" for command in self.git_calls))
+
+    def test_git_failure_propagates(self):
+        with patch.object(
+            generator.subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                generator.installer_hash("v1.1.50", self.verification)
+
+    def test_missing_immutable_or_wrong_tag(self):
+        for release in (
+            {},
+            {"tag_name": "v1.1.50", "immutable": False},
+            {"tag_name": "v1.1.49", "immutable": True},
+        ):
+            with (
+                self.subTest(release=release),
+                patch.object(generator, "gh", self.fake_gh),
+            ):
+                self.calls = []
+                self.release = release
+                with self.assertRaises(ValueError):
+                    generator.generate("1.1.50")
+                self.assertEqual(len(self.calls), 1)
+
+    def test_verification_or_download_failure_preserves_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "pkg/python").mkdir(parents=True)
+            (root / "pkg/python/uv.go").write_text('IngestrVersionV1 = "1.1.50"')
+            output = root / "pkg/python/ingestr_hashes.json"
+            output.write_text("previous trusted output")
+            for failure in ("verify", "download", "verify-asset"):
+                with (
+                    self.subTest(failure=failure),
+                    patch.object(generator, "ROOT", root),
+                    patch.object(generator, "gh", self.fake_gh),
+                    patch("sys.argv", ["generator"]),
+                ):
+                    self.fail = failure
+                    with self.assertRaises(subprocess.CalledProcessError):
+                        generator.main()
+                    self.assertEqual(output.read_text(), "previous trusted output")
+
+    def test_check_rejects_stale_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "pkg/python").mkdir(parents=True)
+            (root / "pkg/python/uv.go").write_text('IngestrVersionV1 = "1.1.50"')
+            output = root / "pkg/python/ingestr_hashes.json"
+            output.write_text("{}")
+            with (
+                patch.object(generator, "ROOT", root),
+                patch.object(generator, "gh", self.fake_gh),
+                patch("sys.argv", ["generator", "--check"]),
+            ):
+                with self.assertRaisesRegex(ValueError, "differ"):
+                    generator.main()
+                self.assertEqual(output.read_text(), "{}")
+
+    def test_no_latest_or_version_injection(self):
+        for version in ("latest", "v1.1.50", "1.1.50/other", "1.1.50;false"):
+            with patch.object(generator, "gh") as gh, self.assertRaises(ValueError):
+                generator.generate(version)
+            gh.assert_not_called()
+
+    def test_gh_errors_propagate_and_host_is_pinned(self):
+        with (
+            patch.dict("os.environ", {"GH_HOST": "other.example"}),
+            patch(
+                "subprocess.run", side_effect=subprocess.CalledProcessError(1, "gh")
+            ) as run,
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                generator.gh("release", "verify", "v1.1.50", "--repo", generator.REPO)
+            self.assertTrue(run.call_args.kwargs["check"])
+            self.assertEqual(run.call_args.kwargs["env"]["GH_HOST"], "github.com")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Changes
- Automatically authenticate the pinned immutable ingestr release and all five archives using official GitHub CLI verification during builds.
- Derive the shared installer hash from the attested source commit and embed it alongside archive hashes; keep generated JSON out of Git.
- Verify shared installer bytes before execution and pass the trusted archive hash through its optional -s parameter. Preserve native Windows no-shell verification and existing cache-hit behavior.
- Fail closed for unknown fresh-download versions and verification errors. Update the pin to v1.1.54, release/build wiring, documentation, and regression coverage.

## Verification
- make format passed (fast lint: 0 issues).
- make build tag=dev passed.
- Live generation authenticated v1.1.54 source and all five archives; compiled binary contains the resulting installer and archive metadata.
- Published commit-pinned installer matches its embedded SHA-256 and exposes -s.
- Changed-document Markdown lint and git diff --check passed.
- Tests were not run during implementation at karakanb’s request. A fresh testing orb has now been requested for this PR.

## Build requirements
Developers need Python 3.11+, Git, and an authenticated maintained gh supporting release verification. End users need no gh, credentials, or signing-tool bootstrap. Direct go build / Docker / GoReleaser invocations require make ingestr-hashes first; normal Makefile and release paths arrange generation automatically.